### PR TITLE
feat(lmcache): support GLM hybrid DCP geometry

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -762,7 +762,7 @@ RUN --mount=type=cache,target=/opt/uv/cache \
 # Install FlashInfer JIT cache (requires CUDA-version-specific index URL)
 # https://docs.flashinfer.ai/installation.html
 # From versions.json: .flashinfer.version
-ARG FLASHINFER_VERSION=0.6.17
+ARG FLASHINFER_VERSION=0.6.18
 RUN --mount=type=cache,target=/opt/uv/cache \
     uv pip install --system flashinfer-jit-cache==${FLASHINFER_VERSION} \
         --index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.')

--- a/docker/glm53-flash/lmcache-d16-overlay/README.md
+++ b/docker/glm53-flash/lmcache-d16-overlay/README.md
@@ -1,0 +1,20 @@
+# GLM-5.3 LMCache D16 overlay
+
+This directory contains the LMCache-owned portion of the qualified GLM-5.3
+integration. It is intentionally separate from vLLM source. Apply the files
+under `overlay/` to LMCache 0.5.4 and rebuild its CUDA extension with the
+included patches at LMCache commit
+`3e11b8ed191631e6f098b8038235823f1a410b24`.
+
+The overlay provides:
+
+- DCP/interleave-aware cache identity and logical group spans;
+- BLHNC/BLNHC padded packed-stride transfers;
+- one- and two-argument Mamba alignment validation;
+- authoritative engine-group registration geometry;
+- lifecycle-safe cuMem POSIX-FD IPC without `cudaDeviceReset`; and
+- legacy D2H stores for compressed logical geometry while retaining native
+  H2D retrieval and native D2H for uncompressed object groups.
+
+The sibling `single-container/` directory documents and supervises the
+production one-container deployment.

--- a/docker/glm53-flash/lmcache-d16-overlay/README.md
+++ b/docker/glm53-flash/lmcache-d16-overlay/README.md
@@ -1,8 +1,8 @@
 # GLM-5.3 LMCache D16 overlay
 
-This directory contains the LMCache-owned portion of the qualified GLM-5.3
-integration. It is intentionally separate from vLLM source. Apply the files
-under `overlay/` to LMCache 0.5.4 and rebuild its CUDA extension with the
+This directory contains the packaged LMCache and vLLM core overlays for the
+qualified GLM-5.3 integration. Apply the files under `overlay/` to the runtime
+site-packages, use LMCache 0.5.4, and rebuild its CUDA extension with the
 included patches at LMCache commit
 `3e11b8ed191631e6f098b8038235823f1a410b24`.
 
@@ -12,9 +12,20 @@ The overlay provides:
 - BLHNC/BLNHC padded packed-stride transfers;
 - one- and two-argument Mamba alignment validation;
 - authoritative engine-group registration geometry;
+- exact committed Mamba boundary handoffs from vLLM core;
+- sparse LMCache Mamba chunk sources, where retained checkpoints use their
+  physical block IDs and unavailable historical checkpoints use null block 0,
+  while attention groups retain their normal dense block history;
 - lifecycle-safe cuMem POSIX-FD IPC without `cudaDeviceReset`; and
 - legacy D2H stores for compressed logical geometry while retaining native
   H2D retrieval and native D2H for uncompressed object groups.
+
+The exact-boundary behavior depends on the scheduler and connector semantics
+from [#526](https://github.com/local-inference-lab/vllm/pull/526) and
+[#527](https://github.com/local-inference-lab/vllm/pull/527). In particular,
+connector reconciliation cannot advertise a prefix beyond the lagging Mamba
+state, and the scheduler must forward each core-selected
+`(request_id, group_id, physical_block_id, boundary_tokens)` handoff.
 
 The sibling `single-container/` directory documents and supervises the
 production one-container deployment.

--- a/docker/glm53-flash/lmcache-d16-overlay/lmcache_cuda_ops_odd_width.patch
+++ b/docker/glm53-flash/lmcache-d16-overlay/lmcache_cuda_ops_odd_width.patch
@@ -1,0 +1,26 @@
+diff --git a/csrc/cuda/mp_mem_kernels.cu b/csrc/cuda/mp_mem_kernels.cu
+index 5963b8ab..01cf52b5 100644
+--- a/csrc/cuda/mp_mem_kernels.cu
++++ b/csrc/cuda/mp_mem_kernels.cu
+@@ -447,9 +447,6 @@ void multi_layer_block_kv_transfer(
+     PageBufferShapeDesc shape_desc, int lmcache_chunk_size,
+     EngineKVFormat engine_kv_format, int skip_prefix_n_blocks) {
+   int head_bytes = shape_desc.hs * shape_desc.element_size;
+-  TORCH_CHECK(head_bytes % sizeof(uint16_t) == 0, "head_size * element_size (",
+-              head_bytes, ") must be divisible by 2 for vectorized access");
+-
+   if (engine_kv_format == EngineKVFormat::NL_X_NB_BSV_BSS) {
+     // Blocked-scale indexer cache: the per-token fp32 scale must be a whole
+     // number of transfer units, so pin 4-byte units regardless of row width.
+@@ -464,8 +461,10 @@ void multi_layer_block_kv_transfer(
+     LAUNCH_TEMPLATED(uint4);  // 16 bytes per copy
+   } else if (head_bytes % sizeof(uint32_t) == 0) {
+     LAUNCH_TEMPLATED(uint32_t);  // 4 bytes per copy
+-  } else {
+-    LAUNCH_TEMPLATED(uint16_t);  // 2 bytes per copy (minimum granularity)
++  } else if (head_bytes % sizeof(uint16_t) == 0) {
++    LAUNCH_TEMPLATED(uint16_t);  // 2 bytes per copy
++  } else {
++    LAUNCH_TEMPLATED(uint8_t);  // odd packed content width
+   }
+ }

--- a/docker/glm53-flash/lmcache-d16-overlay/lmcache_cuda_ops_odd_width.patch
+++ b/docker/glm53-flash/lmcache-d16-overlay/lmcache_cuda_ops_odd_width.patch
@@ -12,7 +12,7 @@ index 5963b8ab..01cf52b5 100644
    if (engine_kv_format == EngineKVFormat::NL_X_NB_BSV_BSS) {
      // Blocked-scale indexer cache: the per-token fp32 scale must be a whole
      // number of transfer units, so pin 4-byte units regardless of row width.
-@@ -464,8 +461,10 @@ void multi_layer_block_kv_transfer(
+@@ -464,7 +461,9 @@ void multi_layer_block_kv_transfer(
      LAUNCH_TEMPLATED(uint4);  // 16 bytes per copy
    } else if (head_bytes % sizeof(uint32_t) == 0) {
      LAUNCH_TEMPLATED(uint32_t);  // 4 bytes per copy

--- a/docker/glm53-flash/lmcache-d16-overlay/lmcache_cuda_ops_slot_stride.patch
+++ b/docker/glm53-flash/lmcache-d16-overlay/lmcache_cuda_ops_slot_stride.patch
@@ -75,19 +75,21 @@ index e19f1ebb..79b8bcfc 100644
 -    const int block_size, const int head_size, const int skip_prefix_n_tokens) {
 +    const int block_size, const int head_size, const int skip_prefix_n_tokens,
 +    const int64_t block_stride_elems) {
-@@ -634,3 +650,4 @@ void multi_layer_kv_transfer_templated(
+@@ -634,3 +650,6 @@ void multi_layer_kv_transfer_templated(
 
    lmc::check_block_size(engine_kv_format, block_size);
    lmc::check_head_size(engine_kv_format, head_size_xword);
++  TORCH_CHECK(block_stride_elems % elements_per_xword == 0,
++              "block_stride_elems must be divisible by elements_per_xword");
 +  const int64_t block_stride_xwords = block_stride_elems / elements_per_xword;
-@@ -906,4 +923,5 @@ void multi_layer_kv_transfer(
+@@ -906,4 +925,5 @@ void multi_layer_kv_transfer(
      const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
      const int page_buffer_size, const TransferDirection direction,
      const EngineKVFormat engine_kv_format, const int block_size,
 -    const int head_size, const int skip_prefix_n_tokens) {
 +    const int head_size, const int skip_prefix_n_tokens,
 +    const int64_t block_stride_elems) {
-@@ -915,5 +933,5 @@ void multi_layer_kv_transfer(
+@@ -915,5 +935,5 @@ void multi_layer_kv_transfer(
        multi_layer_kv_transfer_templated<type>(                          \
            key_value, key_value_ptrs, slot_mapping, paged_memory_device, \
            page_buffer_size, direction, engine_kv_format, block_size,    \

--- a/docker/glm53-flash/lmcache-d16-overlay/lmcache_cuda_ops_slot_stride.patch
+++ b/docker/glm53-flash/lmcache-d16-overlay/lmcache_cuda_ops_slot_stride.patch
@@ -1,15 +1,19 @@
 diff --git a/csrc/cuda/mem_kernels.cu b/csrc/cuda/mem_kernels.cu
-index e19f1ebb..79b8bcfc 100644
+index e19f1ebb..4fc93605 100644
 --- a/csrc/cuda/mem_kernels.cu
 +++ b/csrc/cuda/mem_kernels.cu
-@@ -214,4 +214,5 @@ template <EngineKVFormat format>
+@@ -214,7 +214,8 @@ template <EngineKVFormat format>
  __device__ __forceinline__ int64_t page_buffer_offset(
      const int k_or_v, const int token_idx, const int scalar_offset,
      const int scalars_per_token, const int page_buffer_size,
 -    const int block_size, const int head_size) {
 +    const int block_size, const int head_size,
 +    const int64_t block_stride_xwords) {
-@@ -292,13 +293,26 @@ __device__ __forceinline__ int64_t page_buffer_offset(
+   /*
+   logical semantics of arguments (agnostic to physical format):
+   k_or_v:            0 for key, 1 for value
+@@ -290,17 +291,30 @@ __device__ __forceinline__ int64_t page_buffer_offset(
+            head_offset;
    } else if constexpr (format == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS ||
                         format == EngineKVFormat::NL_X_NB_NH_BS_CS) {
 -    const int hs2 = 2 * head_size;  // packed K+V width per head (xword units)
@@ -43,24 +47,41 @@ index e19f1ebb..79b8bcfc 100644
 +    return block_idx * block_step +
 +           static_cast<int64_t>(block_offset) * scalars_per_token +
 +           scalar_offset;
-@@ -436,3 +449,3 @@ __global__ void load_and_reshape_multi_layer_fused_kernel(
+   }
+   // DSA indexer: page [BSxvals][BSxscales]; 4B units, so scale == 1 unit
+   else if constexpr (format == EngineKVFormat::NL_X_NB_BSV_BSS) {
+@@ -436,7 +450,7 @@ __global__ void load_and_reshape_multi_layer_fused_kernel(
+                          num_tokens, num_layers);
      const int64_t vllm_offset =
          page_buffer_offset<format>(k_or_v, slot_idx, i, scalars_per_token,
 -                                   page_buffer_size, block_size, head_size);
 +                                   page_buffer_size, block_size, head_size, 0);
-@@ -464,4 +477,4 @@ __global__ void load_and_reshape_multi_layer_kernel(
+     if (DIRECTION)
+       chunk.key_value[lmcache_offset] = paged_buffer_ptr[vllm_offset];
+     else
+@@ -464,7 +478,7 @@ __global__ void load_and_reshape_multi_layer_kernel(
      const int64_t* __restrict__ slot_mapping,   // [num_tokens]
      const int scalars_per_token, const int num_tokens, const int num_layers,
      const int page_buffer_size, const int block_size, const int head_size,
 -    const int skip_prefix_n_tokens) {
 +    const int skip_prefix_n_tokens, const int64_t block_stride_xwords) {
-@@ -487,3 +500,4 @@ __global__ void load_and_reshape_multi_layer_kernel(
+   const int token_id = blockIdx.x;
+   const int layer_id = blockIdx.y;
+   const int k_or_v = blockIdx.z;
+@@ -486,8 +500,9 @@ __global__ void load_and_reshape_multi_layer_kernel(
+                          num_tokens, num_layers);
+-
++
      const int64_t vllm_offset =
          page_buffer_offset<format>(k_or_v, slot_idx, i, scalars_per_token,
 -                                   page_buffer_size, block_size, head_size);
 +                                   page_buffer_size, block_size, head_size,
 +                                   block_stride_xwords);
-@@ -599,5 +613,6 @@ T* get_kernel_ptr(TENSOR_TYPE& tensor) {
+-
++
+     if (DIRECTION)  // 1 is paged buffer to LMCache
+       key_value[lmcache_offset] = paged_buffer_ptr[vllm_offset];
+@@ -599,7 +614,8 @@ T* get_kernel_ptr(TENSOR_TYPE& tensor) {
        <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,          \
                                     slot_mapping_ptr, num_xwords, num_tokens, \
                                     num_layers, page_buffer_size, block_size, \
@@ -68,50 +89,67 @@ index e19f1ebb..79b8bcfc 100644
 +                                   head_size_xword, skip_prefix_n_tokens,    \
 +                                   block_stride_xwords);                    \
    C10_CUDA_KERNEL_LAUNCH_CHECK();
-@@ -614,4 +629,5 @@ void multi_layer_kv_transfer_templated(
+-
++
+ template <typename T>
+@@ -614,7 +630,8 @@ void multi_layer_kv_transfer_templated(
      const torch::Tensor& slot_mapping,    // [num_tokens],
      const torch::Device& paged_memory_device, const int page_buffer_size,
      const TransferDirection direction, const EngineKVFormat engine_kv_format,
 -    const int block_size, const int head_size, const int skip_prefix_n_tokens) {
 +    const int block_size, const int head_size, const int skip_prefix_n_tokens,
 +    const int64_t block_stride_elems) {
-@@ -634,3 +650,6 @@ void multi_layer_kv_transfer_templated(
-
+   T* key_value_ptr = get_kernel_ptr<T, torch::Tensor>(key_value);
+   T** page_buffer_ptrs =
+       get_kernel_ptr<T*, const torch::Tensor>(key_value_ptrs);
+@@ -634,5 +651,8 @@ void multi_layer_kv_transfer_templated(
    lmc::check_block_size(engine_kv_format, block_size);
    lmc::check_head_size(engine_kv_format, head_size_xword);
 +  TORCH_CHECK(block_stride_elems % elements_per_xword == 0,
 +              "block_stride_elems must be divisible by elements_per_xword");
 +  const int64_t block_stride_xwords = block_stride_elems / elements_per_xword;
-@@ -906,4 +925,5 @@ void multi_layer_kv_transfer(
+   TORCH_CHECK(
+       engine_kv_format != EngineKVFormat::NL_X_NB_BSV_BSS || sizeof(T) == 4,
+       "NL_X_NB_BSV_BSS requires 4-byte transfer units (row bytes "
+@@ -906,7 +926,8 @@ void multi_layer_kv_transfer(
      const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
      const int page_buffer_size, const TransferDirection direction,
      const EngineKVFormat engine_kv_format, const int block_size,
 -    const int head_size, const int skip_prefix_n_tokens) {
 +    const int head_size, const int skip_prefix_n_tokens,
 +    const int64_t block_stride_elems) {
-@@ -915,5 +935,5 @@ void multi_layer_kv_transfer(
+   int num_origin_elements = key_value.size(3);
+   int copy_size = num_origin_elements * key_value.element_size();
+ #ifndef LAUNCH_MULTI_LAYER_KV_TRANSFER
+@@ -915,7 +936,7 @@ void multi_layer_kv_transfer(
        multi_layer_kv_transfer_templated<type>(                          \
            key_value, key_value_ptrs, slot_mapping, paged_memory_device, \
            page_buffer_size, direction, engine_kv_format, block_size,    \
 -          head_size, skip_prefix_n_tokens);                             \
 +          head_size, skip_prefix_n_tokens, block_stride_elems);         \
      } while (0)
+ #endif
+   if (copy_size % 8 == 0) {
 diff --git a/csrc/cuda/mem_kernels.cuh b/csrc/cuda/mem_kernels.cuh
 index 6385338b..61a36c26 100644
 --- a/csrc/cuda/mem_kernels.cuh
 +++ b/csrc/cuda/mem_kernels.cuh
-@@ -13,4 +13,5 @@ void multi_layer_kv_transfer(
+@@ -13,7 +13,8 @@ void multi_layer_kv_transfer(
      const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
      const int page_buffer_size, const TransferDirection direction,
      const EngineKVFormat engine_kv_format, const int block_size = 0,
 -    const int head_size = 0, const int skip_prefix_n_tokens = 0);
 +    const int head_size = 0, const int skip_prefix_n_tokens = 0,
 +    const int64_t block_stride_elems = 0);
+-
++
+ // Max chunks per fused launch; the by-value pack must fit the 4 KB
+ // kernel-arg buffer.
 diff --git a/csrc/cuda/pybind.cpp b/csrc/cuda/pybind.cpp
 index 416075df..abaf01fb 100644
 --- a/csrc/cuda/pybind.cpp
 +++ b/csrc/cuda/pybind.cpp
-@@ -33,16 +33,17 @@ PYBIND11_MODULE(cuda_ops, m) {
+@@ -33,18 +33,19 @@ PYBIND11_MODULE(cuda_ops, m) {
           const torch::Tensor& slot_mapping,
           const torch::Device& paged_memory_device, const int page_buffer_size,
           int direction, int engine_kv_format, const int block_size = 0,
@@ -132,3 +170,5 @@ index 416075df..abaf01fb 100644
 -      py::arg("skip_prefix_n_tokens") = 0,
 +      py::arg("skip_prefix_n_tokens") = 0, py::arg("block_stride_elems") = 0,
        py::call_guard<py::gil_scoped_release>());
+   m.def("multi_layer_kv_transfer_unilateral",
+         [](torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,

--- a/docker/glm53-flash/lmcache-d16-overlay/lmcache_cuda_ops_slot_stride.patch
+++ b/docker/glm53-flash/lmcache-d16-overlay/lmcache_cuda_ops_slot_stride.patch
@@ -1,0 +1,132 @@
+diff --git a/csrc/cuda/mem_kernels.cu b/csrc/cuda/mem_kernels.cu
+index e19f1ebb..79b8bcfc 100644
+--- a/csrc/cuda/mem_kernels.cu
++++ b/csrc/cuda/mem_kernels.cu
+@@ -214,4 +214,5 @@ template <EngineKVFormat format>
+ __device__ __forceinline__ int64_t page_buffer_offset(
+     const int k_or_v, const int token_idx, const int scalar_offset,
+     const int scalars_per_token, const int page_buffer_size,
+-    const int block_size, const int head_size) {
++    const int block_size, const int head_size,
++    const int64_t block_stride_xwords) {
+@@ -292,13 +293,26 @@ __device__ __forceinline__ int64_t page_buffer_offset(
+   } else if constexpr (format == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS ||
+                        format == EngineKVFormat::NL_X_NB_NH_BS_CS) {
+-    const int hs2 = 2 * head_size;  // packed K+V width per head (xword units)
++    const int packed_head_size =
++        format == EngineKVFormat::NL_X_NB_NH_BS_CS ? head_size : 2 * head_size;
+     const int block_idx = token_idx / block_size;
+     const int block_offset = token_idx % block_size;
+-    const int head_idx = scalar_offset / hs2;
+-    const int head_offset = scalar_offset % hs2;
+-    const int num_heads = scalars_per_token / hs2;
+-    return block_idx * num_heads * block_size * hs2 +
+-           head_idx * block_size * hs2 + block_offset * hs2 + head_offset;
++    const int head_idx = scalar_offset / packed_head_size;
++    const int head_offset = scalar_offset % packed_head_size;
++    const int num_heads = scalars_per_token / packed_head_size;
++    const int64_t block_step =
++        block_stride_xwords > 0
++            ? block_stride_xwords
++            : static_cast<int64_t>(num_heads) * block_size * packed_head_size;
++    return block_idx * block_step + head_idx * block_size * packed_head_size +
++           block_offset * packed_head_size + head_offset;
+   } else if constexpr (format == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS ||
+                        format == EngineKVFormat::NL_X_NB_BS_NH_CS) {
+-    return token_idx * scalars_per_token + scalar_offset;
++    const int block_idx = token_idx / block_size;
++    const int block_offset = token_idx % block_size;
++    const int64_t block_step =
++        block_stride_xwords > 0
++            ? block_stride_xwords
++            : static_cast<int64_t>(block_size) * scalars_per_token;
++    return block_idx * block_step +
++           static_cast<int64_t>(block_offset) * scalars_per_token +
++           scalar_offset;
+@@ -436,3 +449,3 @@ __global__ void load_and_reshape_multi_layer_fused_kernel(
+     const int64_t vllm_offset =
+         page_buffer_offset<format>(k_or_v, slot_idx, i, scalars_per_token,
+-                                   page_buffer_size, block_size, head_size);
++                                   page_buffer_size, block_size, head_size, 0);
+@@ -464,4 +477,4 @@ __global__ void load_and_reshape_multi_layer_kernel(
+     const int64_t* __restrict__ slot_mapping,   // [num_tokens]
+     const int scalars_per_token, const int num_tokens, const int num_layers,
+     const int page_buffer_size, const int block_size, const int head_size,
+-    const int skip_prefix_n_tokens) {
++    const int skip_prefix_n_tokens, const int64_t block_stride_xwords) {
+@@ -487,3 +500,4 @@ __global__ void load_and_reshape_multi_layer_kernel(
+     const int64_t vllm_offset =
+         page_buffer_offset<format>(k_or_v, slot_idx, i, scalars_per_token,
+-                                   page_buffer_size, block_size, head_size);
++                                   page_buffer_size, block_size, head_size,
++                                   block_stride_xwords);
+@@ -599,5 +613,6 @@ T* get_kernel_ptr(TENSOR_TYPE& tensor) {
+       <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,          \
+                                    slot_mapping_ptr, num_xwords, num_tokens, \
+                                    num_layers, page_buffer_size, block_size, \
+-                                   head_size_xword, skip_prefix_n_tokens);   \
++                                   head_size_xword, skip_prefix_n_tokens,    \
++                                   block_stride_xwords);                    \
+   C10_CUDA_KERNEL_LAUNCH_CHECK();
+@@ -614,4 +629,5 @@ void multi_layer_kv_transfer_templated(
+     const torch::Tensor& slot_mapping,    // [num_tokens],
+     const torch::Device& paged_memory_device, const int page_buffer_size,
+     const TransferDirection direction, const EngineKVFormat engine_kv_format,
+-    const int block_size, const int head_size, const int skip_prefix_n_tokens) {
++    const int block_size, const int head_size, const int skip_prefix_n_tokens,
++    const int64_t block_stride_elems) {
+@@ -634,3 +650,4 @@ void multi_layer_kv_transfer_templated(
+
+   lmc::check_block_size(engine_kv_format, block_size);
+   lmc::check_head_size(engine_kv_format, head_size_xword);
++  const int64_t block_stride_xwords = block_stride_elems / elements_per_xword;
+@@ -906,4 +923,5 @@ void multi_layer_kv_transfer(
+     const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
+     const int page_buffer_size, const TransferDirection direction,
+     const EngineKVFormat engine_kv_format, const int block_size,
+-    const int head_size, const int skip_prefix_n_tokens) {
++    const int head_size, const int skip_prefix_n_tokens,
++    const int64_t block_stride_elems) {
+@@ -915,5 +933,5 @@ void multi_layer_kv_transfer(
+       multi_layer_kv_transfer_templated<type>(                          \
+           key_value, key_value_ptrs, slot_mapping, paged_memory_device, \
+           page_buffer_size, direction, engine_kv_format, block_size,    \
+-          head_size, skip_prefix_n_tokens);                             \
++          head_size, skip_prefix_n_tokens, block_stride_elems);         \
+     } while (0)
+diff --git a/csrc/cuda/mem_kernels.cuh b/csrc/cuda/mem_kernels.cuh
+index 6385338b..61a36c26 100644
+--- a/csrc/cuda/mem_kernels.cuh
++++ b/csrc/cuda/mem_kernels.cuh
+@@ -13,4 +13,5 @@ void multi_layer_kv_transfer(
+     const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
+     const int page_buffer_size, const TransferDirection direction,
+     const EngineKVFormat engine_kv_format, const int block_size = 0,
+-    const int head_size = 0, const int skip_prefix_n_tokens = 0);
++    const int head_size = 0, const int skip_prefix_n_tokens = 0,
++    const int64_t block_stride_elems = 0);
+diff --git a/csrc/cuda/pybind.cpp b/csrc/cuda/pybind.cpp
+index 416075df..abaf01fb 100644
+--- a/csrc/cuda/pybind.cpp
++++ b/csrc/cuda/pybind.cpp
+@@ -33,16 +33,17 @@ PYBIND11_MODULE(cuda_ops, m) {
+          const torch::Tensor& slot_mapping,
+          const torch::Device& paged_memory_device, const int page_buffer_size,
+          int direction, int engine_kv_format, const int block_size = 0,
+-         const int head_size = 0, const int skip_prefix_n_tokens = 0) {
++         const int head_size = 0, const int skip_prefix_n_tokens = 0,
++         const int64_t block_stride_elems = 0) {
+         return multi_layer_kv_transfer(
+             key_value, key_value_ptrs, slot_mapping, paged_memory_device,
+             page_buffer_size, static_cast<TransferDirection>(direction),
+             static_cast<EngineKVFormat>(engine_kv_format), block_size,
+-            head_size, skip_prefix_n_tokens);
++            head_size, skip_prefix_n_tokens, block_stride_elems);
+       },
+       py::arg("key_value"), py::arg("key_value_ptrs"), py::arg("slot_mapping"),
+       py::arg("paged_memory_device"), py::arg("page_buffer_size"),
+       py::arg("direction"), py::arg("engine_kv_format"),
+       py::arg("block_size") = 0, py::arg("head_size") = 0,
+-      py::arg("skip_prefix_n_tokens") = 0,
++      py::arg("skip_prefix_n_tokens") = 0, py::arg("block_stride_elems") = 0,
+       py::call_guard<py::gil_scoped_release>());

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/dcp_layout.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/dcp_layout.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Resolved LMCache geometry for vLLM DCP and hybrid KV cache groups."""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Iterable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_DCP_LAYOUT_NAMESPACE = "##lmcache-dcp-layout-v1-"
+_MAX_LCM_EXPANSION_FACTOR = 16
+
+
+def _leaf_specs(spec: Any) -> list[Any]:
+    """Return leaf specs from vLLM's optional uniform-type wrapper."""
+    per_layer_specs = getattr(spec, "kv_cache_specs", None)
+    if isinstance(per_layer_specs, dict):
+        return list(per_layer_specs.values())
+    return [spec]
+
+
+def _iter_kv_cache_specs(kv_cache_config: Any | None) -> Iterable[Any]:
+    """Yield resolved leaf specs without depending on a vLLM helper API."""
+    if kv_cache_config is None:
+        return
+    for group in getattr(kv_cache_config, "kv_cache_groups", ()) or ():
+        yield from _leaf_specs(group.kv_cache_spec)
+
+
+def _is_spec_kind(spec: Any, class_name: str) -> bool:
+    return any(cls.__name__ == class_name for cls in type(spec).__mro__)
+
+
+def _is_attention_spec(spec: Any) -> bool:
+    return _is_spec_kind(spec, "AttentionSpec")
+
+
+def _is_mamba_spec(spec: Any) -> bool:
+    return _is_spec_kind(spec, "MambaSpec")
+
+
+def get_tokens_per_block(spec: Any, dcp_size: int) -> int:
+    """Resolve one engine group's span in global scheduler tokens.
+
+    Attention block IDs address rank-local DCP shards and therefore span the
+    physical attention block multiplied by DCP. Recurrent blocks are
+    replicated and retain their physical span.
+    """
+    leaves = _leaf_specs(spec)
+    if not leaves:
+        raise ValueError("KV cache group has no leaf specs")
+    block_sizes = {int(leaf.block_size) for leaf in leaves}
+    if len(block_sizes) != 1:
+        raise ValueError(
+            "All leaf KV cache specs in one group must share a block size; "
+            f"got {sorted(block_sizes)}"
+        )
+    block_size = block_sizes.pop()
+    if block_size <= 0:
+        raise ValueError(f"KV cache block size must be positive, got {block_size}")
+    if any(_is_attention_spec(leaf) for leaf in leaves):
+        return block_size * dcp_size
+    return block_size
+
+
+def get_group_tokens_per_block(
+    vllm_config: Any,
+    kv_cache_config: Any | None,
+) -> list[int]:
+    """Return all engine-group spans in global scheduler coordinates."""
+    dcp_size = int(
+        getattr(vllm_config.parallel_config, "decode_context_parallel_size", 1)
+    )
+    groups = (
+        getattr(kv_cache_config, "kv_cache_groups", ()) or ()
+        if kv_cache_config is not None
+        else ()
+    )
+    return [
+        get_tokens_per_block(group.kv_cache_spec, dcp_size) for group in groups
+    ] or [int(vllm_config.cache_config.block_size) * dcp_size]
+
+
+def get_lmcache_scheduler_block_size(
+    vllm_config: Any,
+    kv_cache_config: Any | None,
+) -> int:
+    """Resolve the least scheduler span aligned to every physical group."""
+    group_spans = get_group_tokens_per_block(vllm_config, kv_cache_config)
+    scheduler_block_size = math.lcm(*group_spans)
+    largest_group_span = max(group_spans)
+    if scheduler_block_size > largest_group_span * _MAX_LCM_EXPANSION_FACTOR:
+        logger.warning(
+            "LMCache resolved a scheduler block of %d tokens from group spans "
+            "%s (%.1fx the largest span); near-coprime geometry can make "
+            "cache chunks too coarse",
+            scheduler_block_size,
+            group_spans,
+            scheduler_block_size / largest_group_span,
+        )
+    return scheduler_block_size
+
+
+def get_lmcache_model_name(vllm_config: Any) -> str:
+    """Decorate cache identity when DCP interleave changes the byte layout."""
+    model_name = str(vllm_config.model_config.model)
+    parallel_config = vllm_config.parallel_config
+    dcp_size = int(getattr(parallel_config, "decode_context_parallel_size", 1))
+    interleave = int(getattr(parallel_config, "cp_kv_cache_interleave_size", 1))
+    if dcp_size <= 1:
+        return model_name
+    return f"{model_name}{_DCP_LAYOUT_NAMESPACE}d{dcp_size}-interleave{interleave}"
+
+
+def get_lmcache_base_model_name(model_name: str) -> str:
+    """Recover the served model name from an LMCache cache identity."""
+    return model_name.partition(_DCP_LAYOUT_NAMESPACE)[0]
+
+
+def get_resolved_attention_block_sizes(
+    vllm_config: Any,
+    kv_cache_config: Any | None,
+) -> set[int]:
+    """Return all resolved physical attention block sizes."""
+    block_sizes = {
+        int(spec.block_size)
+        for spec in _iter_kv_cache_specs(kv_cache_config)
+        if _is_attention_spec(spec)
+    }
+    return block_sizes or {int(vllm_config.cache_config.block_size)}
+
+
+def validate_mamba_step_alignment(
+    vllm_config: Any,
+    kv_cache_config: Any | None = None,
+) -> None:
+    """Require each scheduler step to advance a full resolved Mamba block."""
+    if getattr(vllm_config.cache_config, "mamba_cache_mode", "none") != "align":
+        return
+    mamba_block_sizes = {
+        int(spec.block_size)
+        for spec in _iter_kv_cache_specs(kv_cache_config)
+        if _is_mamba_spec(spec)
+    }
+    if len(mamba_block_sizes) > 1:
+        raise ValueError(
+            "All Mamba KV cache groups must use one physical block size; got "
+            f"{sorted(mamba_block_sizes)}."
+        )
+    block_size = (
+        next(iter(mamba_block_sizes))
+        if mamba_block_sizes
+        else int(vllm_config.cache_config.block_size)
+    )
+    max_batched = int(vllm_config.scheduler_config.max_num_batched_tokens)
+    if max_batched < block_size:
+        raise ValueError(
+            "Mamba-hybrid models with LMCache require "
+            "max_num_batched_tokens >= block_size so every prefill step "
+            "advances at least one full block; got "
+            f"max_num_batched_tokens={max_batched}, block_size={block_size}. "
+            f"Set --max-num-batched-tokens to at least {block_size}."
+        )
+
+
+def validate_dcp_support(
+    vllm_config: Any,
+    n_servers: int,
+    kv_cache_config: Any | None = None,
+) -> None:
+    """Fail closed on incomplete DCP ownership or incompatible interleave."""
+    parallel_config = vllm_config.parallel_config
+    dcp_size = int(getattr(parallel_config, "decode_context_parallel_size", 1))
+    if dcp_size <= 1:
+        return
+
+    pcp_size = int(getattr(parallel_config, "prefill_context_parallel_size", 1))
+    if pcp_size > 1:
+        raise ValueError(
+            "LMCacheMPConnector does not support prefill-context parallelism "
+            f"together with DCP (got pcp={pcp_size}, dcp={dcp_size})."
+        )
+
+    interleave = int(getattr(parallel_config, "cp_kv_cache_interleave_size", 1))
+    if interleave < 1:
+        raise ValueError(
+            "LMCacheMPConnector requires cp_kv_cache_interleave_size >= 1 "
+            f"under DCP (got {interleave})."
+        )
+    incompatible = sorted(
+        block_size
+        for block_size in get_resolved_attention_block_sizes(
+            vllm_config, kv_cache_config
+        )
+        if interleave > block_size or block_size % interleave != 0
+    )
+    if incompatible:
+        raise ValueError(
+            f"cp_kv_cache_interleave_size ({interleave}) must be no greater "
+            "than and evenly divide every resolved attention block size; "
+            f"incompatible sizes: {incompatible}."
+        )
+
+    world_size = int(parallel_config.world_size)
+    if n_servers <= 0 or world_size % n_servers:
+        raise ValueError(
+            f"world_size ({world_size}) must be divisible by n_servers ({n_servers})"
+        )
+    ranks_per_server = world_size // n_servers
+    if ranks_per_server < dcp_size or ranks_per_server % dcp_size:
+        raise ValueError(
+            "Each LMCache server needs a whole-number set of "
+            f"decode_context_parallel_size ({dcp_size}) shards, but "
+            f"{n_servers} server(s) leave only {ranks_per_server} rank(s) each."
+        )

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/kv_cache_group_edits.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/kv_cache_group_edits.py
@@ -52,6 +52,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheSpec,
     KVCacheSpecKind,
+    UniformTypeKVCacheSpecs,
     get_kv_cache_spec_kind,
 )
 
@@ -520,10 +521,9 @@ class _SubpagedMLAAttentionViewEdit(KVCacheGroupEdit):
     ) -> torch.Tensor:
         """Re-view ``kv_cache`` at logical-block granularity.
 
-        The tensor is kernel-paged as ``(num_kernel_pages, 2,
-        kernel_block_size, num_kv_heads, head_size)``; the result is
-        ``(num_logical_blocks, 2, spec.block_size, num_heads, head_size)``
-        over the same storage.
+        The tensor is kernel-paged as ``(num_kernel_pages,
+        kernel_block_size, entry_size)``; the result is
+        ``(num_logical_blocks, spec.block_size, -1)`` over the same storage.
 
         Raises:
             ValueError: If the layout is not the expected kernel-paged shape,
@@ -605,8 +605,13 @@ def apply_kv_cache_group_edits(
     edited = dict(kv_caches)
     counts: Counter[str] = Counter()
     for group in kv_cache_config.kv_cache_groups:
-        spec = group.kv_cache_spec
+        group_spec = group.kv_cache_spec
         for name in group.layer_names:
+            spec = (
+                group_spec.kv_cache_specs[name]
+                if isinstance(group_spec, UniformTypeKVCacheSpecs)
+                else group_spec
+            )
             for edit in _EDITS:
                 if edit.matches(spec, kv_caches[name]):
                     edited[name] = edit.apply(spec, kv_caches[name], layout_hints)

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/kv_cache_group_edits.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/kv_cache_group_edits.py
@@ -1,0 +1,619 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Centralized edits to vLLM kv cache specs.
+
+This is needed to mask out attention-specific details while making sure that
+LMCache can still store / load KV cache correctly.
+
+Currently there are three edits, one per :class:`KVCacheGroupEdit` subclass
+below. All are for Mamba-hybrid models; the registry is only consulted when
+``kv_cache_config.has_mamba_layers``. :func:`validate_kv_cache_groups`
+additionally rejects, at startup, group specs the transfer path cannot serve
+correctly yet (see its docstring).
+
+Reference design: vLLM PR #42828 ("[KVConnector][DSV4] HMA support for
+Mooncake store connector") solves the same problem class for an external KV
+store. Check it again when working on any of the following:
+
+- Extending :func:`validate_kv_cache_groups` (its connector validates and
+  rejects unsupported specs up front, with one aggregated error).
+- Per-group store/load masks (SWA / Mamba tail-only transfer, the
+  "sliding-window load-plan trimming" deferred in the hybrid design doc):
+  its ``MooncakeStoreCoordinator.store_mask`` / ``load_mask`` derive masks
+  from vLLM's own per-spec managers. Requires per-group objects in LMCache
+  (``ObjectKey.object_group_id``, LMCache #3608).
+- Hit-length computation for hybrid models: its ``ExternalCachedBlockPool``
+  duck-types vLLM's ``BlockPool`` over a ``(group_id, hash)`` existence set
+  and reuses ``KVCacheSpecRegistry`` manager classes, so promised hits are
+  consumable by construction. NOTE: LMCache's lookup doubles as prefetch, so
+  vLLM's lookup-first-then-trim flow does not map directly -- this needs its
+  own design before borrowing.
+- Eagle + HMA: see its ``apply_eagle`` notes (the eagle last-block prune must
+  be applied exactly once between hit-length and mask computation).
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from abc import ABC, abstractmethod
+from collections import Counter
+from collections.abc import Mapping
+from typing import TypeAlias
+
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.gpu_connector.utils import LayoutHints
+
+# Third Party
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheSpec,
+    KVCacheSpecKind,
+    get_kv_cache_spec_kind,
+)
+
+logger = init_logger(__name__)
+
+# One registered cache value: a paged KV tensor, or [conv_state, ssm_state]
+# for Mamba layers.
+RegisteredKVCache: TypeAlias = torch.Tensor | list[torch.Tensor]
+
+# Synthetic head count for a reinterpreted page. The page is opaque bytes, so
+# one "head" holding the whole per-(K/V) slab is enough; head_size is derived
+# to fill the page.
+_SYNTHETIC_NUM_HEADS = 1
+
+# Standard-paged (non-MLA) attention kinds eligible for the sub-paged edit.
+_SUBPAGEABLE_ATTENTION_KINDS = frozenset(
+    {
+        KVCacheSpecKind.FULL_ATTENTION,
+        KVCacheSpecKind.SLIDING_WINDOW,
+        KVCacheSpecKind.CHUNKED_LOCAL_ATTENTION,
+        KVCacheSpecKind.SINK_FULL_ATTENTION,
+    }
+)
+
+
+def _declares_slot_compression(spec: KVCacheSpec) -> bool:
+    """Return whether a spec declares slot compression (must not be edited).
+
+    Covers ``MLAAttentionSpec.compress_ratio > 1`` (DeepSeek-V4 slot packing)
+    and ``TQFullAttentionSpec.tq_slot_size > 0`` (TurboQuant slots); such
+    groups belong to the compression path in ``lmcache.v1.kv_layer_groups``.
+    """
+    return (
+        getattr(spec, "compress_ratio", 1) > 1 or getattr(spec, "tq_slot_size", 0) > 0
+    )
+
+
+def _leaf_specs(spec: KVCacheSpec) -> list[KVCacheSpec]:
+    """Return a group spec's leaf specs, unwrapping ``UniformTypeKVCacheSpecs``."""
+    inner = getattr(spec, "kv_cache_specs", None)
+    if isinstance(inner, dict):
+        return list(inner.values())
+    return [spec]
+
+
+def validate_kv_cache_groups(kv_cache_config: KVCacheConfig | None) -> None:
+    """Reject KV cache group specs the transfer path cannot serve correctly.
+
+    Rejected, with one aggregated error listing every offending group:
+
+    - ``CrossAttentionSpec`` (encoder-decoder caches).
+    - Mamba groups with ``mamba_cache_mode != "align"``: other modes keep no
+      reusable per-block state snapshots.
+
+    Specs declaring slot compression (``compress_ratio > 1`` /
+    ``tq_slot_size > 0``, e.g. DeepSeek-V4) are NOT rejected: they are served
+    by the compression path in ``lmcache.v1.kv_layer_groups`` and merely
+    skipped by the edits here (see ``_declares_slot_compression``).
+
+    Args:
+        kv_cache_config: vLLM ``KVCacheConfig``; ``None`` skips validation
+            (callers without the config validate again at registration).
+
+    Raises:
+        ValueError: Listing every unsupported group and why.
+    """
+    if kv_cache_config is None:
+        return
+    unsupported: list[str] = []
+    for group_idx, group in enumerate(kv_cache_config.kv_cache_groups):
+        for spec in _leaf_specs(group.kv_cache_spec):
+            kind = get_kv_cache_spec_kind(spec)
+            if kind == KVCacheSpecKind.CROSS_ATTENTION:
+                unsupported.append(f"group {group_idx}: CrossAttentionSpec")
+            elif (
+                kind == KVCacheSpecKind.MAMBA
+                and getattr(spec, "mamba_cache_mode", "none") != "align"
+            ):
+                unsupported.append(
+                    f"group {group_idx}: MambaSpec with mamba_cache_mode="
+                    f"'{getattr(spec, 'mamba_cache_mode', 'none')}' "
+                    f"(only 'align' keeps reusable state snapshots)"
+                )
+    if unsupported:
+        raise ValueError(
+            "LMCache cannot serve this model's KV cache groups: "
+            + "; ".join(unsupported)
+            + ". See lmcache/integration/vllm/kv_cache_group_edits.py."
+        )
+
+
+def _synthetic_attention_shape(elems_per_page: int, block_size: int) -> tuple[int, int]:
+    """Factor a page's element count into the synthetic attention layout.
+
+    Args:
+        elems_per_page: Total elements in one page (one logical block).
+        block_size: Logical block size (tokens per page).
+
+    Returns:
+        ``(num_heads, head_size)`` such that
+        ``2 * block_size * num_heads * head_size == elems_per_page``.
+
+    Raises:
+        ValueError: If the page size does not factor into the target shape.
+    """
+    denom = 2 * block_size * _SYNTHETIC_NUM_HEADS
+    if elems_per_page % denom != 0:
+        raise ValueError(
+            f"page ({elems_per_page} elems) does not factor into "
+            f"(2, block_size={block_size}, num_heads={_SYNTHETIC_NUM_HEADS}, head_size)"
+        )
+    return _SYNTHETIC_NUM_HEADS, elems_per_page // denom
+
+
+class KVCacheGroupEdit(ABC):
+    """One structural edit rule for a KV cache group's registered cache.
+
+    ``matches`` must be side-effect free and decide purely from the vLLM spec
+    and the registered cache value; ``apply`` must return a view over the same
+    storage (never a copy). ``name`` labels the rule in logs.
+    """
+
+    name: str
+
+    @abstractmethod
+    def matches(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> bool:
+        """Return whether this rule applies to the layer's registered cache.
+
+        Args:
+            spec: The layer's vLLM KV cache spec (from its group).
+            kv_cache: The layer's registered cache value -- a tensor, or a
+                list of tensors for Mamba layers.
+        """
+
+    @abstractmethod
+    def apply(
+        self,
+        spec: KVCacheSpec,
+        kv_cache: RegisteredKVCache,
+        layout_hints: LayoutHints,
+    ) -> torch.Tensor:
+        """Return the edited view for a layer this rule matched.
+
+        Args:
+            spec: The layer's vLLM KV cache spec (from its group).
+            kv_cache: The layer's registered cache value.
+            layout_hints: The layout hints from vLLM (see :class:`LayoutHints`).
+
+        Raises:
+            ValueError: If the cache's layout violates the rule's invariants.
+        """
+
+
+class _MambaPageViewEdit(KVCacheGroupEdit):
+    """Convert a Mamba page to its equivalent: a sliding-window-style layer.
+
+    A Mamba layer registers ``[conv_state, ssm_state]`` -- two tensors with
+    different shapes and dtypes sharing one padded page per block
+    (``conv | ssm | pad``) -- which LMCache's attention-shaped transfer path
+    cannot represent. Each page is one recurrent state snapshot, equivalent
+    for caching purposes to one block of a sliding-window attention layer with
+    window == block_size: only the last matched block is ever consumed. The
+    edit reinterprets the page buffer as one
+    ``[#blocks, 2, block_size, 1, head_size]`` tensor in the conv state's
+    dtype, with ``head_size`` derived to fill the page exactly.
+
+    The view's dims are addressing metadata only; the bytes are opaque
+    (conv | ssm | pad, not K/V), so content-aware processing does not apply.
+    """
+
+    name = "mamba-page-view"
+
+    def matches(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> bool:
+        return get_kv_cache_spec_kind(spec) == KVCacheSpecKind.MAMBA and isinstance(
+            kv_cache, list
+        )
+
+    def apply(
+        self,
+        spec: KVCacheSpec,
+        kv_cache: RegisteredKVCache,
+        _layout_hints: LayoutHints,
+    ) -> torch.Tensor:
+        # vLLM lays out one padded page per block as (conv | ssm | pad), and
+        # the conv state is the view that starts at the page base: its leading
+        # dim is the block count and its per-block stride is one full page.
+        # Re-striding it therefore covers the whole page, ssm and pad included.
+        if not isinstance(kv_cache, list) or not kv_cache:
+            raise ValueError(
+                f"expected a Mamba [conv_state, ssm_state] tensor list, "
+                f"got {type(kv_cache).__name__}"
+            )
+        conv_state = kv_cache[0]
+        if conv_state.storage_offset() != 0:
+            raise ValueError(
+                f"Mamba conv state must view the page base, got "
+                f"storage_offset={conv_state.storage_offset()}"
+            )
+        if conv_state.stride(0) * conv_state.element_size() != spec.page_size_bytes:
+            raise ValueError(
+                f"Mamba conv state per-block stride "
+                f"({conv_state.stride(0) * conv_state.element_size()} bytes) "
+                f"does not equal the page size ({spec.page_size_bytes} bytes)"
+            )
+        num_blocks = conv_state.shape[0]
+        elems_per_page = spec.page_size_bytes // conv_state.element_size()
+        num_heads, head_size = _synthetic_attention_shape(
+            elems_per_page, spec.block_size
+        )
+        flat = conv_state.as_strided((num_blocks, elems_per_page), (elems_per_page, 1))
+        return flat.reshape(num_blocks, 2, spec.block_size, num_heads, head_size)
+
+
+class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
+    """Re-view a kernel-paged attention tensor as logical-block pages.
+
+    For a Mamba-hybrid model vLLM inflates the attention block size to align
+    with the Mamba page (e.g. 544 for Qwen3.5-0.8B), and that size is used for
+    all prefix-caching logic at the scheduler. But at the worker the attention
+    kernel has to run at block size 32 for numerical stability (vLLM #27753,
+    working around the NaN-propagation issue
+    Dao-AILab/flash-attention#1974), so the registered tensor is paged as
+
+        ``[#blocks, 2, 32, #heads, head_size]``
+
+    which makes LMCache detect block size 32, mistake the group for a
+    DeepSeek-compression layer (``block size < scheduler block size``), and
+    corrupt the store/retrieve. Fix: re-view the tensor at the scheduler
+    block size (one logical block = its 17 contiguous kernel pages),
+
+        ``[#blocks / 17, 2, 544, 1, head_size']``
+
+    Cost: before this fix ``kv_caches[:, 0]`` is just the K tensor; after, it
+    interleaves K and V at kernel-page granularity. The bytes round-trip
+    correctly (store and retrieve share the mapping), but the dims are no
+    longer semantic, so content-aware processing does not apply.
+    """
+
+    name = "subpaged-attention-view"
+
+    def matches(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> bool:
+        return (
+            # Standard-paged attention only; MLA layouts and declared slot
+            # compression (DeepSeek) belong to other transfer paths.
+            get_kv_cache_spec_kind(spec) in _SUBPAGEABLE_ATTENTION_KINDS
+            and not _declares_slot_compression(spec)
+            # (num_blocks, 2, block_size, num_heads, head_size) layout whose
+            # block dim disagrees with the scheduler block-id unit -- the
+            # backend re-paged the tensor at its kernel block size.
+            and isinstance(kv_cache, torch.Tensor)
+            and kv_cache.ndim == 5
+            and kv_cache.shape[2] != spec.block_size
+        )
+
+    def apply(
+        self,
+        spec: KVCacheSpec,
+        kv_cache: RegisteredKVCache,
+        _layout_hints: LayoutHints,
+    ) -> torch.Tensor:
+        """Re-view ``kv_cache`` at logical-block granularity.
+
+        The tensor is kernel-paged as ``(num_kernel_pages, 2,
+        kernel_block_size, num_kv_heads, head_size)``; the result is
+        ``(num_logical_blocks, 2, spec.block_size, num_heads, head_size)``
+        over the same storage.
+
+        Raises:
+            ValueError: If the layout is not the expected kernel-paged shape,
+                the sizes do not divide evenly, or the kernel pages of one
+                logical block do not tile its page bytes exactly (which would
+                indicate an undeclared packed layout that must not be edited).
+        """
+        if not isinstance(kv_cache, torch.Tensor) or kv_cache.shape[1] != 2:
+            got = (
+                tuple(kv_cache.shape)
+                if isinstance(kv_cache, torch.Tensor)
+                else type(kv_cache).__name__
+            )
+            raise ValueError(
+                f"expected a (num_blocks, 2, block_size, num_heads, head_size) "
+                f"attention KV tensor, got {got}"
+            )
+        logical_block_size = spec.block_size
+        kernel_block_size = kv_cache.shape[2]
+        if logical_block_size % kernel_block_size != 0:
+            raise ValueError(
+                f"logical block size {logical_block_size} is not a multiple of "
+                f"kernel block size {kernel_block_size}"
+            )
+        ratio = logical_block_size // kernel_block_size
+
+        num_kernel_pages = kv_cache.shape[0]
+        if num_kernel_pages % ratio != 0:
+            raise ValueError(
+                f"kernel page count {num_kernel_pages} is not a multiple of "
+                f"the logical/kernel block ratio {ratio}"
+            )
+        kernel_page_bytes = kv_cache.shape[1:].numel() * kv_cache.element_size()
+        if kernel_page_bytes * ratio != spec.page_size_bytes:
+            raise ValueError(
+                f"{ratio} kernel pages ({kernel_page_bytes * ratio} bytes) do "
+                f"not tile the logical page ({spec.page_size_bytes} bytes)"
+            )
+        if not kv_cache.is_contiguous():
+            raise ValueError(
+                "kernel-paged attention KV tensor must be contiguous to "
+                "re-view as logical pages"
+            )
+
+        num_blocks = num_kernel_pages // ratio
+        elems_per_page = spec.page_size_bytes // kv_cache.element_size()
+        num_heads, head_size = _synthetic_attention_shape(
+            elems_per_page, logical_block_size
+        )
+        return kv_cache.view(num_blocks, 2, logical_block_size, num_heads, head_size)
+
+
+######################
+# vLLM 0.26.0 or later
+######################
+
+
+class _MambaUnifiedViewEdit(KVCacheGroupEdit):
+    """Expose padded unified-Mamba pages only to the LMCache connector.
+
+    This is for vLLM >= 0.26.0, where the unified KV cache layout is implemented.
+
+    The model-facing tensor contains the real recurrent-state bytes but uses a
+    padded physical page stride. LMCache needs the complete padded page in
+    ``[num_blocks, 1, block_size, content_size]`` form. Build that as a
+    connector-owned zero-copy view without changing vLLM's tensor object.
+    """
+
+    name = "mamba-unified-view"
+
+    def matches(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> bool:
+        """
+        Matches the mamba kv cache with unified layout.
+        """
+        return (
+            get_kv_cache_spec_kind(spec) == KVCacheSpecKind.MAMBA
+            and isinstance(kv_cache, torch.Tensor)
+            and kv_cache.ndim == 4
+        )
+
+    def apply(
+        self,
+        spec: KVCacheSpec,
+        kv_cache: RegisteredKVCache,
+        layout_hints: LayoutHints,
+    ) -> torch.Tensor:
+        """
+        Convert padded [num_blocks, 1, 1, state_size] storage to
+        [num_blocks, 1, vllm_block_size, head_size] for HND/BLHNC layout, or
+        [num_blocks, vllm_block_size, 1, head_size] for NHD/BLNHC layout.
+        Blocks-first layouts preserve the physical pool block stride.
+        """
+        assert isinstance(kv_cache, torch.Tensor), (
+            "single-layer KV cache must be a torch.Tensor"
+        )
+        if kv_cache.shape[1:3] != (1, 1) or kv_cache.stride(-1) != 1:
+            raise ValueError(
+                "unified Mamba cache must have model-facing shape "
+                f"[num_blocks, 1, 1, state_size] with contiguous bytes, got "
+                f"shape={tuple(kv_cache.shape)}, stride={kv_cache.stride()}"
+            )
+
+        item_size = kv_cache.element_size()
+        state_content_bytes = spec.state_content_size_bytes
+        if kv_cache.shape[-1] * item_size != state_content_bytes:
+            raise ValueError(
+                "model-facing unified Mamba cache must expose exactly the "
+                f"recurrent state ({state_content_bytes} bytes), got "
+                f"{kv_cache.shape[-1] * item_size} bytes"
+            )
+        if spec.page_size_bytes % item_size:
+            raise ValueError(
+                f"Mamba page size {spec.page_size_bytes} is not divisible by "
+                f"tensor element size {item_size}"
+            )
+
+        elems_per_page = spec.page_size_bytes // item_size
+        if elems_per_page % spec.block_size:
+            raise ValueError(
+                f"Mamba page ({elems_per_page} elements) does not divide into "
+                f"block_size={spec.block_size}"
+            )
+        content_size = elems_per_page // spec.block_size
+        num_blocks = kv_cache.shape[0]
+        if num_blocks == 0:
+            raise ValueError("unified Mamba cache must contain at least one block")
+
+        physical_page_stride = kv_cache.stride(0)
+        if physical_page_stride < elems_per_page:
+            raise ValueError(
+                f"Mamba physical page stride {physical_page_stride} elements "
+                f"is smaller than its padded page ({elems_per_page} elements)"
+            )
+
+        storage_offset = kv_cache.storage_offset()
+        storage_bytes = kv_cache.untyped_storage().nbytes()
+        if storage_bytes % item_size:
+            raise ValueError(
+                f"Mamba storage size {storage_bytes} is not divisible by "
+                f"tensor element size {item_size}"
+            )
+        storage_elems = storage_bytes // item_size
+        first_content_offset = storage_offset
+        last_content_offset = (
+            storage_offset
+            + (num_blocks - 1) * physical_page_stride
+            + (spec.block_size - 1) * content_size
+            + (content_size - 1)
+        )
+        if first_content_offset < 0 or last_content_offset >= storage_elems:
+            raise ValueError(
+                "padded unified Mamba view escapes storage: "
+                f"first={first_content_offset}, last={last_content_offset}, "
+                f"storage_elements={storage_elems}"
+            )
+
+        hnd = kv_cache.as_strided(
+            (num_blocks, 1, spec.block_size, content_size),
+            (physical_page_stride, elems_per_page, content_size, 1),
+            storage_offset=storage_offset,
+        )
+        kv_layout = layout_hints.get("kv_layout", "none")
+        if kv_layout in ("NHD", "BLNHC"):
+            return hnd.transpose(1, 2)
+        elif kv_layout in ("HND", "BLHNC"):
+            return hnd
+        else:
+            raise ValueError(
+                f"Unsupported kv_layout: {kv_layout}. Expected NHD, HND, "
+                "BLHNC, or BLNHC."
+            )
+
+
+class _SubpagedMLAAttentionViewEdit(KVCacheGroupEdit):
+    """Re-view a kernel-paged attention tensor as logical-block pages.
+
+    For vLLM 0.26 or later
+
+    Example on Kimi K3 , where 768 is the block size
+    - Input: [N * 12, 64, 576]
+    - Output: [N, 768, 576] (where 768 = 12 * 64)
+    """
+
+    name = "subpaged-mla-attention-view"
+
+    def matches(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> bool:
+        return (
+            get_kv_cache_spec_kind(spec) == KVCacheSpecKind.MLA_ATTENTION
+            and not _declares_slot_compression(spec)
+            and isinstance(kv_cache, torch.Tensor)
+            and kv_cache.ndim == 3
+            and kv_cache.shape[1] != spec.block_size
+        )
+
+    def apply(
+        self,
+        spec: KVCacheSpec,
+        kv_cache: RegisteredKVCache,
+        _layout_hints: LayoutHints,
+    ) -> torch.Tensor:
+        """Re-view ``kv_cache`` at logical-block granularity.
+
+        The tensor is kernel-paged as ``(num_kernel_pages, 2,
+        kernel_block_size, num_kv_heads, head_size)``; the result is
+        ``(num_logical_blocks, 2, spec.block_size, num_heads, head_size)``
+        over the same storage.
+
+        Raises:
+            ValueError: If the layout is not the expected kernel-paged shape,
+                the sizes do not divide evenly, or the kernel pages of one
+                logical block do not tile its page bytes exactly (which would
+                indicate an undeclared packed layout that must not be edited).
+        """
+        assert isinstance(kv_cache, torch.Tensor)
+        logical_block_size = spec.block_size
+        kernel_block_size = kv_cache.shape[1]
+        if logical_block_size % kernel_block_size != 0:
+            raise ValueError(
+                f"logical block size {logical_block_size} is not a multiple of "
+                f"kernel block size {kernel_block_size}"
+            )
+        ratio = logical_block_size // kernel_block_size
+
+        num_kernel_pages = kv_cache.shape[0]
+        if num_kernel_pages % ratio != 0:
+            raise ValueError(
+                f"kernel page count {num_kernel_pages} is not a multiple of "
+                f"the logical/kernel block ratio {ratio}"
+            )
+        kernel_page_bytes = kv_cache.shape[1:].numel() * kv_cache.element_size()
+        if kernel_page_bytes * ratio != spec.page_size_bytes:
+            raise ValueError(
+                f"{ratio} kernel pages ({kernel_page_bytes * ratio} bytes) do "
+                f"not tile the logical page ({spec.page_size_bytes} bytes)"
+            )
+        if not kv_cache.is_contiguous():
+            raise ValueError(
+                "kernel-paged attention KV tensor must be contiguous to "
+                "re-view as logical pages"
+            )
+
+        return kv_cache.view(num_kernel_pages // ratio, logical_block_size, -1)
+
+
+# Rule registry, in match priority order.
+_EDITS: tuple[KVCacheGroupEdit, ...] = (
+    _MambaUnifiedViewEdit(),
+    _MambaPageViewEdit(),
+    _SubpagedMLAAttentionViewEdit(),
+    _SubpagedAttentionViewEdit(),
+)
+
+
+def apply_kv_cache_group_edits(
+    kv_cache_config: KVCacheConfig | None,
+    kv_caches: Mapping[str, RegisteredKVCache],
+    layout_hints: LayoutHints,
+) -> dict[str, RegisteredKVCache]:
+    """Apply all KV cache group metadata edits for LMCache registration.
+
+    Each layer is checked against the ``_EDITS`` rules (first match wins) and
+    re-viewed by the matching rule; layers matching no rule pass through
+    unchanged. ``None`` configs and configs without Mamba groups are returned
+    as-is (as a dict): all current rules only apply to Mamba-hybrid models.
+
+    Args:
+        kv_cache_config: vLLM ``KVCacheConfig`` (read for per-group specs).
+        kv_caches: Registered tensors keyed by layer name. Mamba entries are
+            ``[conv_state, ssm_state]`` lists; others are single tensors.
+        layout_hints: layout hints from vLLM (see :class:`LayoutHints`).
+
+    Returns:
+        A new ``dict`` with edited layers re-viewed, others untouched.
+
+    Raises:
+        ValueError: If the groups fail :func:`validate_kv_cache_groups`, or a
+            matched layer's cache layout violates its rule's invariants (see
+            each rule's ``apply``).
+    """
+    # Backstop for connectors initialized without a kv_cache_config.
+    validate_kv_cache_groups(kv_cache_config)
+    if kv_cache_config is None or not kv_cache_config.has_mamba_layers:
+        return dict(kv_caches)
+
+    edited = dict(kv_caches)
+    counts: Counter[str] = Counter()
+    for group in kv_cache_config.kv_cache_groups:
+        spec = group.kv_cache_spec
+        for name in group.layer_names:
+            for edit in _EDITS:
+                if edit.matches(spec, kv_caches[name]):
+                    edited[name] = edit.apply(spec, kv_caches[name], layout_hints)
+                    counts[edit.name] += 1
+                    break
+    logger.info(
+        "KV cache group edits applied: %s",
+        dict(counts) if counts else "none",
+    )
+    return edited

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/kv_cache_groups.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/kv_cache_groups.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Build LMCache engine group infos from vLLM KV cache group metadata."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.gpu_connector.utils import LayoutHints
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+
+logger = init_logger(__name__)
+
+
+def _is_sliding_window_spec(spec: Any) -> bool:
+    """Return whether the KV cache spec is a vLLM sliding-window spec.
+
+    Checked by class name so this module stays importable without vLLM.
+    Subclasses such as ``SlidingWindowMLASpec`` count.
+    """
+    return any(cls.__name__ == "SlidingWindowSpec" for cls in type(spec).__mro__)
+
+
+def _is_mamba_align_spec(spec: Any) -> bool:
+    """Return whether the spec is an align-mode Mamba/linear-attention spec.
+
+    Align-mode Mamba layers keep only the state snapshot of the last block, so
+    they behave exactly like a cross-chunk sliding window of one block: a hit of
+    length ``L`` needs only the last block present. Checked by class name (like
+    :func:`_is_sliding_window_spec`) so this module stays importable without vLLM.
+    """
+    return (
+        any(cls.__name__ == "MambaSpec" for cls in type(spec).__mro__)
+        and getattr(spec, "mamba_cache_mode", "none") == "align"
+    )
+
+
+def _resolve_per_layer_sw_sizes(
+    vllm_groups: Sequence[Any],
+    layer_to_idx: Mapping[str, int],
+    num_layers: int,
+) -> list[int]:
+    """Resolve the sliding window size in tokens for each registered KV tensor.
+
+    Will resolve -1 for non-sliding-window layers.
+
+    Args:
+        vllm_groups: vLLM ``KVCacheGroupSpec`` instances.
+        layer_to_idx: Layer name to registered tensor index mapping.
+        num_layers: Number of registered KV tensors.
+
+    Returns:
+        A list of length ``num_layers`` mapping each registered tensor index
+        to its cross-chunk window size in tokens: the sliding window for
+        sliding-window attention, the engine-side block size for align-mode
+        Mamba/linear layers (a one-block window), or ``-1`` for full-attention
+        layers.
+    """
+    per_layer_sw_size = [-1] * num_layers
+    for group in vllm_groups:
+        spec = getattr(group, "kv_cache_spec", None)
+        if spec is None:
+            continue
+        # ``UniformTypeKVCacheSpecs`` carries per-layer specs in
+        # ``kv_cache_specs``; other specs apply to all of the group's layers.
+        per_layer_specs = getattr(spec, "kv_cache_specs", None)
+        for name in group.layer_names:
+            layer_spec = per_layer_specs[name] if per_layer_specs else spec
+            if _is_sliding_window_spec(layer_spec):
+                per_layer_sw_size[layer_to_idx[name]] = layer_spec.sliding_window
+            elif _is_mamba_align_spec(layer_spec):
+                per_layer_sw_size[layer_to_idx[name]] = layer_spec.block_size
+    return per_layer_sw_size
+
+
+def _merge_layer_sw_sizes(per_layer_sw_size: list[int], indices: list[int]) -> int:
+    """Merge the per-layer sliding window sizes of one LMCache group.
+
+    Args:
+        per_layer_sw_size: Sliding window size per registered tensor index.
+        indices: Registered tensor indices of the group's layers.
+
+    Returns:
+        The group's common sliding window size in tokens, or ``-1`` when the
+        layers are not sliding-window attention.
+
+    Raises:
+        ValueError: If the layers have different non-negative sliding window sizes.
+    """
+    sw_sizes = {per_layer_sw_size[idx] for idx in indices}
+    if len(sw_sizes) != 1:
+        raise ValueError(
+            f"Layers with indices {indices} have different sliding window sizes "
+            f"{sw_sizes}, but they are in the same group. This should "
+            "not happen because vLLM should only group layers with the same "
+            "KV cache spec, but got inconsistent metadata or registered tensors."
+        )
+    return sw_sizes.pop()
+
+
+def create_engine_group_infos_from_vllm(
+    kv_cache_config: Any,
+    kv_caches: Mapping[str, Any],
+    layout_hints: LayoutHints | None = None,
+    group_tokens_per_block: Sequence[int] | None = None,
+) -> list[EngineGroupInfo]:
+    """Build the LMCache engine group infos from vLLM metadata and registered tensors.
+
+    This is the single entry point for the vLLM -> LMCache conversion. It reads
+    the vLLM-specific fields (``KVCacheConfig.kv_cache_groups`` and
+    ``KVCacheGroupSpec.layer_names`` from the v1 KV cache interface), maps each
+    engine KV cache group's layer names to registered tensor indices, then
+    splits the layers by physical transfer identity using the real tensors (via
+    the shared :func:`lmcache.v1.kv_layer_groups.group_layers_by_identity`).
+    vLLM-specific field access is intentionally confined to this function.
+
+    Args:
+        kv_cache_config: vLLM ``KVCacheConfig`` describing the engine KV cache
+            groups (or ``None`` / no groups, which yields a single-group spec).
+        kv_caches: Registered KV tensors keyed by layer name, in registration
+            order. Keys provide the layer-name -> tensor-index mapping; values
+            are inspected for physical shape and dtype.
+        layout_hints: Optional engine-provided layout hints forwarded to format
+            detection (e.g. ``NHD``/``HND`` and compression metadata).
+        group_tokens_per_block: Optional logical token span for each engine
+            group, indexed by engine group id. When omitted, each vLLM group's
+            raw ``kv_cache_spec.block_size`` is preserved.
+
+    Returns:
+        The list of ``EngineGroupInfo`` in protocol order, i.e. the LMCache group
+        order used by store/retrieve block IDs.
+    """
+    # First Party
+    from lmcache.utils import EngineType
+    from lmcache.v1.gpu_connector.utils import (
+        normalize_and_discover_per_layer_formats,
+    )
+    from lmcache.v1.kv_layer_groups import (
+        EXCLUDED_ENGINE_GROUP,
+        group_layers_by_identity,
+    )
+
+    # vLLM-specific field access (confined to this function): map each
+    # registered KV tensor to its vLLM engine KV cache group index. vLLM places
+    # every registered layer in exactly one group; layers in different groups
+    # have disjoint block-id spaces and must not share an LMCache group. ``None``
+    # means a single (non-hybrid) group, i.e. every layer shares one block-id
+    # space.
+    per_layer_discoverable_kv_caches = list(kv_caches.values())
+    layer_to_idx = {name: idx for idx, name in enumerate(kv_caches.keys())}
+    vllm_groups = (
+        getattr(kv_cache_config, "kv_cache_groups", ()) or ()
+        if kv_cache_config is not None
+        else ()
+    )
+    if group_tokens_per_block is not None:
+        num_engine_groups = len(vllm_groups) or 1
+        if len(group_tokens_per_block) != num_engine_groups:
+            raise ValueError(
+                f"group_tokens_per_block has {len(group_tokens_per_block)} "
+                f"entries but vLLM has {num_engine_groups} engine groups"
+            )
+        for engine_group_id, tokens_per_block in enumerate(group_tokens_per_block):
+            if tokens_per_block <= 0:
+                raise ValueError(
+                    f"group {engine_group_id} tokens_per_block "
+                    f"{tokens_per_block} must be positive"
+                )
+
+    layer_index_groups = [
+        [layer_to_idx[name] for name in group.layer_names] for group in vllm_groups
+    ]
+    normalized_kv_caches, engine_kv_formats = normalize_and_discover_per_layer_formats(
+        per_layer_discoverable_kv_caches,
+        layer_index_groups,
+        EngineType.VLLM,
+        layout_hints,
+    )
+    num_layers = len(engine_kv_formats)
+    # Layers absent from every engine group's ``layer_names`` are cross-layer
+    # KV-sharing layers (e.g. google/gemma-4-E4B-it): vLLM aliases them to a
+    # target owner's KV tensor, so the owner's group already covers them. Tag
+    # them EXCLUDED_ENGINE_GROUP so they form no group of their own (a
+    # wrong-block-size group would corrupt the per-group block-id counts).
+    per_layer_group_idx: list[int] | None = None
+    tokens_per_block_by_engine_group: dict[int, int] = {}
+    if group_tokens_per_block is not None:
+        tokens_per_block_by_engine_group.update(enumerate(group_tokens_per_block))
+    per_layer_sw_size = [-1] * num_layers
+    if vllm_groups:
+        per_layer_group_idx = [EXCLUDED_ENGINE_GROUP] * num_layers
+        for engine_group_id, group in enumerate(vllm_groups):
+            # The spec's block_size is the logical tokens covered by one of
+            # this group's paged chunks (block IDs); the physical slot count
+            # per chunk is discovered later from the registered tensors.
+            if group_tokens_per_block is None:
+                tokens_per_block_by_engine_group[engine_group_id] = (
+                    group.kv_cache_spec.block_size
+                )
+            for name in group.layer_names:
+                per_layer_group_idx[layer_to_idx[name]] = engine_group_id
+        per_layer_sw_size = _resolve_per_layer_sw_sizes(
+            vllm_groups, layer_to_idx, num_layers
+        )
+
+    # Within one vLLM engine group, layers can have different hidden dimensions
+    # (e.g. a different head count), which require different GPU copy kernels.
+    # ``group_layers_by_identity`` splits each engine group further by physical
+    # transfer identity (kv_size, num_heads, head_size, block_size, dtype), so
+    # every resulting LMCache group can be served by a single copy kernel. It is
+    # the shared, engine-neutral primitive the server reuses to reproduce the
+    # same grouping from the registered tensors.
+    return [
+        EngineGroupInfo(
+            engine_group_id=identity.engine_group_idx,
+            layer_indices=tuple(indices),
+            tokens_per_block=tokens_per_block_by_engine_group.get(
+                identity.engine_group_idx, 0
+            ),
+            sw_size_tokens=_merge_layer_sw_sizes(per_layer_sw_size, indices),
+        )
+        for identity, indices in group_layers_by_identity(
+            normalized_kv_caches,
+            engine_kv_formats,
+            per_layer_group_idx,
+        )
+    ]

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -1,0 +1,1299 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Standard
+import sys
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
+
+# Third Party
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1,
+    KVConnectorMetadata,
+    KVConnectorRole,
+)
+
+try:
+    # Third Party
+    from vllm.distributed.kv_transfer.kv_connector.v1.base import SupportsHMA
+except ImportError:
+    # Older vLLM builds do not expose HMA. They cannot route per-group
+    # request-finished calls, but keeping the class importable preserves
+    # legacy single-group behavior.
+    class SupportsHMA:  # type: ignore[no-redef]
+        pass
+
+
+# Third Party
+import torch
+import zmq
+
+# First Party
+from lmcache import torch_dev
+from lmcache.banner import print_banner_once
+from lmcache.integration.vllm.dcp_layout import (
+    get_group_tokens_per_block,
+    get_lmcache_base_model_name,
+    get_lmcache_model_name,
+    get_lmcache_scheduler_block_size,
+    validate_dcp_support,
+    validate_mamba_step_alignment,
+)
+from lmcache.integration.vllm.experimental import dispatch
+from lmcache.integration.vllm.kv_cache_group_edits import (
+    apply_kv_cache_group_edits,
+    validate_kv_cache_groups,
+)
+from lmcache.integration.vllm.kv_cache_groups import (
+    create_engine_group_infos_from_vllm,
+)
+from lmcache.integration.vllm.lazy_offload_pending_store import (
+    LazyOffloadPendingStore,
+)
+from lmcache.integration.vllm.lmcache_mp_metadata import (
+    LMCacheMPConnectorMetadata,
+    LMCacheMPRequestMetadata,
+    LMCacheMPRequestState,
+    LMCacheMPRequestTracker,
+    LMCacheMPWorkerMetadata,
+)
+from lmcache.integration.vllm.utils import (
+    mla_only,
+    vllm_layout_hints,
+)
+from lmcache.utils import init_logger as lmcache_init_logger
+
+from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.outputs import KVConnectorOutput
+from vllm.v1.request import RequestStatus
+
+try:
+    # First Party
+    from lmcache.integration.vllm.vllm_multi_process_adapter import (
+        LMCacheMPSchedulerAdapter,
+        LMCacheMPWorkerAdapter,
+        ParallelStrategy,
+        send_lmcache_request,
+    )
+
+    try:
+        # First Party
+        from lmcache.v1.multiprocess.custom_types import (  # type: ignore[attr-defined]
+            RequestAllocationRecord,
+        )
+    except ImportError:
+        # First Party
+        from lmcache.v1.multiprocess.custom_types import (
+            BlockAllocationRecord as RequestAllocationRecord,
+        )
+except ImportError:
+    # Third Party
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import (
+        BlockAllocationRecord as RequestAllocationRecord,
+    )
+
+    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_integration import (  # type: ignore[no-redef]
+        LMCacheMPSchedulerAdapter,
+        LMCacheMPWorkerAdapter,
+        ParallelStrategy,
+    )
+
+if TYPE_CHECKING:
+    # Third Party
+    from vllm.distributed.kv_events import KVCacheEvent
+    from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+        KVConnectorPromMetrics,
+        KVConnectorStats,
+        PromMetric,
+        PromMetricT,
+    )
+    from vllm.forward_context import ForwardContext
+    from vllm.v1.core.block_pool import BlockPool
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.request import Request
+
+logger = lmcache_init_logger(__name__)
+
+
+# Helper functions
+def _has_preemption_reqs(scheduler_output: SchedulerOutput) -> bool:
+    """Return whether the scheduler output contains preemption-related requests.
+
+    Checks for the presence of resumed or preempted requests in the
+    scheduler output.
+
+    A preemption is detected if:
+    - ``scheduled_cached_reqs.resumed_req_ids``: Requests resumed from
+      preemption this step.
+    - ``scheduler_output.preempted_req_ids``: Requests preempted this step.
+
+    Args:
+        scheduler_output: The vLLM scheduler output for this step.
+
+    Returns:
+        True if preemption-related requests exist, False otherwise.
+    """
+    cached_reqs = getattr(scheduler_output, "scheduled_cached_reqs", None)
+
+    # Primary signal: requests resumed from preemption this step.
+    resumed_ids = getattr(cached_reqs, "resumed_req_ids", None)
+    if resumed_ids:
+        logger.warning("<preempted> by resumed requests: %s", resumed_ids)
+        return True
+
+    # Primary signal: requests preempted this step.
+    preempted_ids = getattr(scheduler_output, "preempted_req_ids", None)
+    if preempted_ids:
+        logger.warning("<preempted> by preempted requests: %s", preempted_ids)
+        return True
+
+    return False
+
+
+def build_parallel_strategy_from_vllm_config(
+    vllm_config: "VllmConfig",
+    n_servers: int,
+) -> ParallelStrategy:
+    """Build a ParallelStrategy from a vLLM config.
+
+    Centralises the (vllm_config -> KV parallel geometry) mapping.
+
+    Args:
+        vllm_config: The vLLM configuration object.
+        n_servers: Number of LMCache servers backing this deployment.
+
+    Returns:
+        The constructed ParallelStrategy.
+    """
+    pc = vllm_config.parallel_config
+    return ParallelStrategy(
+        mla_only=mla_only(vllm_config.model_config),
+        vllm_world_size=pc.world_size,
+        vllm_worker_id=pc.rank,
+        tp_size=pc.tensor_parallel_size,
+        pp_size=pc.pipeline_parallel_size,
+        n_servers=n_servers,
+    )
+
+
+def _ensure_zmq_scheme(server_url: str) -> str:
+    """Ensure a ZMQ server URL carries a transport scheme.
+
+    ZeroMQ requires an explicit transport (e.g. ``tcp://``) in the address;
+    a bare ``host:port`` such as ``127.0.0.1:5557`` is rejected with
+    ``ZMQError: Invalid argument``. Users naturally configure
+    ``lmcache.mp.host`` as a plain IP/hostname, so prepend ``tcp://`` when no
+    scheme is present.
+
+    Args:
+        server_url: A server URL, with or without a ``<scheme>://`` prefix.
+
+    Returns:
+        The URL with a transport scheme, defaulting to ``tcp://``.
+    """
+    if "://" in server_url:
+        return server_url
+    return f"tcp://{server_url}"
+
+
+class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
+    """
+    The connector for LMCache multi-process mode.
+
+    Extra configs (kv_transfer_config.extra_config):
+
+    Multi-server deployment:
+    - lmcache.mp.server_urls: server URL list or comma-separated string,
+      e.g. "tcp://host1:6667,tcp://host2:6667".
+
+    Single-server deployment:
+    - lmcache.mp.host: the host of the LMCache server.
+    - lmcache.mp.port: the port of the LMCache server.
+
+    - lmcache.mp.mq_timeout: timeout (seconds) for message queue requests.
+    - lmcache.mp.heartbeat_interval: interval (seconds) between server
+      heartbeat pings.
+    - lmcache.mp.eager_prefetch: submit the LMCache lookup when a request
+      enters vLLM's waiting queue. Disabled by default.
+    """
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        role: KVConnectorRole,
+        kv_cache_config: "KVCacheConfig | None" = None,
+    ):
+        super().__init__(vllm_config, role, kv_cache_config)
+
+        # Fail fast on the physical geometry vLLM resolved, before the server
+        # handshake below. The CLI cache block can differ for hybrid models.
+        kv_cache_config = getattr(self, "_kv_cache_config", None)
+        validate_mamba_step_alignment(vllm_config, kv_cache_config)
+        validate_kv_cache_groups(kv_cache_config)
+        group_tokens_per_block = get_group_tokens_per_block(
+            vllm_config, kv_cache_config
+        )
+        scheduler_block_size = get_lmcache_scheduler_block_size(
+            vllm_config, kv_cache_config
+        )
+        cache_model_name = get_lmcache_model_name(vllm_config)
+
+        assert vllm_config.kv_transfer_config is not None
+
+        self._eager_prefetch: bool = bool(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "lmcache.mp.eager_prefetch", False
+            )
+        )
+
+        # Multi-server: prefer lmcache.mp.server_urls (list or comma-separated
+        # string) over the single-server lmcache.mp.host / lmcache.mp.port.
+        server_urls_cfg = vllm_config.kv_transfer_config.get_from_extra_config(
+            "lmcache.mp.server_urls", None
+        )
+        if server_urls_cfg:
+            if isinstance(server_urls_cfg, list):
+                server_urls = [u.strip() for u in server_urls_cfg if u.strip()]
+            else:
+                server_urls = [
+                    u.strip() for u in server_urls_cfg.split(",") if u.strip()
+                ]
+        else:
+            # Legacy single-server fallback.
+            server_host = vllm_config.kv_transfer_config.get_from_extra_config(
+                "lmcache.mp.host", "tcp://localhost"
+            )
+            server_port = vllm_config.kv_transfer_config.get_from_extra_config(
+                "lmcache.mp.port", 5555
+            )
+            server_urls = [f"{server_host}:{server_port}"]
+
+        # Normalize so a bare host:port (no transport scheme) is accepted;
+        # ZMQ requires an explicit transport such as ``tcp://``.
+        server_urls = [_ensure_zmq_scheme(u) for u in server_urls]
+
+        # The server count is derived from lmcache.mp.server_urls.
+        n_servers = len(server_urls)
+
+        assert vllm_config.parallel_config.world_size % n_servers == 0, (
+            f"world_size ({vllm_config.parallel_config.world_size}) must be "
+            f"divisible by n_servers ({n_servers})"
+        )
+        validate_dcp_support(vllm_config, n_servers, kv_cache_config)
+        logger.info(
+            "LMCache resolved KV group spans=%s scheduler_block_size=%d "
+            "cache_model_name=%s base_model_name=%s",
+            group_tokens_per_block,
+            scheduler_block_size,
+            cache_model_name,
+            get_lmcache_base_model_name(cache_model_name),
+        )
+
+        # Multi-server + DP is not supported yet.
+        dp_size = getattr(vllm_config.parallel_config, "data_parallel_size", 1)
+        if n_servers > 1 and dp_size > 1:
+            raise ValueError(
+                "LMCacheMPConnector multi-server mode (n_servers > 1) does not "
+                f"support data parallelism yet; got dp_size={dp_size}. "
+                "DP across multiple LMCache servers will be "
+                "supported in a follow-up PR."
+            )
+
+        # Multi-server + MLA: only TP is supported (no PP).
+        # PP splits layers across nodes, which would cause per-piece
+        # reader counts to vary per (server, pp_stage) pair and break
+        # the single-``tp_size`` LOOKUP / FREE_LOOKUP_LOCKS protocol.
+        # Non-MLA mode is not affected by this restriction.
+        if n_servers > 1:
+            pp_size = vllm_config.parallel_config.pipeline_parallel_size
+            if pp_size > 1:
+                raise ValueError(
+                    "LMCacheMPConnector multi-server mode only supports "
+                    "tensor parallelism (TP), not pipeline parallelism (PP). "
+                    f"Got pp_size={pp_size}."
+                )
+
+        zmq_context = zmq.Context.instance()
+        parallel_strategy = build_parallel_strategy_from_vllm_config(
+            vllm_config, n_servers
+        )
+
+        self.dispatcher = None
+
+        # Lazy offload configuration: when enabled, store operations are
+        # deferred until some threshold is reached, rather than submitted at every step
+        self.lazy_offload = vllm_config.kv_transfer_config.get_from_extra_config(
+            "lmcache.mp.lazy_offload", False
+        )
+
+        if self.role == KVConnectorRole.SCHEDULER:
+            # Banner from the scheduler role only, so tensor-parallel
+            # deployments print it once rather than once per worker.
+            print_banner_once(sys.stderr)
+            self.scheduler_adapter = LMCacheMPSchedulerAdapter(
+                server_urls=server_urls,
+                context=zmq_context,
+                model_name=cache_model_name,
+                vllm_block_size=scheduler_block_size,
+                parallel_strategy=parallel_strategy,
+                extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
+            )
+            self.request_trackers: dict[str, LMCacheMPRequestTracker] = {}
+
+            # GPU block pool reference
+            self._gpu_block_pool: BlockPool | None = None
+
+            # Initialize pending store for lazy offload mode
+            if self.lazy_offload:
+                self._pending_store = LazyOffloadPendingStore(
+                    vllm_config.kv_transfer_config.kv_connector_extra_config
+                )
+        elif self.role == KVConnectorRole.WORKER:
+            # Node routing: a worker connects only to its local LMCache server.
+            # Global ranks are assigned to nodes in contiguous blocks:
+            #   node 0 → ranks [0, ranks_per_node),
+            #   node 1 → [ranks_per_node, 2 * ranks_per_node), ...
+            ranks_per_node = parallel_strategy.vllm_world_size // n_servers
+            local_server_url = server_urls[
+                parallel_strategy.vllm_worker_id // ranks_per_node
+            ]
+            self.worker_adapter = LMCacheMPWorkerAdapter(
+                server_url=local_server_url,
+                context=zmq_context,
+                model_name=cache_model_name,
+                vllm_block_size=scheduler_block_size,
+                parallel_strategy=parallel_strategy,
+                extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
+            )
+            if self.transfer_intermediate_tensors:
+                # First Party
+                from lmcache.integration.vllm.experimental import (
+                    FeatureContext,
+                    init_dispatcher,
+                )
+                from lmcache.v1.multiprocess.modules.experimental import TRANSFER_QUERY
+
+                ctx = FeatureContext(
+                    worker_adapter=self.worker_adapter,
+                    send_lmcache_request=send_lmcache_request,
+                )
+                requested = (
+                    {TRANSFER_QUERY} if self.transfer_intermediate_tensors else set()
+                )
+                self.dispatcher = init_dispatcher(ctx, requested)
+                self.worker_adapter.dispatcher = self.dispatcher
+        else:
+            raise ValueError(f"Unknown KVConnectorRole: {self.role}")
+
+        # Tokens covered by one paged chunk (one block ID) of each engine
+        # group, from the group's KV cache spec. Hybrid models can mix
+        # different values (e.g. gemma-4: sliding-window groups 32,
+        # full-attention groups 16; DeepSeek V4: 256/64/8/4). Falls back to
+        # the engine's base block size when no group metadata is available
+        # (single non-hybrid group).
+        self._group_tokens_per_block = group_tokens_per_block
+        for engine_group_idx, tokens_per_block in enumerate(
+            self._group_tokens_per_block
+        ):
+            if tokens_per_block <= 0:
+                raise ValueError(
+                    f"group {engine_group_idx} tokens_per_block "
+                    f"{tokens_per_block} must be positive"
+                )
+        # Smallest token count aligned to every group's paged-chunk
+        # boundary; used to round down vLLM APC hit counts.
+        self._hit_alignment_tokens = scheduler_block_size
+        if self.role == KVConnectorRole.SCHEDULER:
+            # Chunk boundaries must land on every group's paged-chunk
+            # boundary so per-group block-id slicing stays aligned.
+            lmcache_tokens_per_chunk = self.scheduler_adapter.lmcache_tokens_per_chunk
+            for engine_group_idx, tokens_per_block in enumerate(
+                self._group_tokens_per_block
+            ):
+                if lmcache_tokens_per_chunk % tokens_per_block != 0:
+                    raise ValueError(
+                        f"LMCache chunk size {lmcache_tokens_per_chunk} must be "
+                        f"a multiple of group {engine_group_idx} "
+                        f"tokens_per_block {tokens_per_block}"
+                    )
+
+    @property
+    def role(self) -> KVConnectorRole:
+        return self._role
+
+    @property
+    def transfer_intermediate_tensors(self) -> bool:
+        cfg = self._vllm_config.kv_transfer_config
+        if cfg is None:
+            return False
+        vllm_transfer = cfg.get_from_extra_config(
+            "lmcache.mp.transfer_intermediate_tensors", False
+        )
+        return vllm_transfer
+
+    # ==============================
+    # Worker-side methods
+    # ==============================
+
+    def _get_connector_metadata(self) -> KVConnectorMetadata:
+        """Get the connector metadata.
+
+        This function should only be called inside the connector.
+
+        Returns:
+            ConnectorMetadata: the connector metadata.
+        """
+
+        # Should only be called while set to valid metadata.
+        assert self._connector_metadata is not None
+        return self._connector_metadata
+
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+        """
+        Initialize with the KV caches. Useful for pre-registering the
+        KV Caches in the KVConnector (e.g. for NIXL).
+
+        Args:
+            kv_caches: dictionary of layer names, kv cache
+        """
+        logger.info("Registering kv caches!")
+        kv_cache_config = getattr(self, "_kv_cache_config", None)
+        # Must precede both group-info creation and transfer registration so
+        # they see the same edited views.
+        layout_hints = vllm_layout_hints()
+        kv_caches = apply_kv_cache_group_edits(
+            kv_cache_config, kv_caches, layout_hints=layout_hints
+        )
+        engine_group_infos = create_engine_group_infos_from_vllm(
+            kv_cache_config,
+            kv_caches,
+            layout_hints=layout_hints,
+            group_tokens_per_block=self._group_tokens_per_block,
+        )
+        self.worker_adapter.register_kv_caches(
+            kv_caches, engine_group_infos=engine_group_infos
+        )
+        if self.dispatcher is not None:
+            dispatch(
+                self.dispatcher,
+                "register",
+                kv_caches=kv_caches,
+                kv_cache_config=kv_cache_config,
+                vllm_config=self._vllm_config,
+            )
+        return
+
+    def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
+        """
+        Start loading the KV cache from the connector to vLLM's paged
+        KV buffer. This is called from the forward context before the
+        forward pass to enable async loading during model execution.
+
+        Args:
+            forward_context (ForwardContext): the forward context.
+            **kwargs: additional arguments for the load operation
+
+        Note:
+            The number of elements in kv_caches and layer_names should be
+            the same.
+
+        """
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, LMCacheMPConnectorMetadata)
+
+        request_ids = []
+        ops = []
+        cache_salts = []
+
+        for meta in metadata.requests:
+            if meta.direction != "RETRIEVE":
+                continue
+            request_ids.append(meta.request_id)
+            ops.append(meta.op)
+            cache_salts.append(meta.cache_salt)
+
+        if len(request_ids) == 0:
+            return
+
+        event = torch_dev.Event(interprocess=True)
+        event.record()
+
+        self.worker_adapter.batched_submit_retrieve_requests(
+            request_ids, ops, event, cache_salts=cache_salts
+        )
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        """
+        Block until the KV for a specific layer is loaded into vLLM's
+        paged buffer. This is called from within attention layer to ensure
+        async copying from start_load_kv is complete.
+
+        This interface will be useful for layer-by-layer pipelining.
+
+        Args:
+            layer_name: the name of that layer
+        """
+        return
+
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Start saving a layer of KV cache from vLLM's paged buffer
+        to the connector. This is called from within attention layer to
+        enable async copying during execution.
+
+        Args:
+            layer_name (str): the name of the layer.
+            kv_layer (torch.Tensor): the paged KV buffer of the current
+                layer in vLLM.
+            attn_metadata (AttentionMetadata): the attention metadata.
+            **kwargs: additional arguments for the save operation.
+        """
+        if self.dispatcher is not None:
+            dispatch(
+                self.dispatcher,
+                "save_kv_layer",
+                layer_name=layer_name,
+                metadata=self._get_connector_metadata(),
+                attn_metadata=attn_metadata,
+                **kwargs,
+            )
+        return
+
+    def wait_for_save(self):
+        """
+        Block until all the save operations is done. This is called
+        as the forward context exits to ensure that the async saving
+        from save_kv_layer is complete before finishing the forward.
+
+        This prevents overwrites of paged KV buffer before saving done.
+        """
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, LMCacheMPConnectorMetadata)
+
+        request_ids = []
+        ops = []
+        cache_salts = []
+        for meta in metadata.requests:
+            if meta.direction != "STORE":
+                continue
+            request_ids.append(meta.request_id)
+            ops.append(meta.op)
+            cache_salts.append(meta.cache_salt)
+
+        if len(request_ids) == 0:
+            if self.dispatcher is not None:
+                dispatch(self.dispatcher, "wait_for_save", event=None)
+            return
+
+        event = torch_dev.Event(interprocess=True)
+        event.record()
+
+        self.worker_adapter.batched_submit_store_requests(
+            request_ids, ops, event, cache_salts=cache_salts
+        )
+        if self.dispatcher is not None:
+            dispatch(self.dispatcher, "wait_for_save", event=event)
+
+    # TODO: How does lmcache driven path handle preemption?
+    # NOTE1: handle_preemptions is called by vllm each step regardless
+    #        preemption really happens or not.
+    # NOTE2: preemption hint is managed by KVConnectorRole.SCHEDULER,
+    #        that's why here we have to judge preemption by
+    #        need_flush_before_forward flag which is set by SCHEDULER.
+    def handle_preemptions(self, kv_connector_metadata: KVConnectorMetadata) -> None:
+        """Flush async engine-driven stores only when scheduler metadata requests it.
+
+        Args:
+            kv_connector_metadata: Connector metadata produced by the scheduler;
+                only acts when it is a :class:`LMCacheMPConnectorMetadata` with
+                ``need_flush_before_forward=True``.
+        """
+        worker_adapter = getattr(self, "worker_adapter", None)
+        if self.role != KVConnectorRole.WORKER or worker_adapter is None:
+            return
+        need_flush_before_forward = (
+            isinstance(kv_connector_metadata, LMCacheMPConnectorMetadata)
+            and kv_connector_metadata.need_flush_before_forward
+        )
+        worker_adapter.handle_preemptions(need_flush_before_forward)
+
+    def get_finished(
+        self, finished_req_ids: set[str]
+    ) -> tuple[set[str] | None, set[str] | None]:
+        """
+        Notifies worker-side connector ids of requests that have
+        finished generating tokens on the worker.
+        The scheduler process (via the Executors) will use this output
+        to track which workers are done.
+
+        Returns:
+            ids of requests that have finished asynchronous transfer
+            (requests that previously returned True from request_finished()),
+            tuple of (sending/saving ids, recving/loading ids).
+            The finished saves/sends req ids must belong to a set provided in a
+            call to this method (this call or a prior one).
+        """
+        if self.lazy_offload:
+            val = self.worker_adapter.get_finished_with_lazy_offload()
+        else:
+            val = self.worker_adapter.get_finished(finished_req_ids)
+        # logger.error("Finished req ids: %s, %s", val[0], val[1])
+        return val
+
+    def build_connector_worker_meta(self):
+        if not self.lazy_offload:
+            return None
+        completed_store_requests = self.worker_adapter.get_completed_store_requests()
+        if completed_store_requests:
+            return LMCacheMPWorkerMetadata(
+                completed_store_requests=completed_store_requests
+            )
+        else:
+            return None
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """
+        Get the set of block IDs that failed to load.
+
+        Returns:
+            Set of block IDs that encountered load errors.
+            Empty set if no load errors occurred.
+
+        Notes:
+            - Applies to both sync- and async-loading requests.
+            - Async loading: failed blocks may be reported in any forward pass
+              up to and including the pass where the request ID is returned by
+              `get_finished()`. Even if failures occur, the request must still
+              be reported via `get_finished()`, and the failed block IDs must
+              appear here no later than that same pass.
+            - Sync loading: failed blocks should be reported in the forward
+              pass in which they are detected.
+        """
+        return self.worker_adapter.get_block_ids_with_load_errors()
+
+    def shutdown(self):
+        """
+        Shutdown the connector. This is called when the worker process
+        is shutting down to ensure that all the async operations are
+        completed and the connector is cleaned up properly.
+        """
+        if hasattr(self, "worker_adapter"):
+            self.worker_adapter.shutdown()
+        if hasattr(self, "scheduler_adapter"):
+            self.scheduler_adapter.shutdown()
+        return None
+
+    def get_kv_connector_stats(self) -> "KVConnectorStats | None":
+        """
+        Get the KV connector stats collected during the last interval.
+        """
+        return None
+
+    # ==============================
+    # Scheduler-side methods
+    # ==============================
+
+    def bind_gpu_block_pool(self, gpu_block_pool: "BlockPool") -> None:
+        """Bind GPU block pool so that we can touch blocks during stores.
+        Called by Scheduler after kv_cache_manager is ready."""
+        if self.role == KVConnectorRole.SCHEDULER:
+            logger.info("Bind GPU block pool in LMCacheMPConnector scheduler")
+            self._gpu_block_pool = gpu_block_pool
+            if self.lazy_offload:
+                self._pending_store.bind_gpu_block_pool(gpu_block_pool)
+
+    def get_num_new_matched_tokens(
+        self,
+        request: "Request",
+        num_computed_tokens: int,
+    ) -> tuple[int | None, bool]:
+        """
+        Get number of new tokens that can be loaded from the
+        external KV cache beyond the num_computed_tokens.
+
+        Args:
+            request (Request): the request object.
+            num_computed_tokens (int): the number of locally
+                computed tokens for this request
+
+        Returns:
+            A tuple with the following elements:
+                - An optional number of tokens that can be loaded from the
+                  external KV cache beyond what is already computed.
+                  If None, it means that the connector needs more time to
+                  determine the number of matched tokens, and the scheduler
+                  should query for this request again later.
+                - `True` if external KV cache tokens will be loaded
+                  asynchronously (between scheduler steps). Must be
+                  'False' if the first element is 0.
+
+        Notes:
+            The connector should only consider the largest prefix of prompt-
+            tokens for which KV cache is actually available at the time of the
+            call. If the cache cannot be loaded for some tokens (e.g., due to
+            connectivity issues or eviction), those tokens must not be taken
+            into account.
+        """
+        tracker = self._get_or_create_request_tracker(request)
+        # TODO: support loading KV for preempted requests in the future
+        if request.status == RequestStatus.PREEMPTED:
+            return 0, False
+
+        self.scheduler_adapter.maybe_submit_lookup_request(
+            request.request_id,
+            token_ids=tracker.get_token_ids(),
+            cache_salt=tracker.cache_salt,
+        )
+
+        ret = self.scheduler_adapter.check_lookup_result(request.request_id)
+        if ret is None:
+            return None, True
+
+        if ret == 0:
+            return 0, False
+
+        assert ret % self.scheduler_adapter.lmcache_tokens_per_chunk == 0
+
+        # Update num stored tokens for the tracker
+        tracker.increase_num_stored_tokens(ret)
+
+        # Save the vllm and lmcache hit tokens. The vLLM hit count is
+        # rounded down to a boundary aligned for every engine group (e.g.
+        # a full-prompt APC hit reports ``num_prompt_tokens - 1``), so the
+        # retrieve-skip range stays paged-chunk-aligned in all groups.
+        tracker.num_vllm_hit_tokens = (
+            num_computed_tokens
+            // self._hit_alignment_tokens
+            * self._hit_alignment_tokens
+        )
+        tracker.num_lmcache_hit_tokens = ret
+
+        need_to_load = max(0, ret - num_computed_tokens)
+
+        # In full-prompt-hit case, we need to recompute the last token.
+        # Without this, num_computed_tokens would equal request.num_tokens,
+        # causing num_new_tokens to be 0 and triggering the
+        # `assert num_new_tokens > 0` in the scheduler.
+        if ret == len(request.all_token_ids):
+            need_to_load = max(0, need_to_load - 1)
+
+        logger.debug(
+            "vLLM hit is: %d, Need to load is %d", num_computed_tokens, need_to_load
+        )
+        return need_to_load, need_to_load > 0
+
+    def on_new_request(self, request: "Request") -> None:
+        """Submit an LMCache lookup when a request enters the waiting queue.
+
+        Args:
+            request (Request): The request object.
+        """
+        if self.role != KVConnectorRole.SCHEDULER:
+            return
+        if not self._eager_prefetch or request.resumable:
+            return
+
+        tracker = self._get_or_create_request_tracker(request)
+        self.scheduler_adapter.maybe_submit_lookup_request(
+            request.request_id,
+            token_ids=list(request.all_token_ids),
+            cache_salt=tracker.cache_salt,
+        )
+
+    def update_state_after_alloc(
+        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+    ):
+        """
+        Update KVConnector state after block allocation.
+
+        If get_num_new_matched_tokens previously returned True for a
+        request, this function may be called twice for that same request -
+        first when blocks are allocated for the connector tokens to be
+        asynchronously loaded into, and second when any additional blocks
+        are allocated, after the load/transfer is complete.
+
+        Args:
+            request (Request): the request object.
+            blocks (KVCacheBlocks): the blocks allocated for the request.
+            num_external_tokens (int): the number of tokens that will be
+                loaded from the external KV cache.
+        """
+        # NOTE: `blocks` comes from kv_cache_manager.get_blocks(request_id),
+        # which returns ALL blocks for the request (not just newly allocated).
+        # This function may be called twice for async-load requests:
+        #   1st call: blocks = initial allocation (APC + fresh)
+        #   2nd call: blocks = all blocks
+        #  (initial + newly allocated for remaining tokens)
+        # We must only append the NEW blocks beyond what's already tracked
+        # to avoid duplication, which would corrupt the store path's block indexing.
+        tracker = self._get_request_tracker(request.request_id)
+        block_ids = blocks.get_block_ids() or ()
+
+        # Only append blocks beyond what's already tracked, per engine group.
+        existing_counts = tracker.num_allocated_blocks()
+        new_block_ids: list[list[int]] = []
+        for engine_group_idx, group_blocks in enumerate(block_ids):
+            existing = existing_counts.get(engine_group_idx, 0)
+            new_block_ids.append(list(group_blocks[existing:]))
+        if any(new_block_ids):
+            tracker.append_block_ids(tuple(new_block_ids))
+
+        # Update the state of the tracker
+        condition = tracker.needs_retrieve()
+        if tracker.state == LMCacheMPRequestState.PREFETCHING:
+            # If need to retrieve, change to WAITING_FOR_LOAD
+            # Otherwise, change to READY
+            tracker.state = (
+                LMCacheMPRequestState.WAITING_FOR_LOAD
+                if condition
+                else LMCacheMPRequestState.READY
+            )
+            # Clean up lookup future in scheduler adapter
+            self.scheduler_adapter.cleanup_lookup_result(request.request_id)
+
+            # Free locks on chunks that vLLM already computed and won't
+            # retrieve from LMCache.
+            if tracker.num_lmcache_hit_tokens > 0:
+                if not condition:
+                    # No retrieve needed — free ALL locked chunks
+                    free_end = tracker.num_lmcache_hit_tokens
+                else:
+                    # Note(Roy): Boundary misalignment between vLLM blocks and LMCache
+                    # blocks is handled in free_lookup_locks. It makes sure that if
+                    # the last vLLM computed block ends in the middle of a LMCache
+                    # block, the end LMCache block is not freed (i.e., floor division)
+                    # since it will still be needed by vLLM and such block's lock will
+                    # be freed by vLLM's retrieve.
+                    free_end = tracker.num_vllm_hit_tokens
+
+                if free_end > 0:
+                    self.scheduler_adapter.free_lookup_locks(
+                        token_ids=tracker.get_token_ids(),
+                        start=0,
+                        end=free_end,
+                        request_id=request.request_id,
+                        cache_salt=tracker.cache_salt,
+                    )
+                    logger.debug(
+                        "Free locks of tokens %d-%d since it is cached by vLLM.",
+                        0,
+                        free_end,
+                    )
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> KVConnectorMetadata:
+        """
+        Build the connector metadata for this step.
+
+        This function should NOT modify fields in the scheduler_output.
+        Also, calling this function will reset the state of the connector.
+
+        Args:
+            scheduler_output (SchedulerOutput): the scheduler output object.
+        """
+        metadata = LMCacheMPConnectorMetadata()
+        metadata.need_flush_before_forward = _has_preemption_reqs(scheduler_output)
+
+        self._process_retrieve_requests(metadata)
+        self._process_new_requests(scheduler_output, metadata)
+        self._process_cached_requests(scheduler_output, metadata)
+
+        if len(metadata) > 0:
+            logger.debug("Final connector metadata: %s", metadata)
+
+        # Report block allocation deltas to LMCache for observability
+        self._report_block_allocation_deltas(scheduler_output)
+
+        return metadata
+
+    def update_connector_output(self, connector_output: KVConnectorOutput):
+        """
+        Update KVConnector state from worker-side connectors output.
+
+        Args:
+            connector_output (KVConnectorOutput): the worker-side
+                connectors output.
+        """
+        if not self.lazy_offload:
+            return
+        if not self._gpu_block_pool:
+            raise ValueError("Lazy offload is enabled but gpu block pool is not binded")
+        meta = connector_output.kv_connector_worker_meta
+        if not isinstance(meta, LMCacheMPWorkerMetadata):
+            return
+        for req_id, count in meta.completed_store_requests.items():
+            if self.scheduler_adapter.update_pending_store_count(req_id, count):
+                gpu_block_ids = self._pending_store.get_request_gpu_block_ids(req_id)
+                self._gpu_block_pool.free_blocks(
+                    [self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids]
+                )
+                self._pending_store.remove_request_gpu_block_ids(req_id)
+                self.scheduler_adapter.end_session(req_id)
+
+    def request_finished(
+        self,
+        request: "Request",
+        block_ids: list[int],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """
+        Called exactly once when a request has finished, before its blocks are
+        freed.
+
+        The connector may assumes responsibility for freeing the blocks
+        asynchronously by returning True.
+
+        Returns:
+            True if the request is being saved/sent asynchronously and blocks
+            should not be freed until the request_id is returned from
+            get_finished().
+            Optional KVTransferParams to be included in the request outputs
+            returned by the engine.
+        """
+
+        params: dict[str, Any] | None = getattr(request, "kv_transfer_params", None)
+        return_params: dict[str, Any] | None = {} if params is not None else None
+
+        if (
+            params is not None
+            and return_params is not None
+            and "cached_token_stats" in params
+        ):
+            request_tracker = self._get_request_tracker(request.request_id)
+            num_vllm = request_tracker.num_vllm_hit_tokens
+            num_lmcache = request_tracker.num_lmcache_hit_tokens
+            return_params["cached_token_stats"] = {
+                "num_vllm_cached_tokens": num_vllm,
+                "num_lmcache_cached_tokens": num_lmcache,
+                "num_lmcache_extra_cached_tokens": max(0, num_lmcache - num_vllm),
+            }
+
+        # Clean up request tracker to prevent memory leak
+        self._cleanup_request_tracker(request.request_id)
+
+        # have not been offloaded, the touch operation in end_session is incorrect
+        # Notify LMCache to end the session for this request
+        self.scheduler_adapter.end_session(request.request_id)
+
+        if self.lazy_offload:
+            self._pending_store.mark_req_finished(request.request_id)
+            return False, (return_params or None)
+        return True, (return_params or None)
+
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """HMA request-finished entry point; cleanup is request-id based."""
+        return self.request_finished(request, block_ids[0] if block_ids else [])
+
+    def take_events(self) -> Iterable["KVCacheEvent"]:
+        """
+        Take the KV cache events from the connector.
+
+        Yields:
+            New KV cache events since the last call.
+        """
+        return ()
+
+    @classmethod
+    def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:
+        """
+        Get the required KV cache layout for this connector.
+        Args:
+            vllm_config (VllmConfig): the vllm config.
+
+        Returns:
+            str: the required KV cache layout. e.g. HND, or NHD.
+            None if the connector does not require a specific layout.
+        """
+
+        if cls is KVConnectorBase_V1:
+            raise TypeError(
+                "get_required_kvcache_layout should not be called "
+                "on the abstract base class"
+            )
+        return None
+
+    def get_finished_count(self) -> int | None:
+        """
+        Get the count of requests expected to complete send/receive operations
+        via this connector. This method is used to initialize the
+        KVOutputAggregator, overwriting the default world_size.
+
+        Returns:
+            int: expected sending or receiving completion count.
+        """
+        return None
+
+    @classmethod
+    def build_kv_connector_stats(
+        cls, data: dict[str, Any] | None = None
+    ) -> "KVConnectorStats | None":
+        """
+        KVConnectorStats resolution method. This method allows dynamically
+        registered connectors to return their own KVConnectorStats object,
+        which can implement custom aggregation logic on the data dict.
+        """
+        return None
+
+    @classmethod
+    def build_prom_metrics(
+        cls,
+        vllm_config: "VllmConfig",
+        metric_types: dict[type["PromMetric"], type["PromMetricT"]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ) -> "KVConnectorPromMetrics | None":
+        """
+        Create a KVConnectorPromMetrics subclass which should register
+        per-connector Prometheus metrics and implement observe() to
+        expose connector transfer stats via Prometheus.
+        """
+        return None
+
+    ##############################
+    # Helper functions
+    ##############################
+    def _process_retrieve_requests(
+        self,
+        metadata: LMCacheMPConnectorMetadata,
+    ) -> None:
+        lmcache_tokens_per_chunk = self.scheduler_adapter.lmcache_tokens_per_chunk
+
+        for request_tracker in self.request_trackers.values():
+            if request_tracker.state != LMCacheMPRequestState.WAITING_FOR_LOAD:
+                continue
+            r_metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
+                request_tracker,
+                lmcache_tokens_per_chunk,
+                group_tokens_per_block=self._group_tokens_per_block,
+            )
+            if r_metadata is not None:
+                metadata.add_request_metadata(r_metadata)
+            request_tracker.state = LMCacheMPRequestState.READY
+
+    def _process_new_requests(
+        self,
+        scheduler_output: SchedulerOutput,
+        metadata: LMCacheMPConnectorMetadata,
+    ) -> None:
+        lmcache_tokens_per_chunk = self.scheduler_adapter.lmcache_tokens_per_chunk
+
+        for new_request in scheduler_output.scheduled_new_reqs:
+            request_tracker = self._get_request_tracker(new_request.req_id)
+
+            num_new_tokens = scheduler_output.num_scheduled_tokens[new_request.req_id]
+            request_tracker.increase_num_scheduled_tokens(num_new_tokens)
+
+            r_meta = LMCacheMPRequestMetadata.GetStoreMetadata(
+                request_tracker,
+                lmcache_tokens_per_chunk,
+                self._group_tokens_per_block,
+            )
+            if r_meta is not None:
+                if self.lazy_offload:
+                    self._pending_store.add(r_meta)
+                else:
+                    metadata.add_request_metadata(r_meta)
+        # if scheduler_output.total_num_scheduled_tokens is 0,
+        # vllm `gpu_model_runner` will call `kv_connector_no_forward`
+        # in `execute_model`, which will result in lose some store ops.
+        # So we only trigger lazy offload when
+        # scheduler_output.total_num_scheduled_tokens > 0
+        if scheduler_output.total_num_scheduled_tokens:
+            self._process_lazy_offload_store_requests(metadata)
+
+    def _process_cached_requests(
+        self,
+        scheduler_output: SchedulerOutput,
+        metadata: LMCacheMPConnectorMetadata,
+    ) -> None:
+        lmcache_tokens_per_chunk = self.scheduler_adapter.lmcache_tokens_per_chunk
+
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        for idx, request_id in enumerate(cached_reqs.req_ids):
+            request_tracker = self._get_request_tracker(request_id)
+
+            # Update block ids
+            new_block_ids = cached_reqs.new_block_ids[idx] or ()
+            if request_id not in cached_reqs.resumed_req_ids:
+                request_tracker.append_block_ids(new_block_ids)
+
+            # Use the incremental num_scheduled_tokens to
+            # stay consistent with _process_new_requests.
+            num_new_tokens = scheduler_output.num_scheduled_tokens[request_id]
+            request_tracker.increase_num_scheduled_tokens(num_new_tokens)
+
+            r_meta = LMCacheMPRequestMetadata.GetStoreMetadata(
+                request_tracker,
+                lmcache_tokens_per_chunk,
+                self._group_tokens_per_block,
+            )
+            if r_meta is not None:
+                if self.lazy_offload:
+                    self._pending_store.add(r_meta)
+                else:
+                    metadata.add_request_metadata(r_meta)
+        # if scheduler_output.total_num_scheduled_tokens is 0,
+        # vllm `gpu_model_runner` will call `kv_connector_no_forward`
+        # in `execute_model`, which will result in lose some store ops.
+        # So we only trigger lazy offload when
+        # scheduler_output.total_num_scheduled_tokens > 0
+        if scheduler_output.total_num_scheduled_tokens:
+            self._process_lazy_offload_store_requests(metadata)
+
+    def _process_lazy_offload_store_requests(
+        self, metadata: LMCacheMPConnectorMetadata
+    ):
+        if not self.lazy_offload:
+            return
+
+        if not self._gpu_block_pool:
+            raise ValueError("Lazy offload is enabled but no GPU block pool is bound")
+
+        # Each item aggregates store metadata for one request. Chunked prefill
+        # or the scheduler's ``max-num-batched-tokens`` limit can schedule one
+        # request multiple times, with each metadata entry containing only that
+        # scheduling pass's blocks.
+        for item in self._pending_store.pop_items_for_offload():
+            request_id = item.request_id
+            for meta, old_block_hashes in item.metadatas:
+                gpu_block_ids = list(old_block_hashes.keys())
+                self._gpu_block_pool.touch(
+                    [self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids]
+                )
+                new_block_hashes = {
+                    bid: self._gpu_block_pool.blocks[bid].block_hash
+                    for bid in gpu_block_ids
+                }
+                if old_block_hashes == new_block_hashes:
+                    # remove block hashes and free blocks until store is done
+                    metadata.add_request_metadata(meta)
+                    self._pending_store.update_request_gpu_block_ids(
+                        request_id, gpu_block_ids
+                    )
+                else:
+                    logger.warning(
+                        "Part block hashes mismatch for request %s, skip it",
+                        request_id,
+                    )
+                    self._gpu_block_pool.free_blocks(
+                        [self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids]
+                    )
+                    break
+
+    def _report_block_allocation_deltas(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> None:
+        """Gather per-request block allocation deltas and report to LMCache.
+
+        For new requests: all allocated_block_ids and token_ids are new.
+        For cached requests: only newly appended block_ids and token_ids.
+        The L0 allocation telemetry is flat today, so HMA reports engine group 0.
+        """
+        records: list[RequestAllocationRecord] = []
+
+        # New requests: send all tokens covering all allocated blocks so
+        # the L0 metrics subscriber can correctly map each block to its
+        # actual token content (not just the newly-scheduled slice).
+        for new_request in scheduler_output.scheduled_new_reqs:
+            tracker = self.request_trackers.get(new_request.req_id)
+            if tracker is None:
+                continue
+            primary_block_ids = tracker.allocated_block_ids.get(0, [])
+            num_blocks = len(primary_block_ids)
+            total_tokens = num_blocks * self._group_tokens_per_block[0]
+            records.append(
+                RequestAllocationRecord(
+                    req_id=new_request.req_id,
+                    new_block_ids=list(primary_block_ids),
+                    new_token_ids=tracker.get_token_ids()[:total_tokens],
+                )
+            )
+
+        # Cached requests: only the newly added blocks and their full
+        # token content.  We send all tokens covered by the new blocks
+        # (not just the tokens scheduled this step) so the L0 subscriber
+        # can correctly identify block content.
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        for idx, request_id in enumerate(cached_reqs.req_ids):
+            # The L0 subscriber works on the primary (group 0) block-id list.
+            new_group_block_ids = cached_reqs.new_block_ids[idx]
+            new_block_ids = new_group_block_ids[0] if new_group_block_ids else []
+            if not new_block_ids:
+                continue
+            tracker = self.request_trackers.get(request_id)
+            if tracker is None:
+                continue
+            # The new blocks sit at the end of the request's block list.
+            # Compute the token range they cover.
+            total_blocks = len(tracker.allocated_block_ids.get(0, []))
+            num_new_blocks = len(new_block_ids)
+            tokens_per_block = self._group_tokens_per_block[0]
+            start_token = (total_blocks - num_new_blocks) * tokens_per_block
+            end_token = total_blocks * tokens_per_block
+            new_token_ids = tracker.get_token_ids()[start_token:end_token]
+            records.append(
+                RequestAllocationRecord(
+                    req_id=request_id,
+                    new_block_ids=new_block_ids,
+                    new_token_ids=new_token_ids,
+                )
+            )
+
+        if records:
+            self.scheduler_adapter.report_block_allocations(records)
+
+    def _get_request_tracker(self, request_id: str) -> LMCacheMPRequestTracker:
+        assert request_id in self.request_trackers, (
+            f"Request tracker for request_id {request_id} not found. "
+        )
+        return self.request_trackers[request_id]
+
+    def _get_or_create_request_tracker(
+        self, request: "Request"
+    ) -> LMCacheMPRequestTracker:
+        request_id = request.request_id
+        # Remove the old trackers that is created before the preemption
+        if (
+            request.status == RequestStatus.PREEMPTED
+            and request_id in self.request_trackers
+        ):
+            tracker = self.request_trackers[request_id]
+
+            # NOTE: since this function may be called multiple times
+            # for a single request (because get_num_new_matched_tokens
+            # may be called multiple times) for the same request, we
+            # will only do the remove if the tracker is not in the "fresh"
+            # state, i.e., PREFETCHING
+            if tracker.state != LMCacheMPRequestState.PREFETCHING:
+                self.request_trackers.pop(request_id)
+
+        if request_id not in self.request_trackers:
+            new_tracker = LMCacheMPRequestTracker(request)
+            self.request_trackers[request_id] = new_tracker
+        return self.request_trackers[request_id]
+
+    def _cleanup_request_tracker(self, request_id: str) -> None:
+        """
+        Clean up request tracker and associated lookup future for a request.
+        This should be called when a request is finished to prevent memory leak.
+        """
+        # Clean up request tracker
+        if self.request_trackers.pop(request_id, None):
+            logger.debug(
+                "[KVConnector] Cleaned up request_tracker for request %s",
+                request_id,
+            )

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -1089,7 +1089,9 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         """Record exact core-selected Mamba state blocks for future stores."""
         handoffs = getattr(scheduler_output, "partial_tail_offloads", None) or {}
         for request_id, entries in handoffs.items():
-            tracker = self._get_request_tracker(request_id)
+            tracker = self.request_trackers.get(request_id)
+            if tracker is None:
+                continue
             for group_id, block_id, boundary_tokens in entries:
                 if group_id not in self._mamba_group_ids or block_id < 0:
                     continue

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -118,6 +118,16 @@ if TYPE_CHECKING:
 logger = lmcache_init_logger(__name__)
 
 
+def _is_mamba_group_spec(spec: Any) -> bool:
+    """Return whether a resolved KV group contains Mamba recurrent state."""
+    inner = getattr(spec, "kv_cache_specs", None)
+    specs = inner.values() if isinstance(inner, dict) else (spec,)
+    return any(
+        any(cls.__name__ == "MambaSpec" for cls in type(item).__mro__)
+        for item in specs
+    )
+
+
 # Helper functions
 def _has_preemption_reqs(scheduler_output: SchedulerOutput) -> bool:
     """Return whether the scheduler output contains preemption-related requests.
@@ -395,6 +405,13 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         # the engine's base block size when no group metadata is available
         # (single non-hybrid group).
         self._group_tokens_per_block = group_tokens_per_block
+        self._mamba_group_ids = {
+            group_idx
+            for group_idx, group in enumerate(
+                getattr(kv_cache_config, "kv_cache_groups", ())
+            )
+            if _is_mamba_group_spec(group.kv_cache_spec)
+        }
         for engine_group_idx, tokens_per_block in enumerate(
             self._group_tokens_per_block
         ):
@@ -904,6 +921,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         metadata = LMCacheMPConnectorMetadata()
         metadata.need_flush_before_forward = _has_preemption_reqs(scheduler_output)
 
+        self._ingest_exact_mamba_boundary_blocks(scheduler_output)
         self._process_retrieve_requests(metadata)
         self._process_new_requests(scheduler_output, metadata)
         self._process_cached_requests(scheduler_output, metadata)
@@ -1065,6 +1083,20 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
     ##############################
     # Helper functions
     ##############################
+    def _ingest_exact_mamba_boundary_blocks(
+        self, scheduler_output: SchedulerOutput
+    ) -> None:
+        """Record exact core-selected Mamba state blocks for future stores."""
+        handoffs = getattr(scheduler_output, "partial_tail_offloads", None) or {}
+        for request_id, entries in handoffs.items():
+            tracker = self._get_request_tracker(request_id)
+            for group_id, block_id, boundary_tokens in entries:
+                if group_id not in self._mamba_group_ids or block_id < 0:
+                    continue
+                tracker.exact_mamba_boundary_blocks.setdefault(group_id, {})[
+                    boundary_tokens
+                ] = block_id
+
     def _process_retrieve_requests(
         self,
         metadata: LMCacheMPConnectorMetadata,
@@ -1100,6 +1132,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 request_tracker,
                 lmcache_tokens_per_chunk,
                 self._group_tokens_per_block,
+                self._mamba_group_ids,
             )
             if r_meta is not None:
                 if self.lazy_offload:
@@ -1139,6 +1172,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 request_tracker,
                 lmcache_tokens_per_chunk,
                 self._group_tokens_per_block,
+                self._mamba_group_ids,
             )
             if r_meta is not None:
                 if self.lazy_offload:

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/lmcache_mp_metadata.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/lmcache_mp_metadata.py
@@ -1,0 +1,447 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Standard
+import enum
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.integration.vllm.utils import (
+    apply_mm_hashes_to_token_ids,
+    extract_mm_features,
+)
+from lmcache.integration.vllm.vllm_multi_process_adapter import LoadStoreOp
+from lmcache.v1.multiprocess.group_view import slice_block_ids_per_group
+
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorMetadata,
+    KVConnectorWorkerMetadata,
+)
+from vllm.v1.utils import ConstantList
+
+if TYPE_CHECKING:
+    # Third Party
+    from vllm.v1.request import Request
+
+
+class LMCacheMPRequestState(enum.Enum):
+    """
+    State machine:
+    PREFETCHING -- update_state_after_alloc --> WAITING_FOR_LOAD
+    WAITING_FOR_LOAD -- process_loading_requests --> READY
+    """
+
+    PREFETCHING = enum.auto()
+    WAITING_FOR_LOAD = enum.auto()
+    READY = enum.auto()
+
+
+@dataclass
+class LMCacheMPRequestTracker:
+    # NOTE: this class used vLLM data structures, should be part of
+    # vLLM integration code
+
+    request_id: str
+
+    # Read-only list to track the token ids
+    all_token_ids: ConstantList[int]
+
+    # Block ids will be updated at update_states_after_alloc and
+    # during generation. Keyed by engine_group_idx; non-HMA models use 0.
+    allocated_block_ids: dict[int, list[int]] = field(default_factory=dict)
+
+    # Exact core-issued Mamba boundary states, keyed by request -> group ->
+    # boundary token count -> physical block ID. Positional Mamba block-table
+    # snapshots are unsafe because align-mode tables are sparse and mutable.
+    exact_mamba_boundary_blocks: dict[int, dict[int, int]] = field(
+        default_factory=dict
+    )
+
+    # Number of scheduled tokens in this request. We keep tracking this to
+    # avoid saving tokens whose KV has not been computed yet.
+    num_scheduled_tokens: int = 0
+
+    # Number of tokens stored will be initialized when lookup the external
+    # hit tokens and will be updated when processing new requests and cached
+    # requests.
+    num_stored_tokens: int = 0
+
+    # Staging load operation -- save vllm and lmcache hit tokens during lookup
+    num_vllm_hit_tokens: int = 0
+    num_lmcache_hit_tokens: int = 0
+
+    # Main state
+    state: LMCacheMPRequestState = LMCacheMPRequestState.PREFETCHING
+
+    cache_salt: str = ""
+
+    mm_adjusted_prompt_ids: list[int] = field(default_factory=list)
+
+    def __init__(self, request: "Request"):
+        self.request_id = request.request_id
+        self.cache_salt: str = request.cache_salt or ""
+        self.all_token_ids = request.all_token_ids
+        self.allocated_block_ids = {}
+        self.exact_mamba_boundary_blocks = {}
+        self.num_stored_tokens = 0
+        self.num_vllm_hit_tokens = 0
+        self.num_lmcache_hit_tokens = 0
+        self.state = LMCacheMPRequestState.PREFETCHING
+        self.mm_adjusted_prompt_ids = []
+        mm_hashes, mm_positions = extract_mm_features(request)
+        if mm_hashes and mm_positions:
+            prompt_ids = torch.tensor(request.prompt_token_ids)
+            apply_mm_hashes_to_token_ids(prompt_ids, mm_hashes, mm_positions)
+            self.mm_adjusted_prompt_ids = prompt_ids.tolist()
+
+    ####
+    # Check the state of the request
+    ####
+    def needs_retrieve(self) -> bool:
+        """Check whether the current request needs retrieve, will be used
+        update_stage_after_alloc"""
+        return (
+            self.num_lmcache_hit_tokens > self.num_vllm_hit_tokens
+            and self.state != LMCacheMPRequestState.READY
+        )
+
+    def is_ready_for_retrieving(self) -> bool:
+        """Check whether the current request is ready for retrieving,
+        will be used in process_loading_requests"""
+        return (
+            self.state == LMCacheMPRequestState.WAITING_FOR_LOAD
+            and self.needs_retrieve()
+        )
+
+    ####
+    # Update internal states
+    ####
+    def increase_num_scheduled_tokens(self, num_new_tokens: int):
+        self.num_scheduled_tokens += num_new_tokens
+
+    def increase_num_stored_tokens(self, num_new_tokens: int):
+        """Increase the number of stored tokens for the current request
+        This function will be called when processing the cached requests.
+        """
+        self.num_stored_tokens += num_new_tokens
+
+    def append_block_ids(
+        self,
+        new_block_ids: tuple[list[int], ...],
+    ):
+        """Update the block ids for the current request
+        This function will be called when processing the cached requests.
+        """
+        for engine_group_idx, group_block_ids in enumerate(new_block_ids):
+            if group_block_ids:
+                self.allocated_block_ids.setdefault(engine_group_idx, []).extend(
+                    group_block_ids
+                )
+
+    def num_allocated_blocks(self) -> dict[int, int]:
+        return {
+            engine_group_idx: len(blocks)
+            for engine_group_idx, blocks in self.allocated_block_ids.items()
+        }
+
+    def get_token_ids(self) -> list[int]:
+        """Return the token ids to use for LMCache key derivation."""
+        if not self.mm_adjusted_prompt_ids:
+            return list(self.all_token_ids)
+        num_prompt_tokens = len(self.mm_adjusted_prompt_ids)
+        return self.mm_adjusted_prompt_ids + list(
+            self.all_token_ids[num_prompt_tokens:]
+        )
+
+    ####
+    # For debugging
+    ####
+    def __repr__(self) -> str:
+        return (
+            f"LMCacheMPRequestTracker(request_id={self.request_id}, "
+            f"num_tokens={len(self.all_token_ids)}, "
+            f"num_allocated_blocks="
+            f"{self.num_allocated_blocks()}, "
+            f"num_stored_tokens={self.num_stored_tokens}, "
+            f"vllm_hit_tokens={self.num_vllm_hit_tokens}, "
+            f"lmcache_hit_tokens={self.num_lmcache_hit_tokens}, "
+            f"state={self.state})"
+        )
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+
+def apply_exact_mamba_store_blocks(
+    tracker: LMCacheMPRequestTracker,
+    block_ids: list[list[int]],
+    group_tokens_per_block: list[int],
+    mamba_group_ids: set[int],
+    lmcache_tokens_per_chunk: int,
+    start_token_idx: int,
+    end_token_idx: int,
+) -> None:
+    """Replace positional Mamba IDs with one ID per LMCache chunk.
+
+    Each chunk uses its exact physical ID when available and null block 0
+    otherwise. Separated object groups skip null historical Mamba chunks.
+    """
+    replacements: dict[int, list[int]] = {}
+    for group_id in mamba_group_ids:
+        exact = tracker.exact_mamba_boundary_blocks.get(group_id, {})
+        # Align-mode recurrent state is one snapshot per LMCache chunk: the
+        # state at the chunk end. It is not per-token attention KV, so interior
+        # engine block positions are intentionally absent.
+        boundaries = range(
+            start_token_idx + lmcache_tokens_per_chunk,
+            end_token_idx + 1,
+            lmcache_tokens_per_chunk,
+        )
+        exact_ids = [exact.get(boundary, 0) for boundary in boundaries]
+        replacements[group_id] = exact_ids
+
+    for group_id, exact_ids in replacements.items():
+        block_ids[group_id] = exact_ids
+
+
+@dataclass
+class LMCacheMPRequestMetadata:
+    request_id: str
+    direction: Literal["STORE", "RETRIEVE"]
+    op: LoadStoreOp
+    cache_salt: str = ""
+
+    @staticmethod
+    def GetStoreMetadata(
+        tracker: LMCacheMPRequestTracker,
+        lmcache_tokens_per_chunk: int,
+        group_tokens_per_block: list[int],
+        mamba_group_ids: set[int] | None = None,
+    ) -> "LMCacheMPRequestMetadata | None":
+        """
+        Generate the store metadata for the current request tracker.
+
+        Args:
+            tracker: The request tracker to generate the metadata from.
+            lmcache_tokens_per_chunk: the number of tokens in a LMCache data chunk
+            group_tokens_per_block: per-engine-group tokens covered by one
+                paged chunk (one block ID) of that group, i.e. the group's
+                KV cache spec ``block_size``. Must each divide
+                ``lmcache_tokens_per_chunk`` (hybrid models can mix different values).
+        """
+        num_engine_groups = len(group_tokens_per_block)
+        # NOTE: the invariant here is that `num_stored_tokens` should
+        # always be a multiple of `lmcache_tokens_per_chunk`
+        # TODO: This should be checked every time we update the num_stored_tokens
+        #
+        # Why computed_tokens uses max(num_vllm_hit_tokens, num_lmcache_hit_tokens):
+        #
+        # Both values represent a prefix of tokens whose KV data is already
+        # available (either from vLLM APC or from LMCache), so they must NOT
+        # be summed (that would double-count the overlapping prefix).
+        #
+        # * num_lmcache_hit_tokens: LMCache-hit tokens are already counted in
+        #   num_stored_tokens (set during lookup), so they must be included
+        #   here to keep the upper bound consistent.  They are NOT re-stored.
+        # * num_vllm_hit_tokens: LMCache stores in units of chunks, so
+        #   num_lmcache_hit_tokens is rounded DOWN to the nearest chunk
+        #   boundary.  When vLLM APC hits more tokens than that rounded value
+        #   (e.g. APC=704 tokens, LMCache=512 tokens after chunk alignment),
+        #   using only num_lmcache_hit_tokens would set the upper bound too
+        #   low and silently skip the APC-hit tokens that fall between the
+        #   two values, causing under-storing.  Taking the max ensures we
+        #   always use the tighter (larger) of the two hit counts.
+        computed_tokens = tracker.num_scheduled_tokens + max(
+            tracker.num_vllm_hit_tokens, tracker.num_lmcache_hit_tokens
+        )
+        # Each group covers ``len(block_ids) * tokens_per_block`` tokens; the
+        # storable prefix is bounded by the least-covered group (e.g.
+        # gemma-4 sliding: one 32-token ID covers 2x the tokens of a
+        # 16-token full-attention ID).
+        allocated_lengths = tracker.num_allocated_blocks()
+        allocated_tokens = (
+            min(
+                allocated_lengths.get(engine_group_idx, 0)
+                * group_tokens_per_block[engine_group_idx]
+                for engine_group_idx in range(num_engine_groups)
+            )
+            if num_engine_groups > 0
+            else 0
+        )
+        min_available_tokens = min(
+            len(tracker.all_token_ids),
+            allocated_tokens,
+            computed_tokens,
+        )
+        num_staging_tokens = min_available_tokens - tracker.num_stored_tokens
+        num_chunks = num_staging_tokens // lmcache_tokens_per_chunk
+
+        if num_chunks >= 1:
+            start_token_idx = tracker.num_stored_tokens
+            end_token_idx = start_token_idx + num_chunks * lmcache_tokens_per_chunk
+            block_ids = slice_block_ids_per_group(
+                tracker.allocated_block_ids,
+                group_tokens_per_block,
+                start_token_idx,
+                end_token_idx,
+            )
+            if mamba_group_ids:
+                apply_exact_mamba_store_blocks(
+                    tracker,
+                    block_ids,
+                    group_tokens_per_block,
+                    mamba_group_ids,
+                    lmcache_tokens_per_chunk,
+                    start_token_idx,
+                    end_token_idx,
+                )
+            token_ids = tracker.get_token_ids()
+            op = LoadStoreOp(
+                token_ids=token_ids,
+                block_ids=block_ids,
+                start=start_token_idx,
+                end=end_token_idx,
+            )
+
+            ret = LMCacheMPRequestMetadata(
+                request_id=tracker.request_id,
+                direction="STORE",
+                op=op,
+                cache_salt=tracker.cache_salt,
+            )
+
+            # Update the request tracker
+            tracker.increase_num_stored_tokens(end_token_idx - start_token_idx)
+            return ret
+
+        return None
+
+    @staticmethod
+    def GetRetrieveMetadata(
+        tracker: LMCacheMPRequestTracker,
+        lmcache_tokens_per_chunk: int,
+        group_tokens_per_block: list[int],
+    ) -> "LMCacheMPRequestMetadata | None":
+        """
+        Generate the retrieve metadata for the current request tracker.
+
+        Args:
+            tracker: The request tracker to generate the metadata from.
+            lmcache_tokens_per_chunk: the number of tokens in a LMCache data chunk
+            group_tokens_per_block: per-engine-group tokens covered by one
+                paged chunk (one block ID) of that group, i.e. the group's
+                KV cache spec ``block_size``. Must each divide
+                ``lmcache_tokens_per_chunk`` (hybrid models can mix different values).
+        """
+        if not tracker.is_ready_for_retrieving():
+            return None
+
+        # |---------------------|-----------------|----------------|
+        # | num_vllm_hit_tokens |
+        # | lmcache chunk 1   | lmcache chunk 2   |
+        #                     |  need to retrieve |
+
+        start_token_idx = (
+            tracker.num_vllm_hit_tokens
+            // lmcache_tokens_per_chunk
+            * lmcache_tokens_per_chunk
+        )
+        end_token_idx = tracker.num_lmcache_hit_tokens
+        assert end_token_idx % lmcache_tokens_per_chunk == 0, (
+            "The number of LMCache hit tokens should be a multiple of the "
+            "LMCache chunk size. "
+        )
+        assert len(tracker.all_token_ids) >= end_token_idx, (
+            "The number of tokens should be greater than or equal to the "
+            "number of LMCache hit tokens. "
+        )
+        if end_token_idx > start_token_idx:
+            block_ids = slice_block_ids_per_group(
+                tracker.allocated_block_ids,
+                group_tokens_per_block,
+                start_token_idx,
+                end_token_idx,
+            )
+            token_ids = tracker.get_token_ids()
+
+            # Compute how many tokens at the start of the retrieve range
+            # overlap with APC-shared blocks. The server must skip writing
+            # to these positions to avoid a cross-stream data race: the
+            # retrieve writes on the LMCache CUDA stream while concurrent
+            # requests may read these APC-shared blocks on the vLLM stream.
+            skip_first_n_tokens = tracker.num_vllm_hit_tokens - start_token_idx
+
+            op = LoadStoreOp(
+                token_ids=token_ids,
+                block_ids=block_ids,
+                start=start_token_idx,
+                end=end_token_idx,
+                skip_first_n_tokens=skip_first_n_tokens,
+            )
+
+            ret = LMCacheMPRequestMetadata(
+                request_id=tracker.request_id,
+                direction="RETRIEVE",
+                op=op,
+                cache_salt=tracker.cache_salt,
+            )
+            return ret
+
+        return None
+
+
+class LMCacheMPConnectorMetadata(KVConnectorMetadata):
+    def __init__(self):
+        super().__init__()
+        self.requests: list[LMCacheMPRequestMetadata] = []
+        self.need_flush_before_forward: bool = False
+
+    def add_request_metadata(self, request_metadata: LMCacheMPRequestMetadata):
+        self.requests.append(request_metadata)
+
+    def __len__(self):
+        return len(self.requests)
+
+    # For debugging
+    def __str__(self):
+        request_strs = []
+        for req_meta in self.requests:
+            request_strs.append(
+                f"RequestMetadata(request_id={req_meta.request_id}, "
+                f"direction={req_meta.direction}, "
+                f"num_blocks={len(req_meta.op.flat_block_ids)}, "
+                f"block_ids={req_meta.op.block_ids})"
+            )
+        return (
+            f"need_flush_before_forward={self.need_flush_before_forward}; ["
+            + "\n".join(request_strs)
+            + "]"
+        )
+
+    def __repr__(self):
+        return self.__str__()
+
+
+@dataclass
+class LMCacheMPWorkerMetadata(KVConnectorWorkerMetadata):
+    """Worker -> Scheduler metadata for completed store events.
+
+    Each worker reports {req_id: 1} for newly completed stores.
+    ``aggregate()`` sums counts across workers within a step.
+    The scheduler-side manager accumulates across steps and processes
+    a store completion only when count reaches ``world_size``.
+    """
+
+    completed_store_requests: dict[str, int]
+
+    def aggregate(
+        self, other: "KVConnectorWorkerMetadata"
+    ) -> "KVConnectorWorkerMetadata":
+        assert isinstance(other, LMCacheMPWorkerMetadata)
+        merged = dict(self.completed_store_requests)
+        for k, v in other.completed_store_requests.items():
+            merged[k] = merged.get(k, 0) + v
+        return LMCacheMPWorkerMetadata(completed_store_requests=merged)

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1594,6 +1594,7 @@ class LMCacheMPWorkerAdapter:
     ) -> set[str]:
         """Merge LMCache-side and engine-side finished store info."""
         self.finished_stores.update(finished_req_ids_from_lmcache)
+        self._returned_finished.intersection_update(finished_req_ids_from_engine)
         ret_stores = set()
         for req_id in finished_req_ids_from_engine:
             if req_id in self._returned_finished:

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1594,10 +1594,10 @@ class LMCacheMPWorkerAdapter:
     ) -> set[str]:
         """Merge LMCache-side and engine-side finished store info."""
         self.finished_stores.update(finished_req_ids_from_lmcache)
-        self._returned_finished.intersection_update(finished_req_ids_from_engine)
         ret_stores = set()
         for req_id in finished_req_ids_from_engine:
             if req_id in self._returned_finished:
+                self._returned_finished.discard(req_id)
                 continue
             if req_id in self.finished_stores or req_id in self.store_futures:
                 self.previously_finished.add(req_id)

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1,0 +1,1983 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Standard
+import enum
+import os
+import threading
+import uuid
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, NoReturn, Protocol
+
+# Third Party
+import torch
+import zmq
+
+# First Party
+from lmcache import torch_dev
+from lmcache.integration.request_telemetry.factory import RequestTelemetryFactory
+from lmcache.integration.vllm.experimental import dispatch
+from lmcache.integration.vllm.utils import vllm_layout_hints
+from lmcache.utils import EngineType, _lmcache_nvtx_annotate, init_logger
+from lmcache.v1.multiprocess.custom_types import (
+    BlockAllocationRecord,
+    IPCCacheServerKey,
+)
+from lmcache.v1.multiprocess.group_view import (
+    EngineGroupInfo,
+    expand_engine_block_ids,
+)
+from lmcache.v1.multiprocess.mq import MessageQueueClient, MessagingFuture
+from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
+from lmcache.v1.multiprocess.transfer_context import (
+    EngineDrivenTransferContext,
+    MPTransferMode,
+    TransferContext,
+    create_transfer_context,
+)
+from lmcache.v1.multiprocess.transfer_context.worker_transfer import _resolve_mode
+from lmcache.v1.periodic_thread import PeriodicThread, ThreadLevel, ThreadRunSummary
+from lmcache.v1.platform.cuda.cumem_ipc import CuMemIPCUnsupportedError
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.integration.vllm.experimental import Dispatcher
+
+logger = init_logger(__name__)
+
+
+class ExtraConfigDefault(enum.Enum):
+    """Centralized default values for extra_config keys.
+
+    Each member's *name* is the key used in the extra_config dict,
+    and its *value* is the default.
+    """
+
+    # Timeout (seconds) for blocking MQ requests: initial
+    # chunk-size query, KV cache registration/unregistration,
+    # and other synchronous operations.
+    mq_timeout = 300.0
+    # Interval (seconds) between periodic heartbeat pings
+    # to the server.
+    heartbeat_interval = 5.0
+    # Routing mode for ``create_transfer_context``: ``auto`` keeps the
+    # historical CUDA -> lmcache_driven / others -> engine_driven dispatch;
+    # ``lmcache_driven`` forces the IPC / SHM zero-copy path where the
+    # LMCache server pulls data via device handles;
+    # ``engine_driven`` forces the worker-side gather/scatter copy path.
+    # Mirrors the ``LMCACHE_MP_TRANSFER_MODE`` env var; this extra_config
+    # key wins when both are set.
+    mp_transfer_mode = "auto"
+
+
+# Backward-compatible aliases for the legacy `lmcache_mp_connector_0180`
+# entry point, which still passes these as positional/keyword args.
+DEFAULT_MQ_TIMEOUT: float = ExtraConfigDefault.mq_timeout.value
+DEFAULT_HEARTBEAT_INTERVAL: float = ExtraConfigDefault.heartbeat_interval.value
+
+_EXTRA_CONFIG_KEY_PREFIX = "lmcache.mp."
+
+# Floor (seconds) of the MP server's worker reap timeout. It only covers the
+# default 10 s heartbeat interval (3 x 10 s); the adapter warns at startup
+# when 3 x heartbeat_interval exceeds it (server timeout must be raised too).
+_SERVER_REAP_TIMEOUT_FLOOR_SECONDS: float = 30.0
+
+
+def _resolve_extra_config(
+    extra_config: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Resolve extra_config against :class:`ExtraConfigDefault`.
+
+    Keys in *extra_config* are expected to carry the
+    ``lmcache.mp.`` prefix (e.g. ``lmcache.mp.mq_timeout``).
+    The prefix is stripped before matching against
+    :class:`ExtraConfigDefault` members.
+
+    All ``lmcache.mp.*`` entries are logged.  Entries whose
+    value differs from the default are additionally marked as
+    *overridden*.
+
+    Args:
+        extra_config: User-supplied config dict (may be *None*).
+
+    Returns:
+        A dict keyed by :pyattr:`ExtraConfigDefault` member names.
+    """
+    stripped: dict[str, Any] = {}
+    if extra_config is not None:
+        for k, v in extra_config.items():
+            if k.startswith(_EXTRA_CONFIG_KEY_PREFIX):
+                short = k[len(_EXTRA_CONFIG_KEY_PREFIX) :]
+                stripped[short] = v
+
+    resolved: dict[str, Any] = {}
+    for item in ExtraConfigDefault:
+        default = item.value
+        raw = stripped.get(item.name)
+        value = type(default)(raw) if raw is not None else default
+        if value != default:
+            logger.info(
+                "%s%s = %s (overridden, default: %s)",
+                _EXTRA_CONFIG_KEY_PREFIX,
+                item.name,
+                value,
+                default,
+            )
+        else:
+            logger.info(
+                "%s%s = %s",
+                _EXTRA_CONFIG_KEY_PREFIX,
+                item.name,
+                value,
+            )
+        resolved[item.name] = value
+    return resolved
+
+
+class _IpcEvent(Protocol):
+    def ipc_handle(self) -> Any: ...
+
+    def wait(self, stream: Any = None) -> None: ...
+
+
+def send_lmcache_request(
+    mq_client: MessageQueueClient,
+    request_type: RequestType,
+    payloads: list[Any],
+) -> MessagingFuture[Any]:
+    """
+    Helper function to send the request to the LMCache multiprocess server
+
+    Args:
+        mq_client: The LMCache multiprocess mode message queue client
+        request_type: The request type
+        payloads: The request payloads
+
+    Returns:
+        A messaging future for the request
+    """
+
+    future = mq_client.submit_request(
+        request_type, payloads, get_response_class(request_type)
+    )
+    return future
+
+
+def get_lmcache_chunk_size(
+    mq_client: MessageQueueClient,
+    timeout: float = DEFAULT_MQ_TIMEOUT,
+) -> int:
+    """
+    Helper function to get the LMCache chunk size from the server
+
+    Args:
+        mq_client: The LMCache multiprocess mode message queue client
+        timeout: Timeout in seconds for the blocking request.
+
+    Returns:
+        An integer representing the LMCache chunk size
+    """
+    future = send_lmcache_request(mq_client, RequestType.GET_CHUNK_SIZE, [])
+    lmcache_tokens_per_chunk = future.result(timeout=timeout)
+    return lmcache_tokens_per_chunk
+
+
+def get_experimental(
+    mq_client: MessageQueueClient,
+    timeout: float = DEFAULT_MQ_TIMEOUT,
+) -> set[str]:
+    """Query the experimental capabilities a server advertises.
+
+    Args:
+        mq_client: The LMCache multiprocess mode message queue client.
+        timeout: Seconds to wait for the server's response.
+
+    Returns:
+        Experimental features built into the server (now `transfer_query`).
+    """
+    future = send_lmcache_request(mq_client, RequestType.GET_EXPERIMENTAL, [])
+    try:
+        return set(future.result(timeout=timeout))
+    except TimeoutError:
+        logger.warning(
+            "LMCache server did not answer GET_EXPERIMENTAL within %ss; "
+            "treating it as advertising no experimental capabilities.",
+            timeout,
+        )
+        return set()
+
+
+def _raise_server_unreachable(server_url: str, timeout: float) -> NoReturn:
+    """Raise a verbose ConnectionError when the LMCache MP server is
+    unreachable.
+
+    The message intentionally spells out the most common cause (the
+    standalone ``lmcache server`` process is not running), the URL that
+    was being dialed, and the exact command to start it -- so that users
+    landing here via ``vllm serve --kv-offloading-backend lmcache`` are
+    not left guessing.
+    """
+    hint = (
+        "Cannot reach the LMCache MP server at "
+        f"'{server_url}' within {timeout}s.\n"
+        "This usually means the standalone LMCache server is not "
+        "running, or it is listening on a different host/port.\n"
+        "To start one locally with the default port (5555):\n"
+        "    lmcache server --l1-size-gb 20 --eviction-policy LRU\n"
+        "To target a different host/port, override via "
+        "kv_connector_extra_config (lmcache.mp.host / lmcache.mp.port), "
+        "e.g.:\n"
+        '    --kv-transfer-config \'{"kv_connector":'
+        '"LMCacheMPConnector","kv_role":"kv_both",'
+        '"kv_connector_extra_config":{"lmcache.mp.host":'
+        '"tcp://localhost","lmcache.mp.port":5555}}\'\n'
+        "See https://docs.lmcache.ai/mp/quickstart.html for details."
+    )
+    logger.warning(hint)
+    raise ConnectionError(hint) from None
+
+
+def send_ping(
+    mq_client: MessageQueueClient,
+    timeout: float,
+    instance_id: int | None = None,
+) -> bool:
+    """Send a PING request and return the result.
+
+    Args:
+        mq_client: The message queue client.
+        timeout: Seconds to wait for the server's response.
+        instance_id: The worker's instance ID so the server can refresh its
+            liveness, or None for an untracked prober (scheduler adapter).
+
+    Returns:
+        True if server is healthy, False on timeout or error.
+    """
+    try:
+        future = send_lmcache_request(mq_client, RequestType.PING, [instance_id])
+        return future.result(timeout=timeout)
+    except TimeoutError:
+        return False
+    except Exception:
+        logger.debug("Ping failed with exception", exc_info=True)
+        return False
+
+
+@dataclass
+class ParallelStrategy:
+    mla_only: bool
+    """
+    True only for pure-MLA models. This flag indicates whether the KV cache
+    tensor is replicated across TP ranks.
+    """
+
+    vllm_world_size: int
+    """Number of workers managed by one vLLM scheduler (TP × PP; excludes DP).
+
+    Mirrors ``vllm.parallel_config.world_size``.
+    """
+
+    vllm_worker_id: int
+    """This worker's rank within its scheduler group."""
+
+    tp_size: int
+    """The tensor parallel size."""
+
+    pp_size: int
+    """The pipeline parallel size."""
+
+    n_servers: int
+    """Number of LMCache servers backing this deployment"""
+
+    @property
+    def kv_world_size(self) -> int:
+        """Number of pieces a single token chunk's KV cache is split into
+        on the LMCache server storage."""
+        if self.mla_only:
+            # In this PR we do not support PP + TP + MLA in multi-server mode.
+            # A precondition check enforces pp_size == 1, so kv_world_size for
+            # MLA can be derived as world_size / tp_size.
+            return self.vllm_world_size // self.tp_size
+        return self.vllm_world_size // self.n_servers
+
+    @property
+    def kv_worker_id(self) -> int:
+        """Index of the piece of a single token chunk's KV cache
+        that the current worker is responsible for,
+        in ``[0, kv_world_size)``."""
+        if self.mla_only:
+            return self.vllm_worker_id // self.tp_size
+        return self.vllm_worker_id % (self.vllm_world_size // self.n_servers)
+
+    @property
+    def kv_tp_size(self) -> int:
+        """Tensor-parallel size as seen from a single LMCache server."""
+        return self.tp_size // self.n_servers
+
+    @property
+    def is_kv_writer(self) -> bool:
+        """Whether this rank is responsible for storing KV."""
+        if not self.mla_only:
+            return True
+        # MLA-only: only first rank per node is a writer.
+        return self.vllm_worker_id % (self.tp_size // self.n_servers) == 0
+
+
+def _normalize_adapter_init_args(
+    vllm_block_size: int,
+    parallel_strategy: ParallelStrategy | int,
+    legacy_block_size: int | None,
+    mq_timeout: float,
+) -> tuple[int, ParallelStrategy, float]:
+    """Normalize adapter constructor args from old and new vLLM connectors.
+
+    Args:
+        vllm_block_size: The vLLM block size for the current connector API, or
+            the legacy KV world size when ``parallel_strategy`` is an int.
+        parallel_strategy: The current ``ParallelStrategy`` object, or the
+            legacy KV worker id from older vLLM MP connectors.
+        legacy_block_size: The legacy vLLM block size passed positionally by
+            older vLLM MP connectors.
+        mq_timeout: Timeout in seconds for synchronous message queue requests.
+
+    Returns:
+        A tuple of normalized ``(vllm_block_size, parallel_strategy,
+        mq_timeout)``.
+
+    Raises:
+        TypeError: If the connector argument shape is not supported.
+    """
+    if isinstance(parallel_strategy, ParallelStrategy):
+        return vllm_block_size, parallel_strategy, mq_timeout
+    if not isinstance(parallel_strategy, int) or legacy_block_size is None:
+        raise TypeError(
+            "parallel_strategy must be ParallelStrategy, or legacy "
+            "(kv_world_size, kv_worker_id, block_size) arguments"
+        )
+
+    kv_world_size = int(vllm_block_size)
+    kv_worker_id = int(parallel_strategy)
+    strategy = ParallelStrategy(
+        mla_only=False,
+        vllm_world_size=kv_world_size,
+        vllm_worker_id=kv_worker_id,
+        tp_size=kv_world_size,
+        pp_size=1,
+        n_servers=1,
+    )
+    return int(legacy_block_size), strategy, mq_timeout
+
+
+class HeartbeatThread(PeriodicThread):
+    """Periodically checks server health via PING.
+
+    Manages a threading.Event that adapters use to gate operations.
+    When unhealthy, the adapter enters degraded mode; if the server
+    recovers, the adapter automatically resumes normal operation.
+    """
+
+    def __init__(
+        self,
+        mq_client: MessageQueueClient,
+        health_event: threading.Event,
+        interval: float = DEFAULT_HEARTBEAT_INTERVAL,
+        instance_id: int | None = None,
+    ):
+        """
+        Args:
+            mq_client: The message queue client used to send PING requests.
+            health_event: A threading.Event shared with the adapter.
+                Set when the server is healthy, cleared when unhealthy.
+                Adapters check this event to decide whether to proceed
+                with operations or enter degraded mode.
+            interval: Seconds between heartbeat pings and ping timeout.
+            instance_id: The worker's instance ID sent with each PING so the
+                server can refresh its liveness, or None for an untracked
+                prober (the scheduler adapter).
+        """
+        super().__init__(
+            name="lmcache-heartbeat",
+            interval=interval,
+            level=ThreadLevel.CRITICAL,
+        )
+        self._mq_client = mq_client
+        self._health_event = health_event
+        self._interval = interval
+        self._instance_id = instance_id
+
+        # Optional callback invoked on the unhealthy->healthy edge,
+        # before the health event is set. See register_recover_callback.
+        def noop() -> bool:
+            return True
+
+        self._recover_callback: Callable[[], bool] = noop
+
+    def register_recover_callback(self, callback: Callable[[], bool]) -> None:
+        """Register a callback fired on the unhealthy->healthy transition.
+
+        The callback runs **before** the health event is set. It must
+        return ``True`` on success (event will be set) or ``False`` on
+        failure (event will stay cleared, and the next heartbeat will
+        invoke the callback again on the next successful PING).
+
+        The callback function should NEVER raise exceptions.
+
+        Intended for setup work that must complete before downstream
+        callers observe the recovery — for example, re-registering KV
+        caches with a server that just restarted.
+
+        Should be called before :meth:`start`. Only one callback is
+        supported; a second call replaces the first.
+
+        Args:
+            callback: Zero-arg callable returning a success bool.
+        """
+        self._recover_callback = callback
+
+    def _execute(self) -> ThreadRunSummary:
+        """Run one heartbeat cycle: ping, recover callback, event update.
+
+        A cycle that observes a stop request returns without firing the
+        callback or touching the event — a straggler success after
+        UNREGISTER must not re-register a ghost context.
+        """
+        was_healthy = self._health_event.is_set()
+        healthy = send_ping(
+            self._mq_client, timeout=self._interval, instance_id=self._instance_id
+        )
+
+        if self.stop_requested:
+            return ThreadRunSummary(
+                success=True,
+                message="stop requested; skipping health update",
+            )
+
+        need_trigger_recover = (
+            healthy and not was_healthy and self._recover_callback is not None
+        )
+
+        # Try to call recover callback
+        if need_trigger_recover:
+            logger.warning(
+                "LMCache server is healthy again, triggering recovery callback"
+            )
+            # If the callback fails, it should not become healthy
+            healthy = self._recover_callback()
+
+        if healthy:
+            self._health_event.set()
+            if not was_healthy:
+                logger.warning(
+                    "LMCache server is healthy again — resuming normal operation"
+                )
+        else:
+            self._health_event.clear()
+            if was_healthy:
+                logger.warning("LMCache server is unhealthy — entering degraded mode")
+
+        return ThreadRunSummary(
+            success=True,
+            message="healthy" if healthy else "unhealthy",
+        )
+
+
+@dataclass
+class LoadStoreOp:
+    token_ids: list[int]
+    """Token IDs for the load/store operation"""
+
+    block_ids: list[list[int]]
+    """Block IDs for the load/store operation, indexed by engine KV cache
+    group (one inner list per engine group). Worker submit paths expand
+    this to LMCache KV group order before sending requests to the server.
+    """
+
+    start: int = 0
+    """Start token index"""
+
+    end: int = 0
+    """End token index"""
+
+    skip_first_n_tokens: int = 0
+    """Number of tokens to skip writing at the beginning of the retrieve
+    range. Used to avoid overwriting APC-shared GPU blocks during retrieve."""
+
+    @property
+    def flat_block_ids(self) -> list[int]:
+        """Return all block IDs flattened for group-blind error paths.
+
+        Handles both the normal ``list[list[int]]`` format and the
+        IPC-flattened ``list[int]`` format that vLLM v0.19.0 produces when
+        ``SchedulerOutput`` serializes single-element nested lists across
+        process boundaries (e.g. ``[[20, 21]]`` → ``[20, 21]``).
+        Returns an empty list when ``block_ids`` is empty.
+        """
+        if not self.block_ids:
+            return []
+        # Defend against IPC serialization flattening [[20, 21, …]] → [20, 21, …]
+        if isinstance(self.block_ids[0], int):
+            return list(self.block_ids)
+        return [
+            block_id
+            for group_block_ids in self.block_ids
+            for block_id in group_block_ids
+        ]
+
+
+StoreResult = bool
+RetrieveResult = bool
+LookupResult = int
+
+
+class LMCacheMPSchedulerAdapter:
+    def __init__(
+        self,
+        server_urls: list[str],
+        context: zmq.Context,
+        model_name: str,
+        vllm_block_size: int,
+        parallel_strategy: ParallelStrategy | int,
+        legacy_block_size: int | None = None,
+        *,
+        mq_timeout: float = DEFAULT_MQ_TIMEOUT,
+        heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
+        extra_config: dict[str, Any] | None = None,
+    ):
+        """
+        Args:
+            server_urls: The servers URL for the LMCache message queue
+            context: The ZMQ context
+            model_name: The model name used for LMCache keys
+            vllm_block_size: The block size used in vLLM
+            parallel_strategy:
+                The parallel strategy, which includes `mla_only`,
+                `kv_world_size`, `kv_worker_id` and so on. Older vLLM
+                connectors pass the KV worker id here.
+            legacy_block_size: The vLLM block size passed positionally by
+                older vLLM connectors.
+            mq_timeout: Timeout in seconds for message queue requests.
+                Ignored when ``extra_config`` is provided.
+            heartbeat_interval: Interval in seconds between heartbeat pings.
+                Ignored when ``extra_config`` is provided.
+            extra_config: Optional dict with keys starting with
+                ``lmcache.mp.`` (e.g., ``lmcache.mp.mq_timeout``). When
+                provided, it overrides ``mq_timeout`` / ``heartbeat_interval``.
+        """
+        vllm_block_size, parallel_strategy, mq_timeout = _normalize_adapter_init_args(
+            vllm_block_size,
+            parallel_strategy,
+            legacy_block_size,
+            mq_timeout,
+        )
+        assert len(server_urls) >= 1, "At least one server url required"
+        self._server_urls: list[str] = list(server_urls)
+        self.mq_clients: dict[str, MessageQueueClient] = {
+            url: MessageQueueClient(url, context) for url in self._server_urls
+        }
+        if extra_config is not None:
+            cfg = _resolve_extra_config(extra_config)
+            mq_timeout = cfg[ExtraConfigDefault.mq_timeout.name]
+            heartbeat_interval = cfg[ExtraConfigDefault.heartbeat_interval.name]
+        self._mq_timeout = mq_timeout
+
+        # Lookup state tracking:
+        # - _pending_lookups: request_ids submitted but not yet resolved
+        # - _finished_lookup_results: cached chunk count keyed by request_id,
+        #   so that repeated calls to check_lookup_result return the same value
+        #   even after the server has already popped the job (exactly-once).
+        # - _per_server_hits: {request_id: {server_url: hit_chunks}}.
+        #   Per-server hit counts, used to detect disagreement and free tail locks.
+        self._pending_lookups: set[str] = set()
+        self._finished_lookup_results: dict[str, int] = {}
+        self._per_server_hits: dict[str, dict[str, int]] = {}
+        self._lookup_params: dict[str, tuple[list[int], str]] = {}
+
+        self.model_name = model_name
+        self.parallel_strategy = parallel_strategy
+
+        # Read chunk size from lmcache
+        chunk_sizes: dict[str, int] = {}
+        for url, client in self.mq_clients.items():
+            try:
+                chunk_sizes[url] = get_lmcache_chunk_size(
+                    client, timeout=self._mq_timeout
+                )
+            except TimeoutError:
+                for c in self.mq_clients.values():
+                    c.close()
+                _raise_server_unreachable(url, self._mq_timeout)
+
+        # All servers must share chunk_size, otherwise the min() aggregation
+        # over per-server hits would mix different granularities.
+        unique_sizes = set(chunk_sizes.values())
+        if len(unique_sizes) != 1:
+            raise ValueError(
+                f"All LMCache servers must share the same chunk_size, got {chunk_sizes}"
+            )
+        self.lmcache_tokens_per_chunk = unique_sizes.pop()
+
+        assert self.lmcache_tokens_per_chunk % vllm_block_size == 0, (
+            "LMCache chunk size should be a multiple of vLLM block size"
+        )
+        self.blocks_in_chunk = self.lmcache_tokens_per_chunk // vllm_block_size
+
+        # Health state: one Event per server. The adapter is considered healthy
+        # only if ALL per-server events are set (any unhealthy server taints
+        # the whole adapter, matching the min() semantics used for lookups).
+        self._health_events: dict[str, threading.Event] = {}
+        for url in self._server_urls:
+            ev = threading.Event()
+            ev.set()
+            self._health_events[url] = ev
+
+        # Heartbeat thread is created but NOT started yet.
+        # It will be lazily started on the first lookup
+        # request, by which time vLLM is fully ready.
+        self._heartbeat_interval = heartbeat_interval
+        self._heartbeats: dict[str, HeartbeatThread] = {}
+        self._heartbeats_started = False
+        self._heartbeat_lock = threading.Lock()
+
+        # For TP/PP: track partial store completions across steps.
+        # Events must be reported by all world_size workers before considered complete.
+        self._expected_worker_count = parallel_strategy.vllm_world_size
+        self._store_request_pending_counts: dict[str, int] = {}
+
+    @property
+    def world_size(self) -> int:
+        """Get the kv world size."""
+        return self.parallel_strategy.kv_world_size
+
+    @property
+    def tp_size(self) -> int:
+        """The tensor parallel size."""
+        return self.parallel_strategy.kv_tp_size
+
+    @property
+    def is_healthy(self) -> bool:
+        """True iff every backing LMCache server is healthy."""
+        return all(ev.is_set() for ev in self._health_events.values())
+
+    def _ensure_heartbeat_started(self) -> None:
+        """Lazily start the heartbeat thread on first use."""
+        if self._heartbeats_started:
+            return
+        with self._heartbeat_lock:
+            if self._heartbeats_started:
+                return
+            for url, client in self.mq_clients.items():
+                if url in self._heartbeats:
+                    continue
+                hb = HeartbeatThread(
+                    mq_client=client,
+                    health_event=self._health_events[url],
+                    interval=self._heartbeat_interval,
+                )
+                hb.start()
+                self._heartbeats[url] = hb
+            self._heartbeats_started = True
+
+    @_lmcache_nvtx_annotate
+    def maybe_submit_lookup_request(
+        self,
+        request_id: str,
+        token_ids: list[int],
+        cache_salt: str = "",
+    ):
+        """
+        Submit a new lookup request to LMCache if there is no ongoing request.
+
+        Sends a LOOKUP request to the server and blocks until a prefetch
+        job ID is returned.  The actual prefetch result can then be polled
+        via ``check_lookup_result``.
+
+        Args:
+            request_id: The ID of the lookup request. The same ID indicates it's
+                from the same request
+            token_ids: Token IDs to lookup from LMCache
+            cache_salt: Per-user isolation salt. Requests with different
+                cache_salt values produce separate cache entries.
+
+        Returns:
+            None
+
+        Notes:
+            This function will have a side-effect: submitting a look up request to
+            LMCache, which will essentially 'lock' the KV cache chunks in the LMCache
+            for later retrieve operations.
+            In the meantime, this function will record the lookup request, and the
+            status of the look up request can be checked by `check_lookup_result`.
+        """
+        self._ensure_heartbeat_started()
+
+        if not self.is_healthy:
+            return
+
+        if request_id in self._pending_lookups:
+            # Skip if there is already a lookup request
+            return
+
+        aligned_end = (
+            len(token_ids) // self.lmcache_tokens_per_chunk
+        ) * self.lmcache_tokens_per_chunk
+
+        key = self._create_key(
+            token_ids,
+            start=0,
+            end=aligned_end,
+            request_id=request_id,
+            cache_salt=cache_salt,
+        ).no_worker_id_version()
+
+        futures: dict[str, MessagingFuture[Any]] = {
+            url: send_lmcache_request(
+                self.mq_clients[url],
+                RequestType.LOOKUP,
+                [key, self.tp_size],
+            )
+            for url in self._server_urls
+        }
+
+        # Any one server failure means the whole lookup fails.
+        for url, fut in futures.items():
+            try:
+                fut.result(timeout=self._mq_timeout)
+            except TimeoutError:
+                logger.warning(
+                    "LOOKUP to %s timed out after %ss. Marking server as unhealthy.",
+                    url,
+                    self._mq_timeout,
+                )
+                self._health_events[url].clear()
+                return
+
+        self._pending_lookups.add(request_id)
+        self._lookup_params[request_id] = (token_ids, cache_salt)
+
+    def _free_inconsistent_lookup_locks(
+        self,
+        request_id: str,
+        per_server: dict[str, int],
+        min_chunks: int,
+    ) -> None:
+        """Release over-hit tail locks on servers that reported more than min.
+
+        When servers disagree on hit chunk counts, servers reporting more
+        than min_chunks have locked chunks in the range
+        [min_chunks * tokens_per_chunk, hit_chunks * tokens_per_chunk)
+        that will never be retrieved. This method frees those tail locks.
+
+        Args:
+            request_id: The lookup request ID.
+            per_server: Per-server hit chunk counts.
+            min_chunks: Minimum hit chunk count across all servers.
+        """
+        token_ids_l, cs = self._lookup_params.pop(request_id, (None, None))
+        if token_ids_l is not None:
+            for url, hit_chunks in per_server.items():
+                if hit_chunks <= min_chunks:
+                    continue
+                tail_end = min(
+                    hit_chunks * self.lmcache_tokens_per_chunk, len(token_ids_l)
+                )
+                tail_key = self._create_key(
+                    token_ids=token_ids_l,
+                    start=min_chunks * self.lmcache_tokens_per_chunk,
+                    end=tail_end,
+                    request_id=request_id,
+                    cache_salt=cs or "",
+                ).no_worker_id_version()
+                send_lmcache_request(
+                    self.mq_clients[url],
+                    RequestType.FREE_LOOKUP_LOCKS,
+                    [tail_key, self.tp_size],
+                )
+
+    @_lmcache_nvtx_annotate
+    def check_lookup_result(self, request_id: str) -> int | None:
+        """
+        Check the result of a previously submitted lookup request.
+
+        Sends a QUERY_PREFETCH_STATUS request to the servers and blocks
+        until the server responds.  Returns the matched token count
+        when the prefetch is complete, or None if still in progress.
+
+        Args:
+            request_id: The ID of the lookup request submitted in
+                `maybe_submit_lookup_request`
+
+        Returns:
+            An integer representing the total number of tokens matched
+            in LMCache (prefix matching), or
+            None if the lookup request is not finished yet.
+        """
+        if request_id not in self._pending_lookups:
+            # No job — either unhealthy at submit time or already cleaned up.
+            # Return the cached aggregate if any, otherwise 0.
+            return self._finished_lookup_results.get(request_id, 0)
+
+        if not self.is_healthy:
+            # Server went down — give up on this lookup
+            return 0
+
+        if request_id in self._finished_lookup_results:
+            # Aggregation already done; return the cached value.
+            return self._finished_lookup_results[request_id]
+
+        # Persistent accumulator for this request. A server present in
+        # the dict has already handed over its final hit count and must
+        # not be polled again; absence means "not yet observed".
+        per_server = self._per_server_hits.setdefault(request_id, {})
+        unresolved_urls = [u for u in self._server_urls if u not in per_server]
+
+        futures: dict[str, MessagingFuture[Any]] = {
+            url: send_lmcache_request(
+                self.mq_clients[url],
+                RequestType.QUERY_PREFETCH_STATUS,
+                [request_id],
+            )
+            for url in unresolved_urls
+        }
+
+        for url, fut in futures.items():
+            try:
+                r = fut.result(timeout=self._mq_timeout)
+            except TimeoutError:
+                logger.warning(
+                    "QUERY_PREFETCH_STATUS to %s timed out. Marking unhealthy.",
+                    url,
+                )
+                self._health_events[url].clear()
+                return 0
+            if r is None:
+                continue
+            per_server[url] = int(r)
+
+        if len(per_server) < len(self._server_urls):
+            return None
+
+        min_chunks = min(per_server.values())
+        max_chunks = max(per_server.values())
+        if min_chunks != max_chunks:
+            logger.warning(
+                "[req=%s] LMCache hit mismatch across servers: %s → take min=%d",
+                request_id,
+                dict(per_server),
+                min_chunks,
+            )
+            self._free_inconsistent_lookup_locks(request_id, per_server, min_chunks)
+
+        token_count = min_chunks * self.lmcache_tokens_per_chunk
+
+        self._finished_lookup_results[request_id] = token_count
+        return token_count
+
+    def num_blocks_per_chunk(self) -> int:
+        """
+        Returns:
+            The number of vllm blocks in a LMCache data chunk
+        """
+        return self.blocks_in_chunk
+
+    def cleanup_lookup_result(self, request_id: str) -> None:
+        """
+        Clean up lookup state for a finished request to prevent memory leak.
+        Args:
+            request_id: The ID of the finished request.
+        """
+        self._pending_lookups.discard(request_id)
+        self._finished_lookup_results.pop(request_id, None)
+        self._per_server_hits.pop(request_id, None)
+        self._lookup_params.pop(request_id, None)
+
+    def shutdown(self) -> None:
+        """Shutdown the scheduler adapter and its resources."""
+        for client in self.mq_clients.values():
+            client.close()
+        with self._heartbeat_lock:
+            for hb in self._heartbeats.values():
+                hb.stop()
+
+    def free_lookup_locks(
+        self,
+        token_ids: list[int],
+        start: int,
+        end: int,
+        request_id: str,
+        cache_salt: str = "",
+    ) -> None:
+        """Release read locks acquired during lookup without a full retrieve.
+
+        Use this when some chunks matched by lookup overlap with blocks that
+        vLLM has already computed, so they will never be retrieved.  Calling
+        this prevents those chunks from holding read locks until TTL expiry.
+
+        Or use this when a request is cancelled or aborted after lookup but
+        before retrieve to avoid holding read locks until TTL expiry.
+
+        When ``start`` or ``end`` is not aligned to the chunk size, the
+        entire chunk containing start boundary is freed but not end boundary.
+        It is caller's responsibility to properly align the boundaries.
+
+        Args:
+            token_ids: Token IDs for the key (same as used in lookup).
+            start: Start token index.
+            end: End token index.
+            request_id: The request ID.
+            cache_salt: Per-user isolation salt.
+        """
+        if not self.is_healthy:
+            return
+
+        # Free [start, end) on every server.
+        base_key = self._create_key(
+            token_ids,
+            start=start,
+            end=end,
+            request_id=request_id,
+            cache_salt=cache_salt,
+        ).no_worker_id_version()
+        for url in self._server_urls:
+            send_lmcache_request(
+                self.mq_clients[url],
+                RequestType.FREE_LOOKUP_LOCKS,
+                [base_key, self.tp_size],
+            )
+
+    def end_session(self, request_id: str) -> None:
+        """
+        Notify LMCache server to remove the session for a finished request.
+        Args:
+            request_id: The ID of the finished request.
+        """
+        if not self.is_healthy:
+            return
+
+        for url in self._server_urls:
+            send_lmcache_request(
+                self.mq_clients[url],
+                RequestType.END_SESSION,
+                [request_id],
+            )
+
+    def report_block_allocations(
+        self,
+        records: list[BlockAllocationRecord],
+    ) -> None:
+        """Report vLLM GPU block allocation deltas to LMCache server.
+
+        Fire-and-forget: does not wait for a response. If the server
+        is unhealthy the report is silently dropped.
+
+        Args:
+            records: List of BlockAllocationRecord with per-request
+                block and token allocation deltas.
+        """
+        if not self.is_healthy or not records:
+            return
+
+        for url in self._server_urls:
+            send_lmcache_request(
+                self.mq_clients[url],
+                RequestType.REPORT_BLOCK_ALLOCATION,
+                [os.getpid(), self.model_name, records],
+            )
+
+    # Helper functions
+    def _create_key(
+        self,
+        token_ids: list[int],
+        start: int,
+        end: int,
+        request_id: str,
+        cache_salt: str = "",
+    ) -> IPCCacheServerKey:
+        """Convert token IDs to an IPC cache engine key.
+
+        Args:
+            token_ids: The token IDs.
+            start: Start token index.
+            end: End token index.
+            request_id: The request ID.
+            cache_salt: Per-user isolation salt.
+
+        Returns:
+            IPCCacheServerKey: The constructed key.
+        """
+        # NOTE: for the scheduler adapter, we don't have a worker id,
+        # so we set it to None in the key.
+        return IPCCacheServerKey(
+            model_name=self.model_name,
+            world_size=self.world_size,
+            worker_id=None,
+            token_ids=tuple(token_ids),
+            start=start,
+            end=end,
+            request_id=request_id,
+            cache_salt=cache_salt,
+        )
+
+    def update_pending_store_count(self, req_id: str, count: int) -> bool:
+        """
+        Update the pending store count for a request.
+
+        Args:
+            req_id: The request ID.
+            count: The number of workers that have finished the request.
+
+        Returns:
+            True if the store request is finished, False otherwise.
+        """
+        total = self._store_request_pending_counts.get(req_id, 0) + count
+        if total >= self._expected_worker_count:
+            self._store_request_pending_counts.pop(req_id, None)
+            return True
+        else:
+            self._store_request_pending_counts[req_id] = total
+            return False
+
+
+class LMCacheMPWorkerAdapter:
+    def __init__(
+        self,
+        server_url: str,
+        context: zmq.Context,
+        model_name: str,
+        vllm_block_size: int,
+        parallel_strategy: ParallelStrategy | int,
+        legacy_block_size: int | None = None,
+        *,
+        mq_timeout: float = DEFAULT_MQ_TIMEOUT,
+        heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
+        extra_config: dict[str, Any] | None = None,
+    ):
+        """Initialize the worker adapter for current or legacy vLLM callers.
+
+        Args:
+            server_url: The server URL for the LMCache message queue.
+            context: The ZMQ context.
+            model_name: The model name used for LMCache keys.
+            vllm_block_size: The block size used in vLLM, or legacy KV world
+                size when ``parallel_strategy`` is an int.
+            parallel_strategy: Current ``ParallelStrategy`` metadata, or the
+                legacy KV worker id from older vLLM connectors.
+            legacy_block_size: The vLLM block size passed positionally by
+                older vLLM connectors.
+            mq_timeout: Timeout in seconds for message queue requests.
+                Ignored when ``extra_config`` is provided.
+            heartbeat_interval: Interval in seconds between heartbeat pings.
+                Ignored when ``extra_config`` is provided.
+            extra_config: Optional dict with keys starting with
+                ``lmcache.mp.`` (e.g., ``lmcache.mp.mq_timeout``). When
+                provided, it overrides ``mq_timeout`` / ``heartbeat_interval``.
+
+        Raises:
+            TypeError: If the connector argument shape is unsupported.
+        """
+        vllm_block_size, parallel_strategy, mq_timeout = _normalize_adapter_init_args(
+            vllm_block_size,
+            parallel_strategy,
+            legacy_block_size,
+            mq_timeout,
+        )
+        if extra_config is not None:
+            cfg = _resolve_extra_config(extra_config)
+            mq_timeout = cfg[ExtraConfigDefault.mq_timeout.name]
+            heartbeat_interval = cfg[ExtraConfigDefault.heartbeat_interval.name]
+            # Only treat ``mp_transfer_mode`` as an explicit override when
+            # the user actually set it in extra_config; otherwise leave it
+            # as ``None`` so ``create_transfer_context`` can still consult
+            # the ``LMCACHE_MP_TRANSFER_MODE`` env var.
+            mp_mode_key = (
+                _EXTRA_CONFIG_KEY_PREFIX + ExtraConfigDefault.mp_transfer_mode.name
+            )
+            if mp_mode_key in extra_config:
+                self._mp_transfer_mode = cfg[ExtraConfigDefault.mp_transfer_mode.name]
+            else:
+                self._mp_transfer_mode = None
+        else:
+            self._mp_transfer_mode = None
+        self.mq_client = MessageQueueClient(server_url, context)
+        self._mq_timeout = mq_timeout
+
+        # Instance id for GPU worker. uuid4-derived (OS entropy) rather
+        # than os.getpid() to avoid collision in containerized deployments.
+        # Masked to 63 bits to stay signed-int64-safe for any msgpack peer.
+        self.instance_id: int = uuid.uuid4().int & ((1 << 63) - 1)
+        logger.info(
+            "LMCache MP worker adapter created with instance_id=%d",
+            self.instance_id,
+        )
+
+        # Registered kv caches from vLLM
+        self.kv_caches: dict[str, torch.Tensor] = {}
+        self.engine_group_infos: list[EngineGroupInfo] = []
+
+        # Transport context for transfer operations.
+        self.transfer_ctx: TransferContext | None = None
+
+        # Request futures
+        self.store_futures: dict[str, MessagingFuture[StoreResult]] = {}
+        # request_id -> (future, block_ids)
+        self.retrieve_futures: dict[
+            str, tuple[MessagingFuture[RetrieveResult], list[int]]
+        ] = {}
+        # The IPC handle is not enough by itself; CUDA needs the exporting
+        # event object to stay alive until the consumer is done with it.
+        self.store_events: dict[str, _IpcEvent] = {}
+        self.retrieve_events: dict[str, _IpcEvent] = {}
+
+        # Block IDs that failed due to retrieve timeout
+        self.error_block_ids: set[int] = set()
+
+        # Retrieve request ids dropped by the unhealthy early-return of
+        # submit_retrieve_request. get_finished must still report each id
+        # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS.
+        self._dropped_retrieves: set[str] = set()
+
+        # The store requests that have finished execution in LMCache
+        self.finished_stores: set[str] = set()
+        # The finished request ids that are passed via vLLM and also
+        # have corresponding store requests submitted to LMCache before
+        self.previously_finished: set[str] = set()
+        # Request IDs already returned as finished_sending to the scheduler.
+        # Prevents re-reporting the same ID after drain clears tracking sets.
+        self._returned_finished: set[str] = set()
+
+        self.model_name = model_name
+        self.parallel_strategy = parallel_strategy
+
+        # Read chunk size from lmcache
+        try:
+            lmcache_tokens_per_chunk = get_lmcache_chunk_size(
+                self.mq_client, timeout=self._mq_timeout
+            )
+        except TimeoutError:
+            self.mq_client.close()
+            _raise_server_unreachable(server_url, self._mq_timeout)
+        self.lmcache_tokens_per_chunk = lmcache_tokens_per_chunk
+        assert lmcache_tokens_per_chunk % vllm_block_size == 0, (
+            "LMCache chunk size should be a multiple of vLLM block size"
+        )
+        self.blocks_in_chunk = lmcache_tokens_per_chunk // vllm_block_size
+
+        # Experimental intermediate tensor transfer
+        self.experimental: set[str] = get_experimental(
+            self.mq_client, timeout=self._mq_timeout
+        )
+        self.dispatcher: Dispatcher | None = None
+
+        # Health state (shared with heartbeat thread)
+        self._health_event = threading.Event()
+        self._health_event.set()
+
+        # Heartbeat thread is created but NOT started yet.
+        # It will be lazily started on the first store or retrieve
+        # request, by which time vLLM is fully ready (model loaded,
+        # KV caches allocated, warmup & CUDA graph capture done).
+        self._heartbeat_interval = heartbeat_interval
+        self._heartbeat: HeartbeatThread | None = None
+        self._heartbeat_lock = threading.Lock()
+        if 3 * heartbeat_interval > _SERVER_REAP_TIMEOUT_FLOOR_SECONDS:
+            logger.warning(
+                "lmcache.mp.heartbeat_interval is %.1fs, so 3 x "
+                "heartbeat_interval (%.1fs) exceeds the MP server's "
+                "default worker reap timeout floor (%.1fs). Raise the "
+                "server's worker reap timeout to at least 3 x the "
+                "heartbeat interval, or the server may reap this "
+                "worker between heartbeats.",
+                heartbeat_interval,
+                3 * heartbeat_interval,
+                _SERVER_REAP_TIMEOUT_FLOOR_SECONDS,
+            )
+
+        # request telemetry, used for prefill-decode disagg
+        # TODO: pass down the configuration via vLLM connector config
+        # instead of env var
+        self.request_telemetry = RequestTelemetryFactory.create(
+            telemetry_type=os.getenv("LMCACHE_REQUEST_TELEMETRY_TYPE", "noop"),
+            config={
+                "endpoint": os.getenv(
+                    "LMCACHE_REQUEST_TELEMETRY_ENDPOINT",
+                    "http://localhost:5768/api/v1/telemetry",
+                ),
+            },
+        )
+
+        self.lazy_offload = (
+            extra_config.get("lmcache.mp.lazy_offload", False)
+            if extra_config
+            else False
+        )
+
+        # Completed store requests to report via build_connector_worker_meta
+        self._completed_store_requests: dict[str, int] = {}
+
+    @property
+    def is_healthy(self) -> bool:
+        """Whether the LMCache server is healthy.
+
+        Reflects the most recent heartbeat result. KV cache
+        re-registration on the unhealthy->healthy transition is handled
+        by the heartbeat thread itself via ``register_recover_callback``,
+        so this property only reads the shared event.
+        """
+        return self._health_event.is_set()
+
+    @property
+    def world_size(self) -> int:
+        """Get the kv world size."""
+        return self.parallel_strategy.kv_world_size
+
+    @property
+    def worker_id(self) -> int:
+        """Get the kv worker id."""
+        return self.parallel_strategy.kv_worker_id
+
+    @property
+    def is_kv_writer(self) -> bool:
+        """Whether this worker is responsible for storing KV."""
+        return self.parallel_strategy.is_kv_writer
+
+    def register_kv_caches(
+        self,
+        kv_caches: dict[str, torch.Tensor],
+        engine_group_infos: Sequence[EngineGroupInfo] = (),
+    ) -> None:
+        """
+        Register the kv caches with LMCache server.
+
+        Args:
+            kv_caches: A dict of kv caches to register. The keys are the
+                layer names and the values are the corresponding tensors.
+            engine_group_infos: LMCache-owned engine KV cache group metadata.
+
+        Raises:
+            ConnectionError: if the server does not respond within
+                mq_timeout.
+            ValueError: if the LMCache chunk size is not a multiple of an
+                engine group's ``tokens_per_block`` (chunk boundaries would
+                not align with that group's paged-chunk boundaries).
+        """
+        logger.info("Registering kv caches")
+        for info in engine_group_infos:
+            if (
+                info.tokens_per_block > 0
+                and self.lmcache_tokens_per_chunk % info.tokens_per_block
+            ):
+                raise ValueError(
+                    f"LMCache chunk size {self.lmcache_tokens_per_chunk} must be a "
+                    f"multiple of engine group {info.engine_group_id} "
+                    f"tokens_per_block {info.tokens_per_block}"
+                )
+        self.kv_caches = kv_caches
+        self.engine_group_infos = list(engine_group_infos)
+        self._send_register_kv_caches_request(kv_caches)
+
+    def _block_ids_per_group(self, op: LoadStoreOp) -> list[list[int]]:
+        return expand_engine_block_ids(self.engine_group_infos, op.block_ids)
+
+    def _send_register_kv_caches_request(
+        self,
+        kv_caches: dict[str, torch.Tensor],
+    ) -> None:
+        """Submit a REGISTER_KV_CACHE request and wait for the response.
+
+        Shared by the public ``register_kv_caches`` entry point and the
+        heartbeat recovery path (``_reregister_kv_caches_callback``).
+
+        Args:
+            kv_caches: The KV cache dict to register.
+
+        Raises:
+            ConnectionError: if the server does not respond within
+                mq_timeout.
+        """
+        self.kv_caches = kv_caches
+        transfer_ctx = create_transfer_context(kv_caches, mode=self._mp_transfer_mode)
+        layout_hints = vllm_layout_hints()
+        self.transfer_ctx = transfer_ctx
+        try:
+            # Register on the local, not self.transfer_ctx: a concurrent
+            # shutdown() may null self.transfer_ctx between publish and this
+            # call. The local is always non-None.
+            transfer_ctx.register(
+                self.instance_id,
+                kv_caches,
+                self.model_name,
+                self.world_size,
+                self.blocks_in_chunk,
+                self.mq_client,
+                self._mq_timeout,
+                send_request=send_lmcache_request,
+                layout_hints=layout_hints,
+                engine_group_infos=self.engine_group_infos,
+                engine_type=EngineType.VLLM,
+            )
+        except CuMemIPCUnsupportedError:
+            resolved_mode = _resolve_mode(self._mp_transfer_mode)
+            if resolved_mode is MPTransferMode.LMCACHE_DRIVEN:
+                raise
+            if resolved_mode is not MPTransferMode.AUTO:
+                raise
+            logger.warning(
+                "cuMem CUDA IPC is unavailable; falling back to engine-driven "
+                "before registration"
+            )
+            transfer_ctx.close()
+            transfer_ctx = create_transfer_context(
+                kv_caches, mode=MPTransferMode.ENGINE_DRIVEN
+            )
+            self.transfer_ctx = transfer_ctx
+            transfer_ctx.register(
+                self.instance_id,
+                kv_caches,
+                self.model_name,
+                self.world_size,
+                self.blocks_in_chunk,
+                self.mq_client,
+                self._mq_timeout,
+                send_request=send_lmcache_request,
+                layout_hints=layout_hints,
+                engine_group_infos=self.engine_group_infos,
+                engine_type=EngineType.VLLM,
+            )
+        except TimeoutError:
+            raise ConnectionError(
+                "LMCache server did not respond to "
+                "register_kv_caches within "
+                f"{self._mq_timeout}s. Is the server running?"
+            ) from None
+
+    def _ensure_heartbeat_started(self) -> None:
+        """Lazily start the heartbeat thread on first store/retrieve.
+
+        The heartbeat starts healthy (the event was set at construction). A
+        live worker pings every interval, refreshing its server-side
+        ``last_seen``, so it is never reaped while alive -- no re-registration
+        is needed at startup, and the first store/retrieve is not gated. The
+        recover callback still re-registers on a genuine unhealthy->healthy
+        edge (server restart).
+        """
+        if self._heartbeat is not None:
+            return
+        with self._heartbeat_lock:
+            if self._heartbeat is not None:
+                return
+            heartbeat = HeartbeatThread(
+                mq_client=self.mq_client,
+                health_event=self._health_event,
+                interval=self._heartbeat_interval,
+                instance_id=self.instance_id,
+            )
+            heartbeat.register_recover_callback(self._reregister_kv_caches_callback)
+            heartbeat.start()
+            self._heartbeat = heartbeat
+
+    def _heartbeat_stop_requested(self) -> bool:
+        """Whether a created heartbeat thread has a stop requested.
+
+        Returns:
+            ``True`` only if a heartbeat exists and its stop was requested.
+        """
+        heartbeat = self._heartbeat
+        return heartbeat is not None and heartbeat.stop_requested
+
+    def _reregister_kv_caches_callback(self) -> bool:
+        """Heartbeat recover callback: re-register KV caches after the
+        server returns. Runs on the heartbeat thread, before the health
+        event is set.
+
+        Returns:
+            ``True`` if nothing needs re-registering or registration
+            succeeds; ``False`` on failure or a requested heartbeat stop
+            (event stays cleared; retried on the next successful PING).
+        """
+        if not self.kv_caches:
+            # Nothing was registered yet (server flapped before the
+            # very first register_kv_caches). Treat as success so the
+            # health event can be set.
+            return True
+
+        # Skip the rebuild if a shutdown already requested the heartbeat stop.
+        if self._heartbeat_stop_requested():
+            logger.info("Heartbeat stop requested; skipping KV cache re-registration")
+            return False
+
+        try:
+            self._send_register_kv_caches_request(self.kv_caches)
+        except ConnectionError:
+            logger.exception(
+                "Failed to re-register KV caches after server recovery; "
+                "will retry on next heartbeat"
+            )
+            return False
+        except Exception:
+            logger.exception(
+                "Unexpected error during KV cache re-registration; "
+                "will retry on next heartbeat"
+            )
+            return False
+        logger.warning("Finished re-registering KV caches after server recovery")
+
+        if self.dispatcher is not None and not self.dispatcher.reregister():
+            logger.warning(
+                "Failed to re-register dispatcher after server recovery; "
+                "will retry on next heartbeat"
+            )
+            return False
+
+        return True
+
+    @_lmcache_nvtx_annotate
+    def submit_store_request(
+        self,
+        request_id: str,
+        op: LoadStoreOp,
+        event: _IpcEvent,
+        cache_salt: str = "",
+    ):
+        """
+        Submit a KV cache store request to LMCache
+
+        Args:
+            request_id: The ID of the request
+            op: The LoadStoreOp describing the store operation.
+            event: The CUDA event that is recorded after the current
+                model inference step
+            cache_salt: Per-user isolation salt.
+        """
+        self._ensure_heartbeat_started()
+
+        if not self.is_kv_writer:
+            return
+
+        if not self.is_healthy:
+            return
+
+        assert op.token_ids is not None
+        key = self._create_key(
+            op.token_ids,
+            op.start,
+            op.end,
+            request_id=request_id,
+            cache_salt=cache_salt,
+        )
+        if self.transfer_ctx is None:
+            raise RuntimeError(
+                "Transfer context is not initialized. "
+                "Call register_kv_caches() before submitting store requests."
+            )
+        future = self.transfer_ctx.submit_store(
+            request_id,
+            key,
+            self.instance_id,
+            self.kv_caches,
+            self._block_ids_per_group(op),
+            event,
+            self.blocks_in_chunk,
+        )
+        self.store_futures[request_id] = future
+        self.store_events[request_id] = event
+
+    @_lmcache_nvtx_annotate
+    def submit_retrieve_request(
+        self,
+        request_id: str,
+        op: LoadStoreOp,
+        event: _IpcEvent,
+        cache_salt: str = "",
+    ) -> None:
+        """
+        Submit a KV cache retrieve request to LMCache
+
+        When the server is unhealthy the request is not submitted: blocks
+        are flagged via ``error_block_ids`` (vLLM recomputes) and the id is
+        recorded so ``get_finished`` still reports it exactly once.
+
+        Args:
+            request_id: The ID of the request
+            op: The LoadStoreOp describing the retrieve operation.
+            event: The CUDA event that is recorded after the current
+                model inference step
+            cache_salt: Per-user isolation salt.
+        """
+        self._ensure_heartbeat_started()
+
+        if not self.is_healthy:
+            self.error_block_ids.update(op.flat_block_ids)
+            self._dropped_retrieves.add(request_id)
+            return
+
+        assert op.token_ids is not None
+        key = self._create_key(
+            op.token_ids,
+            op.start,
+            op.end,
+            request_id=request_id,
+            cache_salt=cache_salt,
+        )
+        if self.transfer_ctx is None:
+            raise RuntimeError(
+                "Transfer context is not initialized. "
+                "Call register_kv_caches() before submitting retrieve requests."
+            )
+        future = self.transfer_ctx.submit_retrieve(
+            request_id,
+            key,
+            self.instance_id,
+            self.kv_caches,
+            self._block_ids_per_group(op),
+            event,
+            self.blocks_in_chunk,
+            skip_first_n_tokens=op.skip_first_n_tokens,
+        )
+        self.retrieve_futures[request_id] = (future, op.flat_block_ids)
+        self.retrieve_events[request_id] = event
+
+    @_lmcache_nvtx_annotate
+    def batched_submit_store_requests(
+        self,
+        request_ids: list[str],
+        ops: list[LoadStoreOp],
+        event: _IpcEvent,
+        cache_salts: list[str] | None = None,
+    ):
+        """
+        Submit a batched store request to LMCache
+
+        Args:
+            request_ids: The IDs of the requests
+            ops: The LoadStoreOps describing the store operations. Should have
+                the same length as request_ids
+            event: The CUDA event that is recorded after the current
+                model inference step
+            cache_salts: Per-user isolation salts, one per request. If None,
+                all requests use cache_salt="". The list length should be the same as
+                request_ids.
+        """
+        if cache_salts is None:
+            cache_salts = [""] * len(request_ids)
+        for request_id, op, salt in zip(request_ids, ops, cache_salts, strict=False):
+            self.submit_store_request(request_id, op, event, cache_salt=salt)
+
+    @_lmcache_nvtx_annotate
+    def batched_submit_retrieve_requests(
+        self,
+        request_ids: list[str],
+        ops: list[LoadStoreOp],
+        event: _IpcEvent,
+        cache_salts: list[str] | None = None,
+    ):
+        """
+        Submit a batched retrieve request to LMCache
+
+        Args:
+            request_ids: The IDs of the requests
+            ops: The LoadStoreOps describing the retrieve operations. Should have
+                the same length as request_ids
+            event: The CUDA event that is recorded after the current
+                model inference step
+            cache_salts: Per-user isolation salts, one per request. If None,
+                all requests use cache_salt="". The list length should be same as
+                request_ids.
+        """
+        if cache_salts is None:
+            cache_salts = [""] * len(request_ids)
+        for request_id, op, salt in zip(request_ids, ops, cache_salts, strict=False):
+            self.submit_retrieve_request(request_id, op, event, cache_salt=salt)
+
+    def _process_finished_stores(
+        self,
+        finished_req_ids_from_lmcache: set[str],
+        finished_req_ids_from_engine: set[str],
+    ) -> set[str]:
+        """Merge LMCache-side and engine-side finished store info."""
+        self.finished_stores.update(finished_req_ids_from_lmcache)
+        ret_stores = set()
+        for req_id in finished_req_ids_from_engine:
+            if req_id in self._returned_finished:
+                continue
+            if req_id in self.finished_stores or req_id in self.store_futures:
+                self.previously_finished.add(req_id)
+            else:
+                ret_stores.add(req_id)
+        ret_stores.update(self._update_and_get_finished_store())
+        self._returned_finished.update(ret_stores)
+        return ret_stores
+
+    @_lmcache_nvtx_annotate
+    def get_finished(
+        self, finished_req_ids_from_engine: set[str]
+    ) -> tuple[set[str] | None, set[str] | None]:
+        """
+        Check and get the finished store and retrieve requests.
+
+        Args:
+            finished_req_ids_from_engine: the set of request ids that are
+                reported as finished from the vLLM engine side.
+
+        Returns:
+            A tuple of two sets:
+            - The first set contains the finished store request ids. The returned
+                store request ids MUST be seen before in the
+                `finished_req_ids_from_engine`.
+            - The second set contains the finished retrieve request ids,
+                including retrieves dropped at submit time while unhealthy
+                (reported exactly once; blocks already in error_block_ids).
+
+        Notes:
+            When enabling async scheduling in vLLM, the same request ID may appear
+            multiple times in `finished_req_ids_from_engine`. The adapter should
+            take care of deduplicating the request IDs and only return the request
+            IDs that have not been returned before.
+        """
+        if self.dispatcher is not None:
+            dispatch(self.dispatcher, "reclaim")
+
+        # If unhealthy, drain all pending futures immediately
+        if not self.is_healthy:
+            finished_stores = set(self.store_futures.keys())
+            finished_retrieves = set()
+            for request_id, (
+                _r_future,
+                r_block_ids,
+            ) in self.retrieve_futures.items():
+                finished_retrieves.add(request_id)
+                self.error_block_ids.update(r_block_ids)
+            self.store_futures.clear()
+            self.retrieve_futures.clear()
+            self.store_events.clear()
+            self.retrieve_events.clear()
+
+            # Retrieves dropped at submit time still must be reported,
+            # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS.
+            # Swap-drain (not update-then-clear): a concurrent
+            # submit_retrieve_request add lands in the old set (reported now)
+            # or the fresh set (reported next call), never lost.
+            dropped = self._dropped_retrieves
+            self._dropped_retrieves = set()
+            finished_retrieves.update(dropped)
+
+            ret_stores = self._process_finished_stores(
+                finished_stores, finished_req_ids_from_engine
+            )
+            # A request may have a pending retrieve AND appear in
+            # finished_req_ids_from_engine (it ran without loading KV after
+            # the server died).  The scheduler processes finished_recving
+            # first and deletes the request, so we must not also report it
+            # in finished_sending.
+            ret_stores -= finished_retrieves
+            return ret_stores, finished_retrieves
+
+        finished_stores = set()
+        finished_retrieves = set()
+        for request_id, s_future in self.store_futures.items():
+            if not s_future.query():
+                continue
+
+            s_result = s_future.result(timeout=60)
+            finished_stores.add(request_id)
+
+            if not s_result:
+                logger.error(
+                    "Something went wrong when processing the "
+                    "store request for request_id=%s",
+                    request_id,
+                )
+
+        for request_id, (r_future, _) in self.retrieve_futures.items():
+            if not r_future.query():
+                continue
+
+            r_result = r_future.result(timeout=60)
+            finished_retrieves.add(request_id)
+
+            if not r_result:
+                logger.error(
+                    "Something went wrong when processing the "
+                    "retrieve request for request_id=%s, result=%s",
+                    request_id,
+                    r_result,
+                )
+
+        # Remove the finished requests from the tracking dicts
+        for request_id in finished_stores:
+            self.store_futures.pop(request_id, None)
+            self.store_events.pop(request_id, None)
+        for request_id in finished_retrieves:
+            self.retrieve_futures.pop(request_id, None)
+            self.retrieve_events.pop(request_id, None)
+
+        # Retrieves dropped while unhealthy still must be reported,
+        # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS. No
+        # finished_sending dedup is needed (unlike the unhealthy branch): a
+        # dropped retrieve's request is parked in WAITING_FOR_REMOTE_KVS until
+        # this report, so it cannot also be engine-finished in the same call.
+        # Swap-drain so a concurrent submit_retrieve_request add is never lost.
+        dropped = self._dropped_retrieves
+        self._dropped_retrieves = set()
+        finished_retrieves.update(dropped)
+
+        # Update the internal states
+        ret_stores = self._process_finished_stores(
+            finished_stores, finished_req_ids_from_engine
+        )
+
+        # the invocation of `get_finished` means that
+        # these requests' KV caches are already fully stored.
+        # or the requests normally ends without any store.
+        if ret_stores:
+            self.request_telemetry.on_request_store_finished(
+                request_ids_set=ret_stores,
+                model_name=self.model_name,
+                world_size=self.world_size,
+                kv_rank=self.worker_id,
+            )
+
+        return ret_stores, finished_retrieves
+
+    # TODO(chunxiaozheng): There are some duplicated codes
+    #  with `get_finished`, optimize it later.
+    @_lmcache_nvtx_annotate
+    def get_finished_with_lazy_offload(
+        self,
+    ) -> tuple[set[str] | None, set[str] | None]:
+        """
+        Check and get the finished store and retrieve requests in lazy offload mode.
+
+        Returns:
+            A tuple of two sets:
+            - The first set contains the finished store request ids.
+                In lazy offload mode, return None directly.
+            - The second set contains the finished retrieve request ids,
+                including retrieves dropped at submit time while unhealthy
+                (reported exactly once; blocks already in error_block_ids).
+        """
+        if not self.lazy_offload:
+            raise ValueError(
+                "get_finished_with_lazy_offload is only available in lazy offload mode"
+            )
+
+        if self.dispatcher is not None:
+            dispatch(self.dispatcher, "reclaim")
+
+        # If unhealthy, drain all pending futures immediately
+        if not self.is_healthy:
+            finished_stores = set(self.store_futures.keys())
+            finished_retrieves = set()
+            for request_id, (
+                _r_future,
+                r_block_ids,
+            ) in self.retrieve_futures.items():
+                finished_retrieves.add(request_id)
+                self.error_block_ids.update(r_block_ids)
+            self.store_futures.clear()
+            self.retrieve_futures.clear()
+            self.store_events.clear()
+            self.retrieve_events.clear()
+
+            # Retrieves dropped at submit time still must be reported,
+            # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS.
+            # Swap-drain (not update-then-clear): a concurrent
+            # submit_retrieve_request add lands in the old set (reported now)
+            # or the fresh set (reported next call), never lost.
+            dropped = self._dropped_retrieves
+            self._dropped_retrieves = set()
+            finished_retrieves.update(dropped)
+
+            for req_id in finished_stores:
+                self._completed_store_requests[req_id] = 1
+            return None, finished_retrieves
+
+        finished_stores = set()
+        finished_retrieves = set()
+        for request_id, s_future in self.store_futures.items():
+            if not s_future.query():
+                continue
+
+            s_result = s_future.result(timeout=60)
+            finished_stores.add(request_id)
+
+            if not s_result:
+                logger.error(
+                    "Something went wrong when processing the "
+                    "store request for request_id=%s",
+                    request_id,
+                )
+
+        for request_id, (r_future, _) in self.retrieve_futures.items():
+            if not r_future.query():
+                continue
+
+            r_result = r_future.result(timeout=60)
+            finished_retrieves.add(request_id)
+
+            if not r_result:
+                logger.error(
+                    "Something went wrong when processing the "
+                    "retrieve request for request_id=%s, result=%s",
+                    request_id,
+                    r_result,
+                )
+
+        # Remove the finished requests from the tracking dicts
+        for request_id in finished_stores:
+            self.store_futures.pop(request_id, None)
+            self.store_events.pop(request_id, None)
+        for request_id in finished_retrieves:
+            self.retrieve_futures.pop(request_id, None)
+            self.retrieve_events.pop(request_id, None)
+
+        # Retrieves dropped while unhealthy still must be reported,
+        # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS. No
+        # finished_sending dedup is needed (unlike the unhealthy branch): a
+        # dropped retrieve's request is parked in WAITING_FOR_REMOTE_KVS until
+        # this report, so it cannot also be engine-finished in the same call.
+        # Swap-drain so a concurrent submit_retrieve_request add is never lost.
+        dropped = self._dropped_retrieves
+        self._dropped_retrieves = set()
+        finished_retrieves.update(dropped)
+
+        # the invocation of `get_finished` means that
+        # these requests' KV caches are already fully stored.
+        # or the requests normally ends without any store.
+        if finished_stores:
+            self.request_telemetry.on_request_store_finished(
+                request_ids_set=finished_stores,
+                model_name=self.model_name,
+                world_size=self.world_size,
+                kv_rank=self.worker_id,
+            )
+
+        for req_id in finished_stores:
+            self._completed_store_requests[req_id] = 1
+        return None, finished_retrieves
+
+    def get_completed_store_requests(self) -> dict[str, int] | None:
+        """Return completed store requests since the last call."""
+        if not self._completed_store_requests:
+            return None
+        completed_store_requests = self._completed_store_requests
+        self._completed_store_requests = {}
+        return completed_store_requests
+
+    def num_blocks_per_chunk(self) -> int:
+        """
+        Returns:
+            The number of vllm blocks in a LMCache data chunk
+        """
+        return self.blocks_in_chunk
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """
+        Returns the block IDs that failed due to retrieve timeout,
+        then clears the internal set.
+        """
+        errors = self.error_block_ids.copy()
+        self.error_block_ids.clear()
+        return errors
+
+    def handle_preemptions(self, need_flush_before_forward: bool) -> None:
+        """Handle worker-side preemption hints from connector metadata.
+
+        When ``need_flush_before_forward`` is true, synchronize deferred
+        engine-driven gather work before the next forward pass can overwrite
+        paged KV blocks.
+
+        Args:
+            need_flush_before_forward: When True, flush in-flight gather
+                operations on the transfer context. When False, this is a no-op.
+        """
+        if not need_flush_before_forward:
+            return
+        if not self.is_healthy or self.transfer_ctx is None:
+            return
+        self.transfer_ctx.flush_inflight_stores()
+        # Force device sync here, compare to preemption, perf panelty is trivial
+        torch_dev.synchronize()
+
+    def shutdown(self) -> None:
+        """
+        Shutdown the LMCache MP worker adapter.
+
+        Stops the heartbeat (if started) before UNREGISTER: no new ping
+        on the closing mq_client, and a straggler in-flight cycle cannot
+        re-register or flip the health event after unregistration.
+        """
+        with self._heartbeat_lock:
+            if self._heartbeat is not None:
+                self._heartbeat.stop()
+
+        logger.info("Unregistering kv caches")
+        try:
+            unregister_type = (
+                RequestType.UNREGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT
+                if isinstance(self.transfer_ctx, EngineDrivenTransferContext)
+                else RequestType.UNREGISTER_KV_CACHE
+            )
+            send_lmcache_request(
+                self.mq_client,
+                unregister_type,
+                [self.instance_id],
+            ).result(timeout=self._mq_timeout)
+        except TimeoutError:
+            logger.warning(
+                "LMCache server did not respond to unregister within %ss. "
+                "Proceeding with shutdown.",
+                self._mq_timeout,
+            )
+
+        if self.dispatcher is not None:
+            dispatch(self.dispatcher, "shutdown")
+
+        if self.transfer_ctx is not None:
+            self.transfer_ctx.close()
+            self.transfer_ctx = None
+
+        self.mq_client.close()
+        self.request_telemetry.close()
+
+    # Helper functions
+    def _update_and_get_finished_store(
+        self,
+    ) -> set[str]:
+        """Converge the internal states about finished stores
+        and returns the 'safe finished store request ids' back
+        """
+        safe_finished_s = self.finished_stores.intersection(self.previously_finished)
+        self.finished_stores.difference_update(self.previously_finished)
+        self.previously_finished.difference_update(safe_finished_s)
+
+        return safe_finished_s
+
+    def _create_key(
+        self,
+        token_ids: list[int],
+        start: int,
+        end: int,
+        request_id: str,
+        cache_salt: str = "",
+    ) -> IPCCacheServerKey:
+        """Convert token IDs to an IPC cache engine key.
+
+        Args:
+            token_ids: The token IDs.
+            start: Start token index.
+            end: End token index.
+            request_id: The request ID.
+            cache_salt: Per-user isolation salt.
+
+        Returns:
+            IPCCacheServerKey: The constructed key.
+        """
+        return IPCCacheServerKey(
+            model_name=self.model_name,
+            world_size=self.world_size,
+            worker_id=self.worker_id,
+            token_ids=tuple(token_ids),
+            start=start,
+            end=end,
+            request_id=request_id,
+            cache_salt=cache_salt,
+        )

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/vllm/v1/core/kv_cache_manager.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/vllm/v1/core/kv_cache_manager.py
@@ -1,0 +1,886 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import itertools
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal, overload
+
+from vllm.distributed.kv_events import BlockStored, KVCacheEvent
+from vllm.logger import init_logger
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core.kv_cache_coordinator import (
+    HybridKVCacheCoordinator,
+    get_kv_cache_coordinator,
+)
+from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
+from vllm.v1.core.kv_cache_utils import KVCacheBlock, KVCacheBlockCopy
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    CrossAttentionSpec,
+    EncoderOnlyAttentionSpec,
+    KVCacheConfig,
+    MambaSpec,
+    get_kv_cache_spec_kind,
+    get_kv_cache_spec_sliding_window,
+)
+from vllm.v1.metrics.stats import PrefixCacheStats
+from vllm.v1.request import Request, RequestStatus
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class KVCacheBlocks:
+    """
+    The allocation result of KVCacheManager, work as the interface between
+    Scheduler and KVCacheManager, to hide KVCacheManager's internal data
+    structure from the Scheduler.
+    """
+
+    blocks: tuple[Sequence[KVCacheBlock], ...]
+    """
+    `blocks[i][j]` refers to the i-th kv_cache_group
+    and the j-th block of tokens.We don't use block of
+    tokens as the outer dimension because it assumes all
+    kv_cache_groups have the same number of blocks, which is true for now but
+    will be broken if we want to give different block_size to different
+    kv_cache_groups in the future.
+
+    Each single type KVCacheBlocks could be represented as:
+    - list[KVCacheBlock] for more than one KVCacheBlock
+    - an empty tuple for requests without KVCacheBlock
+      (a precomputed KVCacheBlocks is in KVCacheManager to avoid GC overhead)
+    """
+
+    def __add__(self, other: "KVCacheBlocks") -> "KVCacheBlocks":
+        """Adds two KVCacheBlocks instances."""
+        return KVCacheBlocks(
+            tuple(
+                list(itertools.chain(blk1, blk2))
+                for blk1, blk2 in zip(self.blocks, other.blocks)
+            )
+        )
+
+    @overload
+    def get_block_ids(
+        self,
+        allow_none: Literal[False] = False,
+    ) -> tuple[list[int], ...]: ...
+
+    @overload
+    def get_block_ids(
+        self,
+        allow_none: Literal[True] = True,
+    ) -> tuple[list[int], ...] | None: ...
+
+    def get_block_ids(
+        self,
+        allow_none: bool = False,
+    ) -> tuple[list[int], ...] | None:
+        """
+        Converts the KVCacheBlocks instance to block_ids.
+
+        Returns:
+            tuple[list[int], ...]: A tuple of lists where:
+                - the outer tuple corresponds to KV cache groups
+                - each inner list contains the block_ids of the blocks in that
+                  group
+        """
+        if allow_none and all(len(group) == 0 for group in self.blocks):
+            return None
+        return tuple([blk.block_id for blk in group] for group in self.blocks)
+
+    def get_unhashed_block_ids(self) -> list[int]:
+        """Get block_ids of unhashed blocks from KVCacheBlocks instance."""
+        assert len(self.blocks) == 1, "Only one group is supported"
+        return [block.block_id for block in self.blocks[0] if block.block_hash is None]
+
+    def get_unhashed_block_ids_all_groups(self) -> list[list[int]]:
+        """Get block_ids of unhashed blocks from KVCacheBlocks instance."""
+        # Skip padding blocks.
+        return [
+            [
+                block.block_id
+                for block in group
+                if block.block_hash is None and not block.is_null
+            ]
+            for group in self.blocks
+        ]
+
+    def new_empty(self) -> "KVCacheBlocks":
+        """
+        Creates a new KVCacheBlocks instance with no blocks.
+        """
+        return KVCacheBlocks(tuple(() for _ in range(len(self.blocks))))
+
+
+class KVCacheManager:
+    def __init__(
+        self,
+        kv_cache_config: KVCacheConfig,
+        max_model_len: int,
+        scheduler_block_size: int,
+        hash_block_size: int,
+        max_in_flight_tokens: int | None = None,
+        enable_caching: bool = True,
+        use_eagle: bool = False,
+        num_prefill_lookahead: int = 0,
+        log_stats: bool = False,
+        enable_kv_cache_events: bool = False,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+        metrics_collector: KVCacheMetricsCollector | None = None,
+        watermark: float = 0.0,
+    ) -> None:
+        self.max_model_len = max_model_len
+        # When unset, fall back to `max_model_len` so the recycling-aware cap
+        # collapses to the prior (uncapped) admission behavior. The scheduler
+        # always supplies the real value at runtime.
+        if max_in_flight_tokens is None:
+            max_in_flight_tokens = max_model_len
+
+        self.enable_caching = enable_caching
+        self.enable_kv_cache_events = enable_kv_cache_events
+        self.use_eagle = use_eagle
+        self.log_stats = log_stats
+        self.metrics_collector = metrics_collector
+        # FIXME: make prefix cache stats conditional on log_stats. We still need
+        # this comment because when the log stats is enabled there are still
+        # potential configs we could expose in the future.
+        self.prefix_cache_stats = PrefixCacheStats() if log_stats else None
+
+        self.coordinator = get_kv_cache_coordinator(
+            kv_cache_config=kv_cache_config,
+            max_model_len=self.max_model_len,
+            max_in_flight_tokens=max_in_flight_tokens,
+            use_eagle=self.use_eagle,
+            enable_caching=self.enable_caching,
+            enable_kv_cache_events=enable_kv_cache_events,
+            dcp_world_size=dcp_world_size,
+            pcp_world_size=pcp_world_size,
+            scheduler_block_size=scheduler_block_size,
+            hash_block_size=hash_block_size,
+            metrics_collector=self.metrics_collector,
+            num_prefill_lookahead=num_prefill_lookahead,
+        )
+        self.num_kv_cache_groups = len(kv_cache_config.kv_cache_groups)
+        self.block_pool = self.coordinator.block_pool
+        self.kv_cache_config = kv_cache_config
+
+        # Watermark: minimum number of KV cache blocks to keep free when
+        # admitting waiting/preempted requests, to avoid frequent preemptions.
+        assert watermark >= 0.0, "watermark must be non-negative"
+        self.watermark_blocks = int(watermark * kv_cache_config.num_blocks)
+        self.kv_cache_event_metadata = tuple(
+            (
+                get_kv_cache_spec_kind(group.kv_cache_spec).value,
+                get_kv_cache_spec_sliding_window(group.kv_cache_spec),
+            )
+            for group in kv_cache_config.kv_cache_groups
+        )
+
+        # Pre-constructed KVCacheBlocks with no blocks, callers should use this
+        # via create_kv_cache_blocks instead of creating new ones to avoid GC
+        # overhead.
+        #
+        # We use nested tuples to ensure the empty KVCacheBlocks is immutable.
+        self.empty_kv_cache_blocks = KVCacheBlocks(
+            tuple(() for _ in range(self.num_kv_cache_groups))
+        )
+
+        # Off-table cow blocks handed to a KV connector for partial-tail
+        # offload; pinned until the request's blocks are freed.
+        self._partial_tail_pins: dict[str, list[KVCacheBlock]] = {}
+
+    @property
+    def usage(self) -> float:
+        """Get the KV cache usage.
+
+        Returns:
+            The KV cache usage (between 0.0 and 1.0).
+        """
+        return self.block_pool.get_usage()
+
+    def make_prefix_cache_stats(self) -> PrefixCacheStats | None:
+        """Get (and reset) the prefix cache stats.
+
+        Returns:
+            The current prefix caching stats, or None if logging is disabled.
+        """
+        if not self.log_stats:
+            return None
+        stats = self.prefix_cache_stats
+        self.prefix_cache_stats = PrefixCacheStats()
+        return stats
+
+    def prefix_cache_lookup_enabled(self, request: Request) -> bool:
+        """Whether a local prefix cache lookup may be run for this request."""
+        return self.enable_caching and not request.skip_reading_prefix_cache
+
+    def record_prefix_cache_stats(self, request: Request, num_hits: int) -> None:
+        # Don't count a request that skipped the cache lookup.
+        if not self.log_stats or not self.prefix_cache_lookup_enabled(request):
+            return
+        assert self.prefix_cache_stats is not None
+        self.prefix_cache_stats.record(
+            num_tokens=request.num_tokens,
+            num_hits=num_hits,
+            preempted=request.num_preemptions > 0,
+        )
+
+    def get_computed_blocks(self, request: Request) -> tuple[KVCacheBlocks, int, int]:
+        """Get the computed (cached) blocks for the request.
+        Note that the computed blocks must be full.
+
+        Args:
+            request: The request to get the computed blocks.
+
+        Returns:
+            A tuple containing:
+                - A list of blocks that are computed for the request.
+                - The number of computed tokens.
+                - ``shared_prefix_boundary``: the block-aligned token position of
+                  a shared prefix that a sparse-retention group (Mamba / sliding
+                  window) has not cached yet (Marconi-style APC), or 0 if none.
+                  Pinned so sparse prefix-cache retention does not drop
+                  the junction and defeat cross-request reuse.
+        """
+        # We skip finding the prefix cache hit when prefix caching is
+        # disabled or the request is marked as skipping kv cache read
+        # (which happens when the request requires prompt logprobs
+        # or calls a pooling model with all pooling).
+        if not self.prefix_cache_lookup_enabled(request):
+            return self.empty_kv_cache_blocks, 0, 0
+
+        # NOTE: When all tokens hit the cache, we must recompute the last token
+        # to obtain logits. Thus, set max_cache_hit_length to prompt_length - 1.
+        # This can trigger recomputation of an entire block, rather than just
+        # the single last token, because allocate_slots() requires
+        # num_computed_tokens to be block-size aligned. Removing this limitation
+        # could slightly improve performance in the future.
+        max_cache_hit_length = request.num_tokens - 1
+        computed_blocks, num_new_computed_tokens, num_uncached = (
+            self.coordinator.find_longest_cache_hit(
+                request.block_hashes, max_cache_hit_length
+            )
+        )
+
+        # When kv_cache_report_mode is "full", emit BlockStored events
+        # for the reused prefix cache blocks so that external consumers
+        # (e.g. gateway) can learn about them.
+        if (
+            num_new_computed_tokens > 0
+            and self.enable_kv_cache_events
+            and getattr(request, "kv_cache_report_mode", "incremental") == "full"
+        ):
+            for group_idx, group_blocks in enumerate(computed_blocks):
+                num_blocks = len(group_blocks)
+                if num_blocks > 0:
+                    group = self.kv_cache_config.kv_cache_groups[group_idx]
+                    block_size = group.kv_cache_spec.block_size
+                    self.block_pool.emit_cached_block_events(
+                        request,
+                        num_blocks,
+                        block_size,
+                        group_idx,
+                    )
+
+        # The junction to pin is where the lagging sparse-retention group stops
+        # (``num_new_computed_tokens``) plus the uncached shared prefix -- i.e.
+        # the longest single-group hit. Sub-block gaps are left to the mask,
+        # which floors to the alignment boundary (a no-op there).
+        shared_prefix_boundary = (
+            num_new_computed_tokens + num_uncached if num_uncached else 0
+        )
+
+        blocks = self.create_kv_cache_blocks(computed_blocks)
+        return blocks, num_new_computed_tokens, shared_prefix_boundary
+
+    def get_computed_blocks_for_connector(
+        self, request: Request
+    ) -> tuple[KVCacheBlocks, int, int, bool]:
+        """Local prefix-cache lookup for a request scheduled with a KV connector.
+
+        Hybrid (Mamba + full-attention) models can have per-group prefix hits
+        diverge under block pressure: the full-attention tail may be evicted
+        while a deeper Mamba state survives, or vice versa. Report the
+        full-attention hit as the local prefix - the connector transfers the
+        remaining suffix and the Mamba state is transferred unconditionally by
+        nixl's ``_apply_prefix_caching`` - and flag when that hit ran deeper
+        than a lagging group. Such a hit only has a valid Mamba state at its
+        boundary if the connector supplies it, so the caller must fall back to
+        ``get_computed_blocks`` to reconcile when no external tokens are found.
+
+        Non-hybrid models and already-convergent hits use ``get_computed_blocks``.
+
+        Returns:
+            The ``get_computed_blocks`` triple (blocks, number of local computed
+            tokens, shared-prefix boundary) plus ``hit_diverged``.
+        """
+        coordinator = self.coordinator
+        if not (
+            self.kv_cache_config.has_mamba_layers
+            and isinstance(coordinator, HybridKVCacheCoordinator)
+            and coordinator.full_attention_group_id is not None
+        ):
+            return *self.get_computed_blocks(request), False
+
+        if not self.prefix_cache_lookup_enabled(request):
+            return self.empty_kv_cache_blocks, 0, 0, False
+
+        fa_group_id = coordinator.full_attention_group_id
+        computed, per_group_hits = coordinator.find_longest_cache_hit_per_group(
+            request.block_hashes, request.num_tokens - 1
+        )
+        fa_hit = per_group_hits[fa_group_id]
+        if any(hit > fa_hit for hit in per_group_hits):
+            return *self.get_computed_blocks(request), False
+        if any(hit < fa_hit for hit in per_group_hits):
+            return *self.get_computed_blocks(request), True
+
+        num_local = fa_hit
+        blocks = self.create_kv_cache_blocks(computed)
+        return blocks, num_local, 0, False
+
+    def allocate_slots(
+        self,
+        request: Request,
+        num_new_tokens: int,
+        num_new_computed_tokens: int = 0,
+        new_computed_blocks: KVCacheBlocks | None = None,
+        num_lookahead_tokens: int = 0,
+        num_external_computed_tokens: int = 0,
+        delay_cache_blocks: bool = False,
+        num_encoder_tokens: int = 0,
+        full_sequence_must_fit: bool = False,
+        reserved_blocks: int = 0,
+        has_scheduled_reqs: bool = True,
+    ) -> KVCacheBlocks | None:
+        """Add slots for a request with new tokens to append.
+
+        Args:
+            request: The request to allocate slots.
+            num_new_tokens: The number of new tokens to be allocated and computed.
+            num_new_computed_tokens: The number of new computed tokens just
+                hitting the prefix caching, excluding external tokens.
+            new_computed_blocks: The cached blocks for the above new computed
+                tokens, grouped as a tuple by kv cache groups.
+            num_lookahead_tokens: The number of speculative tokens to allocate.
+                This is used by spec decode proposers with kv-cache such
+                as eagle.
+            num_external_computed_tokens: The number of tokens that their
+                KV caches are not cached by vLLM but cached by the connector.
+            delay_cache_blocks: Whether to skip caching the blocks. This is
+                used by P/D when allocating blocks used in a KV transfer
+                which will complete in a future step.
+            num_encoder_tokens: The number of encoder tokens to allocate for
+                cross-attention in encoder-decoder models(e.g., Whisper).
+                For decoder-only models, this should be 0.
+            full_sequence_must_fit: Only allocate blocks if the KV cache has enough
+                free blocks to hold the full sequence, accounting for prefix cache hits
+                and sliding window. Used as an admission gate to prevent over-admitting
+                requests when chunked prefill would otherwise only check the first chunk
+            reserved_blocks: Number of free blocks that must be left available for
+                other in-flight sequences to complete. The actual allocation is only
+                made if it fits within (free blocks - reserved_blocks). Used to gate
+                async KV-connector loads so their initial allocation cannot consume
+                blocks an already in-flight (prefilling) sequence is relying on.
+            has_scheduled_reqs: Whether any requests are already scheduled to run
+                this step, controls whether watermark is applied.
+
+        Blocks layout:
+        ```
+        ----------------------------------------------------------------------
+        | < comp > | < new_comp > | < ext_comp >  | < new >  | < lookahead > |
+        ----------------------------------------------------------------------
+                                                  |   < to be computed >     |
+        ----------------------------------------------------------------------
+                                  |            < to be allocated >           |
+        ----------------------------------------------------------------------
+                                  | < to be cached (roughly, |
+                                  | details below)>          |
+        ----------------------------------------------------------------------
+        | Prefix-cached tokens from either vLLM   |
+        | or connector. Can be safely removed if  |
+        | they are outside sliding window.        |
+        ----------------------------------------------------------------------
+        |   < cached by vLLM >    | not cached by |
+                                  | vLLM, but     |
+        | ref_cnt  | ref_cnt not  | cached by     |
+        | increased| increased yet| connector     |
+        ----------------------------------------------------------------------
+        ```
+
+        Abbrivations:
+
+        ```
+        comp      = request.num_computed_tokens
+        new_comp  = num_new_computed_tokens
+                  = len(new_computed_blocks) * block_size
+        ext_comp  = num_external_computed_tokens, cached by the connector
+        new       = num_new_tokens, including unverified draft tokens
+        lookahead = num_lookahead_tokens
+        ```
+
+        NOTE: for new tokens which include both verified and unverified draft
+        tokens, we only cache the verified tokens (by capping the number at
+        `request.num_tokens`).
+
+        The allocation has three stages:
+        - Free unnecessary blocks in `comp` and check
+           if we have sufficient free blocks (return None if not).
+        - Handle prefix tokens (`comp + new_comp + ext_comp`):
+            - Free unnecessary blocks (e.g. outside sliding window)
+            - Allocate new blocks for `ext_comp` tokens inside
+              sliding window
+        - Allocate new blocks for tokens to be computed (`new + lookahead`)
+
+        Returns:
+            A list of new allocated blocks.
+        """
+        # When loading KV data asynchronously, we may have zero new tokens to
+        # compute while still allocating slots for externally computed tokens.
+        if num_new_tokens == 0 and num_external_computed_tokens == 0:
+            raise ValueError(
+                "num_new_tokens must be greater than 0 when there are no "
+                "external computed tokens"
+            )
+
+        if new_computed_blocks is not None:
+            new_computed_block_list = new_computed_blocks.blocks
+        else:
+            new_computed_block_list = self.empty_kv_cache_blocks.blocks
+
+        # The number of computed tokens is the number of computed tokens plus
+        # the new prefix caching hits
+        num_local_computed_tokens = (
+            request.num_computed_tokens + num_new_computed_tokens
+        )
+        total_computed_tokens = min(
+            num_local_computed_tokens + num_external_computed_tokens,
+            self.max_model_len,
+        )
+
+        watermark_blocks = 0
+        # The watermark is applied to waiting/preempted requests only, and only
+        # when there's at least one request already scheduled.
+        if has_scheduled_reqs and request.status in (
+            RequestStatus.WAITING,
+            RequestStatus.PREEMPTED,
+        ):
+            watermark_blocks = self.watermark_blocks
+
+        if full_sequence_must_fit:
+            # First check and fail if the full request sequence won't fit.
+            full_num_tokens = min(request.num_tokens, self.max_model_len)
+
+            num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
+                request_id=request.request_id,
+                num_tokens=full_num_tokens,
+                new_computed_blocks=new_computed_block_list,
+                num_encoder_tokens=num_encoder_tokens,
+                total_computed_tokens=total_computed_tokens,
+                num_local_computed_tokens=num_local_computed_tokens,
+                num_tokens_main_model=full_num_tokens,
+                apply_admission_cap=True,
+            )
+            required_blocks = num_blocks_to_allocate + watermark_blocks
+            if required_blocks > self.block_pool.get_num_free_blocks():
+                return None
+
+        num_tokens_main_model = total_computed_tokens + num_new_tokens
+        num_tokens_need_slot = min(
+            num_tokens_main_model + num_lookahead_tokens, self.max_model_len
+        )
+
+        # Free the blocks that are skipped during the attention computation
+        # (e.g., tokens outside the sliding window).
+        # We can do this even if we cannot schedule this request due to
+        # insufficient free blocks.
+        # Should call this function before allocating new blocks to reduce
+        # the number of evicted blocks.
+        # Free on the processed-token basis: in-flight steps' attention windows
+        # still read blocks below the optimistic boundary, and rejected spec
+        # tokens can roll it back.
+        self.coordinator.remove_skipped_blocks(
+            request.request_id,
+            max(0, total_computed_tokens - request.num_in_flight_tokens),
+            num_prompt_tokens=request.num_prompt_tokens,
+        )
+
+        num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
+            request_id=request.request_id,
+            num_tokens=num_tokens_need_slot,
+            new_computed_blocks=new_computed_block_list,
+            num_encoder_tokens=num_encoder_tokens,
+            total_computed_tokens=num_local_computed_tokens
+            + num_external_computed_tokens,
+            num_local_computed_tokens=num_local_computed_tokens,
+            num_tokens_main_model=num_tokens_main_model,
+        )
+
+        # Keep `reserved_blocks` free for other in-flight sequences, and an
+        # additional watermark of headroom for waiting/preempted admissions.
+        available_blocks = self.block_pool.get_num_free_blocks() - reserved_blocks
+        required_blocks = num_blocks_to_allocate + watermark_blocks
+        if required_blocks > available_blocks:
+            # Cannot allocate new blocks
+            return None
+
+        if (
+            new_computed_block_list is not self.empty_kv_cache_blocks.blocks
+            or num_external_computed_tokens > 0
+        ):
+            # Append the new computed blocks to the request blocks until now to
+            # avoid the case where the new blocks cannot be allocated.
+            self.coordinator.allocate_new_computed_blocks(
+                request_id=request.request_id,
+                new_computed_blocks=new_computed_block_list,
+                num_local_computed_tokens=num_local_computed_tokens,
+                num_external_computed_tokens=num_external_computed_tokens,
+            )
+
+        new_blocks = self.coordinator.allocate_new_blocks(
+            request.request_id,
+            num_tokens_need_slot,
+            num_tokens_main_model,
+            num_encoder_tokens,
+        )
+
+        # P/D: delay caching blocks if we have to recv from
+        # remote. Update state for locally cached blocks.
+        if not self.enable_caching or delay_cache_blocks:
+            return self.create_kv_cache_blocks(new_blocks)
+
+        # NOTE(woosuk): We want to commit (cache) up to num_local_computed_tokens
+        # + num_external_computed_tokens + num_new_tokens, but must exclude
+        # "non-committable" tokens (e.g., draft tokens that could be rejected).
+        # Therefore, we cap the number at `request.num_tokens`, ensuring only
+        # "finalized" tokens are cached.
+        num_tokens_to_cache = min(
+            total_computed_tokens + num_new_tokens,
+            request.num_tokens,
+        )
+        self.coordinator.cache_blocks(request, num_tokens_to_cache)
+
+        return self.create_kv_cache_blocks(new_blocks)
+
+    def free(self, request: Request) -> None:
+        """Free the blocks allocated for the request.
+        We free the blocks in reverse order so that the tail blocks are evicted
+        first when caching is enabled.
+
+        Args:
+            request: The request to free the blocks.
+        """
+        pins = self._partial_tail_pins.pop(request.request_id, None)
+        if pins:
+            self.block_pool.free_blocks(pins)
+        self.coordinator.free(request.request_id)
+
+    def remove_skipped_blocks(
+        self,
+        request_id: str,
+        processed_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
+    ) -> None:
+        """Remove the blocks that are no longer needed from `blocks` and replace
+        the removed blocks with null_block.
+
+        Args:
+            request_id: The request ID.
+            processed_computed_tokens: Computed-token prefix length covering
+                fully processed and committed tokens only (safe to free).
+            num_prompt_tokens: Optional prompt length for R-SWA gap eviction.
+        """
+        self.coordinator.remove_skipped_blocks(
+            request_id, processed_computed_tokens, num_prompt_tokens
+        )
+
+    def pop_blocks_for_free(self, request: Request) -> list[KVCacheBlock]:
+        """Pop the request's bookkeeping and return its blocks without
+        returning them to the block pool. The caller must eventually free
+        them in reverse order (so that tail blocks are evicted first).
+
+        Args:
+            request: The request to pop the blocks for.
+
+        Returns:
+            The request's blocks in allocation order.
+        """
+        blocks = self.coordinator.pop_blocks_for_free(request.request_id)
+        # Pins ride the same (possibly deferred) free as the request blocks.
+        # Preemption may release a pin under a still-queued offload — the same
+        # exposure normal saves of table blocks already have.
+        pins = self._partial_tail_pins.pop(request.request_id, None)
+        if pins:
+            blocks = pins + blocks
+        return blocks
+
+    def evict_blocks(self, block_ids: set[int]) -> None:
+        """evict blocks from the prefix cache by their block IDs.
+
+        Args:
+            block_ids: Set of block IDs to evict from cache.
+        """
+        self.block_pool.evict_blocks(block_ids)
+
+    def reset_prefix_cache(self) -> bool:
+        """Reset prefix cache. This function may be used in RLHF
+        flows to invalidate prefix caching after the weights are updated,
+        or used for resetting prefix caching status for benchmarking.
+
+        Returns:
+            bool: True if the prefix cache is successfully reset,
+            False otherwise.
+        """
+        if not self.block_pool.reset_prefix_cache():
+            return False
+        if self.log_stats:
+            assert self.prefix_cache_stats is not None
+            self.prefix_cache_stats.reset = True
+        return True
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> list[int]:
+        """Calculate the number of common prefix blocks for each kv cache group.
+
+        The function selects a running request and iterates through its blocks.
+        A block is considered a common prefix block if ALL requests with
+        allocated KV cache share it (i.e., ref_cnt equals the number of entries
+        in req_to_blocks).
+
+        NOTE(woosuk): The number of requests with allocated KV cache is **greater
+        than or equal to** the number of requests scheduled in the current step.
+        This is because having allocated KV cache only indicates that:
+        1. The request has not yet finished, and
+        2. The request holds its blocks unfreed.
+
+        While all scheduled requests must have allocated KV cache, the inverse
+        is not necessarily true. There may be requests with allocated KV cache
+        that are not scheduled in the current step.
+
+        This can result in an edge case where the number of common prefix blocks
+        is 0, even though all scheduled requests share a common prefix. This
+        occurs because there may be unscheduled requests that do not share the
+        common prefix. Currently, this case cannot be easily detected, so the
+        function returns 0 in such cases.
+
+        Args:
+            running_request_id: The request ID of any running request, used to
+                identify the common prefix blocks.
+
+        Returns:
+            list[int]: The number of common prefix blocks for each kv cache
+            group.
+        """
+        return self.coordinator.get_num_common_prefix_blocks(running_request_id)
+
+    def take_events(self) -> list[KVCacheEvent]:
+        """Take the KV cache events from the block pool.
+
+        Returns:
+            A list of KV cache events.
+        """
+        events = self.block_pool.take_events()
+        for event in events:
+            if not isinstance(event, BlockStored):
+                continue
+            if event.group_idx is None:
+                continue
+            if event.group_idx < 0 or event.group_idx >= len(
+                self.kv_cache_event_metadata
+            ):
+                logger.warning(
+                    "Group index `%s` not in KV cache metadata", event.group_idx
+                )
+                continue
+            # Annotate here so BlockPool can keep emitting structural cache
+            # events without owning semantic KV cache spec metadata.
+            kind, sliding_window = self.kv_cache_event_metadata[event.group_idx]
+            event.kv_cache_spec_kind = kind
+            event.kv_cache_spec_sliding_window = sliding_window
+        return events
+
+    def get_blocks(self, request_id: str) -> KVCacheBlocks:
+        """Get the blocks of a request."""
+        return self.create_kv_cache_blocks(self.coordinator.get_blocks(request_id))
+
+    def get_block_ids(self, request_id: str) -> tuple[list[int], ...]:
+        """Get the block ids of a request."""
+        return self.get_blocks(request_id).get_block_ids()
+
+    def get_block_ids_for_computed_tokens(
+        self,
+        request_id: str,
+        num_computed_tokens: int,
+    ) -> tuple[list[int], ...]:
+        """Get block ids covering the request's computed tokens."""
+        block_ids = self.get_block_ids(request_id)
+        clipped_block_ids: list[list[int]] = []
+        for group, ids in zip(self.kv_cache_config.kv_cache_groups, block_ids):
+            spec = group.kv_cache_spec
+            if not isinstance(spec, AttentionSpec) or isinstance(
+                spec, (CrossAttentionSpec, EncoderOnlyAttentionSpec)
+            ):
+                clipped_block_ids.append(ids)
+                continue
+
+            num_valid_blocks = cdiv(num_computed_tokens, spec.block_size)
+            clipped_block_ids.append(ids[:num_valid_blocks])
+        return tuple(clipped_block_ids)
+
+    def estimate_cached_tokens(self, request: Request) -> int:
+        """Estimate the number of tokens cached by the request."""
+        cached_tokens: int | None = None
+        for group, blocks in zip(
+            self.kv_cache_config.kv_cache_groups,
+            self.get_blocks(request.request_id).blocks,
+        ):
+            if isinstance(
+                group.kv_cache_spec,
+                (CrossAttentionSpec, EncoderOnlyAttentionSpec),
+            ):
+                # Cross-attention and encoder-only groups are not prefix cached.
+                continue
+
+            group_cached_tokens = 0
+            for block in blocks:
+                group_cached_tokens = max(
+                    group_cached_tokens,
+                    block.block_hash_num_tokens or 0,
+                )
+
+            cached_tokens = (
+                group_cached_tokens
+                if cached_tokens is None
+                else min(cached_tokens, group_cached_tokens)
+            )
+
+        return cached_tokens or 0
+
+    def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
+        """Cache the blocks for the request, if enabled.
+
+        Args:
+            request: The request to cache the blocks.
+            num_computed_tokens: The number of computed tokens, including tokens
+                that are already cached and tokens to be cached.
+        """
+        if self.enable_caching:
+            self.coordinator.cache_blocks(request, num_computed_tokens)
+
+    def create_kv_cache_blocks(
+        self, blocks: tuple[list[KVCacheBlock], ...]
+    ) -> KVCacheBlocks:
+        # Only create new KVCacheBlocks for non-empty blocks
+        return KVCacheBlocks(blocks) if any(blocks) else self.empty_kv_cache_blocks
+
+    def truncate_computed_blocks(
+        self, blocks: KVCacheBlocks, num_computed_tokens: int
+    ) -> KVCacheBlocks:
+        """Return a lookup-result view truncated at an aligned token endpoint.
+
+        An external hit can supply the final Mamba state even when the local
+        Mamba group ends before this endpoint. Other groups must cover it.
+        Pure slicing: refcounts are untouched and ``blocks`` is not mutated.
+        """
+        truncated: list[list[KVCacheBlock]] = []
+        for group_blocks, manager, group in zip(
+            blocks.blocks,
+            self.coordinator.single_type_managers,
+            self.kv_cache_config.kv_cache_groups,
+            strict=True,
+        ):
+            assert num_computed_tokens % manager.block_size == 0
+            num_blocks = num_computed_tokens // manager.block_size
+            if isinstance(group.kv_cache_spec, MambaSpec):
+                num_blocks = min(num_blocks, len(group_blocks))
+            else:
+                assert num_blocks <= len(group_blocks)
+            truncated.append(list(group_blocks[:num_blocks]))
+        return self.create_kv_cache_blocks(tuple(truncated))
+
+    def take_new_block_ids(self) -> list[int]:
+        """Drain and return new attention block IDs for zeroing."""
+        ids: list[int] = []
+        for mgr in self.coordinator.single_type_managers:
+            ids.extend(mgr.take_new_block_ids())
+        return ids
+
+    def get_zeroing_block_ids_in_range(
+        self, request_id: str, start_token: int, end_token: int
+    ) -> list[int]:
+        """The request's block ids covering [start_token, end_token), from
+        the groups whose new blocks are zeroed by the worker."""
+        ids: list[int] = []
+        for mgr in self.coordinator.single_type_managers:
+            if mgr.records_new_block_ids:
+                start_idx = start_token // mgr.block_size
+                end_idx = cdiv(end_token, mgr.block_size)
+                blocks = mgr.req_to_blocks[request_id]
+                ids.extend(blk.block_id for blk in blocks[start_idx:end_idx])
+        return ids
+
+    def record_blocks_for_zeroing(self, request_id: str, start_token: int) -> None:
+        """Re-record the request's blocks from start_token onwards for
+        zeroing, e.g. blocks a failed async KV load left unwritten.
+
+        start_token must be block-aligned: zeroing a partially-valid block
+        would wipe its valid prefix.
+        """
+        for mgr in self.coordinator.single_type_managers:
+            if mgr.records_new_block_ids:
+                assert start_token % mgr.block_size == 0
+                start_idx = start_token // mgr.block_size
+                blocks = mgr.req_to_blocks[request_id]
+                mgr.new_block_ids.extend(blk.block_id for blk in blocks[start_idx:])
+
+    def take_kv_cache_block_copies(
+        self,
+    ) -> tuple[list[KVCacheBlockCopy], list[KVCacheBlock]]:
+        """Drain pending copies and return their retained endpoints."""
+        pending_copies: list[tuple[KVCacheBlock, KVCacheBlock]] = []
+        for mgr in self.coordinator.single_type_managers:
+            pending_copies.extend(mgr.take_pending_cow_copies())
+        copies = [
+            KVCacheBlockCopy(
+                src_block_id=source_block.block_id,
+                dst_block_id=cow_block.block_id,
+            )
+            for source_block, cow_block in pending_copies
+        ]
+        retained_blocks = [block for pair in pending_copies for block in pair]
+        return copies, retained_blocks
+
+    def take_partial_tail_offloads(self) -> dict[str, list[tuple[int, int, int]]]:
+        """Drain producer partial-tail offload hand-offs per request.
+
+        Returns ``{request_id: [(group_id, block_id, boundary_tokens), ...]}``
+        for the durable boundary blocks of producers' last-prompt-boundary
+        partial tails. Only mamba "align" groups contribute; empty otherwise.
+        A KV connector reads the referenced blocks and offloads them so a later
+        request can hit the sub-block prefix.
+
+        Each handed-off block lives off the request block table, so it is
+        pinned here and unpinned when the request's blocks are freed — for a
+        producer with saved tokens, after the connector reports sends done.
+        """
+        offloads: dict[str, list[tuple[int, int, int]]] = {}
+        for mgr in self.coordinator.single_type_managers:
+            for (
+                req_id,
+                group_id,
+                block,
+                boundary_tokens,
+            ) in mgr.take_pending_partial_tail_offloads():
+                self.block_pool.touch((block,))
+                self._partial_tail_pins.setdefault(req_id, []).append(block)
+                offloads.setdefault(req_id, []).append(
+                    (group_id, block.block_id, boundary_tokens)
+                )
+        return offloads
+
+    def new_step_starts(self) -> None:
+        """Notify the coordinator that a new step is starting."""
+        self.coordinator.new_step_starts()

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1864,6 +1864,7 @@ class SinkFullAttentionManager(FullAttentionManager):
         scheduler_block_size: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
+        needs_kv_cache_zeroing: bool = False,
     ):
         super().__init__(
             kv_cache_spec=kv_cache_spec,
@@ -1873,6 +1874,7 @@ class SinkFullAttentionManager(FullAttentionManager):
             scheduler_block_size=scheduler_block_size,
             dcp_world_size=dcp_world_size,
             pcp_world_size=pcp_world_size,
+            needs_kv_cache_zeroing=needs_kv_cache_zeroing,
         )
         sink_len = kv_cache_spec.sink_len
         assert sink_len is not None and sink_len > 0 and sink_len % self.block_size == 0

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1,0 +1,1984 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import itertools
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from collections.abc import Sequence
+from typing import ClassVar
+
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import (
+    BlockHashList,
+    BlockHashListWithBlockSize,
+    BlockHashWithGroupId,
+    KVCacheBlock,
+    resolve_block_hashes,
+)
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    ChunkedLocalAttentionSpec,
+    CrossAttentionSpec,
+    FullAttentionSpec,
+    HiddenStateCacheSpec,
+    KVCacheSpec,
+    MambaSpec,
+    MLAAttentionSpec,
+    RSWASpec,
+    SinkFullAttentionSpec,
+    SlidingWindowMLASpec,
+    SlidingWindowSpec,
+)
+from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
+from vllm.v1.request import Request
+
+
+class SingleTypeKVCacheManager(ABC):
+    """
+    An abstract base class for a manager that handle the kv cache management
+    logic of one specific type of attention layer.
+    """
+
+    supports_fine_grained_hash_lookup: ClassVar[bool] = False
+
+    def __init__(
+        self,
+        kv_cache_spec: KVCacheSpec,
+        block_pool: BlockPool,
+        enable_caching: bool,
+        kv_cache_group_id: int,
+        scheduler_block_size: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+        needs_kv_cache_zeroing: bool = False,
+        max_admission_blocks_per_request: int | None = None,
+    ) -> None:
+        """
+        Initializes the SingleTypeKVCacheManager.
+        Args:
+            kv_cache_spec: The kv_cache_spec for this manager.
+            block_pool: The block pool.
+            kv_cache_group_id: The id of the kv cache group of this manager.
+            scheduler_block_size: The scheduling granularity (LCM of all group
+                block sizes); a multiple of this manager's ``block_size``.
+            needs_kv_cache_zeroing: Whether worker-side KV cache zeroing needs
+                newly allocated block IDs from this manager.
+            max_admission_blocks_per_request: Recycling-aware per-request
+                block cap used by `get_num_blocks_to_allocate`. Only set for
+                spec types that recycle blocks across chunks (SWA,
+                chunked-local); `None` (the default) means no cap, which is
+                correct for full-attention-style specs that hold every
+                block until the request finishes.
+        """
+        self.scheduler_block_size = scheduler_block_size
+        # The block size for this manager; used for actual block allocation.
+        self.block_size = kv_cache_spec.block_size
+        self.dcp_world_size = dcp_world_size
+        self.pcp_world_size = pcp_world_size
+        if dcp_world_size > 1:
+            self.block_size *= dcp_world_size
+        self.kv_cache_spec = kv_cache_spec
+        self.block_pool = block_pool
+        self.enable_caching = enable_caching
+        self._max_admission_blocks_per_request = max_admission_blocks_per_request
+        # Record newly allocated block ids only when worker-side zeroing will
+        # consume them and this manager holds a spec type that gets zeroed.
+        self._record_new_block_ids = needs_kv_cache_zeroing and isinstance(
+            kv_cache_spec, AttentionSpec
+        )
+        self.new_block_ids: list[int] = []
+
+        # Mapping from request ID to blocks to track the blocks allocated
+        # for each request, so that we can free the blocks when the request
+        # is finished.
+        self.req_to_blocks: defaultdict[str, list[KVCacheBlock]] = defaultdict(list)
+
+        # {req_id: The number of cached blocks for this given request}
+        # This is used to track the number of cached blocks for each request.
+        # This is only used to track the RUNNING requests, we do not track the
+        # data for preempted ones.
+        self.num_cached_block: dict[str, int] = {}
+
+        self.kv_cache_group_id = kv_cache_group_id
+        self._null_block = block_pool.null_block
+
+        # Whether this group's prefix-cache hits drop the EAGLE/MTP lookahead
+        # block. Only consulted by managers whose hit logic is sparse within an
+        # aligned segment (SWA). Initialized lazily by the coordinator after
+        # determining the attention groups.
+        self.use_eagle = False
+
+        # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
+        # managers (full attention, mamba "align"); harmlessly empty elsewhere.
+        self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
+        self._pending_cow_copies: list[tuple[KVCacheBlock, KVCacheBlock]] = []
+        # Partial-tail offload hand-off for external KV connectors: when a
+        # producer registers its last-prompt-boundary partial tail and the
+        # durable boundary block is not on the append-only request block table
+        # (mamba "align" CoW target), record the request, group, block, and
+        # exact token boundary so a connector can offload it under the right
+        # hash. Populated only by mamba "align".
+        self._pending_partial_tail_offloads: list[
+            tuple[str, int, KVCacheBlock, int]
+        ] = []
+
+    @classmethod
+    def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
+        return sum(blk.ref_cnt == 0 and not blk.is_null for blk in blocks)
+
+    def _has_partial_local_hit(
+        self,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        num_local_computed_tokens: int,
+    ) -> bool:
+        # The local prefix-cache hit ends inside one of this manager's
+        # blocks: the shared tail block needs CoW.
+        return (
+            len(new_computed_blocks) > 0
+            and num_local_computed_tokens % self.block_size != 0
+        )
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_local_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        """
+        Get the number of blocks needed to be allocated for the request.
+
+        Args:
+            request_id: The request ID.
+            num_tokens: The total number of tokens that need a slot (including
+                tokens that are already allocated).
+            new_computed_blocks: The new computed blocks just hitting the
+                prefix caching.
+            total_computed_tokens: Include both local and external computed
+                tokens.
+            num_local_computed_tokens: The number of local prefix-cache computed
+                tokens.
+            num_tokens_main_model: The number of tokens for the main model (aka target
+                model in spec decode). w/o spec decode, it is num_tokens;
+                with spec decode, it is num_tokens - num_lookahead_tokens.
+            apply_admission_cap: If True, clamp by `num_required_blocks` by
+                `_max_admission_blocks_per_request`for recycling-aware specs
+                (SWA, chunked-local).
+
+        Returns:
+            The number of blocks to allocate.
+        """
+
+        num_required_blocks = cdiv(num_tokens, self.block_size)
+        if apply_admission_cap and self._max_admission_blocks_per_request is not None:
+            # Recycling-aware specs (SWA, chunked-local) cap the per-request
+            # reservation here so admission matches the startup pool sizer
+            # (`SlidingWindowSpec.max_admission_blocks_per_request` / its
+            # chunked-local counterpart). `remove_skipped_blocks` runs from
+            # `allocate_slots` before each chunk's `get_num_blocks_to_allocate`,
+            # so per-request peak real-held blocks <= this cap, which keeps
+            # `sum(reservations) <= pool` <=> `sum(peak_real_held) <= pool`.
+            # Drift between the two would re-introduce the deadlock from
+            # issue #39734 or, worse, mid-prefill OOM.
+            num_required_blocks = min(
+                num_required_blocks, self._max_admission_blocks_per_request
+            )
+        num_req_blocks = len(self.req_to_blocks.get(request_id, ()))
+
+        if request_id in self.num_cached_block:
+            # Fast-path: a running request won't have any new prefix-cache hits.
+            assert len(new_computed_blocks) == 0
+            # NOTE: With speculative decoding, request's blocks may be allocated
+            # for draft tokens which are later rejected. In this case,
+            # num_required_blocks may be smaller than num_req_blocks.
+            return max(num_required_blocks - num_req_blocks, 0)
+
+        num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
+        num_local_computed_blocks = len(new_computed_blocks) + num_req_blocks
+        # Number of whole blocks that are skipped by the attention window.
+        # If nothing is skipped, this is 0.
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        # We need blocks for the non-skipped suffix. If there are still
+        # local-computed blocks inside the window, they contribute to the
+        # required capacity; otherwise, skipped blocks dominate.
+        num_new_blocks = max(
+            num_required_blocks - max(num_skipped_blocks, num_local_computed_blocks),
+            0,
+        )
+
+        # Among the `new_computed_blocks`, the first `num_skipped_blocks` worth
+        # of blocks are skipped; `num_req_blocks` of those may already be in
+        # `req_to_blocks`, so only skip the remainder from `new_computed_blocks`.
+        num_skipped_new_computed_blocks = max(0, num_skipped_blocks - num_req_blocks)
+
+        # If a computed block is an eviction candidate (in the free queue and
+        # ref_cnt == 0), it will be removed from the free queue when touched by
+        # the allocated request, so we must count it in the free-capacity check.
+        num_evictable_blocks = self._get_num_evictable_blocks(
+            new_computed_blocks[num_skipped_new_computed_blocks:]
+        )
+        if self._has_partial_local_hit(new_computed_blocks, num_local_computed_tokens):
+            # Reserve the extra block that allocate_new_blocks pulls for the
+            # partial-hit CoW redirect.
+            num_new_blocks += 1
+        return num_new_blocks + num_evictable_blocks
+
+    def add_local_computed_blocks(
+        self,
+        request_id: str,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        """
+        Add the locally cached (prefix-hit) blocks to the request:
+        1. Touch the computed blocks (paired with adding them to `req_blocks`)
+           so their ref_cnt exactly tracks the referencing requests.
+        1.5. (Optional) For sliding window, skipped blocks are padded with nulls.
+        2. Add the remaining computed blocks.
+
+        Args:
+            request_id: The request ID.
+            new_computed_blocks: The new computed blocks just hitting the
+                prefix cache.
+            num_local_computed_tokens: The number of local computed tokens.
+            num_external_computed_tokens: The number of external computed tokens.
+        """
+        # The coordinator only calls this for first-time allocations (running
+        # requests are short-circuited there), so the request has no blocks yet.
+        req_blocks = self.req_to_blocks[request_id]
+        assert len(req_blocks) == 0
+        num_total_computed_tokens = (
+            num_local_computed_tokens + num_external_computed_tokens
+        )
+        num_skipped_tokens = self.get_num_skipped_tokens(num_total_computed_tokens)
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        if num_skipped_blocks > 0:
+            # It is possible that all new computed blocks are skipped when
+            # num_skipped_blocks > len(new_computed_blocks).
+            new_computed_blocks = new_computed_blocks[num_skipped_blocks:]
+
+        # Touch the computed blocks to make sure they won't be evicted.
+        if self.enable_caching:
+            self.block_pool.touch(new_computed_blocks)
+        else:
+            assert not any(new_computed_blocks), (
+                "Computed blocks should be empty when prefix caching is disabled"
+            )
+
+        # Skip blocks are padded with null blocks.
+        req_blocks.extend([self._null_block] * num_skipped_blocks)
+        # Add the remaining computed blocks.
+        req_blocks.extend(new_computed_blocks)
+        # All cached hits (including skipped nulls) are already cached; mark
+        # them so cache_blocks() will not try to re-cache blocks that already
+        # have a block_hash set.
+        self.num_cached_block[request_id] = len(req_blocks)
+        if self._has_partial_local_hit(new_computed_blocks, num_local_computed_tokens):
+            # Record the partial tail for the CoW redirect in
+            # allocate_new_blocks; cap the cached count at the full blocks so
+            # cache_blocks() re-caches the private copy once full.
+            block_idx = num_local_computed_tokens // self.block_size
+            self._partial_hit_reqs[request_id] = (block_idx, new_computed_blocks[-1])
+            self.num_cached_block[request_id] = block_idx
+
+    def allocate_external_computed_blocks(
+        self,
+        request_id: str,
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        """
+        Allocate new blocks for external (KV-connector) computed tokens.
+
+        Must run only after every group's local blocks have been touched via
+        `add_local_computed_blocks`, so this group's `get_new_blocks` cannot
+        evict another group's cache-hit blocks (issue #33775).
+
+        Args:
+            request_id: The request ID.
+            num_local_computed_tokens: The number of local computed tokens.
+            num_external_computed_tokens: The number of external computed tokens.
+        """
+        num_total_computed_tokens = (
+            num_local_computed_tokens + num_external_computed_tokens
+        )
+        num_skipped_tokens = self.get_num_skipped_tokens(num_total_computed_tokens)
+        if num_skipped_tokens > 0:
+            # Some external computed tokens may be skipped too.
+            num_external_computed_tokens = min(
+                num_total_computed_tokens - num_skipped_tokens,
+                num_external_computed_tokens,
+            )
+        if num_external_computed_tokens <= 0:
+            return
+
+        req_blocks = self.req_to_blocks[request_id]
+        allocated_blocks = self.block_pool.get_new_blocks(
+            cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
+        )
+        req_blocks.extend(allocated_blocks)
+        if self._record_new_block_ids:
+            self.new_block_ids.extend(b.block_id for b in allocated_blocks)
+
+    def allocate_new_blocks(
+        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+    ) -> list[KVCacheBlock]:
+        """
+        Allocate new blocks for the request to give it at least `num_tokens`
+        token slots.
+
+        Args:
+            request_id: The request ID.
+            num_tokens: The total number of tokens that need a slot (including
+                tokens that are already allocated).
+            num_tokens_main_model: The number of tokens for the main model (aka target
+                model in spec decode). w/o spec decode, it is num_tokens;
+                with spec decode, it is num_tokens - num_lookahead_tokens.
+        Returns:
+            The new allocated blocks.
+        """
+        cow_blocks: list[KVCacheBlock] = []
+        if request_id in self._partial_hit_reqs:
+            # Partial hit: redirect the shared tail to a private CoW block.
+            # Replacing in place keeps the length-based allocation below
+            # correct; the extra block was reserved by
+            # get_num_blocks_to_allocate.
+            block_idx, source_block = self._partial_hit_reqs.pop(request_id)
+            cow_block = self.block_pool.get_new_blocks(1)[0]
+            self._apply_cow(request_id, block_idx, source_block, cow_block)
+            self.new_block_ids.append(cow_block.block_id)
+            cow_blocks.append(cow_block)
+
+        req_blocks = self.req_to_blocks[request_id]
+        num_required_blocks = cdiv(num_tokens, self.block_size)
+        num_new_blocks = num_required_blocks - len(req_blocks)
+        if num_new_blocks <= 0:
+            return cow_blocks
+        else:
+            new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+            req_blocks.extend(new_blocks)
+            if self._record_new_block_ids:
+                self.new_block_ids.extend(b.block_id for b in new_blocks)
+            return cow_blocks + new_blocks
+
+    @property
+    def records_new_block_ids(self) -> bool:
+        """Whether this manager's new blocks are zeroed by the worker."""
+        return self._record_new_block_ids
+
+    def take_new_block_ids(self) -> list[int]:
+        """Drain and return block IDs allocated since the last call."""
+        ids = self.new_block_ids
+        self.new_block_ids = []
+        return ids
+
+    def take_pending_cow_copies(
+        self,
+    ) -> list[tuple[KVCacheBlock, KVCacheBlock]]:
+        """Drain pending CoW source and destination block pairs."""
+        pending_copies = self._pending_cow_copies
+        self._pending_cow_copies = []
+        return pending_copies
+
+    def take_pending_partial_tail_offloads(
+        self,
+    ) -> list[tuple[str, int, KVCacheBlock, int]]:
+        """Drain producer partial-tail hand-offs.
+
+        Entries are ``(req_id, group_id, block, boundary_tokens)``.
+
+        Only mamba "align" populates this. The block lives off the request
+        block table, so the caller must pin it until the connector has read
+        it — nothing else keeps it alive once the CoW retention is released.
+        """
+        pending = self._pending_partial_tail_offloads
+        self._pending_partial_tail_offloads = []
+        return pending
+
+    def _apply_cow(
+        self,
+        request_id: str,
+        block_idx: int,
+        source_block: KVCacheBlock,
+        cow_block: KVCacheBlock,
+    ) -> None:
+        """Redirect a partial prefix-cache hit to a private CoW block.
+
+        Both copy endpoints stay retained until the copy has run on the worker,
+        so a same-step free cannot recycle them: ``source_block`` keeps its
+        hit-ref, ``cow_block`` takes an extra ref beyond the one handed to the
+        request.
+        """
+        req_blocks = self.req_to_blocks[request_id]
+        assert block_idx < len(req_blocks)
+        assert req_blocks[block_idx] is source_block
+        assert not source_block.is_null and source_block.ref_cnt > 0
+        req_blocks[block_idx] = cow_block
+        self._pending_cow_copies.append((source_block, cow_block))
+        cow_block.ref_cnt += 1
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+    ) -> None:
+        """
+        Cache the blocks for the request.
+
+        Args:
+            request: The request.
+            num_tokens: The total number of tokens that need to be cached
+                (including tokens that are already cached).
+            retention_interval: Sparse local-checkpoint granularity. ``None``
+                keeps dense checkpointing; ``0`` keeps only the latest replay
+                boundary; a positive multiple of ``scheduler_block_size`` keeps
+                a tail once per that-sized segment. Only SWA acts on it.
+        """
+        num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
+        num_full_blocks = num_tokens // self.block_size
+
+        if num_cached_blocks >= num_full_blocks:
+            return
+
+        # Token boundaries whose reachable tail must be retained under sparse
+        # retention: the replay boundary (``num_prompt - 1``, capped by
+        # ``get_computed_blocks``) and any detected shared-prefix junction.
+        reachable_boundaries = [request.num_prompt_tokens - 1]
+        if request.shared_prefix_boundary:
+            reachable_boundaries.append(request.shared_prefix_boundary)
+
+        block_mask = self.reachable_block_mask(
+            start_block=num_cached_blocks,
+            end_block=num_full_blocks,
+            alignment_tokens=self.scheduler_block_size,
+            kv_cache_spec=self.kv_cache_spec,
+            use_eagle=self.use_eagle,
+            retention_interval=retention_interval,
+            reachable_boundaries=reachable_boundaries,
+        )
+        self.block_pool.cache_full_blocks(
+            request=request,
+            blocks=self.req_to_blocks[request.request_id],
+            num_cached_blocks=num_cached_blocks,
+            num_full_blocks=num_full_blocks,
+            block_size=self.block_size,
+            kv_cache_group_id=self.kv_cache_group_id,
+            block_mask=block_mask,
+        )
+
+        self.num_cached_block[request.request_id] = num_full_blocks
+
+    @classmethod
+    def reachable_block_mask(
+        cls,
+        start_block: int,
+        end_block: int,
+        alignment_tokens: int | None,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        retention_interval: int | None = None,
+        reachable_boundaries: Sequence[int] = (),
+    ) -> list[bool] | None:
+        """Per-block mask for ``cache_full_blocks``. ``None`` means cache
+        every (non-null) block — the default for full attention.
+
+        Subclasses with sparse hit semantics (SWA / Mamba) override this to skip
+        blocks that can never serve a hit at any alignment-aligned prefix length.
+        ``reachable_boundaries`` are token positions whose reachable tail must be
+        retained; the base (dense) policy ignores them.
+        """
+        return None
+
+    def pop_blocks_for_free(self, request_id: str) -> list[KVCacheBlock]:
+        """
+        Pop the request's bookkeeping and return its blocks without yet
+        returning them to the block pool. The caller is responsible for
+        eventually passing the returned blocks to `block_pool.free_blocks`,
+        freeing them in reverse order (so that tail blocks are evicted first).
+
+        Args:
+            request_id: The request ID.
+
+        Returns:
+            The request's blocks in allocation order.
+        """
+        # Default to [] in case a request is freed (aborted) before alloc.
+        req_blocks = self.req_to_blocks.pop(request_id, [])
+        self.num_cached_block.pop(request_id, None)
+        self._partial_hit_reqs.pop(request_id, None)
+        return req_blocks
+
+    def free(self, request_id: str) -> None:
+        """
+        Free the blocks for the request.
+
+        Args:
+            request_id: The request ID.
+        """
+        # Free blocks in reverse order so that the tail blocks are freed first.
+        self.block_pool.free_blocks(reversed(self.pop_blocks_for_free(request_id)))
+
+    @abstractmethod
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        """
+        Get the number of common prefix blocks for all requests with allocated
+        KV cache.
+
+        Args:
+            running_request_id: The request ID.
+
+        Returns:
+            The number of common prefix blocks for all requests with allocated
+            KV cache.
+        """
+
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        """
+        Get the longest cache hit prefix of the blocks that is not longer than
+        `max_length`. The prefix should be a common prefix hit for all the
+        kv cache groups in `kv_cache_group_ids`. If no cache hit is found,
+        return an empty list.
+        If eagle is enabled, drop the last matched block to force recompute the
+        last block to get the required hidden states for eagle drafting head.
+        For multi-module MTP, this recompute also rewrites the dropped block's
+        draft-layer KVs, which depend on up to num_speculative_tokens - 1
+        tokens past the matched prefix (i.e. on the cache writer's
+        continuation, which the block hash does not cover); the coordinator
+        asserts the block size covers that window.
+        Need to be customized for each attention type.
+
+        Args:
+            block_hashes: The block hashes of the request.
+            max_length: The maximum length of the cache hit prefix.
+            kv_cache_group_ids: The ids of the kv cache groups.
+            block_pool: The block pool.
+            kv_cache_spec: The kv cache spec.
+            drop_eagle_block: Whether to drop the last matched block for EAGLE/MTP.
+                Always False for non-EAGLE/MTP groups, but can be False for EAGLE/MTP
+                groups too if the last block is already dropped (e.g., in a
+                convergence loop in `find_longest_cache_hit`).
+            alignment_tokens: The returned cache hit length (in tokens) should
+                be a multiple of this value (in tokens). By default, it should
+                be set to the block_size.
+            dcp_world_size: The world size of decode context parallelism.
+            pcp_world_size: The world size of prefill context parallelism.
+
+        Returns:
+            A tuple containing cached blocks and the exact cache-hit length in
+            tokens. The cached block tuple has skipped blocks replaced by null
+            blocks for each kv cache group in `kv_cache_group_ids`.
+            For example, sliding window manager should return a list like
+            ([NULL, NULL, KVCacheBlock(7), KVCacheBlock(8)]) for block size 4
+            and sliding window 8 and len(kv_cache_group_ids) = 1.
+        """
+
+        raise NotImplementedError
+
+    def _remove_blocks_in_range(
+        self,
+        request_id: str,
+        first_block: int,
+        last_block: int,
+    ) -> None:
+        """Free blocks in ``[first_block, last_block)`` and replace with null_block.
+
+        Iterates backward so newly-evictable tail blocks are reached even after
+        earlier blocks in the range were nulled in a prior call.
+        """
+        if request_id not in self.req_to_blocks:
+            return
+        if first_block >= last_block:
+            return
+        blocks = self.req_to_blocks[request_id]
+        last_block = min(last_block, len(blocks))
+
+        freed: list[KVCacheBlock] = []
+        for i in range(last_block - 1, first_block - 1, -1):
+            if blocks[i] == self._null_block:
+                break
+            freed.append(blocks[i])
+            blocks[i] = self._null_block
+        if freed:
+            self.block_pool.free_blocks(freed)
+
+    def remove_skipped_blocks(
+        self,
+        request_id: str,
+        processed_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
+    ) -> None:
+        """
+        Remove and free the blocks that are no longer needed for attention computation.
+        The removed blocks should be replaced by null_block.
+
+        This function depends on `get_num_skipped_tokens`, which need to be implemented
+        differently for each attention type.
+
+        Args:
+            request_id: The request ID.
+            processed_computed_tokens: Computed-token prefix length covering
+                fully processed and committed tokens only (safe to free).
+            num_prompt_tokens: Optional prompt length for attention types (e.g.
+                R-SWA) that evict a middle gap rather than a head prefix. Ignored
+                by the default implementation.
+        """
+        del num_prompt_tokens
+        # Remove the blocks that will be skipped during attention computation.
+        num_skipped_tokens = self.get_num_skipped_tokens(processed_computed_tokens)
+        if num_skipped_tokens <= 0:
+            # This indicates that ALL tokens are inside attention window.
+            # Thus we do not need to free any blocks outside attention window.
+            # A typical case is full attention that we never free any token
+            # before the request is finished.
+            return
+        blocks = self.req_to_blocks[request_id]
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        # `num_skipped_tokens` may include tokens that haven't been allocated yet
+        # (e.g., when the attention window moves into the external computed tokens
+        # range), so we must cap to the number of blocks that currently exist for
+        # this request.
+        num_skipped_blocks = min(num_skipped_blocks, len(blocks))
+        self._remove_blocks_in_range(request_id, 0, num_skipped_blocks)
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        """
+        Get the number of tokens that will be skipped for attention computation.
+
+        Args:
+            num_computed_tokens: The number of tokens that have been computed.
+
+        Returns:
+            The number of tokens that will be skipped for attention computation.
+        """
+        # The default behavior is to not skip any tokens.
+        return 0
+
+    def new_step_starts(self) -> None:
+        return None
+
+
+class FullAttentionManager(SingleTypeKVCacheManager):
+    supports_fine_grained_hash_lookup: ClassVar[bool] = True
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        assert isinstance(
+            kv_cache_spec, FullAttentionSpec | ChunkedLocalAttentionSpec
+        ), (
+            "FullAttentionManager can only be used for full attention "
+            "and chunked local attention groups"
+        )
+        block_size = kv_cache_spec.block_size
+        if dcp_world_size > 1:
+            # DCP shards each block's KV across ranks; hashes must be viewed at
+            # the sharded block size.
+            block_size *= dcp_world_size
+        block_hashes = resolve_block_hashes(
+            block_hashes,
+            block_pool.hash_block_size,
+            block_size,
+            supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
+            alignment_tokens=alignment_tokens,
+        )
+
+        # Fine-grained mode (alignment_tokens == hash_block_size <
+        # block_size): resolve_block_hashes kept the raw hash-granularity
+        # list so interior boundaries can be probed.
+        fine_grained = (
+            alignment_tokens < block_size and block_size % alignment_tokens == 0
+        )
+        if fine_grained:
+            # list or lazy BlobBlockHashes view
+            assert isinstance(block_hashes, Sequence)
+            full_block_hashes: BlockHashList = BlockHashListWithBlockSize(
+                block_hashes, alignment_tokens, block_size
+            )
+        else:
+            full_block_hashes = block_hashes
+
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [] for _ in range(len(kv_cache_group_ids))
+        )
+        # Phase 1: longest run of cached full blocks from the start. A missing
+        # block implies every later block misses too (chained hashes).
+        for block_hash in itertools.islice(full_block_hashes, max_length // block_size):
+            cached_block = block_pool.get_cached_block(block_hash, kv_cache_group_ids)
+            if not cached_block:
+                break
+            for computed, cached in zip(computed_blocks, cached_block):
+                computed.append(cached)
+        hit_length = len(computed_blocks[0]) * block_size
+
+        # Phase 2 (fine-grained only): extend into the first non-full block by
+        # probing its interior hash boundaries high-to-low (longest hit first).
+        if fine_grained:
+            # list or lazy BlobBlockHashes view
+            assert isinstance(block_hashes, Sequence)
+            scale_factor = block_size // alignment_tokens
+            first_partial_idx = len(computed_blocks[0]) * scale_factor
+            max_partial_idx = min(
+                first_partial_idx + scale_factor - 1,
+                max_length // alignment_tokens,
+                len(block_hashes),
+            )
+            for fine_idx in range(max_partial_idx - 1, first_partial_idx - 1, -1):
+                cached_tail = block_pool.get_cached_block(
+                    block_hashes[fine_idx], kv_cache_group_ids
+                )
+                if not cached_tail:
+                    continue
+                for computed, cached in zip(computed_blocks, cached_tail):
+                    computed.append(cached)
+                hit_length = (fine_idx + 1) * alignment_tokens
+                break
+
+        # Eagle needs the tokens right before the generation point recomputed:
+        # drop one hash unit when fine-grained (the tail block's KV is
+        # append-only, so it still covers the reduced length), else one cache
+        # block.
+        if drop_eagle_block and hit_length > 0:
+            hit_length -= min(alignment_tokens, block_size)
+        # Round down to the alignment; a no-op when fine-grained (hits land on
+        # hash boundaries by construction) and when alignment_tokens ==
+        # block_size. Then trim blocks past the new tail.
+        hit_length -= hit_length % alignment_tokens
+        num_blocks = cdiv(hit_length, block_size)
+        for computed in computed_blocks:
+            del computed[num_blocks:]
+        return computed_blocks, hit_length
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+    ) -> None:
+        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        hash_block_size = self.block_pool.hash_block_size
+        if self.block_size == hash_block_size:
+            return
+        self._cache_partial_tail_block(request, num_tokens)
+
+    def _cache_partial_tail_block(
+        self,
+        request: Request,
+        num_tokens: int,
+    ) -> None:
+        """Cache the prompt tail when it ends inside a cache block.
+
+        Only the final prompt hash boundary is registered as a partial
+        prefix-cache entry; intermediate hash boundaries inside the same cache
+        block are intentionally skipped.
+        """
+        hash_block_size = self.block_pool.hash_block_size
+        boundary_tokens = request.num_prompt_tokens // hash_block_size * hash_block_size
+        if boundary_tokens == 0 or boundary_tokens > num_tokens:
+            return
+        if boundary_tokens % self.block_size == 0:
+            return
+
+        blocks = self.req_to_blocks[request.request_id]
+        block_idx = boundary_tokens // self.block_size
+        if block_idx >= len(blocks):
+            return
+        self.block_pool.cache_partial_block(
+            request=request,
+            block=blocks[block_idx],
+            num_tokens=boundary_tokens,
+            kv_cache_group_id=self.kv_cache_group_id,
+            block_size=self.block_size,
+        )
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        blocks = self.req_to_blocks[running_request_id]
+        num_common_blocks = 0
+        for block in blocks:
+            if block.ref_cnt == len(self.req_to_blocks):
+                num_common_blocks += 1
+            else:
+                break
+        return num_common_blocks
+
+
+class RSWAManager(FullAttentionManager):
+    """KV cache manager for Reference Sliding Window Attention (R-SWA).
+
+    When ``num_prompt_tokens`` is supplied to ``remove_skipped_blocks``, frees
+    gap blocks between the prefill tail and the current decode window.  This
+    bounds per-request KV memory at O(prefix_len + rswa_window) instead of
+    growing linearly with decode length.
+    """
+
+    def __init__(self, kv_cache_spec: RSWASpec, **kwargs) -> None:
+        super().__init__(kv_cache_spec, **kwargs)
+        self.rswa_window: int = kv_cache_spec.rswa_window
+
+    def remove_skipped_blocks(
+        self,
+        request_id: str,
+        processed_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
+    ) -> None:
+        """Free gap blocks that are no longer needed for attention.
+
+        Gap = blocks entirely within
+            [ceil(prefix_len / block_size) * block_size,
+             max(prefix_len, processed_computed_tokens - rswa_window))
+
+        Freed blocks are replaced with null_block in req_to_blocks so the
+        block_table passed to FA4 is valid (null_block KV is all-zero;
+        rswa_mask_mod marks gap positions as non-visible so FA4 skips them).
+        """
+        if num_prompt_tokens is None:
+            super().remove_skipped_blocks(
+                request_id, processed_computed_tokens, num_prompt_tokens
+            )
+            return
+
+        bs = self.block_size
+        # First block fully after the prefill boundary.
+        first_gap_block = cdiv(num_prompt_tokens, bs)
+        # Decode window start position; blocks before this are evictable.
+        window_start = max(
+            num_prompt_tokens, processed_computed_tokens - self.rswa_window
+        )
+        last_gap_block = window_start // bs  # exclusive upper bound
+        self._remove_blocks_in_range(request_id, first_gap_block, last_gap_block)
+
+
+class SlidingWindowManager(SingleTypeKVCacheManager):
+    def __init__(self, kv_cache_spec: SlidingWindowSpec, **kwargs) -> None:
+        super().__init__(kv_cache_spec, **kwargs)
+        self.sliding_window = kv_cache_spec.sliding_window
+        # Extra trailing tokens to retain below the window (never attended) so a
+        # multi-module MTP store-side lag can still reconstruct the window from
+        # cached blocks.
+        self.extra_retained_tokens = kv_cache_spec.extra_retained_tokens
+
+    @classmethod
+    def _contiguous_blocks_for_hit(
+        cls, window_size: int, block_size: int, use_eagle: bool
+    ) -> int:
+        blocks = cdiv(window_size - 1, block_size)
+        if use_eagle:
+            # Need to drop the last matched block if eagle is enabled. For
+            # sliding window layer, we achieve this by increasing the number of
+            # contiguous blocks needed for prefix cache hit by one and dropping
+            # the last matched block.
+            blocks += 1
+        return blocks
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        assert isinstance(kv_cache_spec, SlidingWindowSpec), (
+            "SlidingWindowManager can only be used for sliding window groups"
+        )
+        assert dcp_world_size == 1, "DCP not support sliding window attn now."
+        assert pcp_world_size == 1, "PCP not support sliding window attn now."
+        # Fine-grained partial hits are not supported for sliding window now
+        assert alignment_tokens % kv_cache_spec.block_size == 0, (
+            "SlidingWindowManager does not support fine-grained (partial) cache hits"
+        )
+        block_hashes = resolve_block_hashes(
+            block_hashes,
+            block_pool.hash_block_size,
+            kv_cache_spec.block_size,
+            supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
+            alignment_tokens=alignment_tokens,
+        )
+
+        # The number of contiguous blocks needed for a prefix cache hit.
+        sliding_window_contiguous_blocks = cls._contiguous_blocks_for_hit(
+            kv_cache_spec.sliding_window, kv_cache_spec.block_size, drop_eagle_block
+        )
+
+        # TODO: reduce i by sliding_window_contiguous_blocks when cache miss, to
+        # optimize the time complexity from O(max_num_blocks) to
+        # O(max_num_blocks / sliding_window_contiguous_blocks +
+        # sliding_window_contiguous_blocks),
+        # which is good for low cache hit rate scenarios.
+        max_num_blocks = max_length // kv_cache_spec.block_size
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [block_pool.null_block] * max_num_blocks
+            for _ in range(len(kv_cache_group_ids))
+        )
+        block_size = kv_cache_spec.block_size
+        num_contiguous_blocks = 0
+        match_found = False
+        # Search from right to left and early stop when a match is found.
+        for i in range(max_num_blocks - 1, -1, -1):
+            if cached_block := block_pool.get_cached_block(
+                block_hashes[i], kv_cache_group_ids
+            ):
+                # Skip prefix matching check if the block is not aligned with
+                # `alignment_tokens`.
+                if num_contiguous_blocks == 0 and block_size != alignment_tokens:
+                    post_pop_blocks = i if drop_eagle_block else i + 1
+                    if (post_pop_blocks * block_size) % alignment_tokens != 0:
+                        continue
+                # Add the cached block to the computed blocks.
+                for computed, cached in zip(computed_blocks, cached_block):
+                    computed[i] = cached
+                num_contiguous_blocks += 1
+                if num_contiguous_blocks >= sliding_window_contiguous_blocks:
+                    # Trim the trailing blocks.
+                    # E.g., [NULL, NULL, 8, 3, NULL, 9] -> [NULL, NULL, 8, 3]
+                    # when sliding_window_contiguous_blocks=2.
+                    for computed in computed_blocks:
+                        del computed[i + num_contiguous_blocks :]
+                    match_found = True
+                    break
+            else:
+                num_contiguous_blocks = 0
+        if not match_found:
+            # The first `num_contiguous_blocks` is a cache hit even if
+            # `num_contiguous_blocks < sliding_window_contiguous_blocks`.
+            for computed in computed_blocks:
+                del computed[num_contiguous_blocks:]
+            while (
+                block_size != alignment_tokens  # Faster for common case.
+                and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+            ):
+                for computed in computed_blocks:
+                    computed.pop()
+        if drop_eagle_block and computed_blocks[0]:
+            for computed in computed_blocks:
+                computed.pop()
+            # Re-align after eagle pop: the pop may break the alignment
+            # when block_size != alignment_tokens (hybrid models with
+            # different page sizes, e.g. Gemma4).
+            while (
+                block_size != alignment_tokens
+                and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+            ):
+                for computed in computed_blocks:
+                    computed.pop()
+        hit_length = len(computed_blocks[0]) * block_size
+        return computed_blocks, hit_length
+
+    @classmethod
+    def reachable_block_mask(
+        cls,
+        start_block: int,
+        end_block: int,
+        alignment_tokens: int | None,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        retention_interval: int | None = None,
+        reachable_boundaries: Sequence[int] = (),
+    ) -> list[bool] | None:
+        assert isinstance(kv_cache_spec, SlidingWindowSpec)
+        if alignment_tokens is None:
+            # Fast path: when the coordinator imposes no alignment constraint.
+            return None
+        assert alignment_tokens % kv_cache_spec.block_size == 0
+
+        block_size = kv_cache_spec.block_size
+        # Contiguous blocks a hit needs at a boundary (incl. the EAGLE peek).
+        need = cls._contiguous_blocks_for_hit(
+            window_size=kv_cache_spec.sliding_window,
+            block_size=block_size,
+            use_eagle=use_eagle,
+        )
+        # The matched run's right edge sits on the aligned boundary block when
+        # EAGLE peeks one block past it (shift=1), otherwise on the last block
+        # before the boundary (shift=0).
+        shift = 1 if use_eagle else 0
+
+        mask = [False] * (end_block - start_block)
+
+        # (1) Segment-boundary tails. ``retention_interval``:
+        #   None -> dense (a tail at every ``alignment_tokens`` boundary);
+        #   0    -> no dense tails (only the replay boundary below);
+        #   >0   -> a tail once per ``retention_interval``-sized segment.
+        segment_tokens = (
+            alignment_tokens
+            if retention_interval is None
+            else (None if retention_interval == 0 else retention_interval)
+        )
+        if segment_tokens is not None:
+            per_segment = segment_tokens // block_size
+            if need >= per_segment:
+                # Every block is reachable; cache them all.
+                return None
+            for i in range(start_block, end_block):
+                if i >= shift and (i - shift) % per_segment >= per_segment - need:
+                    mask[i - start_block] = True
+
+        # (2) Reachable-boundary tails: the replay boundary (``num_prompt - 1``,
+        # capped by ``get_computed_blocks``) and any shared-prefix junction. Both
+        # land before segments would cover them under sparse retention, so keep
+        # the ``need``-block tail ending on each boundary explicitly.
+        if retention_interval is not None:
+            for boundary_tokens in reachable_boundaries:
+                aligned = boundary_tokens // alignment_tokens * alignment_tokens
+                end = aligned // block_size + shift
+                for j in range(max(start_block, end - need), min(end_block, end)):
+                    mask[j - start_block] = True
+
+        return mask
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        """
+        Get the number of tokens that will be skipped for attention computation.
+
+        For sliding window, this corresponds to the tokens that are prior to
+        the current sliding window.
+
+        Example:
+        sliding_window=4, num_computed_tokens=7
+
+        Tokens:   [ 0  1  2  3  4  5  6  7 ]
+                  | ---- computed -----|
+                                         ^ next token to be computed
+                               |-----------| sliding window for next token
+                  |--skipped---|
+
+        The current window contains tokens 4~7. Tokens 0~3 will be skipped for
+        attention computation since they are outside the sliding window.
+        Thus, get_num_skipped_tokens(7) == 4.
+
+        The trailing edge of the window is extended by ``extra_retained_tokens``
+        so that those extra trailing tokens' blocks are retained (but not
+        attended). This is needed for multi-module spec decoding which can
+        re-prefill the last num_spec_prefill_tokens - 1 tokens from the end
+        of the sequence, and thus needs to delay freeing/caching of blocks.
+
+        Args:
+            num_computed_tokens: The number of tokens that have been computed.
+
+        Returns:
+            The number of tokens that will be skipped for attention computation.
+        """
+        return max(
+            0,
+            num_computed_tokens - self.sliding_window + 1 - self.extra_retained_tokens,
+        )
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        """
+        NOTE(Chen): The prefix blocks are null blocks for sliding window layers.
+        So it's not correct to count ref_cnt like FullAttentionManager. Return
+        0 here for correctness. Need to support cascade attention + sliding
+        window in the future.
+        """
+        return 0
+
+
+class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
+    def __init__(self, kv_cache_spec: ChunkedLocalAttentionSpec, **kwargs) -> None:
+        super().__init__(kv_cache_spec, **kwargs)
+        self.attention_chunk_size = kv_cache_spec.attention_chunk_size
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        """
+        For chunked local attention, we need to find the longest cache hit
+        prefix of the blocks that is not longer than `max_length`. The prefix
+        should be a common prefix hit for all the kv cache groups in
+        `kv_cache_group_ids`. If no cache hit is found, return an empty list.
+        note we mark as computed if the whole block is outside of the local
+        window, and set the block as null. Examples:
+
+        1. Attention chunk size of 8, block size of 4, max length of 15
+        for next token at 15th (zero-indexed), 8th - 14th tokens are in
+        the window(needs lookup), 0th - 7th are not in the window,
+        so they are already marked as computed. We check the complete
+        block3 (8th - 11th tokens), Assume block 3 is hit, we will return
+        [null, null, block 3], otherwise, we return [null, null]
+
+        2. Attention chunk size of 8, block size of 4, max length of 16
+        for next token at 16th (zero-indexed), 0th - 15th tokens are not
+        in the window, so they are already marked as computed.
+        we return 4 blocks[null, null, null, null]
+
+        Args:
+            block_hashes: The block hashes of the request.
+            max_length: The maximum length of the cache hit prefix.
+            kv_cache_group_ids: The ids of the kv cache groups.
+            block_pool: The block pool.
+            kv_cache_spec: The kv cache spec.
+            drop_eagle_block: Whether to drop the last matched block for EAGLE/MTP.
+            dcp_world_size: The world size of decode context parallelism.
+            pcp_world_size: The world size of prefill context parallelism.
+            alignment_tokens: The returned cache hit length (in tokens) should
+                be a multiple of this value (in tokens).
+
+        Returns:
+            A list of cached blocks
+        """
+        assert isinstance(kv_cache_spec, ChunkedLocalAttentionSpec), (
+            "ChunkedLocalAttentionManager can only be used for "
+            "chunked local attention groups"
+        )
+        assert drop_eagle_block is False, (
+            "Hybrid KV cache is not supported for " + "eagle + chunked local attention."
+        )
+        assert dcp_world_size == 1, "DCP not support chunked local attn now."
+        assert pcp_world_size == 1, "PCP not support chunked local attn now."
+        assert kv_cache_spec.block_size == alignment_tokens, (
+            "KV cache groups with different block sizes are not compatible with "
+            "chunked local attention now"
+        )
+        block_hashes = resolve_block_hashes(
+            block_hashes,
+            block_pool.hash_block_size,
+            kv_cache_spec.block_size,
+            supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
+            alignment_tokens=alignment_tokens,
+        )
+        max_num_blocks = max_length // kv_cache_spec.block_size
+        if max_length > 0:
+            local_attention_start_idx = (
+                max_length
+                // kv_cache_spec.attention_chunk_size
+                * kv_cache_spec.attention_chunk_size
+            )
+        else:
+            local_attention_start_idx = 0
+        # we marked blocks out of window as computed
+        # with null blocks, and blocks inside window based on cache lookup
+        # result [null] [null] ... [null] [hit block 1 (1st block contain
+        # last window)] [hit block 2] ... [hit block x]
+        local_attention_start_block_idx = (
+            local_attention_start_idx // kv_cache_spec.block_size
+        )
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [block_pool.null_block] * local_attention_start_block_idx
+            for _ in range(len(kv_cache_group_ids))
+        )
+        for i in range(local_attention_start_block_idx, max_num_blocks):
+            block_hash = block_hashes[i]
+            if cached_block := block_pool.get_cached_block(
+                block_hash, kv_cache_group_ids
+            ):
+                for computed, cached in zip(computed_blocks, cached_block):
+                    computed.append(cached)
+            else:
+                break
+        hit_length = len(computed_blocks[0]) * kv_cache_spec.block_size
+        return computed_blocks, hit_length
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        """
+        Get the number of tokens that will be skipped for attention computation.
+
+        For chunked local attention, this corresponds to the tokens that are on
+        the left side of the current chunk.
+
+        Example 1:
+        chunk size = 8, num_computed_tokens = 13
+        Tokens:  [ 0 1 2 3 4 5 6 7 | 8 9 10 11 12 13 14 15 ] ...
+                 | ----- computed ---------------|
+                                                  ^^ next token to be computed
+                                   |----------------| <-- attention window for
+                                                          next token
+                 |--- skipped -----|
+        Output: get_num_skipped_tokens(13) == 8
+
+        Example 2:
+        chunk size = 8, num_computed_tokens = 8
+        Tokens:  [ 0 1 2 3 4 5 6 7 | 8 9 10 11 12 13 14 15 ] ...
+                 | --- computed ---|
+                                     ^ next token to be computed
+                                   |--| <-- attention window for next token
+                 | --- skipped ----|
+        Output: get_num_skipped_tokens(8) == 8
+
+        Example 3:
+        chunk size = 8, num_computed_tokens = 7
+        Tokens:  [ 0 1 2 3 4 5 6 7 | 8 9 10 11 12 13 14 15 ] ...
+                 |---computed---|
+                                 ^ next token to be computed
+                 |-----------------| <-- attention window for next token
+                 no token should be skipped.
+        Output: get_num_skipped_tokens(7) == 0
+
+        Args:
+            num_computed_tokens: The number of tokens that have been computed.
+
+        Returns:
+            The number of tokens that will be skipped for attention computation.
+        """
+        num_skipped_tokens = (
+            num_computed_tokens // self.attention_chunk_size
+        ) * self.attention_chunk_size
+        return num_skipped_tokens
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        """
+        cascade attention is not supported by chunked local attention.
+        """
+        return 0
+
+
+class MambaManager(SingleTypeKVCacheManager):
+    supports_fine_grained_hash_lookup: ClassVar[bool] = True
+
+    def __init__(
+        self, kv_cache_spec: MambaSpec, block_pool: BlockPool, **kwargs
+    ) -> None:
+        super().__init__(kv_cache_spec, block_pool, **kwargs)
+        # Mamba layers use TP instead of DCP, so each rank holds the full
+        # recurrent state. Undo the DCP/PCP block_size scaling that the base
+        # class applies for attention groups whose KV cache is partitioned.
+        self.block_size = kv_cache_spec.block_size
+        self.mamba_cache_mode = kv_cache_spec.mamba_cache_mode
+        self.num_speculative_blocks: int = kv_cache_spec.num_speculative_blocks
+        self.cached_blocks_this_step: set[BlockHashWithGroupId] = set()
+        if self.mamba_cache_mode == "align":
+            # Mapping from request ID to the index of the block
+            # allocated in the previous step
+            self.last_state_block_idx: dict[str, int] = {}
+            # The set of the requests that have been allocated blocks
+            self._allocated_block_reqs: set[str] = set()
+            # Number of internal checkpoint blocks required by each request's
+            # current allocation.
+            self._num_checkpoint_blocks: dict[str, int] = {}
+            # Requests that registered their own last-prompt-boundary partial
+            # tail (producers). On the next step's CoW the boundary state moves
+            # into a private cow_block; we record that block for connector
+            # offload (see _pending_partial_tail_offloads).
+            self._producer_partial_tail_reqs: dict[str, int] = {}
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        assert isinstance(kv_cache_spec, MambaSpec), (
+            "MambaManager can only be used for mamba groups"
+        )
+        assert dcp_world_size == 1, "DCP not support mamba now."
+        assert pcp_world_size == 1, "PCP not support mamba now."
+        block_hashes = resolve_block_hashes(
+            block_hashes,
+            block_pool.hash_block_size,
+            kv_cache_spec.block_size,
+            supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
+            alignment_tokens=alignment_tokens,
+        )
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [] for _ in range(len(kv_cache_group_ids))
+        )
+        hit_length = 0
+
+        block_size = kv_cache_spec.block_size
+        if alignment_tokens < block_size and block_size % alignment_tokens == 0:
+            # list or lazy BlobBlockHashes view
+            assert isinstance(block_hashes, Sequence)
+            hash_block_size = alignment_tokens
+            scale_factor = block_size // hash_block_size
+            max_num_partial_units = min(
+                max_length // hash_block_size, len(block_hashes)
+            )
+            for fine_idx in range(max_num_partial_units - 1, -1, -1):
+                num_tokens = (fine_idx + 1) * hash_block_size
+                block_hash = block_hashes[fine_idx]
+                if cached_block := block_pool.get_cached_block(
+                    block_hash, kv_cache_group_ids
+                ):
+                    block_idx = fine_idx // scale_factor
+                    for computed, cached in zip(computed_blocks, cached_block):
+                        computed.extend([block_pool.null_block] * block_idx)
+                        computed.append(cached)
+                    hit_length = num_tokens
+                    break
+            return computed_blocks, hit_length
+
+        max_num_blocks = max_length // block_size
+        # Search from right to left and early stop when a match is found.
+        for i in range(max_num_blocks - 1, -1, -1):
+            if cached_block := block_pool.get_cached_block(
+                block_hashes[i], kv_cache_group_ids
+            ):
+                # When enable Mamba prefix caching, `block_size` will be aligned
+                # across full attention layers and Mamba layers to ensure the
+                # prefix hit length aligned at block
+                if (
+                    block_size != alignment_tokens  # Faster for common case.
+                    and (i + 1) * block_size % alignment_tokens != 0
+                ):
+                    continue
+                for computed, cached in zip(computed_blocks, cached_block):
+                    # the hit length logic later assumes:
+                    #  hit_length = len(hit_blocks_other_attn[0])
+                    #               * self.other_block_size
+                    # so we insert dummy blocks at the beginning:
+                    computed.extend([block_pool.null_block] * i)
+                    computed.append(cached)
+                hit_length = (i + 1) * block_size
+                break  # we just need the last match - early stopping
+
+        return computed_blocks, hit_length
+
+    @classmethod
+    def reachable_block_mask(
+        cls,
+        start_block: int,
+        end_block: int,
+        alignment_tokens: int | None,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        retention_interval: int | None = None,
+        reachable_boundaries: Sequence[int] = (),
+    ) -> list[bool] | None:
+        """Sparse Mamba state-snapshot retention.
+
+        ``retention_interval``:
+
+          ``None`` -> dense (cache every block; default, unchanged behavior)
+          ``0``    -> keep only the ``reachable_boundaries`` states
+          ``> 0``  -> keep one state per ``retention_interval``-sized segment
+
+        ``reachable_boundaries`` are proven reuse points (the replay boundary and
+        any cross-request shared-prefix junction, Marconi-style APC); their
+        boundary state is always kept so sparse retention does not defeat reuse.
+        """
+        if retention_interval is None or alignment_tokens is None:
+            # Dense caching (default) or no alignment constraint imposed.
+            return None
+        assert isinstance(kv_cache_spec, MambaSpec)
+        block_size = kv_cache_spec.block_size
+        mask = [False] * (end_block - start_block)
+
+        # (1) Segment-boundary states. A Mamba hit needs exactly the single
+        # state block ending on the boundary (no window, and draft models have
+        # no mamba layers, so no eagle shift). Block ``i`` ends at token
+        # ``(i + 1) * block_size``.
+        segment_tokens = None if retention_interval == 0 else retention_interval
+        if segment_tokens is not None:
+            per_segment = segment_tokens // block_size
+            if per_segment <= 1:
+                # Interval at/below the block size: every block is a boundary.
+                return None
+            first_boundary = (
+                start_block + per_segment
+            ) // per_segment * per_segment - 1
+            for i in range(first_boundary - start_block, len(mask), per_segment):
+                mask[i] = True
+
+        # (2) Reachable-boundary states: the replay boundary (``num_prompt - 1``,
+        # capped by ``get_computed_blocks``) and any shared-prefix junction, both
+        # of which segments would otherwise skip under sparse retention. A Mamba
+        # hit needs exactly the single state block ending on the boundary.
+        for boundary_tokens in reachable_boundaries:
+            aligned = boundary_tokens // alignment_tokens * alignment_tokens
+            boundary_block = aligned // block_size - 1
+            if start_block <= boundary_block < end_block:
+                mask[boundary_block - start_block] = True
+
+        return mask
+
+    def remove_skipped_blocks(
+        self,
+        request_id: str,
+        processed_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
+    ) -> None:
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+
+        super().remove_skipped_blocks(
+            request_id, processed_computed_tokens, num_prompt_tokens
+        )
+        if self.mamba_cache_mode == "align":
+            # `last_state_block_idx` refers to the block index allocated two steps ago.
+            # The block allocated in the previous step is used to copy Mamba states
+            # into the block allocated in the current step; the earlier block is
+            # no longer needed and should be freed here.
+            last_state_block_idx = self.last_state_block_idx.get(request_id)
+            # Blocks allocated during prefill may be non-contiguous. Use
+            # `last_state_block_idx` to free the appropriate block and replace it
+            # with a null block.
+            if (
+                last_state_block_idx is not None
+                and last_state_block_idx
+                < cdiv(processed_computed_tokens, self.block_size) - 1
+            ):
+                blocks = self.req_to_blocks[request_id]
+                if blocks[last_state_block_idx] != self._null_block:
+                    self.block_pool.free_blocks([blocks[last_state_block_idx]])
+                    blocks[last_state_block_idx] = self._null_block
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        """
+        cascade attention is not supported by mamba
+        """
+        return 0
+
+    def _needs_internal_checkpoint(
+        self,
+        request_id: str,
+        num_tokens: int,
+        num_computed_tokens: int,
+    ) -> bool:
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+        checkpoint_idx = cdiv(num_tokens, self.block_size) - 2
+        blocks = self.req_to_blocks[request_id]
+        return (
+            self.kv_cache_spec.num_prefill_checkpoint_blocks > 0
+            and num_tokens % self.block_size != 0
+            and num_computed_tokens % self.block_size == 0
+            and checkpoint_idx >= 0
+            and (checkpoint_idx >= len(blocks) or blocks[checkpoint_idx].is_null)
+        )
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_local_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+        if (
+            len(new_computed_blocks) > 0
+            and new_computed_blocks[-1].block_hash in self.cached_blocks_this_step
+        ):
+            # Mamba can't rely on blocks generated by other requests in the current step
+            # To put it in the next step, we return num_gpu_blocks + 1 so
+            # that kv_cache_manager will think there is no enough blocks to allocate now
+            # and don't schedule it in the current step.
+            return self.block_pool.num_gpu_blocks + 1
+        if self.mamba_cache_mode != "align":
+            # Allocate extra `num_speculative_blocks` blocks for
+            # speculative decoding (MTP/EAGLE) with linear attention.
+            if self.num_speculative_blocks > 0:
+                num_tokens += (
+                    self.kv_cache_spec.block_size * self.num_speculative_blocks
+                )
+            return super().get_num_blocks_to_allocate(
+                request_id,
+                num_tokens,
+                new_computed_blocks,
+                total_computed_tokens,
+                num_local_computed_tokens,
+                num_tokens_main_model,
+                apply_admission_cap=apply_admission_cap,
+            )
+        else:
+            # We don't allocate blocks for lookahead tokens in align mode, because if
+            # x * block_size tokens are scheduled, num_tokens is
+            # x * block_size + num_lookahead_tokens and breaks the alignment.
+            # We can ignore lookahead tokens because current draft models don't have
+            # mamba layers.
+            num_tokens = num_tokens_main_model
+
+            # NOTE(tdouble): this is an over-estimate of how many blocks we need because
+            # num_tokens can include draft tokens that will later be rejected.
+            num_required_blocks = (
+                cdiv(num_tokens, self.block_size) + self.num_speculative_blocks
+            )
+            num_new_blocks = (
+                num_required_blocks
+                - len(new_computed_blocks)
+                - len(self.req_to_blocks[request_id])
+            )
+            has_partial_hit = (
+                self._has_partial_local_hit(
+                    new_computed_blocks, num_local_computed_tokens
+                )
+                or request_id in self._partial_hit_reqs
+            )
+            if has_partial_hit:
+                num_new_blocks = max(num_new_blocks, 0) + 1
+            checkpoint_block = int(
+                self._needs_internal_checkpoint(
+                    request_id, num_tokens, total_computed_tokens
+                )
+            )
+            if not apply_admission_cap:
+                self._num_checkpoint_blocks[request_id] = checkpoint_block
+            if num_new_blocks > 0:
+                num_new_blocks = 1 + int(has_partial_hit) + checkpoint_block
+                if request_id not in self._allocated_block_reqs:
+                    num_new_blocks += self.num_speculative_blocks
+
+            num_evictable_computed_blocks = self._get_num_evictable_blocks(
+                new_computed_blocks
+            )
+            return num_new_blocks + num_evictable_computed_blocks
+
+    def allocate_new_blocks(
+        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+    ) -> list[KVCacheBlock]:
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+        if self.mamba_cache_mode != "align":
+            # Allocate extra `num_speculative_blocks` blocks for
+            # speculative decoding (MTP/EAGLE) with linear attention.
+            if self.num_speculative_blocks > 0:
+                num_tokens += self.block_size * self.num_speculative_blocks
+            return super().allocate_new_blocks(
+                request_id, num_tokens, num_tokens_main_model
+            )
+        else:
+            # We don't allocate blocks for lookahead tokens in align mode, because if
+            # x * block_size tokens are scheduled, num_tokens is
+            # x * block_size + num_lookahead_tokens and breaks the alignment.
+            # We can ignore lookahead tokens because current draft models don't have
+            # mamba layers.
+            num_tokens = num_tokens_main_model
+            req_blocks: list[KVCacheBlock] = self.req_to_blocks[request_id]
+            # NOTE(tdouble): this is an over-estimate of how many blocks we need because
+            # num_tokens can include draft tokens that will later be rejected.
+            num_required_blocks = (
+                cdiv(num_tokens, self.block_size) + self.num_speculative_blocks
+            )
+            checkpoint_block = self._num_checkpoint_blocks.get(request_id, 0)
+            partial_hit = self._partial_hit_reqs.get(request_id)
+            has_partial_hit = partial_hit is not None
+            # `num_required_blocks` might be less than `len(req_blocks)` if blocks are
+            # over-allocated at last round.
+            if num_required_blocks <= len(req_blocks) and not has_partial_hit:
+                self._allocated_block_reqs.add(request_id)
+                return []
+            else:
+                prev_block_len = len(req_blocks)
+                blocks_allocated = request_id in self._allocated_block_reqs
+                # Record the last state block
+                if blocks_allocated:
+                    # We always save the running state at the last
+                    # (1 + num_speculative_blocks) block
+                    self.last_state_block_idx[request_id] = (
+                        prev_block_len - 1 - self.num_speculative_blocks
+                    )
+                elif prev_block_len > 0:
+                    # When a new request hits the prefix cache, the last block
+                    # saves the hit state.
+                    self.last_state_block_idx[request_id] = prev_block_len - 1
+
+                num_skipped_blocks = (
+                    num_required_blocks - self.num_speculative_blocks - 1
+                )
+                # null blocks
+                if prev_block_len < num_skipped_blocks:
+                    # minus the internal checkpoint block
+                    # so we don't set null for that block
+                    null_end = num_skipped_blocks - checkpoint_block
+                    req_blocks.extend(
+                        [self._null_block for _ in range(prev_block_len, null_end)]
+                    )
+
+                if blocks_allocated:
+                    # reuse previous speculative blocks in this step
+                    for block_idx in range(
+                        prev_block_len - self.num_speculative_blocks, prev_block_len
+                    ):
+                        if block_idx < num_skipped_blocks:
+                            req_blocks.append(req_blocks[block_idx])
+                            req_blocks[block_idx] = self._null_block
+                        else:
+                            break
+                num_new_blocks = num_required_blocks - len(req_blocks)
+                if has_partial_hit:
+                    num_new_blocks = max(num_new_blocks, 0) + 1
+                max_new_blocks = 1 + int(has_partial_hit) + checkpoint_block
+                if not blocks_allocated:
+                    max_new_blocks += self.num_speculative_blocks
+                assert num_new_blocks <= max_new_blocks
+                new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+                returned_blocks = req_blocks[prev_block_len:]
+                if partial_hit is not None:
+                    block_idx, source_block = partial_hit
+                    cow_block = new_blocks[0]
+                    new_blocks = new_blocks[1:]
+                    if blocks_allocated:
+                        # The worker block table of a running request is
+                        # append-only, so the request must stay on
+                        # source_block. Move the cache entry to cow_block
+                        # instead; the queued copy fills it before forward
+                        # overwrites source_block.
+                        assert req_blocks[block_idx] is source_block
+                        self.block_pool.move_block_hashes(source_block, cow_block)
+                        self._pending_cow_copies.append((source_block, cow_block))
+                        source_block.ref_cnt += 1
+                        boundary_tokens = self._producer_partial_tail_reqs.pop(
+                            request_id, None
+                        )
+                        if boundary_tokens is not None:
+                            # This CoW preserved a producer's own boundary
+                            # state in cow_block; hand it to the connector for
+                            # partial-tail offload once the copy has run.
+                            self._pending_partial_tail_offloads.append(
+                                (
+                                    request_id,
+                                    self.kv_cache_group_id,
+                                    cow_block,
+                                    boundary_tokens,
+                                )
+                            )
+                        if cow_block.block_hash is not None:
+                            # The moved entry is only filled by this step's
+                            # copy, so defer same-step hits on it.
+                            self.cached_blocks_this_step.add(cow_block.block_hash)
+                    else:
+                        self._apply_cow(request_id, block_idx, source_block, cow_block)
+                        returned_blocks = [cow_block] + returned_blocks
+                req_blocks.extend(new_blocks)
+                self._allocated_block_reqs.add(request_id)
+                self._partial_hit_reqs.pop(request_id, None)
+                returned_blocks.extend(new_blocks)
+                return returned_blocks
+
+    def pop_blocks_for_free(self, request_id: str) -> list[KVCacheBlock]:
+        if self.mamba_cache_mode == "align":
+            self._allocated_block_reqs.discard(request_id)
+            self.last_state_block_idx.pop(request_id, None)
+            self._num_checkpoint_blocks.pop(request_id, None)
+            self._producer_partial_tail_reqs.pop(request_id, None)
+            # A hand-off whose request died in this same scheduling pass must
+            # not reach the connector: its unpin hook (free) has already run.
+            self._pending_partial_tail_offloads = [
+                entry
+                for entry in self._pending_partial_tail_offloads
+                if entry[0] != request_id
+            ]
+        return super().pop_blocks_for_free(request_id)
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        """
+        Get the number of tokens whose mamba state are not needed anymore. Mamba only
+        need to keep the state of the last computed token, so we return
+        num_computed_tokens - 1.
+        """
+        return num_computed_tokens - 1
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+    ) -> None:
+        num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
+        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
+        if self.mamba_cache_mode == "align":
+            partial_hash = self._cache_partial_tail_block(request, num_tokens)
+            if partial_hash is not None:
+                self.cached_blocks_this_step.add(partial_hash)
+        if num_cached_blocks_after > num_cached_blocks_before:
+            blocks = self.req_to_blocks[request.request_id]
+            for idx in range(num_cached_blocks_before, num_cached_blocks_after):
+                block = blocks[idx]
+                # Skip null blocks (align-mode skipped states) and blocks that
+                # were not cached this step — with sparse retention
+                # (reachable_block_mask) the intermediate state snapshots carry
+                # no hash and must not be recorded as cached-this-step.
+                if block.is_null or block.block_hash is None:
+                    continue
+                self.cached_blocks_this_step.add(block.block_hash)
+                if self.mamba_cache_mode == "align":
+                    # LMCache must save this exact committed boundary block.
+                    # Positional lookup is unsafe because align-mode block
+                    # tables are sparse and mutable under speculation/CoW.
+                    self._pending_partial_tail_offloads.append(
+                        (
+                            request.request_id,
+                            self.kv_cache_group_id,
+                            block,
+                            (idx + 1) * self.block_size,
+                        )
+                    )
+
+    def new_step_starts(self) -> None:
+        self.cached_blocks_this_step.clear()
+
+    def _cache_partial_tail_block(
+        self,
+        request: Request,
+        num_tokens: int,
+    ) -> BlockHashWithGroupId | None:
+        hash_block_size = self.block_pool.hash_block_size
+        if self.block_size == hash_block_size:
+            return None
+        if num_tokens % self.block_size == 0:
+            return None
+        if num_tokens % hash_block_size != 0:
+            return None
+        latest_prompt_hash_boundary = (
+            request.num_prompt_tokens // hash_block_size
+        ) * hash_block_size
+        if num_tokens != latest_prompt_hash_boundary:
+            return None
+
+        block_idx = num_tokens // self.block_size
+        blocks = self.req_to_blocks[request.request_id]
+        if block_idx >= len(blocks):
+            return None
+        source_block = blocks[block_idx]
+        if source_block.is_null:
+            return None
+
+        partial_hash = self.block_pool.cache_partial_block(
+            request=request,
+            block=source_block,
+            num_tokens=num_tokens,
+            kv_cache_group_id=self.kv_cache_group_id,
+            block_size=self.block_size,
+        )
+        if partial_hash is not None:
+            self._partial_hit_reqs[request.request_id] = (block_idx, source_block)
+            self.num_cached_block[request.request_id] = block_idx
+            # Producer of this partial tail: the boundary state currently lives
+            # in ``source_block`` but the next step's forward overwrites it. The
+            # upcoming CoW copies it into a durable cow_block; record the req so
+            # allocate_new_blocks hands that block to the connector for offload.
+            self._producer_partial_tail_reqs[request.request_id] = num_tokens
+        return partial_hash
+
+
+class CrossAttentionManager(SingleTypeKVCacheManager):
+    """Manager for cross-attention KV cache in encoder-decoder models."""
+
+    def add_local_computed_blocks(
+        self,
+        request_id: str,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        # We do not cache blocks for cross-attention to be shared between
+        # requests, so  `new_computed_blocks` should always be empty.
+        assert len(new_computed_blocks) == 0
+
+    def allocate_external_computed_blocks(
+        self,
+        request_id: str,
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        # Cross-attention does not use prefix caching / external KV loads.
+        return
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+    ) -> None:
+        # We do not cache blocks for cross-attention to be shared between
+        # requests, so this method is not relevant.
+        raise ValueError("Should not be called as prefix caching is disabled.")
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        # Cross-attention blocks contain request-specific encoder states
+        # and are not shared between different requests
+        return 0
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        assert isinstance(kv_cache_spec, CrossAttentionSpec), (
+            "CrossAttentionManager can only be used for cross-attention groups"
+        )
+        # Cross-attention does not benefit from prefix caching since:
+        # 1. Encoder states are unique per request (different audio/image
+        #    inputs)
+        # 2. Encoder states are computed once per request, not incrementally
+        # 3. No reusable prefix exists between different multimodal inputs
+        # Return empty blocks to indicate no cache hits
+        raise NotImplementedError("CrossAttentionManager does not support caching")
+
+
+class SinkFullAttentionManager(FullAttentionManager):
+    def __init__(
+        self,
+        kv_cache_spec: SinkFullAttentionSpec,
+        block_pool: BlockPool,
+        enable_caching: bool,
+        kv_cache_group_id: int,
+        scheduler_block_size: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ):
+        super().__init__(
+            kv_cache_spec=kv_cache_spec,
+            block_pool=block_pool,
+            enable_caching=enable_caching,
+            kv_cache_group_id=kv_cache_group_id,
+            scheduler_block_size=scheduler_block_size,
+            dcp_world_size=dcp_world_size,
+            pcp_world_size=pcp_world_size,
+        )
+        sink_len = kv_cache_spec.sink_len
+        assert sink_len is not None and sink_len > 0 and sink_len % self.block_size == 0
+        num_sink_block = sink_len // self.block_size
+        self.sink_blocks = self.block_pool.free_block_queue.popleft_n(num_sink_block)
+
+
+def get_manager_for_kv_cache_spec(
+    kv_cache_spec: KVCacheSpec,
+    max_in_flight_tokens: int,
+    max_model_len: int,
+    **kwargs,
+) -> SingleTypeKVCacheManager:
+    """
+    Get the appropriate manager for a given KVCacheSpec.
+
+    Uses the KVCacheSpecRegistry to look up the manager class, supporting
+    both built-in and custom specs registered via @register_kv_cache_spec
+    and KVCacheSpecRegistry.register.
+
+    Args:
+        kv_cache_spec: The KVCacheSpec instance
+        max_in_flight_tokens: The max tokens scheduled but not yet settled
+            (one batch per concurrent step); see `VllmConfig.max_in_flight_tokens`
+        max_model_len: The maximum context length the model could serve
+    Returns:
+        An instance of the appropriate SingleTypeKVCacheManager subclass
+    """
+    manager_class = KVCacheSpecRegistry.get_manager_class(kv_cache_spec)
+    assert manager_class is not None, (
+        f"No manager registered for KVCacheSpec {type(kv_cache_spec)}"
+    )
+    # SlidingWindow / ChunkedLocalAttention managers recycle blocks;
+    # the runtime admission cap must match the recycling-aware bound the
+    # startup pool sizer uses (single source of truth: the spec method).
+    # R-SWA also recycles gap blocks but peak physical KV still fits the
+    # full-attention bound (prefix + window <= max_model_len), so it inherits
+    # FullAttentionSpec sizing without a separate admission cap.
+    if isinstance(
+        kv_cache_spec,
+        (SlidingWindowSpec, ChunkedLocalAttentionSpec),
+    ):
+        kwargs["max_admission_blocks_per_request"] = (
+            kv_cache_spec.max_admission_blocks_per_request(
+                max_in_flight_tokens=max_in_flight_tokens,
+                max_model_len=max_model_len,
+            )
+        )
+    manager = manager_class(kv_cache_spec, **kwargs)
+    return manager
+
+
+def register_all_kvcache_specs(vllm_config):
+    """Built-in spec registration"""
+    KVCacheSpecRegistry.register(
+        FullAttentionSpec,
+        FullAttentionManager,
+        uniform_type_base_spec=FullAttentionSpec,
+    )
+
+    KVCacheSpecRegistry.register(
+        SlidingWindowSpec,
+        SlidingWindowManager,
+        uniform_type_base_spec=SlidingWindowSpec,
+    )
+    KVCacheSpecRegistry.register(
+        SlidingWindowMLASpec,
+        SlidingWindowManager,
+        uniform_type_base_spec=SlidingWindowMLASpec,
+    )
+
+    KVCacheSpecRegistry.register(
+        MambaSpec, MambaManager, uniform_type_base_spec=MambaSpec
+    )
+    KVCacheSpecRegistry.register(
+        ChunkedLocalAttentionSpec,
+        ChunkedLocalAttentionManager,
+        uniform_type_base_spec=ChunkedLocalAttentionSpec,
+    )
+    KVCacheSpecRegistry.register(
+        CrossAttentionSpec,
+        CrossAttentionManager,
+        uniform_type_base_spec=CrossAttentionSpec,
+    )
+
+    # FullAttentionSpec subclasses — grouped with FullAttentionSpec
+    KVCacheSpecRegistry.register(
+        MLAAttentionSpec, FullAttentionManager, uniform_type_base_spec=FullAttentionSpec
+    )
+    KVCacheSpecRegistry.register(
+        RSWASpec, RSWAManager, uniform_type_base_spec=FullAttentionSpec
+    )
+    # NOTE(Mengqing): HiddenStateCacheSpec won't take part in
+    # grouping, thus the uniform_type_base_spec is just a
+    # placeholder.
+    KVCacheSpecRegistry.register(
+        HiddenStateCacheSpec,
+        FullAttentionManager,
+        uniform_type_base_spec=FullAttentionSpec,
+    )
+    KVCacheSpecRegistry.register(
+        SinkFullAttentionSpec,
+        SinkFullAttentionManager,
+        uniform_type_base_spec=FullAttentionSpec,
+    )
+
+    from vllm.platforms import current_platform
+
+    current_platform.register_custom_kv_cache_specs(vllm_config)

--- a/docker/glm53-flash/lmcache-d16-overlay/patch_lmcache_padded_packed_stride.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/patch_lmcache_padded_packed_stride.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Enable physical dim-0 stride for LMCache packed HND format 12."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+RELATIVE = Path("lmcache/v1/gpu_connector/utils.py")
+EXPECTED_BEFORE = "659fd0f7c980e405ec6086004c8e912b4371577b4089bbc25610fe23fcfcba5b"
+EXPECTED_AFTER = "71f6e2a740a082955a59df3284fa13dc67d123d61268a3a71c986a4488477df4"
+
+OLD_ALLOWLIST = """\
+_BLOCK_AXIS_FORMATS: frozenset = frozenset(
+    {
+        lmcache_native.EngineKVFormat.NL_X_NB_BS_HS,
+        lmcache_native.EngineKVFormat.NL_X_NB_BSV_BSS,
+    }
+)
+"""
+
+NEW_ALLOWLIST = """\
+_BLOCK_AXIS_FORMATS: frozenset = frozenset(
+    {
+        lmcache_native.EngineKVFormat.NL_X_NB_BS_HS,
+        lmcache_native.EngineKVFormat.NL_X_NB_BSV_BSS,
+        lmcache_native.EngineKVFormat.NL_X_NB_NH_BS_CS,
+    }
+)
+"""
+
+OLD_ERROR = """\
+                    "a supported dim-0-padded format (only "
+                    "NL_X_NB_BS_HS is); downstream transfer kernels "
+"""
+
+NEW_ERROR = """\
+                    "a supported dim-0-padded format (only NL_X_NB_BS_HS and "
+                    "NL_X_NB_NH_BS_CS are); downstream transfer kernels "
+"""
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def patch(root: Path, *, discover: bool = False) -> str:
+    path = root / RELATIVE
+    before_bytes = path.read_bytes()
+    before = digest(before_bytes)
+    if before == EXPECTED_AFTER:
+        return before
+    if before != EXPECTED_BEFORE:
+        raise RuntimeError(f"unexpected source hash for {path}: {before}")
+
+    text = before_bytes.decode()
+    for old, new in (
+        (OLD_ALLOWLIST, NEW_ALLOWLIST),
+        (OLD_ERROR, NEW_ERROR),
+    ):
+        if text.count(old) != 1:
+            raise RuntimeError(f"expected exactly one stride contract site in {path}")
+        text = text.replace(old, new)
+    path.write_text(text)
+
+    after = digest(path.read_bytes())
+    if not discover and after != EXPECTED_AFTER:
+        raise RuntimeError(
+            f"patched source hash mismatch for {path}: {after}, "
+            f"expected {EXPECTED_AFTER}"
+        )
+    return after
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("root", type=Path)
+    parser.add_argument("--discover", action="store_true")
+    args = parser.parse_args()
+    print(patch(args.root, discover=args.discover))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker/glm53-flash/lmcache-d16-overlay/patch_lmcache_padded_packed_stride.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/patch_lmcache_padded_packed_stride.py
@@ -65,14 +65,15 @@ def patch(root: Path, *, discover: bool = False) -> str:
         if text.count(old) != 1:
             raise RuntimeError(f"expected exactly one stride contract site in {path}")
         text = text.replace(old, new)
-    path.write_text(text)
 
-    after = digest(path.read_bytes())
+    after_bytes = text.encode()
+    after = digest(after_bytes)
     if not discover and after != EXPECTED_AFTER:
         raise RuntimeError(
             f"patched source hash mismatch for {path}: {after}, "
             f"expected {EXPECTED_AFTER}"
         )
+    path.write_bytes(after_bytes)
     return after
 
 

--- a/docker/glm53-flash/lmcache-d16-overlay/patch_lmcache_slot_stride.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/patch_lmcache_slot_stride.py
@@ -126,6 +126,7 @@ def patch_torch_ops(text: str, path: Path) -> str:
 
 def patch(root: Path, *, discover: bool = False) -> dict[Path, str]:
     results: dict[Path, str] = {}
+    writes: dict[Path, bytes] = {}
     for relative, transform in (
         (CONNECTORS, patch_connectors),
         (TORCH_OPS, patch_torch_ops),
@@ -138,14 +139,17 @@ def patch(root: Path, *, discover: bool = False) -> dict[Path, str]:
             continue
         if before != EXPECTED_BEFORE[relative]:
             raise RuntimeError(f"unexpected source hash for {path}: {before}")
-        path.write_text(transform(before_bytes.decode(), path))
-        after = digest(path.read_bytes())
+        after_bytes = transform(before_bytes.decode(), path).encode()
+        after = digest(after_bytes)
         if not discover and after != EXPECTED_AFTER[relative]:
             raise RuntimeError(
                 f"patched source hash mismatch for {path}: {after}, "
                 f"expected {EXPECTED_AFTER[relative]}"
             )
+        writes[path] = after_bytes
         results[relative] = after
+    for path, after_bytes in writes.items():
+        path.write_bytes(after_bytes)
     return results
 
 

--- a/docker/glm53-flash/lmcache-d16-overlay/patch_lmcache_slot_stride.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/patch_lmcache_slot_stride.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Forward physical block strides through LMCache slot-transfer connectors."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+import regex as re
+
+CONNECTORS = Path("lmcache/v1/gpu_connector/gpu_connectors.py")
+TORCH_OPS = Path("lmcache/v1/platform/torch_ops.py")
+EXPECTED_BEFORE = {
+    CONNECTORS: "5ae3307a1eef4d66f02c848a3826a97a3895cb125f95da425c2d0eb7614bfe2d",
+    TORCH_OPS: "c7267f48f2ea5a8c1f32e03c528e6b6f2f6b99f1df6ef1e4d622be59b899eb1f",
+}
+EXPECTED_AFTER = {
+    CONNECTORS: "94b230d6ac7cb2fb1676a54a52dfdd322553180729e0eb812d9371d4a494a221",
+    TORCH_OPS: "5df72787a4ed23e126d260f0ad3fa753599866ef6ae41acf3e9777bcc14f859f",
+}
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def replace_once(text: str, old: str, new: str, path: Path) -> str:
+    if text.count(old) != 1:
+        raise RuntimeError(f"expected exactly one patch site in {path}")
+    return text.replace(old, new)
+
+
+def patch_connectors(text: str, path: Path) -> str:
+    text = replace_once(
+        text,
+        """\
+    normalize_and_discover_per_layer_formats,
+    normalize_kv_and_discover_format,
+)
+""",
+        """\
+    normalize_and_discover_per_layer_formats,
+    normalize_kv_and_discover_format,
+    resolve_block_stride_and_log_layout,
+)
+""",
+        path,
+    )
+    text = replace_once(
+        text,
+        """\
+        self.page_buffer_size = self.num_blocks * self.block_size
+        self.head_size = get_head_size(kv_caches, self.engine_kv_format)
+
+        return self.kv_cache_pointers_on_gpu[idx]
+""",
+        """\
+        self.page_buffer_size = self.num_blocks * self.block_size
+        self.head_size = get_head_size(kv_caches, self.engine_kv_format)
+        self.block_stride_elems = (
+            resolve_block_stride_and_log_layout(
+                kv_caches, self.engine_kv_format, layer_idx=0, group_idx=0
+            )
+            or 0
+        )
+
+        return self.kv_cache_pointers_on_gpu[idx]
+""",
+        path,
+    )
+    text = replace_once(
+        text,
+        """\
+        self.page_buffer_size = self.num_blocks * self.block_size
+        self.head_size = get_head_size(self.kvcaches, self.engine_kv_format)
+
+        if self.metadata.kv_layer_groups_manager is None:
+""",
+        """\
+        self.page_buffer_size = self.num_blocks * self.block_size
+        self.head_size = get_head_size(self.kvcaches, self.engine_kv_format)
+        self.block_stride_elems = (
+            resolve_block_stride_and_log_layout(
+                self.kvcaches, self.engine_kv_format, layer_idx=0, group_idx=0
+            )
+            or 0
+        )
+
+        if self.metadata.kv_layer_groups_manager is None:
+""",
+        path,
+    )
+    text, count = re.subn(
+        r"(?m)^(\s*)head_size=self\.head_size,$",
+        r"\1head_size=self.head_size,\n\1block_stride_elems=self.block_stride_elems,",
+        text,
+    )
+    if count != 6:
+        raise RuntimeError(f"expected exactly six slot-transfer call sites in {path}")
+    return text
+
+
+def patch_torch_ops(text: str, path: Path) -> str:
+    return replace_once(
+        text,
+        """\
+    block_size: int = 0,
+    head_size: int = 0,
+    skip_prefix_n_tokens: int = 0,
+):
+""",
+        """\
+    block_size: int = 0,
+    head_size: int = 0,
+    skip_prefix_n_tokens: int = 0,
+    block_stride_elems: int = 0,
+):
+""",
+        path,
+    )
+
+
+def patch(root: Path, *, discover: bool = False) -> dict[Path, str]:
+    results: dict[Path, str] = {}
+    for relative, transform in (
+        (CONNECTORS, patch_connectors),
+        (TORCH_OPS, patch_torch_ops),
+    ):
+        path = root / relative
+        before_bytes = path.read_bytes()
+        before = digest(before_bytes)
+        if before == EXPECTED_AFTER[relative]:
+            results[relative] = before
+            continue
+        if before != EXPECTED_BEFORE[relative]:
+            raise RuntimeError(f"unexpected source hash for {path}: {before}")
+        path.write_text(transform(before_bytes.decode(), path))
+        after = digest(path.read_bytes())
+        if not discover and after != EXPECTED_AFTER[relative]:
+            raise RuntimeError(
+                f"patched source hash mismatch for {path}: {after}, "
+                f"expected {EXPECTED_AFTER[relative]}"
+            )
+        results[relative] = after
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("root", type=Path)
+    parser.add_argument("--discover", action="store_true")
+    args = parser.parse_args()
+    for relative, after in patch(args.root, discover=args.discover).items():
+        print(f"{relative}={after}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker/versions.json
+++ b/docker/versions.json
@@ -68,7 +68,7 @@
       "default": "true"
     },
     "FLASHINFER_VERSION": {
-      "default": "0.6.17"
+      "default": "0.6.18"
     },
     "GDRCOPY_CUDA_VERSION": {
       "default": "12.8"

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -14,8 +14,8 @@ PyNvVideoCodec==2.0.4
 # flashinfer-cubin is not on PyPI since 0.6.14; setup.py excludes it from
 # install_requires so the published wheel does not carry an unresolvable pin
 --extra-index-url https://flashinfer.ai/whl/
-flashinfer-python==0.6.17
-flashinfer-cubin==0.6.17
+flashinfer-python==0.6.18
+flashinfer-cubin==0.6.18
 apache-tvm-ffi==0.1.11
 tilelang==0.1.12
 nvidia-cudnn-frontend>=1.19.1

--- a/tests/v1/kv_connector/unit/test_lmcache_d16_overlay.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_d16_overlay.py
@@ -641,13 +641,16 @@ def test_finished_store_dedup_state_is_pruned_after_engine_converges() -> None:
     probe = namespace["AdapterProbe"]()
     probe.finished_stores = set()
     probe.previously_finished = set()
-    probe.store_futures = {}
+    probe.store_futures = {"request": object()}
     probe._returned_finished = set()
 
-    assert probe._process_finished_stores(set(), {"request"}) == {"request"}
     assert probe._process_finished_stores(set(), {"request"}) == set()
+    probe.store_futures = {}
+    assert probe._process_finished_stores({"request"}, set()) == {"request"}
     assert probe._returned_finished == {"request"}
     assert probe._process_finished_stores(set(), set()) == set()
+    assert probe._returned_finished == {"request"}
+    assert probe._process_finished_stores(set(), {"request"}) == set()
     assert probe._returned_finished == set()
 
 

--- a/tests/v1/kv_connector/unit/test_lmcache_d16_overlay.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_d16_overlay.py
@@ -27,6 +27,10 @@ GROUPS = (
     ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
     "lmcache/integration/vllm/kv_cache_groups.py"
 )
+GROUP_EDITS = (
+    ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
+    "lmcache/integration/vllm/kv_cache_group_edits.py"
+)
 ADAPTER = (
     ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
     "lmcache/integration/vllm/vllm_multi_process_adapter.py"
@@ -47,6 +51,18 @@ CORE_SINGLE_TYPE_MANAGER = (
     ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
     "vllm/v1/core/single_type_kv_cache_manager.py"
 )
+CUDA_SLOT_STRIDE_PATCH = (
+    ROOT
+    / "docker/glm53-flash/lmcache-d16-overlay/lmcache_cuda_ops_slot_stride.patch"
+)
+SLOT_STRIDE_PATCHER = (
+    ROOT / "docker/glm53-flash/lmcache-d16-overlay/patch_lmcache_slot_stride.py"
+)
+PADDED_STRIDE_PATCHER = (
+    ROOT
+    / "docker/glm53-flash/lmcache-d16-overlay/"
+    "patch_lmcache_padded_packed_stride.py"
+)
 
 
 class AttentionSpec:
@@ -61,6 +77,14 @@ class MambaSpec:
 
 def _load_layout():
     spec = importlib.util.spec_from_file_location("lmcache_dcp_layout", DCP_LAYOUT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -250,6 +274,7 @@ def test_scheduler_starts_each_heartbeat_once() -> None:
         keywords=[],
         body=[ensure_started],
         decorator_list=[],
+        type_params=[],
     )
     namespace: dict[str, Any] = {}
     started: list[str] = []
@@ -297,7 +322,14 @@ def test_connector_prefix_is_bounded_by_lagging_mamba_state() -> None:
         if isinstance(node, ast.FunctionDef)
         and node.name == "get_computed_blocks_for_connector"
     )
-    probe = ast.ClassDef("ManagerProbe", [], [], [method], [])
+    probe = ast.ClassDef(
+        name="ManagerProbe",
+        bases=[],
+        keywords=[],
+        body=[method],
+        decorator_list=[],
+        type_params=[],
+    )
 
     class HybridKVCacheCoordinator:
         pass
@@ -437,3 +469,270 @@ def test_connector_ingests_core_mamba_handoffs_before_stores() -> None:
         build_source.index("_process_new_requests")
     )
     assert "self._mamba_group_ids" in process_source
+
+
+def test_cuda_slot_stride_rejects_unaligned_xwords_before_conversion() -> None:
+    patch = CUDA_SLOT_STRIDE_PATCH.read_text()
+
+    check = "TORCH_CHECK(block_stride_elems % elements_per_xword == 0"
+    conversion = "block_stride_elems / elements_per_xword"
+    assert patch.index(check) < patch.index(conversion)
+
+
+def test_group_edits_unwrap_uniform_specs_per_layer() -> None:
+    tree = ast.parse(GROUP_EDITS.read_text())
+    apply_edits = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "apply_kv_cache_group_edits"
+    )
+
+    class UniformTypeKVCacheSpecs:
+        def __init__(self, specs):
+            self.kv_cache_specs = specs
+
+    layer_spec = object()
+    seen_specs = []
+
+    class Edit:
+        name = "probe"
+
+        def matches(self, spec, _cache):
+            seen_specs.append(spec)
+            return True
+
+        def apply(self, spec, cache, _layout_hints):
+            assert spec is layer_spec
+            return f"edited-{cache}"
+
+    namespace = {
+        "Counter": __import__("collections").Counter,
+        "KVCacheConfig": object,
+        "KVCacheSpec": object,
+        "LayoutHints": dict,
+        "Mapping": dict,
+        "RegisteredKVCache": object,
+        "UniformTypeKVCacheSpecs": UniformTypeKVCacheSpecs,
+        "_EDITS": (Edit(),),
+        "logger": SimpleNamespace(info=lambda *_args: None),
+        "validate_kv_cache_groups": lambda _config: None,
+    }
+    exec(
+        compile(
+            ast.fix_missing_locations(
+                ast.Module(body=[apply_edits], type_ignores=[])
+            ),
+            str(GROUP_EDITS),
+            "exec",
+        ),
+        namespace,
+    )
+    config = SimpleNamespace(
+        has_mamba_layers=True,
+        kv_cache_groups=[
+            SimpleNamespace(
+                kv_cache_spec=UniformTypeKVCacheSpecs({"layer": layer_spec}),
+                layer_names=["layer"],
+            )
+        ],
+    )
+
+    assert namespace["apply_kv_cache_group_edits"](
+        config, {"layer": "cache"}, {}
+    ) == {"layer": "edited-cache"}
+    assert seen_specs == [layer_spec]
+
+
+def test_subpaged_mla_docstring_describes_three_dimensional_view() -> None:
+    tree = ast.parse(GROUP_EDITS.read_text())
+    edit = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and node.name == "_SubpagedMLAAttentionViewEdit"
+    )
+    apply = next(
+        node
+        for node in edit.body
+        if isinstance(node, ast.FunctionDef) and node.name == "apply"
+    )
+    docstring = ast.get_docstring(apply)
+
+    assert docstring is not None
+    normalized = " ".join(docstring.split())
+    assert "(num_kernel_pages, kernel_block_size, entry_size)" in normalized
+    assert "(num_logical_blocks, spec.block_size, -1)" in normalized
+
+
+def test_exact_mamba_handoffs_skip_unknown_requests() -> None:
+    tree = ast.parse(CONNECTOR.read_text())
+    connector = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "LMCacheMPConnector"
+    )
+    ingest = next(
+        node
+        for node in connector.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_ingest_exact_mamba_boundary_blocks"
+    )
+    namespace = {"SchedulerOutput": object}
+    exec(
+        compile(
+            ast.fix_missing_locations(ast.Module(body=[ingest], type_ignores=[])),
+            str(CONNECTOR),
+            "exec",
+        ),
+        namespace,
+    )
+    tracker = SimpleNamespace(exact_mamba_boundary_blocks={})
+    probe = SimpleNamespace(
+        request_trackers={"known": tracker},
+        _mamba_group_ids={1},
+    )
+    scheduler_output = SimpleNamespace(
+        partial_tail_offloads={
+            "unknown": [(1, 10, 64)],
+            "known": [(1, 11, 128), (2, 12, 128), (1, -1, 192)],
+        }
+    )
+
+    namespace["_ingest_exact_mamba_boundary_blocks"](probe, scheduler_output)
+
+    assert tracker.exact_mamba_boundary_blocks == {1: {128: 11}}
+
+
+def test_finished_store_dedup_state_is_pruned_after_engine_converges() -> None:
+    tree = ast.parse(ADAPTER.read_text())
+    adapter = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and node.name == "LMCacheMPWorkerAdapter"
+    )
+    methods = [
+        node
+        for node in adapter.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name
+        in {"_process_finished_stores", "_update_and_get_finished_store"}
+    ]
+    probe_class = ast.ClassDef(
+        name="AdapterProbe",
+        bases=[],
+        keywords=[],
+        body=methods,
+        decorator_list=[],
+        type_params=[],
+    )
+    namespace: dict[str, Any] = {}
+    exec(
+        compile(
+            ast.fix_missing_locations(
+                ast.Module(body=[probe_class], type_ignores=[])
+            ),
+            str(ADAPTER),
+            "exec",
+        ),
+        namespace,
+    )
+    probe = namespace["AdapterProbe"]()
+    probe.finished_stores = set()
+    probe.previously_finished = set()
+    probe.store_futures = {}
+    probe._returned_finished = set()
+
+    assert probe._process_finished_stores(set(), {"request"}) == {"request"}
+    assert probe._process_finished_stores(set(), {"request"}) == set()
+    assert probe._returned_finished == {"request"}
+    assert probe._process_finished_stores(set(), set()) == set()
+    assert probe._returned_finished == set()
+
+
+def test_sink_manager_forwards_zeroing_constructor_argument() -> None:
+    tree = ast.parse(CORE_SINGLE_TYPE_MANAGER.read_text())
+    manager = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and node.name == "SinkFullAttentionManager"
+    )
+    constructor = next(
+        node
+        for node in manager.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+    source = ast.unparse(constructor)
+
+    assert "needs_kv_cache_zeroing: bool=False" in source
+    assert "needs_kv_cache_zeroing=needs_kv_cache_zeroing" in source
+
+
+def test_flashinfer_pins_match_docker_metadata() -> None:
+    assert "ARG FLASHINFER_VERSION=0.6.18" in (
+        ROOT / "docker/Dockerfile"
+    ).read_text()
+    assert '"FLASHINFER_VERSION": {\n      "default": "0.6.18"' in (
+        ROOT / "docker/versions.json"
+    ).read_text()
+    cuda_requirements = (ROOT / "requirements/cuda.txt").read_text()
+    assert "flashinfer-python==0.6.18" in cuda_requirements
+    assert "flashinfer-cubin==0.6.18" in cuda_requirements
+
+
+def test_slot_stride_patcher_validates_output_before_write(
+    monkeypatch, tmp_path
+) -> None:
+    patcher = _load_module("slot_stride_patcher", SLOT_STRIDE_PATCHER)
+    connector = Path("connector.py")
+    torch_ops = Path("torch_ops.py")
+    originals = {connector: b"connector", torch_ops: b"torch"}
+    for relative, content in originals.items():
+        (tmp_path / relative).write_bytes(content)
+
+    monkeypatch.setattr(patcher, "CONNECTORS", connector)
+    monkeypatch.setattr(patcher, "TORCH_OPS", torch_ops)
+    monkeypatch.setattr(
+        patcher,
+        "EXPECTED_BEFORE",
+        {relative: patcher.digest(content) for relative, content in originals.items()},
+    )
+    monkeypatch.setattr(
+        patcher,
+        "EXPECTED_AFTER",
+        {connector: patcher.digest(b"changed connector"), torch_ops: "wrong"},
+    )
+    monkeypatch.setattr(
+        patcher, "patch_connectors", lambda _text, _path: "changed connector"
+    )
+    monkeypatch.setattr(
+        patcher, "patch_torch_ops", lambda _text, _path: "changed torch"
+    )
+
+    with pytest.raises(RuntimeError, match="patched source hash mismatch"):
+        patcher.patch(tmp_path)
+    assert (tmp_path / connector).read_bytes() == originals[connector]
+    assert (tmp_path / torch_ops).read_bytes() == originals[torch_ops]
+
+
+def test_padded_stride_patcher_validates_output_before_write(
+    monkeypatch, tmp_path
+) -> None:
+    patcher = _load_module("padded_stride_patcher", PADDED_STRIDE_PATCHER)
+    relative = Path("utils.py")
+    original = b"allowlist\nerror\n"
+    path = tmp_path / relative
+    path.write_bytes(original)
+    monkeypatch.setattr(patcher, "RELATIVE", relative)
+    monkeypatch.setattr(patcher, "EXPECTED_BEFORE", patcher.digest(original))
+    monkeypatch.setattr(patcher, "EXPECTED_AFTER", "wrong")
+    monkeypatch.setattr(patcher, "OLD_ALLOWLIST", "allowlist")
+    monkeypatch.setattr(patcher, "NEW_ALLOWLIST", "new allowlist")
+    monkeypatch.setattr(patcher, "OLD_ERROR", "error")
+    monkeypatch.setattr(patcher, "NEW_ERROR", "new error")
+
+    with pytest.raises(RuntimeError, match="patched source hash mismatch"):
+        patcher.patch(tmp_path)
+    assert path.read_bytes() == original

--- a/tests/v1/kv_connector/unit/test_lmcache_d16_overlay.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_d16_overlay.py
@@ -3,7 +3,11 @@
 
 import ast
 import importlib.util
+import itertools
 import logging
+import os
+import re
+import subprocess
 import sys
 import threading
 from pathlib import Path
@@ -52,15 +56,18 @@ CORE_SINGLE_TYPE_MANAGER = (
     "vllm/v1/core/single_type_kv_cache_manager.py"
 )
 CUDA_SLOT_STRIDE_PATCH = (
-    ROOT
-    / "docker/glm53-flash/lmcache-d16-overlay/lmcache_cuda_ops_slot_stride.patch"
+    ROOT / "docker/glm53-flash/lmcache-d16-overlay/lmcache_cuda_ops_slot_stride.patch"
 )
+CUDA_ODD_WIDTH_PATCH = (
+    ROOT / "docker/glm53-flash/lmcache-d16-overlay/lmcache_cuda_ops_odd_width.patch"
+)
+LMCACHE_SOURCE_COMMIT = "3e11b8ed191631e6f098b8038235823f1a410b24"
+NATIVE_PATCHES = (CUDA_ODD_WIDTH_PATCH, CUDA_SLOT_STRIDE_PATCH)
 SLOT_STRIDE_PATCHER = (
     ROOT / "docker/glm53-flash/lmcache-d16-overlay/patch_lmcache_slot_stride.py"
 )
 PADDED_STRIDE_PATCHER = (
-    ROOT
-    / "docker/glm53-flash/lmcache-d16-overlay/"
+    ROOT / "docker/glm53-flash/lmcache-d16-overlay/"
     "patch_lmcache_padded_packed_stride.py"
 )
 
@@ -259,8 +266,7 @@ def test_scheduler_starts_each_heartbeat_once() -> None:
     adapter_class = next(
         node
         for node in tree.body
-        if isinstance(node, ast.ClassDef)
-        and node.name == "LMCacheMPSchedulerAdapter"
+        if isinstance(node, ast.ClassDef) and node.name == "LMCacheMPSchedulerAdapter"
     )
     ensure_started = next(
         node
@@ -393,8 +399,7 @@ def test_tracker_initializes_exact_mamba_boundary_map() -> None:
     tracker = next(
         node
         for node in tree.body
-        if isinstance(node, ast.ClassDef)
-        and node.name == "LMCacheMPRequestTracker"
+        if isinstance(node, ast.ClassDef) and node.name == "LMCacheMPRequestTracker"
     )
     constructor = next(
         node
@@ -407,9 +412,7 @@ def test_tracker_initializes_exact_mamba_boundary_map() -> None:
 
 def test_exact_mamba_boundaries_replace_only_mamba_source_ids() -> None:
     apply = _load_exact_mamba_store_helper()
-    tracker = SimpleNamespace(
-        exact_mamba_boundary_blocks={0: {9216: 104, 18432: 108}}
-    )
+    tracker = SimpleNamespace(exact_mamba_boundary_blocks={0: {9216: 104, 18432: 108}})
     block_ids = [[1, 2, 3, 4, 5, 6, 7, 8], [9, 10]]
 
     apply(
@@ -453,14 +456,12 @@ def test_connector_ingests_core_mamba_handoffs_before_stores() -> None:
     build_meta = next(
         node
         for node in connector.body
-        if isinstance(node, ast.FunctionDef)
-        and node.name == "build_connector_meta"
+        if isinstance(node, ast.FunctionDef) and node.name == "build_connector_meta"
     )
     process_new = next(
         node
         for node in connector.body
-        if isinstance(node, ast.FunctionDef)
-        and node.name == "_process_new_requests"
+        if isinstance(node, ast.FunctionDef) and node.name == "_process_new_requests"
     )
     build_source = ast.unparse(build_meta)
     process_source = ast.unparse(process_new)
@@ -477,6 +478,76 @@ def test_cuda_slot_stride_rejects_unaligned_xwords_before_conversion() -> None:
     check = "TORCH_CHECK(block_stride_elems % elements_per_xword == 0"
     conversion = "block_stride_elems / elements_per_xword"
     assert patch.index(check) < patch.index(conversion)
+
+
+@pytest.mark.parametrize("patch_path", NATIVE_PATCHES, ids=lambda path: path.stem)
+def test_native_patches_carry_context_git_apply_can_anchor(
+    patch_path: Path,
+) -> None:
+    hunks = _parse_hunks(patch_path.read_text())
+
+    assert hunks
+    for header, body in hunks:
+        old_count = sum(1 for line in body if line[:1] in (" ", "-"))
+        new_count = sum(1 for line in body if line[:1] in (" ", "+"))
+        assert (old_count, new_count) == (header[1], header[3]), header
+        leading = len(list(itertools.takewhile(_is_context, body)))
+        trailing = len(list(itertools.takewhile(_is_context, reversed(body))))
+        assert header[0] == 1 or leading >= 1, header
+        assert trailing >= 1, header
+
+
+def test_native_patches_apply_in_order_to_pinned_lmcache(tmp_path: Path) -> None:
+    source_value = os.environ.get("LMCACHE_SOURCE_DIR")
+    if source_value is None:
+        pytest.skip("set LMCACHE_SOURCE_DIR to exercise ordered git apply")
+
+    source = Path(source_value)
+    source_commit = subprocess.run(
+        ["git", "-C", str(source), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert source_commit == LMCACHE_SOURCE_COMMIT
+
+    checkout = tmp_path / "lmcache"
+    subprocess.run(
+        ["git", "clone", "--quiet", "--no-hardlinks", str(source), str(checkout)],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(checkout), "checkout", "--quiet", LMCACHE_SOURCE_COMMIT],
+        check=True,
+    )
+    for patch_path in NATIVE_PATCHES:
+        subprocess.run(
+            ["git", "-C", str(checkout), "apply", "--check", str(patch_path)],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(checkout), "apply", str(patch_path)],
+            check=True,
+        )
+
+
+def _is_context(line: str) -> bool:
+    return line[:1] == " "
+
+
+def _parse_hunks(patch: str) -> list[tuple[tuple[int, ...], list[str]]]:
+    hunks: list[tuple[tuple[int, ...], list[str]]] = []
+    body: list[str] | None = None
+    for line in patch.split("\n"):
+        match = re.match(r"^@@ -(\d+),(\d+) \+(\d+),(\d+) @@", line)
+        if match:
+            body = []
+            hunks.append((tuple(int(group) for group in match.groups()), body))
+        elif line.startswith("diff --git "):
+            body = None
+        elif body is not None and line[:1] in (" ", "-", "+"):
+            body.append(line)
+    return hunks
 
 
 def test_group_edits_unwrap_uniform_specs_per_layer() -> None:
@@ -520,9 +591,7 @@ def test_group_edits_unwrap_uniform_specs_per_layer() -> None:
     }
     exec(
         compile(
-            ast.fix_missing_locations(
-                ast.Module(body=[apply_edits], type_ignores=[])
-            ),
+            ast.fix_missing_locations(ast.Module(body=[apply_edits], type_ignores=[])),
             str(GROUP_EDITS),
             "exec",
         ),
@@ -538,9 +607,9 @@ def test_group_edits_unwrap_uniform_specs_per_layer() -> None:
         ],
     )
 
-    assert namespace["apply_kv_cache_group_edits"](
-        config, {"layer": "cache"}, {}
-    ) == {"layer": "edited-cache"}
+    assert namespace["apply_kv_cache_group_edits"](config, {"layer": "cache"}, {}) == {
+        "layer": "edited-cache"
+    }
     assert seen_specs == [layer_spec]
 
 
@@ -609,15 +678,13 @@ def test_finished_store_dedup_state_is_pruned_after_engine_converges() -> None:
     adapter = next(
         node
         for node in tree.body
-        if isinstance(node, ast.ClassDef)
-        and node.name == "LMCacheMPWorkerAdapter"
+        if isinstance(node, ast.ClassDef) and node.name == "LMCacheMPWorkerAdapter"
     )
     methods = [
         node
         for node in adapter.body
         if isinstance(node, ast.FunctionDef)
-        and node.name
-        in {"_process_finished_stores", "_update_and_get_finished_store"}
+        and node.name in {"_process_finished_stores", "_update_and_get_finished_store"}
     ]
     probe_class = ast.ClassDef(
         name="AdapterProbe",
@@ -630,9 +697,7 @@ def test_finished_store_dedup_state_is_pruned_after_engine_converges() -> None:
     namespace: dict[str, Any] = {}
     exec(
         compile(
-            ast.fix_missing_locations(
-                ast.Module(body=[probe_class], type_ignores=[])
-            ),
+            ast.fix_missing_locations(ast.Module(body=[probe_class], type_ignores=[])),
             str(ADAPTER),
             "exec",
         ),
@@ -659,8 +724,7 @@ def test_sink_manager_forwards_zeroing_constructor_argument() -> None:
     manager = next(
         node
         for node in tree.body
-        if isinstance(node, ast.ClassDef)
-        and node.name == "SinkFullAttentionManager"
+        if isinstance(node, ast.ClassDef) and node.name == "SinkFullAttentionManager"
     )
     constructor = next(
         node
@@ -674,12 +738,11 @@ def test_sink_manager_forwards_zeroing_constructor_argument() -> None:
 
 
 def test_flashinfer_pins_match_docker_metadata() -> None:
-    assert "ARG FLASHINFER_VERSION=0.6.18" in (
-        ROOT / "docker/Dockerfile"
-    ).read_text()
-    assert '"FLASHINFER_VERSION": {\n      "default": "0.6.18"' in (
-        ROOT / "docker/versions.json"
-    ).read_text()
+    assert "ARG FLASHINFER_VERSION=0.6.18" in (ROOT / "docker/Dockerfile").read_text()
+    assert (
+        '"FLASHINFER_VERSION": {\n      "default": "0.6.18"'
+        in (ROOT / "docker/versions.json").read_text()
+    )
     cuda_requirements = (ROOT / "requirements/cuda.txt").read_text()
     assert "flashinfer-python==0.6.18" in cuda_requirements
     assert "flashinfer-cubin==0.6.18" in cuda_requirements

--- a/tests/v1/kv_connector/unit/test_lmcache_d16_overlay.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_d16_overlay.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import ast
+import importlib.util
+import logging
+import sys
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+pytestmark = pytest.mark.cpu_test
+
+ROOT = Path(__file__).resolve().parents[4]
+DCP_LAYOUT = (
+    ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
+    "lmcache/integration/vllm/dcp_layout.py"
+)
+TRANSFER = (
+    ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
+    "lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py"
+)
+GROUPS = (
+    ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
+    "lmcache/integration/vllm/kv_cache_groups.py"
+)
+ADAPTER = (
+    ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
+    "lmcache/integration/vllm/vllm_multi_process_adapter.py"
+)
+
+
+class AttentionSpec:
+    def __init__(self, block_size: int):
+        self.block_size = block_size
+
+
+class MambaSpec:
+    def __init__(self, block_size: int):
+        self.block_size = block_size
+
+
+def _load_layout():
+    spec = importlib.util.spec_from_file_location("lmcache_dcp_layout", DCP_LAYOUT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _module(name: str, **attributes: object) -> ModuleType:
+    module = ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    return module
+
+
+def _load_group_converter(monkeypatch):
+    def normalize(caches, _groups, _engine_type, _hints):
+        return caches, [cache.kernel for cache in caches]
+
+    def group_layers(_caches, formats, per_layer_group_idx):
+        grouped: dict[tuple[int, str], list[int]] = {}
+        for layer_idx, kernel in enumerate(formats):
+            key = (per_layer_group_idx[layer_idx], kernel)
+            grouped.setdefault(key, []).append(layer_idx)
+        return [
+            (SimpleNamespace(engine_group_idx=group_idx), indices)
+            for (group_idx, _), indices in grouped.items()
+        ]
+
+    def engine_group_info(**kwargs):
+        return SimpleNamespace(**kwargs)
+
+    modules = {
+        "lmcache": _module("lmcache"),
+        "lmcache.logging": _module(
+            "lmcache.logging", init_logger=lambda _: logging.getLogger(__name__)
+        ),
+        "lmcache.utils": _module(
+            "lmcache.utils", EngineType=SimpleNamespace(VLLM="vllm")
+        ),
+        "lmcache.v1": _module("lmcache.v1"),
+        "lmcache.v1.multiprocess": _module("lmcache.v1.multiprocess"),
+        "lmcache.v1.multiprocess.group_view": _module(
+            "lmcache.v1.multiprocess.group_view",
+            EngineGroupInfo=engine_group_info,
+        ),
+        "lmcache.v1.gpu_connector": _module("lmcache.v1.gpu_connector"),
+        "lmcache.v1.gpu_connector.utils": _module(
+            "lmcache.v1.gpu_connector.utils",
+            normalize_and_discover_per_layer_formats=normalize,
+        ),
+        "lmcache.v1.kv_layer_groups": _module(
+            "lmcache.v1.kv_layer_groups",
+            EXCLUDED_ENGINE_GROUP=-1,
+            group_layers_by_identity=group_layers,
+        ),
+    }
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+    spec = importlib.util.spec_from_file_location("lmcache_d16_groups", GROUPS)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.create_engine_group_infos_from_vllm
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(
+        model_config=SimpleNamespace(model="zai-org/GLM-5.3-FP8"),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=4,
+            prefill_context_parallel_size=1,
+            cp_kv_cache_interleave_size=4,
+            world_size=4,
+        ),
+        cache_config=SimpleNamespace(block_size=256, mamba_cache_mode="align"),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=32768),
+    )
+
+
+def test_dcp_layout_resolves_hybrid_geometry_and_cache_identity() -> None:
+    layout = _load_layout()
+    config = _config()
+    kv_cache = SimpleNamespace(
+        kv_cache_groups=[
+            SimpleNamespace(kv_cache_spec=AttentionSpec(2304)),
+            SimpleNamespace(kv_cache_spec=MambaSpec(2304)),
+        ]
+    )
+
+    assert layout.get_group_tokens_per_block(config, kv_cache) == [9216, 2304]
+    assert layout.get_lmcache_scheduler_block_size(config, kv_cache) == 9216
+    identity = layout.get_lmcache_model_name(config)
+    assert identity.endswith("##lmcache-dcp-layout-v1-d4-interleave4")
+    assert layout.get_lmcache_base_model_name(identity) == config.model_config.model
+    layout.validate_dcp_support(config, n_servers=1, kv_cache_config=kv_cache)
+    layout.validate_mamba_step_alignment(config, kv_cache)
+
+
+def test_dcp_layout_identity_includes_noninterleaved_dcp() -> None:
+    layout = _load_layout()
+    config = _config()
+    config.parallel_config.cp_kv_cache_interleave_size = 1
+
+    assert layout.get_lmcache_model_name(config).endswith(
+        "##lmcache-dcp-layout-v1-d4-interleave1"
+    )
+
+
+def test_dcp_layout_fails_closed_on_partial_shard_ownership() -> None:
+    layout = _load_layout()
+    config = _config()
+    config.parallel_config.world_size = 8
+    with pytest.raises(ValueError, match="shards"):
+        layout.validate_dcp_support(config, n_servers=4)
+
+    config.parallel_config.world_size = 12
+    with pytest.raises(ValueError, match="whole-number set"):
+        layout.validate_dcp_support(config, n_servers=2)
+
+
+def test_registration_preserves_authoritative_engine_group_spans(
+    monkeypatch,
+) -> None:
+    convert = _load_group_converter(monkeypatch)
+    groups = [
+        SimpleNamespace(
+            layer_names=[f"layer{index}"],
+            kv_cache_spec=SimpleNamespace(block_size=2304),
+        )
+        for index in range(4)
+    ]
+    caches = {
+        f"layer{index}": SimpleNamespace(kernel=f"kernel{index}") for index in range(4)
+    }
+    infos = convert(
+        SimpleNamespace(kv_cache_groups=groups),
+        caches,
+        group_tokens_per_block=[2304, 2304, 2304, 9216],
+    )
+
+    assert [info.engine_group_id for info in infos] == [0, 1, 2, 3]
+    assert [info.tokens_per_block for info in infos] == [
+        2304,
+        2304,
+        2304,
+        9216,
+    ]
+    assert [9216 // info.tokens_per_block for info in infos] == [4, 4, 4, 1]
+
+
+def test_scheduler_starts_each_heartbeat_once() -> None:
+    tree = ast.parse(ADAPTER.read_text())
+    adapter_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and node.name == "LMCacheMPSchedulerAdapter"
+    )
+    ensure_started = next(
+        node
+        for node in adapter_class.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_ensure_heartbeat_started"
+    )
+    probe_class = ast.ClassDef(
+        name="AdapterProbe",
+        bases=[],
+        keywords=[],
+        body=[ensure_started],
+        decorator_list=[],
+    )
+    namespace: dict[str, Any] = {}
+    started: list[str] = []
+
+    class Heartbeat:
+        def __init__(self, mq_client, health_event, interval):
+            self.client = mq_client
+
+        def start(self):
+            started.append(self.client)
+
+    exec(
+        compile(
+            ast.fix_missing_locations(ast.Module(body=[probe_class], type_ignores=[])),
+            str(ADAPTER),
+            "exec",
+        ),
+        {"HeartbeatThread": Heartbeat},
+        namespace,
+    )
+    adapter = namespace["AdapterProbe"]()
+    adapter._heartbeats_started = False
+    adapter._heartbeat_lock = threading.Lock()
+    adapter._heartbeat_interval = 5.0
+    adapter._heartbeats = {}
+    adapter._health_events = {"a": object(), "b": object()}
+    adapter.mq_clients = {"a": "client-a", "b": "client-b"}
+
+    adapter._ensure_heartbeat_started()
+    adapter._ensure_heartbeat_started()
+
+    assert started == ["client-a", "client-b"]

--- a/tests/v1/kv_connector/unit/test_lmcache_d16_overlay.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_d16_overlay.py
@@ -6,10 +6,9 @@ import importlib.util
 import logging
 import sys
 import threading
-from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
 import pytest
 
@@ -32,6 +31,22 @@ ADAPTER = (
     ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
     "lmcache/integration/vllm/vllm_multi_process_adapter.py"
 )
+CONNECTOR = (
+    ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
+    "lmcache/integration/vllm/lmcache_mp_connector.py"
+)
+METADATA = (
+    ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
+    "lmcache/integration/vllm/lmcache_mp_metadata.py"
+)
+CORE_KV_CACHE_MANAGER = (
+    ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
+    "vllm/v1/core/kv_cache_manager.py"
+)
+CORE_SINGLE_TYPE_MANAGER = (
+    ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
+    "vllm/v1/core/single_type_kv_cache_manager.py"
+)
 
 
 class AttentionSpec:
@@ -50,6 +65,26 @@ def _load_layout():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _load_exact_mamba_store_helper():
+    tree = ast.parse(METADATA.read_text())
+    helper = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "apply_exact_mamba_store_blocks"
+    )
+    namespace = {"LMCacheMPRequestTracker": object}
+    exec(
+        compile(
+            ast.fix_missing_locations(ast.Module(body=[helper], type_ignores=[])),
+            str(METADATA),
+            "exec",
+        ),
+        namespace,
+    )
+    return namespace["apply_exact_mamba_store_blocks"]
 
 
 def _module(name: str, **attributes: object) -> ModuleType:
@@ -247,3 +282,158 @@ def test_scheduler_starts_each_heartbeat_once() -> None:
     adapter._ensure_heartbeat_started()
 
     assert started == ["client-a", "client-b"]
+
+
+def test_connector_prefix_is_bounded_by_lagging_mamba_state() -> None:
+    tree = ast.parse(CORE_KV_CACHE_MANAGER.read_text())
+    manager = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "KVCacheManager"
+    )
+    method = next(
+        node
+        for node in manager.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "get_computed_blocks_for_connector"
+    )
+    probe = ast.ClassDef("ManagerProbe", [], [], [method], [])
+
+    class HybridKVCacheCoordinator:
+        pass
+
+    namespace = {
+        "Request": object,
+        "KVCacheBlocks": object,
+        "HybridKVCacheCoordinator": HybridKVCacheCoordinator,
+    }
+    exec(
+        compile(
+            ast.fix_missing_locations(ast.Module(body=[probe], type_ignores=[])),
+            str(CORE_KV_CACHE_MANAGER),
+            "exec",
+        ),
+        namespace,
+    )
+    manager_probe = namespace["ManagerProbe"]()
+    coordinator = HybridKVCacheCoordinator()
+    coordinator.full_attention_group_id = 0
+    coordinator.find_longest_cache_hit_per_group = lambda *_: (
+        ("fa", "mamba"),
+        [8, 4],
+    )
+    manager_probe.coordinator = coordinator
+    manager_probe.kv_cache_config = SimpleNamespace(has_mamba_layers=True)
+    manager_probe.prefix_cache_lookup_enabled = lambda _request: True
+    manager_probe.create_kv_cache_blocks = lambda computed: ("unsafe", computed)
+    manager_probe.get_computed_blocks = lambda _request: ("reconciled", 4, 0)
+    request = SimpleNamespace(block_hashes=["h"], num_tokens=9)
+
+    assert manager_probe.get_computed_blocks_for_connector(request) == (
+        "reconciled",
+        4,
+        0,
+        True,
+    )
+
+
+def test_mamba_cache_blocks_emits_every_exact_committed_boundary() -> None:
+    tree = ast.parse(CORE_SINGLE_TYPE_MANAGER.read_text())
+    manager = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "MambaManager"
+    )
+    cache_blocks = next(
+        node
+        for node in manager.body
+        if isinstance(node, ast.FunctionDef) and node.name == "cache_blocks"
+    )
+    source = ast.unparse(cache_blocks)
+
+    assert "_pending_partial_tail_offloads.append" in source
+    assert "(idx + 1) * self.block_size" in source
+    assert "block.is_null or block.block_hash is None" in source
+
+
+def test_tracker_initializes_exact_mamba_boundary_map() -> None:
+    tree = ast.parse(METADATA.read_text())
+    tracker = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and node.name == "LMCacheMPRequestTracker"
+    )
+    constructor = next(
+        node
+        for node in tracker.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+
+    assert "self.exact_mamba_boundary_blocks = {}" in ast.unparse(constructor)
+
+
+def test_exact_mamba_boundaries_replace_only_mamba_source_ids() -> None:
+    apply = _load_exact_mamba_store_helper()
+    tracker = SimpleNamespace(
+        exact_mamba_boundary_blocks={0: {9216: 104, 18432: 108}}
+    )
+    block_ids = [[1, 2, 3, 4, 5, 6, 7, 8], [9, 10]]
+
+    apply(
+        tracker,
+        block_ids,
+        group_tokens_per_block=[2304, 9216],
+        mamba_group_ids={0},
+        lmcache_tokens_per_chunk=9216,
+        start_token_idx=0,
+        end_token_idx=18432,
+    )
+    assert block_ids == [[104, 108], [9, 10]]
+
+
+def test_unavailable_mamba_boundaries_use_sparse_null_placeholders() -> None:
+    apply = _load_exact_mamba_store_helper()
+    tracker = SimpleNamespace(
+        exact_mamba_boundary_blocks={0: {18432: 108}},
+    )
+    block_ids = [[1] * 8, [9, 10]]
+
+    apply(
+        tracker,
+        block_ids,
+        group_tokens_per_block=[2304, 9216],
+        mamba_group_ids={0},
+        lmcache_tokens_per_chunk=9216,
+        start_token_idx=0,
+        end_token_idx=18432,
+    )
+    assert block_ids == [[0, 108], [9, 10]]
+
+
+def test_connector_ingests_core_mamba_handoffs_before_stores() -> None:
+    tree = ast.parse(CONNECTOR.read_text())
+    connector = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "LMCacheMPConnector"
+    )
+    build_meta = next(
+        node
+        for node in connector.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "build_connector_meta"
+    )
+    process_new = next(
+        node
+        for node in connector.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_process_new_requests"
+    )
+    build_source = ast.unparse(build_meta)
+    process_source = ast.unparse(process_new)
+
+    assert build_source.index("_ingest_exact_mamba_boundary_blocks") < (
+        build_source.index("_process_new_requests")
+    )
+    assert "self._mamba_group_ids" in process_source


### PR DESCRIPTION
## Summary

Adds the GLM hybrid/DCP geometry and exact Mamba boundary-state contract as a standalone review unit.

### Behavior

- DCP/interleave-aware cache identity
- resolved attention span `2304 × DCP4 = 9216`
- recurrent span `2304`
- authoritative registration geometry and blocks/chunk `[4,4,4,1]`
- hybrid cache-group views and validation
- exact committed Mamba boundary handoffs from vLLM core
- connector prefix reconciliation against the lagging Mamba group
- sparse Mamba store tables: exact retained checkpoints use physical block IDs; unavailable historical checkpoints use null block `0`
- positional Mamba block-table snapshots are never stored under valid prefix keys
- Mamba validator ABI compatibility
- padded packed-stride and odd-width CUDA transfer patches
- pinned qualified FlashInfer 0.6.18 package pair

CUDA IPC allocation transport and lifecycle are intentionally excluded here and submitted in #526. Runtime object-group separation is in #527.

## Why this update

Post-submission qualification found deterministic delayed `lockhandle...` corruption after a successful external cache reload. Store-disabled controls remained coherent. Kernel-group isolation proved recurrent/Mamba H2D state alone was sufficient; attention-only reload remained coherent. The fault was semantic: stale positional recurrent state was stored under valid prefix keys.

This update carries the corrected exact-boundary contract validated by D22 production qualification.

## Verification

- focused geometry/exact-boundary/connector tests: reported in the latest branch commit
- `git diff --check`: clean
- D22 runtime: unique 131,041-token C1 store; C2 external reload of 258,048 tokens total; coherent concurrent responses and unrelated post-reload probe; no `lockhandle`, CUDA error, EngineDead, OOM, restart, or new Xid

Supersedes the geometry portion of closed umbrella PR #522.

## Duplicate-work note

This updates the existing focused submission rather than opening a duplicate. PRs #403 and #482 address different local-prefix alignment paths and do not implement exact committed Mamba state handoff into LMCache.

## AI assistance disclosure

AI assistance was used for implementation and test construction. Devin Kuhn reviewed and directed the behavior.

## Final D22 production receipt (2026-08-30)

The reviewed exact-boundary implementation is live in fleet image `sha256:b73579097f4d68b52c20f7996cbd8f03a27e51bf3109e60ea5cda81105122aab`. Forced GPU-prefix eviction followed by replay retrieved 119,808 tokens externally on all four ranks, kept raw output coherent, and produced no `lockhandle`, Xid, CUDA error, OOM, or EngineDead. All CodeRabbit inline findings on this PR were fixed and answered.

Fleet-owned immutable deployment receipt: Apple-Federal-Credit-Union/fleet-infra#309.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GLM-5.3 LMCache D16 overlay support for hybrid attention and Mamba workloads.
  * Added multi-process cache coordination, prefetching, offloading, recovery, and health monitoring.
  * Added support for custom cache block strides and odd-width data transfers.
  * Added robust KV-cache allocation, lifecycle management, eviction, and prefix-cache handling.
* **Bug Fixes**
  * Improved cache-boundary tracking, shard validation, and connector state recovery.
* **Documentation**
  * Added deployment and overlay documentation.
* **Chores**
  * Updated FlashInfer to version 0.6.18.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->