### PR TITLE
feat(lmcache): add cuMem CUDA IPC transfer lifecycle

### DIFF
--- a/docker/glm53-flash/lmcache-d16-overlay/cumem_shareable_interposer.c
+++ b/docker/glm53-flash/lmcache-d16-overlay/cumem_shareable_interposer.c
@@ -1,0 +1,45 @@
+#define _GNU_SOURCE
+#include <cuda.h>
+#include <dlfcn.h>
+#include <pthread.h>
+
+/*
+ * vLLM's protected cuMem allocator predates shareable-handle allocation
+ * properties. Interpose only cuMemCreate and require POSIX-FD capability.
+ * Current drivers may make vLLM prefer FABRIC handles, which cannot be exported
+ * as POSIX FDs. Allocation, mapping, and ownership stay entirely in the
+ * original vLLM/CUDA implementation.
+ */
+typedef CUresult (*cuMemCreate_fn)(CUmemGenericAllocationHandle *, size_t,
+                                  const CUmemAllocationProp *,
+                                  unsigned long long);
+
+static cuMemCreate_fn real_cuMemCreate;
+static pthread_once_t resolve_once = PTHREAD_ONCE_INIT;
+
+static void resolve_driver_symbol(void) {
+  /*
+   * CUDA is loaded in the extension's local dependency scope, so RTLD_NEXT
+   * alone can miss it. Resolve from the actual driver DSO explicitly.
+   */
+  void *driver = dlopen("libcuda.so.1", RTLD_NOW | RTLD_LOCAL);
+  if (driver != NULL) {
+    real_cuMemCreate = (cuMemCreate_fn)dlsym(driver, "cuMemCreate");
+  }
+}
+
+CUresult cuMemCreate(CUmemGenericAllocationHandle *handle, size_t size,
+                     const CUmemAllocationProp *prop,
+                     unsigned long long flags) {
+  pthread_once(&resolve_once, resolve_driver_symbol);
+  if (real_cuMemCreate == NULL) {
+    return CUDA_ERROR_NOT_INITIALIZED;
+  }
+  if (prop == NULL ||
+      prop->requestedHandleTypes == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
+    return real_cuMemCreate(handle, size, prop, flags);
+  }
+  CUmemAllocationProp shareable = *prop;
+  shareable.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  return real_cuMemCreate(handle, size, &shareable, flags);
+}

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -240,9 +240,25 @@ def all_null_chunk_masks(
     return masks
 
 
+def effective_blocks_per_chunk(cache_context: BaseCacheContext) -> list[int]:
+    """Return block IDs consumed per chunk after sliding-window reduction."""
+    manager = cache_context.kv_layer_groups_manager
+    return [
+        cache_context.calculate_num_blocks(
+            min(
+                cache_context.lmcache_tokens_per_chunk,
+                manager.get_subchunk_sw_size_tokens(group_id),
+            ),
+            group_id,
+        )
+        for group_id in range(manager.num_kernel_groups)
+    ]
+
+
 def downsample_and_stage_block_ids(
     cache_context: BaseCacheContext,
     block_ids: list[list[int]],
+    num_chunks: int,
 ) -> list[torch.Tensor]:
     """Cut the block id lists to skip the unneeded blocks in a chunk and
     stage it into GPU tensors for later use.
@@ -300,9 +316,15 @@ def downsample_and_stage_block_ids(
 
         new_block_ids = []
         old_block_ids = block_ids[kernel_group_id]
-        assert len(old_block_ids) % total_blocks_per_chunk == 0, (
-            f"len(block_ids[{kernel_group_id}]) should be a multiple "
-            f"of total_blocks_per_chunk ({total_blocks_per_chunk}), but got "
+        reduced_count = num_chunks * keep_blocks_per_chunk
+        raw_count = num_chunks * total_blocks_per_chunk
+        if len(old_block_ids) == reduced_count:
+            # Exact Mamba boundary handoffs and other pre-windowed callers
+            # already provide the representation consumed by the transfer.
+            continue
+        assert len(old_block_ids) == raw_count, (
+            f"len(block_ids[{kernel_group_id}]) should be either the raw "
+            f"count {raw_count} or reduced count {reduced_count}, but got "
             f"{len(old_block_ids)}"
         )
 
@@ -1212,15 +1234,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         )
         num_chunks = len(obj_keys_per_obj_group[0])
 
-        # NOTE: different engine groups may have different block sizes, so
-        # ``blocks_per_chunk[i]`` is the number of blocks in one chunk for
-        # group ``i``.
-        blocks_per_chunk = [
-            cache_context.calculate_num_blocks(self._ctx.chunk_size, group_idx)
-            for group_idx in range(
-                cache_context.kv_layer_groups_manager.num_kernel_groups
-            )
-        ]
+        effective_bpc = effective_blocks_per_chunk(cache_context)
 
         with (
             torch_dev.device(cache_context.device),
@@ -1228,43 +1242,36 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         ):
             event = event_backend.create_event(cache_context.device)
 
-            # Fail closed: every LMCache group must have block IDs covering all
-            # chunks. A short list (e.g. a caller/protocol bug) would otherwise
-            # drive the transfer kernel to read out-of-bounds GPU memory, so skip
-            # the whole store and commit nothing rather than caching a partial or
-            # garbage entry. A later request can store it once the block IDs are
-            # complete. Checked on the raw block ids, before cutting drops the
-            # per-chunk blocks that sliding-window groups do not need.
+            # Accept either full per-chunk lists or pre-windowed exact-state
+            # lists, but require complete coverage of every chunk.
             if any(
                 len(group_block_ids) < num_chunks * bpc
                 for group_block_ids, bpc in zip(
-                    gpu_block_ids, blocks_per_chunk, strict=True
+                    gpu_block_ids, effective_bpc, strict=True
                 )
             ):
                 logger.warning(
                     "STORE block ID underflow for request_id=%s: each group needs "
-                    "num_chunks * blocks_per_chunk block IDs for %d chunks "
-                    "(per-group blocks_per_chunk=%s); skipping the store.",
+                    "num_chunks * effective_blocks_per_chunk block IDs for %d "
+                    "chunks (per-group effective_blocks_per_chunk=%s); skipping "
+                    "the store.",
                     key.request_id,
                     num_chunks,
-                    blocks_per_chunk,
+                    effective_bpc,
                 )
                 event_backend.record_event(event, cache_context.stream)
                 return event_backend.export_event(event, cache_context.device), False
 
-            # Chunks whose block ids are all the null block (e.g. align-mode
-            # Mamba chunks holding no real state) carry no valid KV and must not
-            # be committed. Computed on the raw block ids before downsampling
-            # mutates them.
+            # Normalize raw full-chunk IDs and already-windowed exact-state IDs
+            # to the same representation before null-mask evaluation.
+            block_ids_per_group_gpu = downsample_and_stage_block_ids(
+                cache_context, gpu_block_ids, num_chunks
+            )
             skipped_chunks = all_null_chunk_masks(
                 gpu_block_ids,
                 cache_context.kv_layer_groups_manager.object_groups,
-                blocks_per_chunk,
+                effective_bpc,
                 num_chunks,
-            )
-
-            block_ids_per_group_gpu = downsample_and_stage_block_ids(
-                cache_context, gpu_block_ids
             )
 
             producer_event = event_backend.import_event(
@@ -1466,12 +1473,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             ),
         )
 
-        blocks_per_chunk = [
-            cache_context.calculate_num_blocks(self._ctx.chunk_size, group_idx)
-            for group_idx in range(
-                cache_context.kv_layer_groups_manager.num_kernel_groups
-            )
-        ]
+        effective_bpc = effective_blocks_per_chunk(cache_context)
 
         with (
             torch_dev.device(cache_context.device),
@@ -1479,31 +1481,29 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         ):
             event = event_backend.create_event(cache_context.device)
 
-            # Fail closed: a short block-id list would drive the transfer
-            # kernel to write out-of-bounds GPU memory. Checked on the raw
-            # block ids, before cutting drops the per-chunk blocks that
-            # sliding-window groups do not need.
+            # Loads normally receive raw destination block tables. Also accept
+            # pre-windowed tables so validation matches transfer semantics.
             if any(
                 len(group_block_ids) < num_chunks * bpc
                 for group_block_ids, bpc in zip(
-                    gpu_block_ids, blocks_per_chunk, strict=True
+                    gpu_block_ids, effective_bpc, strict=True
                 )
             ):
                 logger.error(
                     "RETRIEVE block ID underflow for request_id=%s: each group "
-                    "needs num_chunks * blocks_per_chunk block IDs for %d "
-                    "chunks (per-group blocks_per_chunk=%s); skipping the "
-                    "retrieve.",
+                    "needs num_chunks * effective_blocks_per_chunk block IDs for "
+                    "%d chunks (per-group effective_blocks_per_chunk=%s); "
+                    "skipping the retrieve.",
                     key.request_id,
                     num_chunks,
-                    blocks_per_chunk,
+                    effective_bpc,
                 )
                 event_backend.record_event(event, cache_context.stream)
                 return event_backend.export_event(event, cache_context.device), False
 
             # Cut and stage all block_ids to GPU once before the transfer
             block_ids_per_group_gpu = downsample_and_stage_block_ids(
-                cache_context, gpu_block_ids
+                cache_context, gpu_block_ids, num_chunks
             )
             producer_event = event_backend.import_event(
                 event_ipc_handle, cache_context.device

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -1,0 +1,1656 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""LMCache-driven KV cache transfer operations for the MPCacheServer."""
+
+# Standard
+import os
+import threading
+import time
+from builtins import ExceptionGroup
+from collections.abc import Generator, Sequence
+from dataclasses import dataclass
+from itertools import islice
+from typing import Any
+
+import lmcache.lmcache_native as lmcache_native
+
+# Third Party
+import torch
+
+# First Party
+from lmcache import device_ops, torch_dev
+from lmcache.logging import init_logger
+from lmcache.utils import (
+    EngineType,
+    _lmcache_nvtx_annotate,
+)
+from lmcache.v1.distributed.api import (
+    MemoryLayoutDesc,
+    ObjectKey,
+)
+from lmcache.v1.gpu_connector.gpu_ops import (
+    build_staging_copies,
+    lmcache_memcpy_async_d2h,
+    lmcache_memcpy_async_h2d,
+)
+from lmcache.v1.gpu_connector.utils import LayoutHints
+from lmcache.v1.kv_layer_groups import ObjectGroupInfo
+from lmcache.v1.memory_allocators.lazy_memory_allocator import LazyMemoryAllocator
+from lmcache.v1.memory_management import GDSMemoryObject, MemoryObj
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.multiprocess.custom_types import (
+    IPCCacheServerKey,
+    KVCache,
+)
+from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
+from lmcache.v1.multiprocess.engine_module import (
+    HandlerSpec,
+    InstanceLivenessTarget,
+    ThreadPoolType,
+)
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+from lmcache.v1.multiprocess.native_completion import (
+    DeviceHostFuncDispatcher,
+    submit_callback_to_stream,
+)
+from lmcache.v1.multiprocess.protocols.base import RequestType
+from lmcache.v1.platform.base.cache_context import BaseCacheContext
+from lmcache.v1.platform.base.event_ipc import (
+    EventIPCBackend,
+    get_event_ipc_backend,
+)
+from lmcache.v1.platform.cache_context import create_cache_context
+
+logger = init_logger(__name__)
+_HAS_NATIVE_OBJECT_GROUP_TRANSFER: bool = hasattr(
+    device_ops, "execute_object_group_transfer"
+)
+_DIAGNOSTIC_LMCACHE_LEGACY_D2H_ENV = "GLM53_DIAGNOSTIC_LMCACHE_LEGACY_D2H"
+_diagnostic_lmcache_legacy_d2h_logged = False
+_diagnostic_lmcache_legacy_d2h_invalid_logged = False
+_production_lmcache_legacy_d2h_logged = False
+
+
+def _diagnostic_lmcache_legacy_d2h_enabled() -> bool:
+    """Return whether the exact legacy-D2H compatibility override is set."""
+    value = os.environ.get(_DIAGNOSTIC_LMCACHE_LEGACY_D2H_ENV)
+    if value == "1":
+        global _diagnostic_lmcache_legacy_d2h_logged
+        if not _diagnostic_lmcache_legacy_d2h_logged:
+            logger.warning(
+                "%s=1: enabling legacy-D2H compatibility override for all "
+                "D2H stores; native H2D retrieval remains enabled",
+                _DIAGNOSTIC_LMCACHE_LEGACY_D2H_ENV,
+            )
+            _diagnostic_lmcache_legacy_d2h_logged = True
+        return True
+
+    if value is not None:
+        global _diagnostic_lmcache_legacy_d2h_invalid_logged
+        if not _diagnostic_lmcache_legacy_d2h_invalid_logged:
+            logger.warning(
+                "Ignoring invalid %s=%r; exact value '1' is required and "
+                "the production D2H policy remains enabled",
+                _DIAGNOSTIC_LMCACHE_LEGACY_D2H_ENV,
+                value,
+            )
+            _diagnostic_lmcache_legacy_d2h_invalid_logged = True
+    return False
+
+
+def _object_group_requires_legacy_d2h(
+    cache_context: BaseCacheContext,
+    object_group_id: int,
+) -> bool:
+    """Return whether this object's D2H plan has compressed logical geometry.
+
+    The consolidated native D2H transfer is unsafe for the proven GLM DCP
+    layout, where at least one kernel group maps a logical block span onto a
+    smaller physical slot span (``tokens_per_block != slots_per_block``).
+    Evaluate only the kernel groups sharing the current object-group plan so
+    uncompressed object groups retain the native D2H path.
+    """
+    manager = cache_context.kv_layer_groups_manager
+    object_group = manager.object_groups[object_group_id]
+    requires_legacy = any(
+        manager.kernel_groups[kernel_group_id].tokens_per_block
+        != manager.kernel_groups[kernel_group_id].slots_per_block
+        for kernel_group_id in object_group.kernel_group_indices
+    )
+    if requires_legacy:
+        global _production_lmcache_legacy_d2h_logged
+        if not _production_lmcache_legacy_d2h_logged:
+            logger.info(
+                "Compressed logical KV geometry detected; D2H stores use "
+                "the production-safe legacy transfer implementation while "
+                "native H2D retrieval remains enabled"
+            )
+            _production_lmcache_legacy_d2h_logged = True
+    return requires_legacy
+
+
+def get_layout_desc(
+    cache_context: BaseCacheContext,
+    num_tokens: int,
+    object_group_id: int,
+) -> MemoryLayoutDesc:
+    """Get the memory layout description for a specific object group.
+
+    The returned layout describes the single memory object that backs
+    ``object_group_id``: one (shape, dtype) entry per kernel group in that
+    object group, in the kernel groups' declared layout order. Kernel groups
+    may have different shapes and dtypes.
+
+    Args:
+        cache_context: The cache context containing the KV cache information.
+        num_tokens: The number of tokens to determine the layout for.
+        object_group_id: Index of the object group whose layout to build.
+
+    Returns:
+        MemoryLayoutDesc: The memory layout description containing shapes and
+        dtypes, one entry per kernel group in the object group.
+    """
+    object_group = cache_context.kv_layer_groups_manager.object_groups[object_group_id]
+    shapes_and_dtypes = [
+        cache_context.get_kernel_group_shape_dtype(num_tokens, kernel_group_idx)
+        for kernel_group_idx in object_group.kernel_group_indices
+    ]
+    shapes, dtypes = zip(*shapes_and_dtypes, strict=False)
+    return MemoryLayoutDesc(shapes=list(shapes), dtypes=list(dtypes))
+
+
+def batched_iteration_with_skip(
+    lst: Sequence,
+    batch_size: int,
+    skip_count: int,
+) -> Generator[tuple[int, tuple], None, None]:
+    """Utility function to iterate over a list in batches with an initial skip.
+
+    Args:
+        lst: The list to iterate over.
+        batch_size: The size of each batch.
+        skip_count: The number of items to skip at the start of the list.
+
+    Yields:
+        Tuples of (batch_start_idx, batch) where batch is a tuple of items
+        from the list, and batch_start_idx is the "original" index of the first
+        item in the batch.
+
+    Raises:
+        ValueError: If batch_size is less than 1 or skip_count is negative.
+
+    Note:
+        Batch_idx is the index of the batch in the original list, accounting
+        for the skipped items. For example, if skip_count is 10 and batch_size
+        is 5, the first yielded batch will have batch_start_idx=10.
+    """
+    if batch_size < 1:
+        raise ValueError("batch size must be at least one")
+    if skip_count < 0:
+        raise ValueError("skip_count must be non-negative")
+
+    it = iter(lst)
+    # Skip the initial items
+    for _ in range(skip_count):
+        next(it, None)
+    batch_start_idx = skip_count
+    while batch := tuple(islice(it, batch_size)):
+        yield batch_start_idx, batch
+        batch_start_idx += len(batch)
+
+
+def all_null_chunk_masks(
+    block_ids: Sequence[Sequence[int]],
+    object_groups: Sequence[ObjectGroupInfo],
+    blocks_per_chunk: Sequence[int],
+    num_chunks: int,
+) -> list[list[bool]]:
+    """Mark, per object group, the chunks whose engine block ids are all null.
+
+    A chunk is null for an object group when every block id of every kernel
+    group in that group is 0 (the vLLM null block). Align-mode Mamba/linear
+    layers produce such chunks: only the block holding the last recurrent state
+    is real, so every earlier chunk is null. These chunks must not be stored --
+    the null block carries no valid KV, and object keys are content hashes, so
+    committing them would serve garbage to a later prefix hit.
+
+    Args:
+        block_ids: Raw per-kernel-group engine block ids (before any downsample),
+            indexed by kernel-group index.
+        object_groups: The object groups, indexed by object-group id.
+        blocks_per_chunk: Blocks in one chunk per kernel group, indexed by
+            kernel-group index.
+        num_chunks: Number of chunks in the request.
+
+    Returns:
+        ``mask[g][i]`` is True iff chunk ``i`` is all-null for object group ``g``.
+    """
+    masks: list[list[bool]] = []
+    for group in object_groups:
+        chunk_null: list[bool] = []
+        for i in range(num_chunks):
+            is_null = True
+            for kg in group.kernel_group_indices:
+                bpc = blocks_per_chunk[kg]
+                if any(block_ids[kg][i * bpc : (i + 1) * bpc]):
+                    is_null = False
+                    break
+            chunk_null.append(is_null)
+        masks.append(chunk_null)
+    return masks
+
+
+def downsample_and_stage_block_ids(
+    cache_context: BaseCacheContext,
+    block_ids: list[list[int]],
+) -> list[torch.Tensor]:
+    """Cut the block id lists to skip the unneeded blocks in a chunk and
+    stage it into GPU tensors for later use.
+
+    This mainly targets the case where a portion of the blocks are not
+    needed for every chunk, such as deepseek v4's swa cache.
+
+    Note that the we do NOT do any object-level skipping here.
+
+    Args:
+        cache_context: The cache context containing the KV cache information.
+        block_ids: The original block id lists, indexed by LMCache KV group index.
+
+    Returns:
+        The cut block id lists, indexed by LMCache KV group index.
+
+    Note:
+        This function has some coupled logic with transfer_kv_per_object_group below.
+        The caller need to make sure that the block ids seen by
+        transfer_kv_per_object_group are produced by this function.
+
+    Example:
+        If a model have 2 kernel groups, one is full attention with block size 32,
+        one is swa attention with block size 32 and sliding window size 64, and
+        LMCache has a chunk size of 128. And there are 2 chunks in total (256 tokens).
+
+        The input will be:
+        [
+          [1, 2, 3, 4, 5, 6, 7, 8],  # block ids for the full attention group
+          [11, 12, 13, 14, 15, 16, 17, 18], # block ids for the swa attention group
+        ]
+
+        The output will be
+        [
+          [1, 2, 3, 4, 5, 6, 7, 8],  # full attention group still needs all block ids
+          [13, 14, 17, 18], # swa attention group only needs the last 2 block per chunk
+        ]
+    """
+    num_kernel_groups = cache_context.kv_layer_groups_manager.num_kernel_groups
+    for kernel_group_id in range(num_kernel_groups):
+        subchunk_sw_size_tokens = (
+            cache_context.kv_layer_groups_manager.get_subchunk_sw_size_tokens(
+                kernel_group_id
+            )
+        )
+        tokens_per_chunk = min(
+            cache_context.lmcache_tokens_per_chunk, subchunk_sw_size_tokens
+        )
+        keep_blocks_per_chunk = cache_context.calculate_num_blocks(
+            tokens_per_chunk, kernel_group_id
+        )
+        total_blocks_per_chunk = cache_context.calculate_num_blocks(
+            cache_context.lmcache_tokens_per_chunk, kernel_group_id
+        )
+
+        new_block_ids = []
+        old_block_ids = block_ids[kernel_group_id]
+        assert len(old_block_ids) % total_blocks_per_chunk == 0, (
+            f"len(block_ids[{kernel_group_id}]) should be a multiple "
+            f"of total_blocks_per_chunk ({total_blocks_per_chunk}), but got "
+            f"{len(old_block_ids)}"
+        )
+
+        for i in range(0, len(old_block_ids), total_blocks_per_chunk):
+            chunk_block_ids = old_block_ids[i : i + total_blocks_per_chunk]
+            new_block_ids.extend(chunk_block_ids[-keep_blocks_per_chunk:])
+
+        block_ids[kernel_group_id] = new_block_ids
+
+    # Stage the cut block ids into GPU tensors
+    block_ids_gpu = cache_context.stage_block_ids(block_ids)
+    return block_ids_gpu
+
+
+def _recalculate_blocks_to_skip(
+    blocks_per_chunk: int,
+    blocks_per_window: int,
+    blocks_to_skip: int,
+) -> int:
+    """Re-calculate the number of blocks to skip for a batch of chunks based
+    on the blocks per chunk and blocks per sliding window WHEN the window
+    size is smaller than the lmcache chunk size.
+
+    Args:
+        blocks_per_chunk: The total number of blocks in one chunk for the
+            current group.
+        blocks_per_window: The number of blocks in the sliding window
+            for the current group. Should be less than or equal to
+            blocks_per_chunk.
+        blocks_to_skip: The number of blocks to skip.
+
+    Returns:
+        The re-calculated number of blocks to skip for the current batch of
+        chunks.
+    """
+    if blocks_per_chunk == blocks_per_window:
+        return blocks_to_skip
+
+    full_windows_to_skip = blocks_to_skip // blocks_per_chunk
+    tail_blocks = blocks_to_skip % blocks_per_chunk
+    tail_blocks_to_skip = tail_blocks - (blocks_per_chunk - blocks_per_window)
+    return full_windows_to_skip * blocks_per_window + max(0, tail_blocks_to_skip)
+
+
+def _run_object_group_transfer_plan(
+    cache_context: BaseCacheContext,
+    block_ids_gpu: list[torch.Tensor],
+    memory_objs: Sequence[MemoryObj | None],
+    object_group_id: int,
+    batch_size: int,
+    skip_first_n_tokens: int,
+    direction: "lmcache_native.TransferDirection",
+) -> None:
+    """Plan and execute one object group's transfer in a single native call.
+
+    This is the fast path of :func:`transfer_kv_per_object_group`: it runs the
+    same batched-iteration / skip logic, but instead of issuing each staging
+    copy and kernel launch immediately (each a GIL release/re-acquire), it
+    resolves every argument to plain pointers/scalars (the "planner", GIL held
+    throughout) and hands the whole plan to ``execute_object_group_transfer``,
+    which issues all of it on the stream within a single GIL release.
+
+    Requires every object to be non-GDS (staged through the lazy-allocator
+    path); the caller skips groups that contain any GDS-backed object.
+
+    Args:
+        cache_context: The GPU cache context containing the KV cache information.
+        block_ids_gpu: GPU block IDs, indexed by LMCache KV group index.
+        memory_objs: The MemoryObj instances to copy. None entries are only
+            valid for D2H (the batch is skipped); H2D raises.
+        object_group_id: Index of the object group being copied.
+        batch_size: Number of memory objects per batched copy.
+        skip_first_n_tokens: Tokens to skip writing at the start of the range.
+        direction: H2D (retrieve) or D2H (store).
+
+    Raises:
+        ValueError: If a None entry is found in memory_objs when direction is
+            H2D, or if an object's size does not match its GPU staging buffer.
+    """
+    lmcache_chunk_size = cache_context.lmcache_tokens_per_chunk
+    kv_groups_manager = cache_context.kv_layer_groups_manager
+    object_group = kv_groups_manager.object_groups[object_group_id]
+    kernel_group_ids = object_group.kernel_group_indices
+    is_h2d = direction == lmcache_native.TransferDirection.H2D
+    max_batch_size = cache_context.max_batch_size
+
+    # --- Per-kernel-group invariants, resolved once (vs. every batch before) ---
+    kernel_group_specs: list[Any] = []
+    spec_index_by_kg: dict[int, int] = {}
+    blocks_per_chunk_by_kg: dict[int, int] = {}
+    blocks_per_window_by_kg: dict[int, int] = {}
+    for kernel_group_id in kernel_group_ids:
+        blocks_per_chunk = cache_context.calculate_num_blocks(
+            lmcache_chunk_size, kernel_group_id
+        )
+        tokens_per_window = min(
+            lmcache_chunk_size,
+            kv_groups_manager.get_subchunk_sw_size_tokens(kernel_group_id),
+        )
+        blocks_per_window = cache_context.calculate_num_blocks(
+            tokens_per_window, kernel_group_id
+        )
+        blocks_per_chunk_by_kg[kernel_group_id] = blocks_per_chunk
+        blocks_per_window_by_kg[kernel_group_id] = blocks_per_window
+
+        paged_ptrs = cache_context.get_kernel_group_kv_pointers(kernel_group_id)
+        block_ids_tensor = block_ids_gpu[kernel_group_id]
+        temp_buffers = [
+            cache_context.get_temp_kernel_group_buffer(slot, kernel_group_id)
+            for slot in range(max_batch_size)
+        ]
+
+        spec_index_by_kg[kernel_group_id] = len(kernel_group_specs)
+        kernel_group_specs.append(
+            device_ops.KernelGroupSpec(
+                paged_ptrs.data_ptr(),
+                [buffer.data_ptr() for buffer in temp_buffers],
+                cache_context.get_shape_desc(kernel_group_id),
+                cache_context.get_slots_per_chunk_in_sw(kernel_group_id),
+                cache_context.get_engine_kv_format(kernel_group_id),
+                block_ids_tensor.data_ptr(),
+                block_ids_tensor.numel(),
+            )
+        )
+
+    # Temp object-group staging buffers (reused per batch slot, like above).
+    object_group_buffers = [
+        cache_context.get_temp_object_group_buffer(slot, object_group_id)
+        for slot in range(max_batch_size)
+    ]
+
+    attn_desc = kv_groups_manager.get_attn_desc()
+    num_objects_to_skip = 0
+    if not attn_desc.is_full_attention(object_group_id) and is_h2d:
+        sw_size_chunks = attn_desc.num_chunks_in_sw[object_group_id]
+        num_objects_to_skip = max(0, len(memory_objs) - sw_size_chunks)
+        logger.debug(
+            "Detected sliding window for object group %d: "
+            "skipping the first %d objects in the batch",
+            object_group_id,
+            num_objects_to_skip,
+        )
+
+    # --- Walk the batches in order, emitting staging + launch work per step ---
+    batch_steps: list[Any] = []
+    for start_object_idx, memory_object_batch in batched_iteration_with_skip(
+        memory_objs, batch_size, skip_count=num_objects_to_skip
+    ):
+        if any(mo is None for mo in memory_object_batch):
+            if is_h2d:
+                raise ValueError(
+                    "MemoryObj is None for some objects in the batch, cannot "
+                    "perform H2D copy. memory_object_batch: "
+                    f"{memory_object_batch}"
+                )
+            else:
+                continue
+
+        batch_len = len(memory_object_batch)
+        batch_start_token = start_object_idx * lmcache_chunk_size
+        batch_end_token = batch_start_token + batch_len * lmcache_chunk_size
+
+        effective_start = max(batch_start_token, skip_first_n_tokens)
+        if effective_start >= batch_end_token:
+            continue
+
+        skip_tokens_in_chunk = effective_start - batch_start_token
+
+        staging = build_staging_copies(
+            memory_object_batch,
+            object_group_buffers[:batch_len],
+            is_h2d,
+        )
+
+        launches: list[Any] = []
+        for kernel_group_id in kernel_group_ids:
+            blocks_per_chunk = blocks_per_chunk_by_kg[kernel_group_id]
+            blocks_per_window = blocks_per_window_by_kg[kernel_group_id]
+
+            start_block_pos = start_object_idx * blocks_per_window
+            end_block_pos = (start_object_idx + batch_len) * blocks_per_window
+
+            orig_skip_blocks = cache_context.calculate_num_blocks(
+                skip_tokens_in_chunk, kernel_group_id
+            )
+            recalculated_skip_blocks = _recalculate_blocks_to_skip(
+                blocks_per_chunk,
+                blocks_per_window,
+                orig_skip_blocks,
+            )
+
+            launches.append(
+                device_ops.LaunchVar(
+                    spec_index_by_kg[kernel_group_id],
+                    start_block_pos,
+                    end_block_pos - start_block_pos,
+                    batch_len,
+                    recalculated_skip_blocks,
+                )
+            )
+
+        batch_steps.append(device_ops.BatchStep(staging, launches))
+
+    if not batch_steps:
+        return
+
+    execute_object_group_transfer = device_ops.execute_object_group_transfer
+    execute_object_group_transfer(
+        direction,
+        cache_context.device,
+        LazyMemoryAllocator.PIN_CHUNK_SIZE,
+        kernel_group_specs,
+        batch_steps,
+    )
+
+
+def transfer_kv_per_object_group(
+    cache_context: BaseCacheContext,
+    block_ids_gpu: list[torch.Tensor],
+    memory_objs: Sequence[MemoryObj | None],
+    object_group_id: int,
+    batch_size: int,
+    skip_first_n_tokens: int,
+    direction: "lmcache_native.TransferDirection",
+) -> None:
+    """Helper function to transfer memory objects of a single object group
+    to/from GPU, with batching support.
+
+    Args:
+        cache_context: The GPU cache context containing the KV cache information.
+        block_ids_gpu: GPU block IDs to retrieve into, indexed by LMCache KV group
+            index. It should satisfy `len(block_ids_gpu[i]) == len(memory_objs) *
+            blocks_per_chunk[i]` for each group `i`.
+            Note that the block IDs list are already on GPU.
+        memory_objs: The list of MemoryObj instances to copy from. It could be
+            None when allocation or retrieval fails. For store (D2H), it should
+            ignore the None entry and continue copying the rest. For retrieve
+            (H2D), it should raise the error and stop copying.
+        object_group_id: Index of the object group being copied.
+        batch_size: The number of memory objects to perform batched copy
+        skip_first_n_tokens: Number of tokens to skip writing at the start of
+            the retrieve range. This avoids overwriting APC-shared GPU blocks that
+            may be read concurrently by other requests.
+        direction: The transfer direction, H2D (retrieve) or D2H (store).
+
+    Raises:
+        ValueError: If it founds None entry in memory_objs when direction is H2D.
+    Note:
+        This function expects the caller to stage the block ids (list[list[int]])
+        into GPU tensors and pass them in as `block_ids_gpu`.
+    """
+    use_legacy_d2h = direction == lmcache_native.TransferDirection.D2H and (
+        _diagnostic_lmcache_legacy_d2h_enabled()
+        or _object_group_requires_legacy_d2h(cache_context, object_group_id)
+    )
+    if (
+        _HAS_NATIVE_OBJECT_GROUP_TRANSFER
+        and not use_legacy_d2h
+        and not any(isinstance(mo, GDSMemoryObject) for mo in memory_objs)
+    ):
+        _run_object_group_transfer_plan(
+            cache_context,
+            block_ids_gpu,
+            memory_objs,
+            object_group_id,
+            batch_size,
+            skip_first_n_tokens,
+            direction,
+        )
+        return
+
+    lmcache_chunk_size = cache_context.lmcache_tokens_per_chunk
+    kv_groups_manager = cache_context.kv_layer_groups_manager
+    object_group = kv_groups_manager.object_groups[object_group_id]
+    kernel_group_ids = object_group.kernel_group_indices
+    is_h2d = direction == lmcache_native.TransferDirection.H2D
+
+    attn_desc = kv_groups_manager.get_attn_desc()
+    num_objects_to_skip = 0
+    if not attn_desc.is_full_attention(object_group_id) and is_h2d:
+        sw_size_chunks = attn_desc.num_chunks_in_sw[object_group_id]
+        num_objects_to_skip = max(0, len(memory_objs) - sw_size_chunks)
+        logger.debug(
+            "Detected sliding window for object group %d: "
+            "skipping the first %d objects in the batch",
+            object_group_id,
+            num_objects_to_skip,
+        )
+
+    for start_object_idx, memory_object_batch in batched_iteration_with_skip(
+        memory_objs, batch_size, skip_count=num_objects_to_skip
+    ):
+        if any(mo is None for mo in memory_object_batch):
+            if is_h2d:
+                raise ValueError(
+                    "MemoryObj is None for some objects in the batch, cannot "
+                    "perform H2D copy. memory_object_batch: "
+                    f"{memory_object_batch}"
+                )
+            else:
+                continue
+
+        batch_len = len(memory_object_batch)
+        batch_start_token = start_object_idx * lmcache_chunk_size
+        batch_end_token = batch_start_token + batch_len * lmcache_chunk_size
+
+        effective_start = max(batch_start_token, skip_first_n_tokens)
+        if effective_start >= batch_end_token:
+            continue
+
+        skip_tokens_in_chunk = effective_start - batch_start_token
+
+        # For H2D, copy from CPU to GPU tmp buffers before the kernel launch
+        if is_h2d:
+            for chunk_idx, memory_obj in enumerate(memory_object_batch):
+                lmcache_memcpy_async_h2d(
+                    memory_obj,
+                    cache_context.get_temp_object_group_buffer(
+                        chunk_idx, object_group_id
+                    ),
+                )
+
+        # Do paged KV copy
+        for kernel_group_id in kernel_group_ids:
+            blocks_per_chunk = cache_context.calculate_num_blocks(
+                lmcache_chunk_size, kernel_group_id
+            )
+            tokens_per_window = min(
+                lmcache_chunk_size,
+                kv_groups_manager.get_subchunk_sw_size_tokens(kernel_group_id),
+            )
+            blocks_per_window = cache_context.calculate_num_blocks(
+                tokens_per_window, kernel_group_id
+            )
+
+            # Get the block ids for this chunk
+            start_block_pos = start_object_idx * blocks_per_window
+            end_block_pos = (start_object_idx + batch_len) * blocks_per_window
+
+            block_ids_curr_batch = block_ids_gpu[kernel_group_id][
+                start_block_pos:end_block_pos
+            ]
+
+            # Re-calculate the skip blocks for this kernel group
+            orig_skip_blocks = cache_context.calculate_num_blocks(
+                skip_tokens_in_chunk, kernel_group_id
+            )
+            recalculated_skip_blocks = _recalculate_blocks_to_skip(
+                blocks_per_chunk,
+                blocks_per_window,
+                orig_skip_blocks,
+            )
+
+            # Launch kernel
+            group_kv_pointers = cache_context.get_kernel_group_kv_pointers(
+                kernel_group_id
+            )
+            group_lmcache_chunk_size = cache_context.get_slots_per_chunk_in_sw(
+                kernel_group_id
+            )
+            tmp_gpu_buffers_batched = [
+                cache_context.get_temp_kernel_group_buffer(
+                    i, kernel_group_id
+                ).data_ptr()
+                for i in range(batch_len)
+            ]
+            device_ops.multi_layer_block_kv_transfer(
+                group_kv_pointers,
+                tmp_gpu_buffers_batched,
+                block_ids_curr_batch,
+                cache_context.device,
+                direction,
+                cache_context.get_shape_desc(kernel_group_id),
+                group_lmcache_chunk_size,
+                cache_context.get_engine_kv_format(kernel_group_id),
+                recalculated_skip_blocks,
+            )
+
+        # For D2H, copy from GPU tmp buffers to CPU after the kernel launch
+        if not is_h2d:
+            for chunk_idx, memory_obj in enumerate(memory_object_batch):
+                lmcache_memcpy_async_d2h(
+                    cache_context.get_temp_object_group_buffer(
+                        chunk_idx, object_group_id
+                    ),
+                    memory_obj,
+                )
+
+
+@dataclass
+class ContextEntry:
+    """Registered cache context metadata for a single worker instance.
+
+    The concrete type is whatever :func:`create_cache_context` returned
+    for the wrapper list at registration time -- a
+    :class:`GPUCacheContext` for CUDA-IPC wrappers, a
+    :class:`CPUCacheContext` for POSIX-SHM wrappers. Both expose
+    the same ``kv_tensors`` / ``engine_kv_format`` / ``num_layers`` / ...
+    duck-typed surface, so downstream consumers stay agnostic.
+
+    Args:
+        cache_context: Platform cache context (GPU or CPU) managing
+            shape and pointers to the registered KV cache tensors.
+        model_name: The name of the model associated with this KV cache.
+        world_size: The world size associated with this KV cache.
+        last_seen: ``time.monotonic()`` of the most recent activity from
+            this instance (register, PING, store, or retrieve). Drives reaping.
+        has_liveness_signal: True once the instance has sent at least one
+            PING. Selects the reap window (timeout vs registration grace).
+            Latched only by PING, never by traffic.
+        event_backend: Cached event backend selected for this context's device.
+    """
+
+    cache_context: BaseCacheContext
+    model_name: str
+    world_size: int
+    last_seen: float = 0.0
+    has_liveness_signal: bool = False
+    event_backend: EventIPCBackend | None = None
+
+
+class LMCacheDrivenTransferModule(InstanceLivenessTarget):
+    """Handles LMCache-driven KV cache transfer operations.
+
+    Owns GPU context registrations and provides handlers for
+    register, unregister, store, and retrieve of GPU KV caches.
+
+    Args:
+        ctx: The shared engine context.
+    """
+
+    def __init__(self, ctx: MPCacheServerContext) -> None:
+        self._ctx = ctx
+        self._cache_contexts: dict[int, ContextEntry] = {}
+        # Guards all reads/writes of _cache_contexts. The reaper mutates it
+        # off the MQ main loop, so register/unregister/store/retrieve and
+        # report_status all serialize through this lock. Held only for dict
+        # ops -- never across context creation, layout-registry calls, or
+        # empty_cache (leaf-lock invariant: no thread holds two locks).
+        self._lock = threading.Lock()
+
+        # Route finish_write / finish_read_prefetched through a C++ host
+        # callback so the driver thread doesn't acquire the GIL.
+        self._device_host_func_dispatcher = DeviceHostFuncDispatcher()
+        self._device_host_func_dispatcher.register(
+            "finish_write",
+            self._ctx.storage_manager.finish_write,
+            payload_type=list[ObjectKey],
+        )
+        self._device_host_func_dispatcher.register(
+            "finish_read_prefetched",
+            self._ctx.storage_manager.finish_read_prefetched,
+            payload_type=list[ObjectKey],
+        )
+        self._device_host_func_dispatcher.start()
+
+    @property
+    def context(self) -> MPCacheServerContext:
+        """Return the shared engine context. Exposed for testing only."""
+        return self._ctx
+
+    def get_and_touch_context_entry(self, instance_id: int) -> ContextEntry | None:
+        """Return the entry for ``instance_id``, refreshing its last-seen time.
+
+        The refresh keeps an actively transferring worker from being reaped
+        even if its PINGs are briefly delayed. Does not latch the
+        ping-proven flag -- only PINGs do that.
+
+        Args:
+            instance_id: The worker instance ID.
+
+        Returns:
+            The entry, or None if the instance is not (or no longer) tracked.
+        """
+        now = time.monotonic()
+        with self._lock:
+            entry = self._cache_contexts.get(instance_id)
+            if entry is not None:
+                entry.last_seen = now
+            return entry
+
+    def context_entries_snapshot(self) -> dict[int, ContextEntry]:
+        """Return a shallow copy of the registry for iteration or status.
+
+        Returns:
+            A new dict mapping instance ID to entry; does not refresh
+            last-seen times.
+        """
+        with self._lock:
+            return dict(self._cache_contexts)
+
+    def touch_instance(self, instance_id: int) -> None:
+        """Refresh the worker's last-seen time and mark it ping-proven.
+
+        A no-op if the instance is not tracked.
+
+        Args:
+            instance_id: The worker instance ID.
+        """
+        now = time.monotonic()
+        with self._lock:
+            entry = self._cache_contexts.get(instance_id)
+            if entry is not None:
+                entry.last_seen = now
+                entry.has_liveness_signal = True
+
+    def tracked_instance_count(self) -> int:
+        """Return the number of currently registered instances."""
+        with self._lock:
+            return len(self._cache_contexts)
+
+    def reap_stale_instances(
+        self, reap_timeout_s: float, registration_grace_s: float
+    ) -> list[int]:
+        """Reap GPU registrations that have gone silent.
+
+        A ping-proven instance is judged against ``reap_timeout_s``; one
+        that has never pinged against the larger ``registration_grace_s``.
+
+        Args:
+            reap_timeout_s: Silence budget for ping-proven instances.
+            registration_grace_s: Silence budget for never-pinged instances.
+
+        Returns:
+            The instance IDs reaped this scan.
+        """
+        now = time.monotonic()
+        reaped: list[tuple[int, ContextEntry]] = []
+        with self._lock:
+            stale_ids = [
+                iid
+                for iid, entry in self._cache_contexts.items()
+                if now - entry.last_seen
+                > (
+                    reap_timeout_s
+                    if entry.has_liveness_signal
+                    else registration_grace_s
+                )
+            ]
+            for iid in stale_ids:
+                reaped.append((iid, self._cache_contexts.pop(iid)))
+        reaped_ids: list[int] = []
+        close_errors: list[BaseException] = []
+        for iid, e in reaped:
+            logger.warning(
+                "Reaped GPU instance %d: silent for %.1fs (pinged=%s)",
+                iid,
+                now - e.last_seen,
+                e.has_liveness_signal,
+            )
+            try:
+                self._release_entries([e])
+            except BaseException as exc:
+                with self._lock:
+                    self._cache_contexts.setdefault(iid, e)
+                close_errors.append(exc)
+            else:
+                reaped_ids.append(iid)
+        reaped.clear()
+        if close_errors:
+            raise ExceptionGroup("stale GPU context cleanup failed", close_errors)
+        return reaped_ids
+
+    def _finalize_cuda_cleanup(self, close_errors: list[BaseException]) -> None:
+        """Collect dropped tensors while preserving reusable CUDA contexts."""
+        try:
+            torch_dev.empty_cache()
+        except BaseException as exc:
+            close_errors.append(exc)
+        ipc_collect = getattr(torch_dev, "ipc_collect", None)
+        if ipc_collect is not None:
+            try:
+                ipc_collect()
+            except BaseException as exc:
+                close_errors.append(exc)
+
+    def _release_entries(self, entries: list[ContextEntry]) -> None:
+        """Release a batch of entries and reclaim their device memory.
+
+        Args:
+            entries: The only remaining references to the released entries.
+                The list is cleared before memory is reclaimed.
+        """
+        if not entries:
+            return
+        close_errors: list[BaseException] = []
+        for entry in entries:
+            try:
+                entry.cache_context.close()
+            except BaseException as exc:
+                close_errors.append(exc)
+                continue
+            try:
+                self._ctx.layout_desc_registry.unregister(
+                    entry.model_name, entry.world_size
+                )
+            except BaseException as exc:
+                close_errors.append(exc)
+        del entry
+        entries.clear()
+        # ipc_collect() only unmaps a CUDA-IPC-imported segment once its last
+        # tensor reference is gone (LMCache#4014), hence the clear() above.
+        self._finalize_cuda_cleanup(close_errors)
+        if close_errors:
+            raise ExceptionGroup("GPU cache context cleanup failed", close_errors)
+
+    def get_handlers(self) -> list[HandlerSpec]:
+        """Return handler specs for all request types this module serves.
+
+        Returns:
+            A list of HandlerSpec entries mapping request types to
+            their handler callables and thread pool assignments.
+        """
+        return [
+            HandlerSpec(
+                RequestType.REGISTER_KV_CACHE,
+                self.register_kv_cache,
+                ThreadPoolType.SYNC,
+            ),
+            HandlerSpec(
+                RequestType.UNREGISTER_KV_CACHE,
+                self.unregister_kv_cache,
+                ThreadPoolType.SYNC,
+            ),
+            HandlerSpec(
+                RequestType.STORE,
+                self.store,
+                ThreadPoolType.AFFINITY,
+            ),
+            HandlerSpec(
+                RequestType.RETRIEVE,
+                self.retrieve,
+                ThreadPoolType.AFFINITY,
+            ),
+        ]
+
+    def report_status(self) -> dict:
+        """Return GPU transfer module status information.
+
+        Returns:
+            A dict containing registered GPU instance IDs and
+            per-instance KV cache layout metadata.
+        """
+        from lmcache.v1.platform.cuda.cumem_ipc import (
+            imported_alias_refcount_total,
+            imported_registration_count,
+        )
+
+        registered_gpu_ids: list[int] = []
+        cache_context_meta: dict[str, dict] = {}
+
+        for instance_id, entry in self.context_entries_snapshot().items():
+            registered_gpu_ids.append(instance_id)
+            ctx = entry.cache_context
+            cache_context_meta[str(instance_id)] = {
+                "model_name": entry.model_name,
+                "world_size": entry.world_size,
+                "kv_cache_layout": ctx.report_status(),
+            }
+
+        return {
+            "registered_gpu_ids": registered_gpu_ids,
+            "cache_context_meta": cache_context_meta,
+            "imported_cumem_allocation_count": imported_registration_count(),
+            "imported_cumem_alias_refcount": imported_alias_refcount_total(),
+        }
+
+    def close(self) -> None:
+        """Release GPU resources owned by this module."""
+        # Stop the drain thread before storage_manager.close() so any
+        # in-flight completions reach a live storage manager.
+        self._device_host_func_dispatcher.stop()
+
+        with self._lock:
+            entries = list(self._cache_contexts.values())
+            self._cache_contexts.clear()
+        self._release_entries(entries)
+
+    def register_kv_cache(
+        self,
+        instance_id: int,
+        kv_caches: KVCache,
+        model_name: str,
+        world_size: int,
+        engine_type: EngineType,
+        layout_hints: LayoutHints,
+        engine_group_infos: list[EngineGroupInfo],
+    ) -> None:
+        """Register the KV cache tensors for a given GPU instance ID.
+
+        Args:
+            instance_id: The GPU instance ID (such as PID).
+            kv_caches: The KV cache tensor wrappers from the
+                serving engine.
+            model_name: The name of the model associated with this KV cache.
+            world_size: The world size associated with this KV cache.
+            engine_type: Which serving engine produced the caches.
+                Forwarded to GPUCacheContext for format detection.
+            layout_hints: See LayoutHints.  Forwarded to
+                GPUCacheContext for GPU KV format detection.
+            engine_group_infos: Engine-neutral KV cache group metadata
+                (already msgspec-decoded by the message queue).
+        """
+        now = time.monotonic()
+        # NOOP-register: an already-registered instance (e.g. a recovering
+        # worker re-registering on its first ping) refreshes its last-seen
+        # time so a stale entry is not reaped right after recovery. REGISTER
+        # is SYNC-serialized on the MQ main loop, so it is the sole inserter.
+        with self._lock:
+            existing = self._cache_contexts.get(instance_id)
+            if existing is not None:
+                existing.last_seen = now
+                logger.info(
+                    "Instance %d already registered; refreshing liveness",
+                    instance_id,
+                )
+                close_errors: list[BaseException] = []
+                for wrapper in kv_caches:
+                    close = getattr(wrapper, "close", None)
+                    if close is None:
+                        continue
+                    try:
+                        close()
+                    except BaseException as exc:
+                        close_errors.append(exc)
+                if close_errors:
+                    raise ExceptionGroup(
+                        "duplicate KV cache registration cleanup failed",
+                        close_errors,
+                    )
+                return
+
+        # Build the context and layout descriptor outside the lock.
+        try:
+            cache_context = create_cache_context(
+                kv_caches,
+                self._ctx.chunk_size,
+                layout_hints=layout_hints or None,
+                engine_group_infos=engine_group_infos,
+                engine_type=engine_type,
+                separate_object_groups=self._ctx.separate_object_groups,
+                full_sw_kv=self._ctx.full_sw_kv,
+            )
+        except BaseException as exc:
+            # create_cache_context materializes wrappers incrementally. A
+            # malformed later descriptor must release all earlier mappings.
+            cleanup_errors: list[BaseException] = [exc]
+            for wrapper in kv_caches:
+                close = getattr(wrapper, "close", None)
+                if close is None:
+                    continue
+                try:
+                    close()
+                except BaseException as cleanup_exc:
+                    cleanup_errors.append(cleanup_exc)
+            self._finalize_cuda_cleanup(cleanup_errors)
+            if len(cleanup_errors) == 1:
+                raise
+            raise ExceptionGroup(
+                "KV cache context construction and cleanup failed",
+                cleanup_errors,
+            ) from exc
+        layout_registered = False
+        try:
+            kv_groups_manager = cache_context.kv_layer_groups_manager
+            num_object_groups = kv_groups_manager.num_object_groups
+            event_backend = get_event_ipc_backend(cache_context.device)
+            event_backend.check_event_support(cache_context.device)
+            layout_desc = get_layout_desc(
+                cache_context, self._ctx.chunk_size, object_group_id=0
+            )
+            # One layout per object group, also in the single-group case: no
+            # None special-casing downstream (group 0 maps to the merged layout).
+            group_layout_descs = {
+                gid: get_layout_desc(
+                    cache_context, self._ctx.chunk_size, object_group_id=gid
+                )
+                for gid in range(num_object_groups)
+            }
+            attn_desc = kv_groups_manager.get_attn_desc()
+            self._ctx.layout_desc_registry.register(
+                model_name,
+                world_size,
+                layout_desc,
+                attn_desc,
+                group_layout_descs=group_layout_descs,
+            )
+            layout_registered = True
+
+            with self._lock:
+                self._cache_contexts[instance_id] = ContextEntry(
+                    cache_context=cache_context,
+                    model_name=model_name,
+                    world_size=world_size,
+                    last_seen=now,
+                    has_liveness_signal=False,
+                    event_backend=event_backend,
+                )
+        except BaseException as exc:
+            cleanup_errors: list[BaseException] = [exc]
+            try:
+                cache_context.close()
+            except BaseException as cleanup_exc:
+                cleanup_errors.append(cleanup_exc)
+            self._finalize_cuda_cleanup(cleanup_errors)
+            if layout_registered:
+                try:
+                    self._ctx.layout_desc_registry.unregister(model_name, world_size)
+                except BaseException as cleanup_exc:
+                    cleanup_errors.append(cleanup_exc)
+            if len(cleanup_errors) == 1:
+                raise
+            raise ExceptionGroup(
+                "KV cache registration and cleanup failed",
+                cleanup_errors,
+            ) from exc
+
+        logger.info(
+            "Registered KV cache for GPU ID %d with %d layers",
+            instance_id,
+            cache_context.num_layers,
+        )
+
+    def unregister_kv_cache(self, instance_id: int) -> None:
+        """Unregister the KV cache tensors for a given GPU instance ID.
+
+        Args:
+            instance_id: The GPU instance ID (such as PID).
+        """
+        with self._lock:
+            popped = [
+                e
+                for e in (self._cache_contexts.pop(instance_id, None),)
+                if e is not None
+            ]
+        if not popped:
+            logger.warning(
+                "No registered GPU context found for instance ID %d", instance_id
+            )
+            return
+
+        # No scalar binding: `popped` must stay the only reference so
+        # _release_entries' reclaim actually unmaps the IPC segments.
+        failed_entry = popped[0]
+        try:
+            self._release_entries(popped)
+        except BaseException:
+            # Keep a partially closed context visible and retryable. In
+            # particular, status must not report it unregistered while an
+            # imported mapping or device context is still held.
+            with self._lock:
+                self._cache_contexts.setdefault(instance_id, failed_entry)
+            raise
+        logger.info("Unregistered KV cache for GPU ID %d", instance_id)
+
+    @_lmcache_nvtx_annotate
+    def store(
+        self,
+        key: IPCCacheServerKey,
+        instance_id: int,
+        gpu_block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+    ) -> tuple[bytes, bool]:
+        """Store the GPU KV cache blocks to CPU.
+
+        Args:
+            key: The IPC key for the KV cache blocks.
+                Must have worker_id != None (worker store operation).
+            instance_id: The GPU instance ID (such as PID).
+            gpu_block_ids: GPU block IDs to store, indexed by LMCache KV
+                group index.
+            event_ipc_handle: The IPC handle of the event to wait on.
+
+        Returns:
+            A tuple where the first element is the IPC handle of the event
+            that signals the completion of the store operation, and the second
+            element indicates whether the store operation completed without a
+            fatal error (not whether every requested chunk was stored; see
+            Notes).
+
+        Raises:
+            ValueError: If no GPU context is registered for the given instance ID.
+            RuntimeError: If the backend does not support IPC event handles.
+
+        Notes:
+            All-or-nothing. If ``gpu_block_ids`` do not fully cover every chunk
+            ``key`` resolves to for every LMCache group (e.g. a caller/protocol
+            bug), or a copy fails, the whole store is skipped and nothing is
+            committed (logged at WARNING); a subsequent retrieve simply misses
+            and the engine recomputes. The boolean result reports whether the
+            store completed without such a failure.
+        """
+        st = time.perf_counter()
+
+        entry = self.get_and_touch_context_entry(instance_id)
+        if entry is None:
+            raise ValueError(f"No GPU context registered for instance ID {instance_id}")
+        cache_context = entry.cache_context
+        model_name = entry.model_name
+        event_backend = entry.event_backend
+        if event_backend is None:
+            raise RuntimeError("Registered cache context has no event backend")
+
+        num_object_groups = cache_context.kv_layer_groups_manager.num_object_groups
+        obj_keys_per_obj_group = self._ctx.resolve_obj_keys(
+            key, list(range(num_object_groups))
+        )
+        num_chunks = len(obj_keys_per_obj_group[0])
+
+        # NOTE: different engine groups may have different block sizes, so
+        # ``blocks_per_chunk[i]`` is the number of blocks in one chunk for
+        # group ``i``.
+        blocks_per_chunk = [
+            cache_context.calculate_num_blocks(self._ctx.chunk_size, group_idx)
+            for group_idx in range(
+                cache_context.kv_layer_groups_manager.num_kernel_groups
+            )
+        ]
+
+        with (
+            torch_dev.device(cache_context.device),
+            torch_dev.stream(cache_context.stream),
+        ):
+            event = event_backend.create_event(cache_context.device)
+
+            # Fail closed: every LMCache group must have block IDs covering all
+            # chunks. A short list (e.g. a caller/protocol bug) would otherwise
+            # drive the transfer kernel to read out-of-bounds GPU memory, so skip
+            # the whole store and commit nothing rather than caching a partial or
+            # garbage entry. A later request can store it once the block IDs are
+            # complete. Checked on the raw block ids, before cutting drops the
+            # per-chunk blocks that sliding-window groups do not need.
+            if any(
+                len(group_block_ids) < num_chunks * bpc
+                for group_block_ids, bpc in zip(
+                    gpu_block_ids, blocks_per_chunk, strict=True
+                )
+            ):
+                logger.warning(
+                    "STORE block ID underflow for request_id=%s: each group needs "
+                    "num_chunks * blocks_per_chunk block IDs for %d chunks "
+                    "(per-group blocks_per_chunk=%s); skipping the store.",
+                    key.request_id,
+                    num_chunks,
+                    blocks_per_chunk,
+                )
+                event_backend.record_event(event, cache_context.stream)
+                return event_backend.export_event(event, cache_context.device), False
+
+            # Chunks whose block ids are all the null block (e.g. align-mode
+            # Mamba chunks holding no real state) carry no valid KV and must not
+            # be committed. Computed on the raw block ids before downsampling
+            # mutates them.
+            skipped_chunks = all_null_chunk_masks(
+                gpu_block_ids,
+                cache_context.kv_layer_groups_manager.object_groups,
+                blocks_per_chunk,
+                num_chunks,
+            )
+
+            block_ids_per_group_gpu = downsample_and_stage_block_ids(
+                cache_context, gpu_block_ids
+            )
+
+            producer_event = event_backend.import_event(
+                event_ipc_handle, cache_context.device
+            )
+            event_backend.wait_event(producer_event, cache_context.stream)
+
+            # CPU-synchronous sentinel: a GPU store is about to be enqueued.
+            # Must be published via publish() (not publish_on_stream) so the
+            # drain thread sees it before MP_REQUEST_END can race MP_STORE_END.
+            self._ctx.event_bus.publish(
+                Event(
+                    event_type=EventType.MP_STORE_SUBMITTED,
+                    session_id=key.request_id,
+                    metadata={"device": str(cache_context.device)},
+                )
+            )
+
+            # Worker 0 only: bindings depend on token content alone, so one
+            # report covers every rank's keys. Published before finish_write
+            # is enqueued so the token bindings precede the write-finished
+            # events on the bus.
+            if key.worker_id == 0 and self._ctx.event_bus.has_subscribers(
+                EventType.MP_TOKENS
+            ):
+                self._publish_token_bindings(key, obj_keys_per_obj_group[0])
+
+            self._ctx.event_bus.publish_on_stream(
+                cache_context.cupy_stream,
+                Event(
+                    event_type=EventType.MP_STORE_START,
+                    session_id=key.request_id,
+                    metadata={
+                        "device": str(cache_context.device),
+                        "engine_id": instance_id,
+                        "model_name": model_name,
+                    },
+                ),
+            )
+
+            reserved_dict: dict[ObjectKey, MemoryObj] = {}
+            all_dict: dict[ObjectKey, MemoryObj] = {}
+            total_bytes: int = 0
+            store_succeeded = False
+            try:
+                for obj_group_id in range(num_object_groups):
+                    obj_keys = obj_keys_per_obj_group[obj_group_id]
+                    skip_mask = skipped_chunks[obj_group_id]
+                    keys_to_reserve = [
+                        k for i, k in enumerate(obj_keys) if not skip_mask[i]
+                    ]
+                    layout_desc = get_layout_desc(
+                        cache_context,
+                        self._ctx.chunk_size,
+                        object_group_id=obj_group_id,
+                    )
+                    reserved_dict = self._ctx.storage_manager.reserve_write(
+                        keys_to_reserve, layout_desc, "new"
+                    )
+                    all_dict.update(reserved_dict)
+                    if reserved_dict:
+                        total_bytes += next(
+                            iter(reserved_dict.values())
+                        ).get_size() * len(reserved_dict)
+
+                    # Keys not in reserved_dict (all-null chunks skipped above, or
+                    # skipped by the storage manager) become None entries; the
+                    # helper skips them for D2H.
+                    memory_objs: list[MemoryObj | None] = [
+                        reserved_dict.get(obj_key) for obj_key in obj_keys
+                    ]
+
+                    # NOTE: batch_size must stay 1 for store.
+                    transfer_kv_per_object_group(
+                        cache_context,
+                        block_ids_per_group_gpu,
+                        memory_objs,
+                        object_group_id=obj_group_id,
+                        batch_size=1,
+                        skip_first_n_tokens=0,
+                        direction=lmcache_native.TransferDirection.D2H,
+                    )
+
+                store_succeeded = True
+            except Exception:
+                logger.exception("Cannot store keys due to exception")
+            finally:
+                event_backend.record_event(event, cache_context.stream)
+                # Fail closed: commit the reserved objects only when every chunk
+                # copied successfully; otherwise the whole store is skipped.
+                stored_count = len(all_dict) if store_succeeded else 0
+                if stored_count:
+                    submit_callback_to_stream(
+                        cache_context.cupy_stream,
+                        "finish_write",
+                        list(all_dict.keys()),
+                    )
+                else:
+                    total_bytes = 0
+                num_tokens = num_chunks * self._ctx.chunk_size if stored_count else 0
+                self._ctx.event_bus.publish_on_stream(
+                    cache_context.cupy_stream,
+                    Event(
+                        event_type=EventType.MP_STORE_END,
+                        session_id=key.request_id,
+                        metadata={
+                            "stored_count": stored_count,
+                            "device": str(cache_context.device),
+                            "engine_id": instance_id,
+                            "model_name": model_name,
+                            "total_bytes": total_bytes,
+                            "num_tokens": num_tokens,
+                        },
+                    ),
+                )
+
+        ed = time.perf_counter()
+        if stored_count:
+            logger.info(
+                "Stored %d tokens in %.3f seconds",
+                num_chunks * self._ctx.chunk_size,
+                ed - st,
+            )
+        return (
+            event_backend.export_event(event, cache_context.device),
+            store_succeeded,
+        )
+
+    @_lmcache_nvtx_annotate
+    def retrieve(
+        self,
+        key: IPCCacheServerKey,
+        instance_id: int,
+        gpu_block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+        skip_first_n_tokens: int = 0,
+    ) -> tuple[bytes, bool]:
+        """Retrieve the CPU KV cache and put into GPU blocks.
+
+        Args:
+            key: The IPC key for the KV cache blocks.
+                Must have worker_id != None (worker retrieve operation).
+            instance_id: The GPU instance ID (such as PID).
+            gpu_block_ids: GPU block IDs to retrieve into, indexed by LMCache
+                KV group index.
+            event_ipc_handle: The IPC handle of the event to wait on.
+            skip_first_n_tokens: Number of tokens to skip writing at
+                the start of the retrieve range. This avoids overwriting
+                APC-shared GPU blocks that may be read concurrently by other
+                requests.
+
+        Returns:
+            A tuple where the first element is the IPC handle of the event
+            that signals the completion of the retrieve operation, and the
+            second element indicates whether the key was successfully retrieved.
+
+        Raises:
+            ValueError: If no GPU context is registered for the given instance ID.
+            RuntimeError: If the backend does not support IPC event handles.
+        """
+        st = time.perf_counter()
+
+        entry = self.get_and_touch_context_entry(instance_id)
+        if entry is None:
+            raise ValueError(f"No GPU context registered for instance ID {instance_id}")
+        cache_context = entry.cache_context
+        model_name = entry.model_name
+        event_backend = entry.event_backend
+        if event_backend is None:
+            raise RuntimeError("Registered cache context has no event backend")
+
+        num_object_groups = cache_context.kv_layer_groups_manager.num_object_groups
+        obj_keys_per_obj_group = self._ctx.resolve_obj_keys(
+            key, list(range(num_object_groups))
+        )
+        num_chunks = len(obj_keys_per_obj_group[0])
+
+        # CPU-synchronous sentinel: a GPU retrieve is about to be enqueued.
+        # Must be published via publish() (not publish_on_stream) so the
+        # drain thread sees it before MP_REQUEST_END can race MP_RETRIEVE_END.
+        self._ctx.event_bus.publish(
+            Event(
+                event_type=EventType.MP_RETRIEVE_SUBMITTED,
+                session_id=key.request_id,
+                metadata={"device": str(cache_context.device)},
+            )
+        )
+
+        self._ctx.event_bus.publish_on_stream(
+            cache_context.cupy_stream,
+            Event(
+                event_type=EventType.MP_RETRIEVE_START,
+                session_id=key.request_id,
+                metadata={
+                    "device": str(cache_context.device),
+                    "engine_id": instance_id,
+                    "model_name": model_name,
+                },
+            ),
+        )
+
+        blocks_per_chunk = [
+            cache_context.calculate_num_blocks(self._ctx.chunk_size, group_idx)
+            for group_idx in range(
+                cache_context.kv_layer_groups_manager.num_kernel_groups
+            )
+        ]
+
+        with (
+            torch_dev.device(cache_context.device),
+            torch_dev.stream(cache_context.stream),
+        ):
+            event = event_backend.create_event(cache_context.device)
+
+            # Fail closed: a short block-id list would drive the transfer
+            # kernel to write out-of-bounds GPU memory. Checked on the raw
+            # block ids, before cutting drops the per-chunk blocks that
+            # sliding-window groups do not need.
+            if any(
+                len(group_block_ids) < num_chunks * bpc
+                for group_block_ids, bpc in zip(
+                    gpu_block_ids, blocks_per_chunk, strict=True
+                )
+            ):
+                logger.error(
+                    "RETRIEVE block ID underflow for request_id=%s: each group "
+                    "needs num_chunks * blocks_per_chunk block IDs for %d "
+                    "chunks (per-group blocks_per_chunk=%s); skipping the "
+                    "retrieve.",
+                    key.request_id,
+                    num_chunks,
+                    blocks_per_chunk,
+                )
+                event_backend.record_event(event, cache_context.stream)
+                return event_backend.export_event(event, cache_context.device), False
+
+            # Cut and stage all block_ids to GPU once before the transfer
+            block_ids_per_group_gpu = downsample_and_stage_block_ids(
+                cache_context, gpu_block_ids
+            )
+            producer_event = event_backend.import_event(
+                event_ipc_handle, cache_context.device
+            )
+            event_backend.wait_event(producer_event, cache_context.stream)
+
+            # Per object group, the prefetch only locked the in-window suffix
+            # (the last ``num_chunks_in_sw`` chunks; the whole prefix for full
+            # attention, where the value is < 0). Read and transfer only those.
+            attn_desc = cache_context.kv_layer_groups_manager.get_attn_desc()
+            group_skips = [
+                0 if window < 0 else max(0, num_chunks - window)
+                for window in attn_desc.num_chunks_in_sw
+            ]
+            expected_retained = sum(num_chunks - skip for skip in group_skips)
+
+            prefetched_keys: list[ObjectKey] = []
+            total_bytes = 0
+            retrieve_succeeded = True
+            try:
+                for obj_group_id in range(num_object_groups):
+                    skip = group_skips[obj_group_id]
+                    in_window_keys = obj_keys_per_obj_group[obj_group_id][skip:]
+                    with self._ctx.storage_manager.read_prefetched_results(
+                        in_window_keys
+                    ) as window_objs:
+                        if not window_objs or len(window_objs) != len(in_window_keys):
+                            logger.error("Some keys not found during retrieve!")
+                            retrieve_succeeded = False
+                            break
+
+                        total_bytes += sum(mo.get_size() for mo in window_objs)
+
+                        # None-pad the skipped prefix to full length so the
+                        # transfer's ``num_objects_to_skip`` and block-id slicing
+                        # line up unchanged; the None entries are never read.
+                        memory_objs: list[MemoryObj | None] = [None] * skip + list(
+                            window_objs
+                        )
+
+                        transfer_kv_per_object_group(
+                            cache_context,
+                            block_ids_per_group_gpu,
+                            memory_objs,
+                            object_group_id=obj_group_id,
+                            batch_size=cache_context.max_batch_size,
+                            skip_first_n_tokens=skip_first_n_tokens,
+                            direction=lmcache_native.TransferDirection.H2D,
+                        )
+                        # Extend only after the copy is enqueued: on exception,
+                        # read_prefetched_results releases this group's locks
+                        # itself, and a key must not be released twice.
+                        prefetched_keys.extend(in_window_keys)
+            except Exception:
+                logger.exception("Cannot retrieve keys due to exception")
+                retrieve_succeeded = False
+            finally:
+                event_backend.record_event(event, cache_context.stream)
+                if prefetched_keys:
+                    submit_callback_to_stream(
+                        cache_context.cupy_stream,
+                        "finish_read_prefetched",
+                        prefetched_keys,
+                    )
+                num_tokens = (
+                    num_chunks * self._ctx.chunk_size
+                    if len(prefetched_keys) == expected_retained
+                    else 0
+                )
+                self._ctx.event_bus.publish_on_stream(
+                    cache_context.cupy_stream,
+                    Event(
+                        event_type=EventType.MP_RETRIEVE_END,
+                        session_id=key.request_id,
+                        metadata={
+                            "retrieved_count": len(prefetched_keys),
+                            "device": str(cache_context.device),
+                            "engine_id": instance_id,
+                            "model_name": model_name,
+                            "cache_salt": key.cache_salt,
+                            "total_bytes": total_bytes,
+                            "num_tokens": num_tokens,
+                        },
+                    ),
+                )
+        if retrieve_succeeded:
+            tokens_retrieved = num_chunks * self._ctx.chunk_size
+            ed = time.perf_counter()
+            logger.info(
+                "Retrieved %d tokens in %.3f seconds",
+                tokens_retrieved,
+                ed - st,
+            )
+
+        return (
+            event_backend.export_event(event, cache_context.device),
+            retrieve_succeeded,
+        )
+
+    def _publish_token_bindings(
+        self, key: IPCCacheServerKey, obj_keys: list[ObjectKey]
+    ) -> None:
+        """Publish one ``MP_TOKENS`` event for ``key``'s chunks.
+
+        Pairs each complete chunk in ``[key.start, key.end)`` with its
+        ObjectKey chunk hash and token position. Must be called at store
+        submission, before the write-finished events reach the bus, so the
+        cache-event subscriber can stamp them onto the STORE entries. A
+        store that later fails leaves only unused cache entries.
+
+        Args:
+            key: The IPC key of the store being submitted.
+            obj_keys: One ObjectKey per complete chunk, in chunk order.
+        """
+        # Complete chunks in [key.start, key.end) paired with the absolute
+        # position of each chunk's first token. Prefix-chained chunk hashes
+        # imply a position without revealing it, so it is reported here. A
+        # trailing partial chunk has no stored KV to bind to.
+        chunk_size = self._ctx.chunk_size
+        token_ids = list(key.token_ids)
+        effective_len = min(len(token_ids), key.end)
+        num_complete = effective_len - effective_len % chunk_size
+        token_offsets = list(range(key.start, num_complete, chunk_size))
+        token_chunks = [
+            token_ids[offset : offset + chunk_size] for offset in token_offsets
+        ]
+        if not token_chunks:
+            return
+        if len(obj_keys) != len(token_chunks):
+            logger.warning(
+                "Skipping token bindings for request %s: %d resolved keys "
+                "vs %d complete chunks in [%d, %d)",
+                key.request_id,
+                len(obj_keys),
+                len(token_chunks),
+                key.start,
+                key.end,
+            )
+            return
+        self._ctx.event_bus.publish(
+            Event(
+                event_type=EventType.MP_TOKENS,
+                session_id=key.request_id,
+                metadata={
+                    "chunk_hashes": [obj_key.chunk_hash for obj_key in obj_keys],
+                    "token_chunks": token_chunks,
+                    "token_offsets": token_offsets,
+                },
+            )
+        )

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -1,0 +1,1145 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Transfer context abstractions for LMCache multiprocess worker adapters."""
+
+# Standard
+import os
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Protocol
+
+# Third Party
+import torch
+
+# First Party
+from lmcache import torch_dev
+from lmcache.utils import EngineType, init_logger
+from lmcache.v1.distributed.api import MemoryLayoutDesc
+from lmcache.v1.gpu_connector.utils import LayoutHints
+from lmcache.v1.multiprocess.custom_types import (
+    EngineDrivenGroupLayout,
+    RegisterEngineDrivenContextPayload,
+)
+from lmcache.v1.multiprocess.futures import MessagingFuture
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+from lmcache.v1.multiprocess.mq import MessageQueueClient
+from lmcache.v1.multiprocess.protocol import RequestType
+from lmcache.v1.multiprocess.protocols.engine import RegisterEngineDrivenContextResponse
+from lmcache.v1.multiprocess.transfer_context.base import (
+    EngineDrivenContext,
+    EngineDrivenContextMetadata,
+    StoreAdmissionRejected,
+    compute_kv_layout,
+    create_engine_driven_context,
+    gather_paged_kv_to_cpu,
+    scatter_cpu_to_paged_kv,
+)
+from lmcache.v1.platform import get_device_spec, resolve_kv_wrapper_factory
+from lmcache.v1.platform.base.event_ipc import (
+    EventIPCBackend,
+    get_event_ipc_backend,
+)
+from lmcache.v1.platform.kv_wrap import wrap_kv_caches
+
+logger = init_logger(__name__)
+
+# Environment variable that lets the user override the default routing
+# performed by :func:`create_transfer_context`. Accepted values match the
+# string values of :class:`MPTransferMode` (``auto`` / ``engine_driven`` /
+# ``lmcache_driven``); ``auto`` reproduces the historical device-type-based
+# dispatch.
+ENV_MP_TRANSFER_MODE = "LMCACHE_MP_TRANSFER_MODE"
+
+
+# Helper functions
+def _supports_async_primitives() -> bool:
+    """Probe whether the worker device supports the async store primitives.
+
+    The async engine-driven store path needs a stream, an event exposing
+    ``record``/``synchronize``/``wait``, and pinned (page-locked) host memory.
+    When any of these is unavailable (e.g. a CPU-only backend), the factory
+    falls back to the synchronous :class:`EngineDrivenTransferContext`. This
+    dispatch is internal and capability-based; there is no user-facing
+    async/sync flag.
+
+    Returns:
+        True if all required async primitives are available, else False.
+    """
+    if not hasattr(torch_dev, "Stream") or not hasattr(torch_dev, "Event"):
+        return False
+    # CPU-only stub exposes Stream/Event but has no real async capability.
+    if hasattr(torch_dev, "is_available") and not torch_dev.is_available():
+        return False
+    try:
+        stream = torch_dev.Stream()
+        event = torch_dev.Event()
+    except Exception:
+        return False
+    for attr in ("record", "synchronize", "wait"):
+        if not callable(getattr(event, attr, None)):
+            del stream, event
+            return False
+    del stream, event
+    try:
+        probe = torch.empty(1, dtype=torch.uint8, device="cpu", pin_memory=True)
+        del probe
+    except (RuntimeError, TypeError):
+        return False
+    return True
+
+
+def _build_engine_driven_context() -> "TransferContext":
+    """Build the engine-driven context, async when device-capable else sync.
+
+    Routes the ``ENGINE_DRIVEN`` and AUTO branches through a single capability
+    check. ``AsyncEngineDrivenTransferContext`` is imported lazily to avoid an
+    import cycle and to keep the synchronous path free of stream/event
+    dependencies.
+
+    Returns:
+        ``AsyncEngineDrivenTransferContext`` when async primitives are
+        available, otherwise ``EngineDrivenTransferContext``.
+    """
+    if _supports_async_primitives():
+        # First Party
+        from lmcache.v1.multiprocess.transfer_context.async_engine_driven import (
+            AsyncEngineDrivenTransferContext,
+        )
+
+        logger.info("Using AsyncEngineDrivenTransferContext for store path")
+        return AsyncEngineDrivenTransferContext()
+
+    logger.info("Using EngineDrivenTransferContext (sync) for store path")
+    return EngineDrivenTransferContext()
+
+
+class MPTransferMode(str, Enum):
+    """Routing mode used by :func:`create_transfer_context`.
+
+    * ``AUTO``: dispatch by ``tensor.device.type`` (CUDA -> lmcache-driven,
+      others -> engine-driven). Preserves the historical behaviour.
+    * ``ENGINE_DRIVEN``: force :class:`EngineDrivenTransferContext`
+      (worker-side gather / scatter copy path).
+    * ``LMCACHE_DRIVEN``: force :class:`LMCacheDrivenTransferContext`
+      (IPC / SHM zero-copy path). Requires a registered KV-wrapper factory
+      for the device.
+    """
+
+    AUTO = "auto"
+    ENGINE_DRIVEN = "engine_driven"
+    LMCACHE_DRIVEN = "lmcache_driven"
+
+
+def _resolve_mode(mode: "str | MPTransferMode | None") -> MPTransferMode:
+    """Coerce ``mode`` into :class:`MPTransferMode`, falling back to env."""
+    raw = (
+        mode
+        if mode is not None
+        else os.environ.get(ENV_MP_TRANSFER_MODE, MPTransferMode.AUTO.value)
+    )
+    if isinstance(raw, MPTransferMode):
+        return raw
+    try:
+        return MPTransferMode(str(raw).lower())
+    except ValueError as exc:
+        valid = ", ".join(m.value for m in MPTransferMode)
+        raise ValueError(
+            "Invalid MP transfer mode {!r} (valid: {})".format(raw, valid)
+        ) from exc
+
+
+def _build_lmcache_driven_context(device_type: str) -> "TransferContext":
+    """Build a :class:`LMCacheDrivenTransferContext` after capability check."""
+    try:
+        resolve_kv_wrapper_factory(device_type)
+    except ValueError as exc:
+        raise ValueError(
+            "MP transfer mode 'lmcache_driven' is not supported for device type "
+            "{!r}: no KV-cache wrapper factory is registered. "
+            "Use mode 'engine_driven' or 'auto' instead.".format(device_type)
+        ) from exc
+    device_spec = get_device_spec(device_type)
+    if device_spec and not device_spec.is_handle_transfer_available():
+        raise ValueError(
+            "MP transfer mode 'lmcache_driven' is not available for device type "
+            "{!r}: required platform capability checks failed. "
+            "Use mode 'engine_driven' or 'auto' instead.".format(device_type)
+        )
+    return LMCacheDrivenTransferContext()
+
+
+class IPCEvent(Protocol):
+    """Protocol for device events used by transport operations."""
+
+    def wait(self, stream: object | None = None) -> None:
+        """Make ``stream`` wait for this event (async ordering primitive)."""
+
+
+SendRequest = Callable[[MessageQueueClient, RequestType, list[object]], MessagingFuture]
+
+
+def _single_group_block_ids(block_ids: list[list[int]]) -> list[int]:
+    """Return the flat block-id list for transports without HMA support."""
+    if len(block_ids) != 1:
+        raise RuntimeError(
+            "engine-driven transfer does not support hybrid KV cache groups"
+        )
+    return block_ids[0]
+
+
+@dataclass(frozen=True)
+class _EngineDrivenWorkerGroup:
+    """Worker-only transfer state for one wire-visible object group."""
+
+    layout: EngineDrivenGroupLayout
+    layer_names: tuple[str, ...]
+    engine_kv_format: Any
+
+
+def _validate_group_block_ids(
+    groups: Sequence[_EngineDrivenWorkerGroup],
+    block_ids: list[list[int]],
+) -> int:
+    """Validate complete group coverage and return the common chunk count."""
+    chunk_counts: list[int] = []
+    for group in groups:
+        engine_group_idx = group.layout.engine_group_idx
+        if engine_group_idx >= len(block_ids):
+            raise ValueError(f"missing block IDs for engine group {engine_group_idx}")
+        group_ids = block_ids[engine_group_idx]
+        blocks_per_chunk = group.layout.blocks_per_chunk
+        if blocks_per_chunk <= 0 or len(group_ids) % blocks_per_chunk:
+            raise ValueError(
+                f"engine group {engine_group_idx} has {len(group_ids)} block IDs; "
+                f"expected a multiple of {blocks_per_chunk}"
+            )
+        chunk_counts.append(len(group_ids) // blocks_per_chunk)
+    if not chunk_counts or len(set(chunk_counts)) != 1:
+        raise ValueError(
+            f"engine-driven groups do not cover one common chunk prefix: {chunk_counts}"
+        )
+    return chunk_counts[0]
+
+
+def _get_kv_device(kv_caches: dict[str, torch.Tensor]) -> torch.device:
+    """Return the device shared by a non-empty KV-cache mapping.
+
+    Args:
+        kv_caches: Worker KV-cache tensors keyed by layer name.
+
+    Returns:
+        The device of the first KV-cache tensor.
+
+    Raises:
+        ValueError: If ``kv_caches`` is empty.
+    """
+    if not kv_caches:
+        raise ValueError("LMCache-driven transfer requires at least one KV cache")
+    return next(iter(kv_caches.values())).device
+
+
+class TransferContext(ABC):
+    """Abstract transport layer for worker-side KV transfer.
+
+    Concrete implementations encapsulate how worker-side store/retrieve
+    operations are transmitted to the multiprocess server. Device-handle paths
+    return event-aware futures backed by MQ requests, while CPU paths may perform
+    gather/scatter synchronously and return already-resolved futures.
+    """
+
+    @abstractmethod
+    def register(
+        self,
+        instance_id: int,
+        _kv_caches: dict[str, torch.Tensor],
+        model_name: str,
+        world_size: int,
+        blocks_in_chunk: int,
+        mq_client: MessageQueueClient,
+        mq_timeout: float,
+        send_request: SendRequest,
+        layout_hints: LayoutHints | None = None,
+        engine_group_infos: Sequence[EngineGroupInfo] = (),
+        engine_type: EngineType = EngineType.VLLM,
+    ) -> None:
+        """Register KV caches with the server and wait for ACK.
+
+        Args:
+            instance_id: Worker process instance identifier.
+            kv_caches: Worker KV cache tensors keyed by layer name.
+            model_name: Model name used by cache keys.
+            world_size: KV world size.
+            blocks_in_chunk: Number of vLLM blocks per LMCache chunk.
+            mq_client: Message queue client used to communicate with server.
+            mq_timeout: Timeout in seconds for synchronous request wait.
+            send_request: Request sender callable used to issue MQ requests.
+            layout_hints: Optional inference-engine-provided layout hints.
+            engine_group_infos: LMCache-owned engine KV cache group metadata.
+            engine_type: Serving engine that produced the caches. Only
+                consumed by the handle path; adapters should pass their
+                own :class:`EngineType` so this transport stays engine-
+                neutral. Defaults to :attr:`EngineType.VLLM` for
+                backwards compatibility.
+
+        Raises:
+            TimeoutError: If server registration does not complete before
+                ``mq_timeout``.
+            RuntimeError: If a concrete context cannot initialize.
+        """
+
+    def register_q(
+        self,
+        instance_id: int,
+        q_caches: dict[str, torch.Tensor],
+        model_name: str,
+        world_size: int,
+        blocks_in_chunk: int,
+        mq_client: MessageQueueClient,
+        mq_timeout: float,
+        send_request: SendRequest,
+        layout_hints: LayoutHints | None = None,
+        engine_group_infos: Sequence[EngineGroupInfo] = (),
+    ) -> None:
+        """Register the paged Q ring with the server under the same worker
+        instance_id but different model_name (model_name##query).
+
+        Args:
+            instance_id: Worker process instance identifier.
+            q_caches: Worker Q cache tensors keyed by layer name.
+            model_name: Model name used by cache keys (model_name##query).
+            world_size: KV world size.
+            blocks_in_chunk: Number of Q ring blocks per LMCache chunk.
+            mq_client: Message queue client used to communicate with server.
+            mq_timeout: Timeout in seconds for synchronous request wait.
+            send_request: Request sender callable used to issue MQ requests.
+            layout_hints: Optional inference-engine-provided layout hints.
+            engine_group_infos: LMCache-owned engine KV cache group metadata.
+
+        Raises:
+            NotImplementedError: If the concrete transport does not support the
+                Q ring (now only lmcache-driven).
+            TimeoutError: If server registration does not complete before
+                ``mq_timeout``.
+            RuntimeError: If a concrete context cannot initialize.
+        """
+        raise NotImplementedError(
+            "Q ring registration is not supported by this transfer context"
+        )
+
+    def submit_q_store(
+        self,
+        request_id: str,
+        key: Any,
+        instance_id: int,
+        q_caches: dict[str, torch.Tensor],
+        block_ids: list[list[int]],
+        event: IPCEvent,
+        blocks_in_chunk: int,
+    ) -> MessagingFuture:
+        """Submit a Q ring store request and return a completion future.
+
+        Args:
+            request_id: External request identifier.
+            key: LMCache key for the Q store range (query-specific model_name).
+            instance_id: Worker process instance identifier (shared with KV).
+            q_caches: Q ring tensors keyed by layer name.
+            block_ids: Q ring block IDs to store, indexed by LMCache KV group id.
+            event: Synchronization event object.
+            blocks_in_chunk: Number of Q ring blocks per LMCache chunk.
+
+        Returns:
+            A future compatible with adapter-side ``query()``/``result()`` flow.
+
+        Raises:
+            NotImplementedError: If the concrete transport does not support the
+                Q ring (only the lmcache-driven path does).
+            RuntimeError: If register_q() was not called first.
+        """
+        raise NotImplementedError(
+            "Q ring store is not supported by this transfer context"
+        )
+
+    @abstractmethod
+    def submit_store(
+        self,
+        request_id: str,
+        key: Any,
+        instance_id: int,
+        kv_caches: dict[str, torch.Tensor],
+        block_ids: list[list[int]],
+        event: IPCEvent,
+        blocks_in_chunk: int,
+    ) -> MessagingFuture:
+        """Submit a store request and return a completion future.
+
+        Args:
+            request_id: External request identifier.
+            key: LMCache key object for the store range.
+            instance_id: Worker process instance identifier.
+            kv_caches: Worker KV cache tensors keyed by layer name.
+            block_ids: vLLM block IDs to store, indexed by LMCache KV group id.
+            event: Synchronization event object.
+            blocks_in_chunk: Number of vLLM blocks per LMCache chunk.
+
+        Returns:
+            A future compatible with adapter-side ``query()``/``result()`` flow.
+
+        Raises:
+            RuntimeError: If register() was not called first.
+        """
+
+    @abstractmethod
+    def submit_retrieve(
+        self,
+        request_id: str,
+        key: Any,
+        instance_id: int,
+        kv_caches: dict[str, torch.Tensor],
+        block_ids: list[list[int]],
+        event: IPCEvent,
+        blocks_in_chunk: int,
+        skip_first_n_tokens: int = 0,
+    ) -> MessagingFuture:
+        """Submit a retrieve request and return a completion future.
+
+        Args:
+            request_id: External request identifier.
+            key: LMCache key object for the retrieve range.
+            instance_id: Worker process instance identifier.
+            kv_caches: Worker KV cache tensors keyed by layer name.
+            block_ids: vLLM block IDs to retrieve into, indexed by LMCache KV
+                group id.
+            event: Synchronization event object.
+            blocks_in_chunk: Number of vLLM blocks per LMCache chunk.
+            skip_first_n_tokens: Number of initial tokens to skip when writing.
+
+        Returns:
+            A future compatible with adapter-side ``query()``/``result()`` flow.
+
+        Raises:
+            RuntimeError: If register() was not called first.
+        """
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release resources held by this context."""
+
+    @abstractmethod
+    def flush_inflight_stores(self) -> None:
+        """Synchronize any in-flight gather operations.
+
+        Subclasses must implement this method. Contexts with no deferred
+        operations should implement it as a no-op. Async contexts that
+        defer GPU->CPU gather work must block until all in-flight stores
+        have completed, so that vLLM cannot overwrite paged KV blocks
+        before they are read.
+        """
+
+
+class LMCacheDrivenTransferContext(TransferContext):
+    """LMCache-driven IPC + MQ future transport context.
+
+    In this mode the serving engine provides device handles (accelerator IPC,
+    or SHM wrappers for CPU with IPC-like semantics) and the LMCache server
+    performs direct device-side data transfer.
+    """
+
+    def __init__(self) -> None:
+        self._mq_client: MessageQueueClient | None = None
+        self._send_request: SendRequest | None = None
+        self._device: torch.device | None = None
+        self._event_backend: EventIPCBackend | None = None
+        self._ipc_wrappers: list[Any] = []
+
+    def register(
+        self,
+        instance_id: int,
+        kv_caches: dict[str, torch.Tensor],
+        model_name: str,
+        world_size: int,
+        _blocks_in_chunk: int,
+        mq_client: MessageQueueClient,
+        mq_timeout: float,
+        send_request: SendRequest,
+        layout_hints: LayoutHints | None = None,
+        engine_group_infos: Sequence[EngineGroupInfo] = (),
+        engine_type: EngineType = EngineType.VLLM,
+    ) -> None:
+        """Register the worker KV cache with the LMCache server.
+
+        Args:
+            instance_id: Worker process instance identifier.
+            kv_caches: Worker KV-cache tensors keyed by layer name.
+            model_name: Model identifier used by the server.
+            world_size: Tensor-parallel world size.
+            _blocks_in_chunk: Engine blocks per LMCache chunk.
+            mq_client: Message-queue client used for requests.
+            mq_timeout: Timeout for the registration response.
+            send_request: Request sender used by this context.
+            layout_hints: Optional KV-layout metadata.
+            engine_group_infos: Optional engine KV-group metadata.
+            engine_type: Serving engine that produced the caches.
+
+        Raises:
+            RuntimeError: If event IPC is unsupported for the KV-cache device.
+            ValueError: If ``kv_caches`` is empty.
+        """
+        device = _get_kv_device(kv_caches)
+        event_backend = get_event_ipc_backend(device)
+        event_backend.check_event_support(device)
+
+        self._mq_client = mq_client
+        self._send_request = send_request
+        wrappers = wrap_kv_caches(kv_caches)
+        if any(type(wrapper).__name__ == "CuMemCudaIPCWrapper" for wrapper in wrappers):
+            logger.info("LMCache MP runtime mode verified: cumem_cuda_ipc")
+        try:
+            future = send_request(
+                mq_client,
+                RequestType.REGISTER_KV_CACHE,
+                [
+                    instance_id,
+                    wrappers,
+                    model_name,
+                    world_size,
+                    engine_type,
+                    layout_hints,
+                    list(engine_group_infos),
+                ],
+            )
+            future.result(timeout=mq_timeout)
+        except BaseException:
+            for wrapper in wrappers:
+                close = getattr(wrapper, "close", None)
+                if close is not None:
+                    close()
+            raise
+        self._ipc_wrappers = wrappers
+        self._device = device
+        self._event_backend = event_backend
+
+    def register_q(
+        self,
+        instance_id: int,
+        q_caches: dict[str, torch.Tensor],
+        model_name: str,
+        world_size: int,
+        _blocks_in_chunk: int,
+        mq_client: MessageQueueClient,
+        mq_timeout: float,
+        send_request: SendRequest,
+        layout_hints: LayoutHints | None = None,
+        engine_group_infos: Sequence[EngineGroupInfo] = (),
+    ) -> None:
+        self._mq_client = mq_client
+        self._send_request = send_request
+        future = send_request(
+            mq_client,
+            RequestType.REGISTER_Q_CACHE,
+            [
+                instance_id,
+                wrap_kv_caches(q_caches),
+                model_name,
+                world_size,
+                EngineType.VLLM,
+                layout_hints,
+                list(engine_group_infos),
+            ],
+        )
+        future.result(timeout=mq_timeout)
+
+    def submit_store(
+        self,
+        _request_id: str,
+        key: Any,
+        instance_id: int,
+        kv_caches: dict[str, torch.Tensor],
+        block_ids: list[list[int]],
+        event: IPCEvent,
+        _blocks_in_chunk: int,
+    ) -> MessagingFuture:
+        """Submit a handle-based store ordered by ``event``.
+
+        Args:
+            _request_id: External request identifier (unused by this transport).
+            key: LMCache key for the store range.
+            instance_id: Worker process instance identifier.
+            _kv_caches: Worker KV-cache tensors accepted for interface
+                consistency; the registered device is reused.
+            block_ids: Engine block IDs indexed by LMCache KV group.
+            event: Producer event that orders reads of the engine KV cache.
+            _blocks_in_chunk: Engine blocks per chunk (unused by this transport).
+
+        Returns:
+            A device-event-aware future for the server response.
+
+        Raises:
+            RuntimeError: If the context is not registered or event IPC is
+                unsupported.
+        """
+        if (
+            self._mq_client is None
+            or self._send_request is None
+            or self._device is None
+            or self._event_backend is None
+        ):
+            raise RuntimeError(
+                "LMCache-driven transfer context is not registered. "
+                "Call register() before submit_store()."
+            )
+        event_ipc_handle = self._event_backend.export_event(event, self._device)
+        return self._send_request(
+            self._mq_client,
+            RequestType.STORE,
+            [key, instance_id, block_ids, event_ipc_handle],
+        ).to_device_future(device=self._device)
+
+    def submit_q_store(
+        self,
+        _request_id: str,
+        key: Any,
+        instance_id: int,
+        _q_caches: dict[str, torch.Tensor],
+        block_ids: list[list[int]],
+        event: IPCEvent,
+        _blocks_in_chunk: int,
+    ) -> MessagingFuture:
+        if (
+            self._mq_client is None
+            or self._send_request is None
+            or self._device is None
+            or self._event_backend is None
+        ):
+            raise RuntimeError(
+                "LMCache-driven transfer context is not registered. "
+                "Call register() before submit_q_store()."
+            )
+        event_ipc_handle = self._event_backend.export_event(event, self._device)
+        return self._send_request(
+            self._mq_client,
+            RequestType.STORE_Q,
+            [key, instance_id, block_ids, event_ipc_handle],
+        ).to_device_future(device=self._device)
+
+    def submit_retrieve(
+        self,
+        _request_id: str,
+        key: Any,
+        instance_id: int,
+        _kv_caches: dict[str, torch.Tensor],
+        block_ids: list[list[int]],
+        event: IPCEvent,
+        _blocks_in_chunk: int,
+        skip_first_n_tokens: int = 0,
+    ) -> MessagingFuture:
+        """Submit a handle-based retrieve ordered by ``event``.
+
+        Args:
+            _request_id: External request identifier (unused by this transport).
+            key: LMCache key for the retrieve range.
+            instance_id: Worker process instance identifier.
+            _kv_caches: Worker KV-cache tensors accepted for interface
+                consistency; the registered device is reused.
+            block_ids: Engine block IDs indexed by LMCache KV group.
+            event: Producer event that orders writes to the engine KV cache.
+            _blocks_in_chunk: Engine blocks per chunk (unused by this transport).
+            skip_first_n_tokens: Initial tokens the server must not overwrite.
+
+        Returns:
+            A device-event-aware future for the server response.
+
+        Raises:
+            RuntimeError: If the context is not registered or event IPC is
+                unsupported.
+        """
+        if (
+            self._mq_client is None
+            or self._send_request is None
+            or self._device is None
+            or self._event_backend is None
+        ):
+            raise RuntimeError(
+                "LMCache-driven transfer context is not registered. "
+                "Call register() before submit_retrieve()."
+            )
+        event_ipc_handle = self._event_backend.export_event(event, self._device)
+        return self._send_request(
+            self._mq_client,
+            RequestType.RETRIEVE,
+            [key, instance_id, block_ids, event_ipc_handle, skip_first_n_tokens],
+        ).to_device_future(device=self._device)
+
+    def close(self) -> None:
+        """Release the message queue and cached event-backend state."""
+        for wrapper in self._ipc_wrappers:
+            close = getattr(wrapper, "close", None)
+            if close is not None:
+                close()
+        self._ipc_wrappers.clear()
+        self._mq_client = None
+        self._send_request = None
+        self._device = None
+        self._event_backend = None
+
+    def flush_inflight_stores(self) -> None:
+        pass
+
+
+class EngineDrivenTransferContext(TransferContext):
+    """Engine-driven transfer context for non-CUDA workers.
+
+    In this mode the engine (worker side) owns the data movement: the
+    worker adapter gathers/packs KV into CPU buffers, commits via
+    message-queue, and the server side persists/rehydrates from storage.
+    """
+
+    def __init__(self) -> None:
+        self._engine_driven_context: EngineDrivenContext | None = None
+        self._layout_hints: LayoutHints | None = None
+        self._engine_kv_format: Any = None
+        self._worker_groups: tuple[_EngineDrivenWorkerGroup, ...] = ()
+
+    def _gather_group_payloads(
+        self,
+        kv_caches: dict[str, torch.Tensor],
+        block_ids: list[list[int]],
+        out_buffers: list[list[torch.Tensor]] | None = None,
+        group_chunk_indices: list[list[int]] | None = None,
+    ) -> list[list[torch.Tensor]]:
+        """Gather every object group in stable registration order."""
+        num_chunks = _validate_group_block_ids(self._worker_groups, block_ids)
+        if out_buffers is not None and len(out_buffers) != len(self._worker_groups):
+            raise ValueError("store buffers do not cover all groups")
+        if group_chunk_indices is not None and len(group_chunk_indices) != len(
+            self._worker_groups
+        ):
+            raise ValueError("store chunk indices do not cover all groups")
+
+        payloads: list[list[torch.Tensor]] = []
+        for group_idx, group in enumerate(self._worker_groups):
+            ids = block_ids[group.layout.engine_group_idx]
+            group_kv = {name: kv_caches[name] for name in group.layer_names}
+            out = out_buffers[group_idx] if out_buffers is not None else None
+            indices = (
+                group_chunk_indices[group_idx]
+                if group_chunk_indices is not None
+                else None
+            )
+            if indices is not None and any(i < 0 or i >= num_chunks for i in indices):
+                raise ValueError(f"group {group_idx} has invalid chunk indices")
+            payloads.append(
+                gather_paged_kv_to_cpu(
+                    group_kv,
+                    ids,
+                    group.layout.blocks_per_chunk,
+                    layout_hints=self._layout_hints,
+                    engine_kv_format=group.engine_kv_format,
+                    out=out,
+                    chunk_indices=indices,
+                )
+            )
+        return payloads
+
+    def _scatter_group_payloads(
+        self,
+        kv_caches: dict[str, torch.Tensor],
+        block_ids: list[list[int]],
+        group_payloads: list[list[torch.Tensor]],
+        skip_first_n_tokens: int,
+    ) -> None:
+        """Validate all groups before scattering any retrieved state."""
+        num_chunks = _validate_group_block_ids(self._worker_groups, block_ids)
+        if len(group_payloads) != len(self._worker_groups):
+            raise ValueError("retrieve payload does not cover all groups")
+        for group_idx, (group, payloads) in enumerate(
+            zip(self._worker_groups, group_payloads, strict=True)
+        ):
+            if len(payloads) != num_chunks:
+                raise ValueError(
+                    f"group {group_idx} returned {len(payloads)} chunks; "
+                    f"expected {num_chunks}"
+                )
+            expected_shape = torch.Size(group.layout.shape)
+            expected_dtype = getattr(torch, group.layout.dtype_str)
+            if any(
+                payload.shape != expected_shape or payload.dtype != expected_dtype
+                for payload in payloads
+            ):
+                raise ValueError(
+                    f"group {group_idx} retrieve payload layout does not match "
+                    "registration"
+                )
+            group_kv = {name: kv_caches[name] for name in group.layer_names}
+            # First Party
+            from lmcache.v1.gpu_connector.utils import (
+                get_num_blocks,
+                normalize_kv_and_discover_format,
+            )
+
+            _, normalized = normalize_kv_and_discover_format(
+                list(group_kv.values()),
+                EngineType.VLLM,
+                layout_hints=self._layout_hints,
+            )
+            num_blocks = get_num_blocks(normalized, group.engine_kv_format)
+            ids = block_ids[group.layout.engine_group_idx]
+            if any(block_id < 0 or block_id >= num_blocks for block_id in ids):
+                raise ValueError(
+                    f"group {group_idx} destination block ID is out of range"
+                )
+
+        for group, payloads in zip(self._worker_groups, group_payloads, strict=True):
+            group_kv = {name: kv_caches[name] for name in group.layer_names}
+            physical_block_size = (
+                group.layout.shape[-2] // group.layout.blocks_per_chunk
+            )
+            group_skip = (
+                skip_first_n_tokens
+                * physical_block_size
+                // group.layout.tokens_per_block
+            )
+            scatter_cpu_to_paged_kv(
+                group_kv,
+                block_ids[group.layout.engine_group_idx],
+                payloads,
+                group.layout.blocks_per_chunk,
+                skip_first_n_tokens=group_skip,
+                layout_hints=self._layout_hints,
+                engine_kv_format=group.engine_kv_format,
+            )
+
+    @property
+    def engine_driven_context(self) -> EngineDrivenContext:
+        """Return the underlying SHM/pickle context created by ``register``.
+
+        Raises:
+            RuntimeError: If accessed before ``register`` has run.
+        """
+        if self._engine_driven_context is None:
+            raise RuntimeError(
+                "EngineDrivenTransferContext is not registered, call register() first."
+            )
+        return self._engine_driven_context
+
+    def register(
+        self,
+        instance_id: int,
+        kv_caches: dict[str, torch.Tensor],
+        model_name: str,
+        world_size: int,
+        blocks_in_chunk: int,
+        mq_client: MessageQueueClient,
+        mq_timeout: float,
+        send_request: SendRequest,
+        layout_hints: LayoutHints | None = None,
+        engine_group_infos: Sequence[EngineGroupInfo] = (),
+        engine_type: EngineType = EngineType.VLLM,
+    ) -> None:
+        """Register KV caches with the non-GPU context server.
+
+        Each ``engine_group_infos`` entry becomes one stable wire/object group.
+        The object carries only kernel-equivalent layers and selects its own
+        engine block-ID address space.
+        """
+        del engine_type
+        layer_names = tuple(kv_caches)
+        if not layer_names:
+            raise ValueError("kv_caches is empty")
+        group_infos = list(engine_group_infos) or [
+            EngineGroupInfo(
+                engine_group_id=0,
+                layer_indices=tuple(range(len(layer_names))),
+            )
+        ]
+        representative_indices = tuple(group_infos[0].layer_indices)
+        if not representative_indices:
+            raise ValueError("engine-driven group 0 has no layers")
+        representative_kv = {
+            layer_names[i]: kv_caches[layer_names[i]] for i in representative_indices
+        }
+        (
+            block_size,
+            num_layers,
+            hidden_dim_size,
+            dtype_str,
+            engine_kv_format,
+            kv_size,
+        ) = compute_kv_layout(representative_kv, layout_hints=layout_hints)
+        self._layout_hints = layout_hints
+        self._engine_kv_format = engine_kv_format
+
+        logical_chunk_tokens = blocks_in_chunk * (
+            engine_group_infos[0].tokens_per_block
+            if engine_group_infos and engine_group_infos[0].tokens_per_block > 0
+            else block_size
+        )
+        worker_groups: list[_EngineDrivenWorkerGroup] = []
+        for object_group_id, info in enumerate(group_infos):
+            indices = tuple(info.layer_indices)
+            if not indices:
+                raise ValueError(f"engine-driven group {object_group_id} has no layers")
+            try:
+                group_kv = {layer_names[i]: kv_caches[layer_names[i]] for i in indices}
+            except IndexError as exc:
+                raise ValueError(
+                    f"engine-driven group {object_group_id} has invalid layer indices"
+                ) from exc
+            (
+                group_block_size,
+                group_num_layers,
+                group_hidden_dim,
+                group_dtype_str,
+                group_format,
+                group_kv_size,
+            ) = compute_kv_layout(group_kv, layout_hints=layout_hints)
+            tokens_per_block = (
+                info.tokens_per_block if info.tokens_per_block > 0 else group_block_size
+            )
+            if logical_chunk_tokens % tokens_per_block:
+                raise ValueError(
+                    f"LMCache chunk size {logical_chunk_tokens} does not align to "
+                    f"group {object_group_id} tokens_per_block {tokens_per_block}"
+                )
+            group_blocks_per_chunk = logical_chunk_tokens // tokens_per_block
+            group_slots_per_chunk = group_blocks_per_chunk * group_block_size
+            group_shape = (
+                (group_num_layers, group_slots_per_chunk, group_hidden_dim)
+                if group_kv_size == 1
+                else (2, group_num_layers, group_slots_per_chunk, group_hidden_dim)
+            )
+            group_layout = EngineDrivenGroupLayout(
+                object_group_id=object_group_id,
+                engine_group_idx=info.engine_group_id,
+                layer_indices=indices,
+                tokens_per_block=tokens_per_block,
+                blocks_per_chunk=group_blocks_per_chunk,
+                shape=group_shape,
+                dtype_str=group_dtype_str,
+            )
+            worker_groups.append(
+                _EngineDrivenWorkerGroup(
+                    layout=group_layout,
+                    layer_names=tuple(layer_names[i] for i in indices),
+                    engine_kv_format=group_format,
+                )
+            )
+        self._worker_groups = tuple(worker_groups)
+
+        # The wire field is named use_mla but only drives the object plane
+        # count: single-plane (kv_size == 1) covers MLA and fused-K/V formats.
+        use_mla_flag = kv_size == 1
+        shape = (
+            torch.Size([num_layers, blocks_in_chunk * block_size, hidden_dim_size])
+            if use_mla_flag
+            else torch.Size(
+                [2, num_layers, blocks_in_chunk * block_size, hidden_dim_size]
+            )
+        )
+        dtype = getattr(torch, dtype_str)
+        layout_desc = MemoryLayoutDesc(shapes=[shape], dtypes=[dtype])
+
+        future = send_request(
+            mq_client,
+            RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT,
+            [
+                RegisterEngineDrivenContextPayload(
+                    instance_id=instance_id,
+                    model_name=model_name,
+                    world_size=world_size,
+                    block_size=block_size,
+                    num_layers=num_layers,
+                    hidden_dim_size=hidden_dim_size,
+                    dtype_str=dtype_str,
+                    use_mla=use_mla_flag,
+                    group_layouts=tuple(group.layout for group in worker_groups),
+                )
+            ],
+        )
+        response = future.result(timeout=mq_timeout)
+        shm_name = ""
+        pool_size = 0
+        if isinstance(response, RegisterEngineDrivenContextResponse):
+            shm_name = response.shm_name
+            pool_size = response.pool_size
+
+        metadata = EngineDrivenContextMetadata(
+            layout_desc=layout_desc,
+            block_size=block_size,
+            use_mla=use_mla_flag,
+            group_layouts=tuple(group.layout for group in worker_groups),
+        )
+        self._engine_driven_context = create_engine_driven_context(
+            metadata,
+            mq_client,
+            mq_timeout,
+            shm_name=shm_name,
+            pool_size=pool_size,
+        )
+        supported_transfer_mode = "SHM" if shm_name and pool_size > 0 else "pickle"
+        logger.info(
+            "Worker non-GPU transfer context registered (instance_id=%d, mode=%s)",
+            instance_id,
+            supported_transfer_mode,
+        )
+
+    def submit_store(
+        self,
+        _request_id: str,
+        key: Any,
+        instance_id: int,
+        kv_caches: dict[str, torch.Tensor],
+        block_ids: list[list[int]],
+        _event: IPCEvent,
+        blocks_in_chunk: int,
+    ) -> MessagingFuture:
+        if self._engine_driven_context is None:
+            raise RuntimeError(
+                "Engine-driven transfer context is not registered. "
+                "Call register() before submit_store()."
+            )
+
+        torch_dev.synchronize()
+        try:
+            result = self._engine_driven_context.prepare_store(key, instance_id)
+        except StoreAdmissionRejected as exc:
+            logger.warning(
+                "Skipping synchronous engine-driven cache store: reason=%s",
+                exc.reason,
+            )
+            future: MessagingFuture[bool] = MessagingFuture()
+            future.set_result(False)
+            return future
+        out_buffers, group_chunk_indices = (
+            result if result is not None else (None, None)
+        )
+        # All chunks already in cache — nothing to gather or commit.
+        if group_chunk_indices is not None and not any(group_chunk_indices):
+            future: MessagingFuture[bool] = MessagingFuture()
+            future.set_result(True)
+            return future
+        aborted = False
+        try:
+            cpu_chunks = self._gather_group_payloads(
+                kv_caches,
+                block_ids,
+                out_buffers=out_buffers,
+                group_chunk_indices=group_chunk_indices,
+            )
+            if out_buffers is not None:
+                # SHM path uses async device->CPU copies; complete them before commit.
+                torch_dev.synchronize()
+            ok = self._engine_driven_context.commit_store(key, instance_id, cpu_chunks)
+        except Exception:
+            if out_buffers is not None:
+                # A gather can fail after enqueuing D2H work. Drain it before
+                # allowing vLLM to reuse the source blocks or SHM slots.
+                torch_dev.synchronize()
+                self._engine_driven_context.abort_store(key, instance_id)
+                aborted = True
+            logger.exception("Synchronous engine-driven store failed")
+            ok = False
+        if out_buffers is not None and not ok and not aborted:
+            self._engine_driven_context.abort_store(key, instance_id)
+
+        future = MessagingFuture()
+        future.set_result(ok)
+        return future
+
+    def submit_retrieve(
+        self,
+        _request_id: str,
+        key: Any,
+        instance_id: int,
+        kv_caches: dict[str, torch.Tensor],
+        block_ids: list[list[int]],
+        _event: IPCEvent,
+        blocks_in_chunk: int,
+        skip_first_n_tokens: int = 0,
+    ) -> MessagingFuture:
+        if self._engine_driven_context is None:
+            raise RuntimeError(
+                "Engine-driven transfer context is not registered. "
+                "Call register() before submit_retrieve()."
+            )
+
+        src_buffers = self._engine_driven_context.prepare_retrieve(key, instance_id)
+        ok = src_buffers is not None
+        if src_buffers is not None:
+            try:
+                self._scatter_group_payloads(
+                    kv_caches,
+                    block_ids,
+                    src_buffers,
+                    skip_first_n_tokens=skip_first_n_tokens,
+                )
+            except (RuntimeError, ValueError, TypeError, IndexError):
+                logger.exception("Failed to scatter retrieved CPU context chunks")
+                ok = False
+            # SHM path: ensure all device writes are complete before releasing
+            # the SHM slot (server may immediately reuse it after commit_retrieve).
+            torch_dev.synchronize()
+        self._engine_driven_context.commit_retrieve(key, instance_id)
+
+        future: MessagingFuture[bool] = MessagingFuture()
+        future.set_result(ok)
+        return future
+
+    def close(self) -> None:
+        if self._engine_driven_context is not None:
+            self._engine_driven_context.close()
+            self._engine_driven_context = None
+
+    def flush_inflight_stores(self) -> None:
+        pass
+
+
+def create_transfer_context(
+    kv_caches: dict[str, torch.Tensor],
+    mode: "str | MPTransferMode | None" = None,
+    **_kwargs: Any,
+) -> TransferContext:
+    """Create a transfer context from KV cache device type.
+
+    The device check is intentionally centralized here. Routing can be
+    overridden via the ``mode`` argument or the ``LMCACHE_MP_TRANSFER_MODE``
+    environment variable; see :class:`MPTransferMode` for accepted values.
+
+    Args:
+        kv_caches: Worker KV cache tensors keyed by layer name.
+        mode: Optional routing override. When ``None`` the value of
+            ``LMCACHE_MP_TRANSFER_MODE`` is consulted, defaulting to
+            :attr:`MPTransferMode.AUTO`.
+        **kwargs: Unused placeholder for forward-compatible factory extension.
+
+    Returns:
+        A concrete :class:`TransferContext` implementation.
+
+    Raises:
+        ValueError: If ``kv_caches`` is empty, has mixed device types, the
+            requested mode string is unknown, or the requested mode is not
+            supported for the worker device.
+    """
+    if not kv_caches:
+        raise ValueError("kv_caches is empty")
+    device_types = {tensor.device.type for tensor in kv_caches.values()}
+    if len(device_types) != 1:
+        raise ValueError(
+            f"All KV cache tensors must share one device type, got {device_types}"
+        )
+    device_type = next(iter(device_types))
+    resolved_mode = _resolve_mode(mode)
+    logger.info(
+        "Creating transfer context (device_type=%s, mode=%s)",
+        device_type,
+        resolved_mode.value,
+    )
+    if resolved_mode is MPTransferMode.LMCACHE_DRIVEN:
+        return _build_lmcache_driven_context(device_type)
+    if resolved_mode is MPTransferMode.ENGINE_DRIVEN:
+        return _build_engine_driven_context()
+    # AUTO: dispatch by device type (CUDA -> handle path, else -> data path).
+    if device_type == "cuda":
+        return LMCacheDrivenTransferContext()
+    return _build_engine_driven_context()

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/v1/platform/cuda/cache_context.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/v1/platform/cuda/cache_context.py
@@ -1,0 +1,676 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+GPU Cache Context management for LMCache multiprocessing.
+
+This module provides GPU-side KV cache management functionality, including:
+- GPUCacheContext: Manages shape and pointers to vLLM GPU KV cache tensors
+- Helper functions for tensor operations and key resolution
+"""
+
+# Standard
+import array
+from builtins import ExceptionGroup
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+# Third Party
+import torch
+
+if TYPE_CHECKING:
+    # Third Party
+    import cupy
+
+# First Party
+from lmcache import torch_dev
+from lmcache.logging import init_logger
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.gds_context import get_gds_context
+from lmcache.v1.gpu_connector.utils import (
+    LayoutHints,
+    get_device,
+    get_group_data_ptrs,
+    normalize_and_discover_per_layer_formats,
+)
+from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
+from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.multiprocess.group_view import (
+    EngineGroupInfo,
+    engine_group_layer_indices,
+)
+from lmcache.v1.platform.base.cache_context import BaseCacheContext
+
+logger = init_logger(__name__)
+
+
+def unwrap_kv_cache_tensors(kv_caches: KVCache) -> list[torch.Tensor]:
+    unwrapped_tensors = []
+    for ipc_wrapper in kv_caches:
+        tensor = ipc_wrapper.to_tensor()
+        unwrapped_tensors.append(tensor)
+    return unwrapped_tensors
+
+
+def list_to_gpu_tensor(lis: list[int], device: torch.device) -> torch.Tensor:
+    return torch.frombuffer(array.array("q", lis), dtype=torch.long).to(
+        device, non_blocking=True
+    )
+
+
+class _TempGPUBuffer:
+    """
+    Manages the temporary GPU buffer for GPUCacheContext
+
+    The logical layout of the temp GPU buffer is (batch size,
+    object group, kernel group).
+
+    Here is an example of batch size = 4, with 2 object groups,
+    and 2 kernel groups per object group:
+    [
+        batch 0:
+            - object group 0: kernel group 0 | kernel group 1 | ...
+            - object group 1: kernel group 2 | kernel group 3 | ...
+
+        batch 1:
+            - object group 0: kernel group 0 | kernel group 1 | ...
+            - object group 1: kernel group 2 | kernel group 3 | ...
+
+        batch 2:
+            - object group 0: kernel group 0 | kernel group 1 | ...
+            - object group 1: kernel group 2 | kernel group 3 | ...
+
+        batch 3:
+            - object group 0: kernel group 0 | kernel group 1 | ...
+            - object group 1: kernel group 2 | kernel group 3 | ...
+    ]
+
+    During the multi-layer copy kernel launch, we will do it at kernel
+    group level, which means we will have:
+    ```
+    gpu_buffers = [
+        get_temp_kernel_group_buffer(batch_idx, kernel_group_idx)
+        for batch_idx in range(batch_size)
+    ]
+    ```
+
+    During the lmcache_memcpy_async launch, we will do it at the object group
+    level, which will be:
+    ```
+    for i in range(batch_size):
+        gpu_buffer = get_temp_object_group_buffer(batch_idx, object_group_idx)
+        lmcache_memcpy_async(...)
+    ```
+    """
+
+    def __init__(
+        self,
+        kv_layer_groups_manager: KVLayerGroupsManager,
+        lmcache_tokens_per_chunk: int,
+        device: torch.device,
+        max_batch_size: int = 4,
+    ) -> None:
+        self._kv_groups_manager = kv_layer_groups_manager
+        self._lmcache_tokens_per_chunk = lmcache_tokens_per_chunk
+        self._max_batch_size = max_batch_size
+
+        self._temp_buffer = torch.empty(
+            self._get_size_for_single_batch() * max_batch_size,
+            dtype=torch.uint8,
+            device=device,
+        )
+
+        # Offset map: (batch_idx, object_group_idx, kernel_group_idx) ->
+        # (byte offset in the temp buffer, size of the buffer in bytes)
+        self._offset_map: dict[tuple[int, int, int], tuple[int, int]] = {}
+
+        # (batch_idx, kernel_group_idx) -> (byte offset for the kernel group,
+        # size of the buffer in bytes).
+        self._offset_map_kernel_group_only: dict[tuple[int, int], tuple[int, int]] = {}
+
+        # (batch_idx, object_group_idx) -> (byte offset for the object group,
+        # size of the buffer in bytes)
+        self._offset_map_object_group_only: dict[tuple[int, int], tuple[int, int]] = {}
+
+        offset = 0
+        for batch_idx in range(max_batch_size):
+            for object_group_idx in range(self._kv_groups_manager.num_object_groups):
+                object_group_size = 0
+                object_group_start_offset = offset
+
+                for kernel_group_idx in self._kv_groups_manager.object_groups[
+                    object_group_idx
+                ].kernel_group_indices:
+                    key = (batch_idx, object_group_idx, kernel_group_idx)
+                    key2 = (batch_idx, kernel_group_idx)
+
+                    size = self._get_size_for_kernel_group(kernel_group_idx)
+                    self._offset_map[key] = (offset, size)
+                    self._offset_map_kernel_group_only[key2] = (offset, size)
+
+                    offset += size
+                    object_group_size += size
+
+                key3 = (batch_idx, object_group_idx)
+                self._offset_map_object_group_only[key3] = (
+                    object_group_start_offset,
+                    object_group_size,
+                )
+
+        # Shape/dtype cache for kernel groups
+        self._shape_cache_kernel_group: dict[int, tuple[torch.Size, torch.dtype]] = {}
+        for kernel_group_idx in range(self._kv_groups_manager.num_kernel_groups):
+            shape = self._get_shape_for_kernel_group(
+                self._lmcache_tokens_per_chunk, kernel_group_idx
+            )
+            group = self._kv_groups_manager.kernel_groups[kernel_group_idx]
+            dtype = group.dtype
+            self._shape_cache_kernel_group[kernel_group_idx] = (shape, dtype)
+
+    # Public APIs
+    @property
+    def max_batch_size(self) -> int:
+        """Maximum number of chunks (batch slots) the buffer holds."""
+        return self._max_batch_size
+
+    @property
+    def buffer(self) -> torch.Tensor:
+        """The flat staging tensor (for GDS cuFile registration)."""
+        return self._temp_buffer
+
+    def get_temp_kernel_group_buffer(
+        self, batch_idx: int, kernel_group_idx: int
+    ) -> torch.Tensor:
+        """
+        Returns the temp GPU buffer for the given batch index and kernel group index.
+        The returned buffer is with the correct shape and dtype for the kernel group.
+
+        Args:
+            batch_idx: Index of the batch (0 <= batch_idx < max_batch_size)
+            kernel_group_idx: Index of the kernel group.
+
+        Returns:
+            The temp GPU buffer for the given batch index and kernel group index.
+
+        Raises:
+            ValueError: If the batch_idx or kernel_group_idx is out of range.
+        """
+        key = (batch_idx, kernel_group_idx)
+        if key not in self._offset_map_kernel_group_only:
+            raise ValueError(
+                f"Invalid batch_idx {batch_idx} or kernel_group_idx {kernel_group_idx}"
+            )
+
+        offset, size = self._offset_map_kernel_group_only[key]
+        shape, dtype = self._shape_cache_kernel_group[kernel_group_idx]
+        return self._temp_buffer[offset : offset + size].view(dtype).view(shape)
+
+    def get_temp_object_group_buffer(
+        self, batch_idx: int, object_group_idx: int
+    ) -> torch.Tensor:
+        """
+        Returns the temp GPU buffer for the given batch index and object group index
+        The returned buffer is a flat uint8 raw tensor.
+
+        Args:
+            batch_idx: Index of the batch (0 <= batch_idx < max_batch_size)
+            object_group_idx: Index of the object group.
+
+        Returns:
+            The temp GPU buffer for the given batch index and object group index.
+        """
+        key = (batch_idx, object_group_idx)
+        if key not in self._offset_map_object_group_only:
+            raise ValueError(
+                f"Invalid batch_idx {batch_idx} or object_group_idx {object_group_idx}"
+            )
+
+        offset, size = self._offset_map_object_group_only[key]
+        return self._temp_buffer[offset : offset + size]
+
+    def get_kernel_group_shape_dtype(
+        self,
+        num_tokens: int,
+        kernel_group_idx: int,
+    ) -> tuple[torch.Size, torch.dtype]:
+        """
+        Returns the shape and dtype for the given kernel group index and
+        number of tokens.
+
+        Will be exported by GPUCacheContext and used to construct the
+        MemoryLayoutDesc
+
+        Args:
+            num_tokens: Number of tokens. Must be a whole number of lmcache
+                chunk size.
+            kernel_group_idx: Index of the kernel group.
+
+        Returns:
+            The shape and dtype for the given kernel group index and
+            number of tokens.
+        """
+        _, dtype = self._shape_cache_kernel_group[kernel_group_idx]
+        shape = self._get_shape_for_kernel_group(num_tokens, kernel_group_idx)
+
+        return shape, dtype
+
+    def get_cache_size_per_token(self) -> int:
+        """
+        Returns the cache size per token (in bytes), summed across all kernel groups.
+        """
+        return self._get_size_for_single_batch() // self._lmcache_tokens_per_chunk
+
+    # Helper functions
+    def _get_shape_for_kernel_group(
+        self,
+        num_tokens: int,
+        kernel_group_idx: int,
+    ) -> torch.Size:
+        """
+        Returns the shape of the temp GPU buffer for the given kernel group index
+
+        Args:
+            num_tokens: Number of tokens
+            kernel_group_idx: Index of the kernel group.
+
+        Returns:
+            The shape of the temp GPU buffer for the given kernel group index.
+
+        Raises:
+            ValueError: If ``num_tokens`` is not a whole number of LMCache
+                chunks.
+        """
+        if num_tokens % self._lmcache_tokens_per_chunk != 0:
+            raise ValueError(
+                f"num_tokens ({num_tokens}) must be a multiple of "
+                f"lmcache_tokens_per_chunk ({self._lmcache_tokens_per_chunk})"
+            )
+
+        group = self._kv_groups_manager.kernel_groups[kernel_group_idx]
+        sd = group.shape_desc
+
+        num_chunks = num_tokens // self._lmcache_tokens_per_chunk
+        num_slots = (
+            self._kv_groups_manager.get_slots_per_chunk_in_sw(kernel_group_idx)
+            * num_chunks
+        )
+
+        return torch.Size(
+            (sd.kv_size, group.num_layers, num_slots, group.hidden_dim_size)
+        )
+
+    def _get_size_for_kernel_group(self, kernel_group_idx: int) -> int:
+        """
+        Returns the size in bytes of the temp GPU buffer for the given kernel group
+        index
+
+        **Assumes the size is lmcache_tokens_per_chunk
+
+        Will only be called during initialization
+        """
+        shape = self._get_shape_for_kernel_group(
+            self._lmcache_tokens_per_chunk, kernel_group_idx
+        )
+        kernel_group = self._kv_groups_manager.kernel_groups[kernel_group_idx]
+        dtype = kernel_group.dtype
+        return shape.numel() * dtype.itemsize
+
+    def _get_size_for_object_group(self, object_group_idx: int) -> int:
+        """
+        Returns the size in bytes of the temp GPU buffer for the given object group
+
+        **Assumes the size is lmcache_tokens_per_chunk
+
+        Will only be called during initialization
+        """
+        object_group = self._kv_groups_manager.object_groups[object_group_idx]
+        return sum(
+            self._get_size_for_kernel_group(kernel_group_idx)
+            for kernel_group_idx in object_group.kernel_group_indices
+        )
+
+    def _get_size_for_single_batch(self) -> int:
+        """
+        Returns the size in bytes of the temp GPU buffer for a single batch
+        (i.e., a single chunk)
+
+        **Assumes the size is lmcache_tokens_per_chunk
+        """
+        return sum(
+            self._get_size_for_object_group(object_group_idx)
+            for object_group_idx in range(self._kv_groups_manager.num_object_groups)
+        )
+
+
+class GPUCacheContext(BaseCacheContext):
+    """
+    Manages the shape and pointers to vLLM GPU KV cache tensors.
+    """
+
+    device_type = "cuda"
+
+    def __init__(
+        self,
+        kv_caches: KVCache,
+        lmcache_tokens_per_chunk: int = 256,
+        layout_hints: LayoutHints | None = None,
+        engine_group_infos: Sequence[EngineGroupInfo] = (),
+        engine_type: EngineType = EngineType.VLLM,
+        separate_object_groups: bool = False,
+        full_sw_kv: bool = False,
+    ):
+        # Retain wrappers for the context lifetime. CuMem wrappers own a
+        # refcounted imported VMM mapping that must outlive every tensor view.
+        self._ipc_wrappers = list(kv_caches)
+        self._closed = False
+        self._gds_registered = False
+        unwrapped = unwrap_kv_cache_tensors(kv_caches)
+        kv_caches_norm, engine_kv_formats = normalize_and_discover_per_layer_formats(
+            unwrapped,
+            engine_group_layer_indices(engine_group_infos),
+            engine_type,
+            layout_hints,
+        )
+        self.device_ = get_device(kv_caches_norm)
+        num_layers_val = len(engine_kv_formats)
+
+        kv_layer_groups_manager = KVLayerGroupsManager(
+            kv_caches_norm,
+            engine_kv_formats=engine_kv_formats,
+            engine_group_infos=engine_group_infos,
+            lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,
+            separate_object_groups=separate_object_groups,
+        )
+        # Set full_sw_kv before the temp buffer / object groups are built so
+        # both are sized for the full (un-windowed) per-chunk geometry.
+        if full_sw_kv:
+            kv_layer_groups_manager.enable_full_sw_kv()
+
+        # Pre-allocated GPU buffer for block IDs (up to 1M elements).
+        # The caller copies block_ids into this buffer before launching the
+        # block-level kernel. Single-thread assumption: no lock needed.
+        _MAX_BLOCK_IDS = 1 << 20
+        block_ids_buffer = torch.empty(
+            _MAX_BLOCK_IDS, dtype=torch.long, device=self.device_
+        )
+
+        super().__init__(
+            kv_caches=kv_caches_norm,
+            device=self.device_,
+            num_layers=num_layers_val,
+            kv_layer_groups_manager=kv_layer_groups_manager,
+            block_ids_buffer=block_ids_buffer,
+            lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,
+        )
+
+        self.group_kv_pointers_: list[torch.Tensor] = []
+        for idx, group in enumerate(self.kv_layer_groups_manager_.kernel_groups):
+            ptrs = get_group_data_ptrs(
+                self.kv_caches_, self.get_engine_kv_format(idx), group.layer_indices
+            )
+            self.group_kv_pointers_.append(list_to_gpu_tensor(ptrs, self.device_))
+
+        # Temporary GPU buffer for transfers — a single flat uint8 buffer
+        self._temp_buffer = _TempGPUBuffer(
+            kv_layer_groups_manager=self.kv_layer_groups_manager_,
+            lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,
+            device=self.device_,
+            max_batch_size=4,
+        )
+
+        # GPU streams
+        self.cuda_stream_ = torch_dev.Stream(device=self.device_)
+
+        # Register the staging buffer with the GDS cuFile context on the
+        # context's CUDA stream.
+        with torch_dev.stream(self.cuda_stream_):
+            get_gds_context().register_gpu_buffer(self._temp_buffer.buffer)
+        self._gds_registered = True
+
+        # Third Party
+        import cupy
+
+        self.cupy_stream_: cupy.cuda.Stream = cupy.cuda.ExternalStream(
+            self.cuda_stream_.cuda_stream, self.device_.index
+        )
+
+        # Extra initialization
+        self.cupy_stream_.launch_host_func(
+            lambda logger: logger.info(
+                "Initialized cuda stream on device %s", str(self.device_)
+            ),
+            logger,
+        )
+
+    def close(self) -> None:
+        """
+        Deregister this context's GDS staging buffer (reverse of __init__).
+        """
+        if self._closed:
+            return
+        close_errors: list[BaseException] = []
+        if self._gds_registered:
+            try:
+                with torch_dev.stream(self.cuda_stream_):
+                    get_gds_context().deregister_gpu_buffer(self._temp_buffer.buffer)
+                torch_dev.synchronize(self.device_)
+            except BaseException as exc:
+                close_errors.append(exc)
+            else:
+                self._gds_registered = False
+        # Drop every tensor alias before releasing imported cuMem mappings.
+        # KV group views, pointer tables, and staging buffers can otherwise keep
+        # DLPack/cupy owners alive across unregister while /status already shows
+        # registered_gpu_ids=[].
+        self.kv_caches_.clear()
+        self.group_kv_pointers_.clear()
+        self.block_ids_buffer_ = None  # type: ignore[assignment]
+        if not self._gds_registered:
+            self._temp_buffer = None  # type: ignore[assignment]
+            self.cupy_stream_ = None  # type: ignore[assignment]
+            self.cuda_stream_ = None  # type: ignore[assignment]
+        for ipc_wrapper in self._ipc_wrappers:
+            if hasattr(ipc_wrapper, "_tensor"):
+                ipc_wrapper._tensor = None
+        remaining_wrappers = []
+        for ipc_wrapper in self._ipc_wrappers:
+            if not hasattr(ipc_wrapper, "close"):
+                continue
+            try:
+                ipc_wrapper.close()
+            except BaseException as exc:  # fail loudly after best-effort siblings
+                close_errors.append(exc)
+                remaining_wrappers.append(ipc_wrapper)
+        self._ipc_wrappers = remaining_wrappers
+        self._closed = not self._gds_registered and not self._ipc_wrappers
+        if close_errors:
+            raise ExceptionGroup(
+                "cuMem IPC wrapper close failed during cache context unregister",
+                close_errors,
+            )
+
+    @property
+    def stream(self) -> Any:
+        """
+        Returns the GPU stream for KV cache operations
+        """
+        return self.cuda_stream_
+
+    @property
+    def cupy_stream(self) -> "cupy.cuda.Stream":
+        return self.cupy_stream_
+
+    def get_kernel_group_kv_pointers(self, kernel_group_idx: int) -> torch.Tensor:
+        """Returns the pre-computed GPU tensor of KV cache pointers for the
+        given kernel group index.
+        """
+        return self.group_kv_pointers_[kernel_group_idx]
+
+    def get_temp_kernel_group_buffer(
+        self, batch_idx: int, kernel_group_idx: int
+    ) -> torch.Tensor:
+        """Returns the temporary GPU buffer for the given batch index and kernel
+        group index, with the correct shape and dtype for the kernel group.
+
+        Args:
+            batch_idx: Index of the batch (0 <= batch_idx < max_batch_size)
+            kernel_group_idx: Index of the kernel group.
+
+        Returns:
+            The temp GPU buffer for the given batch index and kernel group index.
+        """
+        return self._temp_buffer.get_temp_kernel_group_buffer(
+            batch_idx, kernel_group_idx
+        )
+
+    @property
+    def max_batch_size(self) -> int:
+        """Maximum number of chunks processed concurrently in one batch."""
+        return self._temp_buffer.max_batch_size
+
+    def get_temp_object_group_buffer(
+        self, batch_idx: int, object_group_idx: int
+    ) -> torch.Tensor:
+        """Returns the temporary GPU buffer for the given batch index and object
+        group index, as a flat uint8 tensor.
+
+        Args:
+            batch_idx: Index of the batch (0 <= batch_idx < max_batch_size)
+            object_group_idx: Index of the object group.
+
+        Returns:
+            The temp GPU buffer for the given batch index and object group index.
+        """
+        return self._temp_buffer.get_temp_object_group_buffer(
+            batch_idx, object_group_idx
+        )
+
+    def get_kernel_group_shape_dtype(
+        self,
+        num_tokens: int,
+        kernel_group_idx: int,
+    ) -> tuple[torch.Size, torch.dtype]:
+        """Returns the shape and dtype for the given kernel group index and number
+        of tokens.
+        Will be exported by GPUCacheContext and used to construct the MemoryLayoutDesc
+
+        Args:
+            num_tokens: Number of tokens. Must be a whole number of lmcache
+                chunk size.
+            kernel_group_idx: Index of the kernel group.
+
+        Returns:
+            The shape and dtype for the given kernel group index and number of tokens.
+        """
+        return self._temp_buffer.get_kernel_group_shape_dtype(
+            num_tokens, kernel_group_idx
+        )
+
+    def cache_size_per_token(self) -> int:
+        """
+        Returns the cache size per *logical* token (in bytes), summed
+        across all groups. For a compressed group, one physical slot
+        stores ``compress_ratio`` logical tokens, so the per-logical-token
+        contribution is ``physical_slot_bytes // compress_ratio``.
+
+        Reporting-only metric (surfaced via the ``/api/status`` HTTP
+        endpoint and the ``lmcache describe`` CLI); sub-byte truncation
+        from integer division is acceptable.
+        """
+        return self._temp_buffer.get_cache_size_per_token()
+
+
+class PlainGPUCacheContext:
+    """
+    A plain GPU cache context that have a single contiguous 2LTD buffer
+    """
+
+    def __init__(self, kv_caches: KVCache, lmcache_tokens_per_chunk: int = 256):
+        assert len(kv_caches) == 1, (
+            "PlainGPUCacheContext only supports a single KV cache tensor"
+        )
+
+        # KV cache basics
+        self._kv_cache = unwrap_kv_cache_tensors(kv_caches)[0]
+        self._device = self._kv_cache.device
+
+        # Shape related
+        shape = self._kv_cache.shape
+        assert len(shape) == 4, "Expected [2, L, T, D] for plain GPU cache"
+
+        self._num_layers = shape[1]
+        self._num_tokens = shape[2]
+        self._hidden_dim_size = shape[3]
+
+        # Temporary buffer
+        tmp_buffer_shape = self.get_kv_buffer_shape(lmcache_tokens_per_chunk)
+        self._tmp_gpu_buffer = torch.empty(
+            tmp_buffer_shape, dtype=self.dtype, device=self.device
+        )
+
+        # GPU streams
+        self._cuda_stream = torch_dev.Stream(device=self._device)
+        # Third Party
+        import cupy
+
+        self._cupy_stream: cupy.cuda.Stream = cupy.cuda.ExternalStream(
+            self._cuda_stream.cuda_stream, self._device.index
+        )
+
+        # Extra initialization
+        self._cupy_stream.launch_host_func(
+            lambda logger: logger.info(
+                "Initialized cuda stream on device %s", str(self._device)
+            ),
+            logger,
+        )
+
+    def get_kv_buffer_shape(self, num_tokens: int) -> torch.Size:
+        """
+        Returns the shape of the KV buffer for the given number of tokens
+        """
+        return torch.Size((2, self._num_layers, num_tokens, self._hidden_dim_size))
+
+    def get_tmp_gpu_buffer(self, num_tokens: int) -> torch.Tensor:
+        """
+        Returns the temporary GPU buffer for transfers
+        """
+        return self._tmp_gpu_buffer[:, :, :num_tokens, :]
+
+    def slice_kv_cache_on_tokens(self, start: int, end: int) -> torch.Tensor:
+        """
+        Slices the KV cache tensor on the token dimension
+        """
+        return self._kv_cache[:, :, start:end, :]
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._kv_cache.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
+
+    @property
+    def stream(self) -> Any:
+        """Returns the device-specific GPU stream (e.g., torch_dev.Stream)."""
+        return self._cuda_stream
+
+    @property
+    def cupy_stream(self) -> "cupy.cuda.Stream":
+        return self._cupy_stream
+
+    @property
+    def num_layers(self) -> int:
+        return self._num_layers
+
+    @property
+    def num_tokens(self) -> int:
+        return self._num_tokens
+
+    @property
+    def hidden_dim_size(self) -> int:
+        return self._hidden_dim_size
+
+    @property
+    def kv_cache_tensor(self) -> torch.Tensor:
+        return self._kv_cache

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/v1/platform/cuda/cumem_ipc.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/v1/platform/cuda/cumem_ipc.py
@@ -1,0 +1,682 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CUDA VMM allocation sharing for vLLM's cuMem-backed KV cache."""
+
+from __future__ import annotations
+
+import array
+import contextlib
+import ctypes
+import json
+import os
+import secrets
+import socket
+import stat
+import threading
+import time
+from collections.abc import Hashable
+from pathlib import Path
+from typing import Any, NamedTuple, Protocol
+
+
+class CuMemIPCUnsupportedError(RuntimeError):
+    """Raised before registration when a tensor cannot be shared safely."""
+
+
+BROKER_DIR_ENV = "LMCACHE_CUMEM_BROKER_DIR"
+_SOCKET_PREFIX = "lmcu-"
+
+
+def validate_broker_root(
+    directory: str | os.PathLike[str] | None = None,
+    *,
+    require_configured: bool = False,
+) -> Path:
+    """Validate the same-UID directory shared by exporter and importer."""
+    configured = os.environ.get(BROKER_DIR_ENV)
+    if directory is None:
+        if not configured:
+            if require_configured:
+                raise CuMemIPCUnsupportedError(
+                    f"{BROKER_DIR_ENV} must name an existing same-UID directory "
+                    "bind-mounted at the same path in the vLLM and LMCache "
+                    "containers; private /tmp mount namespaces cannot carry "
+                    "cuMem broker sockets"
+                )
+            directory = "/tmp"
+        else:
+            directory = configured
+    root = Path(directory)
+    if not root.is_absolute():
+        raise CuMemIPCUnsupportedError(
+            f"cuMem broker root must be absolute, got {str(root)!r}"
+        )
+    try:
+        metadata = os.lstat(root)
+    except FileNotFoundError as exc:
+        raise CuMemIPCUnsupportedError(
+            f"configured cuMem broker root {root} does not exist; create it and "
+            f"bind-mount it into both containers via {BROKER_DIR_ENV}"
+        ) from exc
+    if stat.S_ISLNK(metadata.st_mode):
+        raise CuMemIPCUnsupportedError(
+            f"cuMem broker root {root} must not be a symlink"
+        )
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise CuMemIPCUnsupportedError(f"cuMem broker root {root} is not a directory")
+    expected_uid = os.getuid()
+    if metadata.st_uid != expected_uid:
+        raise CuMemIPCUnsupportedError(
+            f"cuMem broker root {root} must be owned by UID {expected_uid}, "
+            f"not UID {metadata.st_uid}"
+        )
+    if not os.access(root, os.W_OK | os.X_OK):
+        raise CuMemIPCUnsupportedError(
+            f"cuMem broker root {root} is not writable/searchable by UID {expected_uid}"
+        )
+    return root
+
+
+def _validate_descriptor_path(
+    broker_path: str | os.PathLike[str], broker_root: Path
+) -> Path:
+    path = Path(broker_path)
+    if not path.is_absolute() or ".." in path.parts or path.parent != broker_root:
+        raise CuMemIPCUnsupportedError(
+            f"cuMem broker descriptor path {path} is not directly under configured "
+            f"root {broker_root}; this commonly indicates a container mount namespace "
+            f"mismatch. Set {BROKER_DIR_ENV} to the same bind-mounted path on "
+            "both peers"
+        )
+    return path
+
+
+def _validate_broker_socket(path: Path) -> None:
+    metadata = os.lstat(path)
+    if stat.S_ISLNK(metadata.st_mode):
+        raise CuMemIPCUnsupportedError(
+            f"cuMem broker descriptor path {path} must not be a symlink"
+        )
+    if not stat.S_ISSOCK(metadata.st_mode):
+        raise CuMemIPCUnsupportedError(f"cuMem broker path {path} is not a socket")
+    expected_uid = os.getuid()
+    if metadata.st_uid != expected_uid:
+        raise CuMemIPCUnsupportedError(
+            f"cuMem broker socket {path} must be owned by UID {expected_uid}, "
+            f"not UID {metadata.st_uid}"
+        )
+    mode = stat.S_IMODE(metadata.st_mode)
+    if mode != 0o600:
+        raise CuMemIPCUnsupportedError(
+            f"cuMem broker socket {path} must have mode 0600, not {mode:04o}"
+        )
+
+
+class CuMemAllocationDescriptor(NamedTuple):
+    protocol_version: int
+    allocation_id: str
+    device_uuid: str
+    allocation_size: int
+    broker_path: str
+    broker_token: str
+    handle_type: str
+
+
+def validate_tensor_view(
+    *,
+    allocation_size: int,
+    storage_offset_bytes: int,
+    storage_nbytes: int,
+    shape: tuple[int, ...],
+    stride: tuple[int, ...],
+    itemsize: int,
+) -> None:
+    """Fail closed unless a strided tensor view is inside storage/allocation."""
+    if len(shape) != len(stride):
+        raise ValueError("tensor shape/stride rank mismatch")
+    if any(dim < 0 for dim in shape):
+        raise ValueError("negative tensor dimension")
+    if any(step < 0 for step in stride):
+        raise ValueError("negative tensor stride is unsupported")
+    if itemsize <= 0 or storage_offset_bytes < 0 or storage_nbytes < 0:
+        raise ValueError("invalid tensor storage metadata")
+    if storage_offset_bytes % itemsize:
+        raise ValueError("storage offset is not dtype aligned")
+    if storage_offset_bytes + storage_nbytes > allocation_size:
+        raise ValueError("tensor storage exceeds cuMem allocation")
+    if not shape or any(dim == 0 for dim in shape):
+        required = 0
+    else:
+        required = (
+            1 + sum((dim - 1) * step for dim, step in zip(shape, stride))
+        ) * itemsize
+    if required > storage_nbytes:
+        raise ValueError("tensor view exceeds physical storage extent")
+
+
+class CuMemFDLease:
+    """Exporter-side reference keeping a brokered CUDA allocation FD alive."""
+
+    def __init__(
+        self,
+        broker: CuMemFDBroker,
+        allocation_id: str,
+        broker_path: str,
+        broker_token: str,
+    ) -> None:
+        self._broker = broker
+        self.allocation_id = allocation_id
+        self.broker_path = broker_path
+        self.broker_token = broker_token
+        self._closed = False
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            self._broker.release(self.allocation_id)
+
+
+class CuMemFDBroker:
+    """Process-local SCM_RIGHTS broker for serializable POSIX CUDA handles."""
+
+    def __init__(self, directory: str | os.PathLike[str] = "/tmp") -> None:
+        root = validate_broker_root(directory)
+        self.root = root
+        self._cleanup_stale_sockets()
+        name = f"{_SOCKET_PREFIX}{os.getpid()}-{secrets.token_hex(4)}.sock"
+        self.path = str(root / name)
+        if len(self.path.encode()) >= 104:
+            raise CuMemIPCUnsupportedError(
+                f"cuMem broker socket path is too long: {self.path!r}; configure a "
+                f"shorter shared path with {BROKER_DIR_ENV}"
+            )
+        self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        previous_umask = os.umask(0o177)
+        try:
+            self._socket.bind(self.path)
+        finally:
+            os.umask(previous_umask)
+        os.chmod(self.path, 0o600, follow_symlinks=False)
+        self._socket.listen()
+        self._socket.settimeout(0.2)
+        self._lock = threading.Lock()
+        self._by_id: dict[str, tuple[str, int, Hashable, int]] = {}
+        self._by_key: dict[Hashable, str] = {}
+        self._closed = threading.Event()
+        self._thread = threading.Thread(
+            target=self._serve, name="lmcache-cumem-fd-broker", daemon=True
+        )
+        self._thread.start()
+
+    def _cleanup_stale_sockets(self) -> None:
+        """Remove dead same-UID broker sockets left by crashed exporters."""
+        for candidate in self.root.glob(f"{_SOCKET_PREFIX}*.sock"):
+            try:
+                metadata = os.lstat(candidate)
+                if (
+                    metadata.st_uid != os.getuid()
+                    or not stat.S_ISSOCK(metadata.st_mode)
+                    or stat.S_ISLNK(metadata.st_mode)
+                ):
+                    continue
+                try:
+                    owner_pid = int(candidate.name.split("-", 2)[1])
+                except (IndexError, ValueError):
+                    continue
+                try:
+                    os.kill(owner_pid, 0)
+                except ProcessLookupError:
+                    pass
+                except PermissionError:
+                    continue
+                else:
+                    # A live exporter may be between bind() and listen().
+                    continue
+                probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                try:
+                    probe.settimeout(0.05)
+                    probe.connect(str(candidate))
+                except (ConnectionRefusedError, FileNotFoundError):
+                    with contextlib.suppress(FileNotFoundError):
+                        os.unlink(candidate)
+                except OSError:
+                    continue
+                finally:
+                    probe.close()
+            except FileNotFoundError:
+                continue
+
+    @property
+    def registration_count(self) -> int:
+        with self._lock:
+            return len(self._by_id)
+
+    def register(self, key: Hashable, fd: int) -> CuMemFDLease:
+        with self._lock:
+            existing_id = self._by_key.get(key)
+            if existing_id is not None:
+                token, owned_fd, saved_key, refs = self._by_id[existing_id]
+                self._by_id[existing_id] = (token, owned_fd, saved_key, refs + 1)
+                return CuMemFDLease(self, existing_id, self.path, token)
+            allocation_id = secrets.token_hex(16)
+            token = secrets.token_hex(32)
+            self._by_key[key] = allocation_id
+            self._by_id[allocation_id] = (token, os.dup(fd), key, 1)
+            return CuMemFDLease(self, allocation_id, self.path, token)
+
+    def release(self, allocation_id: str) -> None:
+        with self._lock:
+            entry = self._by_id.get(allocation_id)
+            if entry is None:
+                return
+            token, fd, key, refs = entry
+            if refs > 1:
+                self._by_id[allocation_id] = (token, fd, key, refs - 1)
+                return
+            self._by_id.pop(allocation_id)
+            self._by_key.pop(key, None)
+        os.close(fd)
+
+    def _serve(self) -> None:
+        while not self._closed.is_set():
+            try:
+                conn, _ = self._socket.accept()
+            except TimeoutError:
+                continue
+            except OSError:
+                break
+            with conn:
+                try:
+                    peer = conn.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, 12)
+                    peer_uid = int.from_bytes(peer[4:8], byteorder="little")
+                    if peer_uid != os.getuid():
+                        continue
+                    request = json.loads(conn.recv(4096).decode())
+                    allocation_id = str(request["allocation_id"])
+                    token = str(request["token"])
+                    with self._lock:
+                        saved = self._by_id.get(allocation_id)
+                        if saved is None or not secrets.compare_digest(saved[0], token):
+                            continue
+                        fd = saved[1]
+                    rights = array.array("i", [fd])
+                    conn.sendmsg(
+                        [b"F"],
+                        [(socket.SOL_SOCKET, socket.SCM_RIGHTS, rights)],
+                    )
+                except (KeyError, ValueError, OSError, json.JSONDecodeError):
+                    continue
+
+    def close(self) -> None:
+        if self._closed.is_set():
+            return
+        self._closed.set()
+        self._socket.close()
+        self._thread.join(timeout=1)
+        with self._lock:
+            entries = list(self._by_id.values())
+            self._by_id.clear()
+            self._by_key.clear()
+        for _, fd, _, _ in entries:
+            os.close(fd)
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(self.path)
+
+
+def receive_fd(
+    broker_path: str,
+    broker_token: str,
+    allocation_id: str,
+    *,
+    broker_root: str | os.PathLike[str] | None = None,
+    retry_timeout: float = 10.0,
+) -> int:
+    """Receive one duplicate allocation FD from its exporting worker."""
+    root = validate_broker_root(
+        broker_root,
+        require_configured=broker_root is None,
+    )
+    path = _validate_descriptor_path(broker_path, root)
+    deadline = time.monotonic() + max(0.0, retry_timeout)
+    while True:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            _validate_broker_socket(path)
+            sock.settimeout(max(0.2, min(10.0, retry_timeout or 0.2)))
+            sock.connect(str(path))
+            sock.sendall(
+                json.dumps(
+                    {"token": broker_token, "allocation_id": allocation_id}
+                ).encode()
+            )
+            payload, ancillary, _, _ = sock.recvmsg(
+                1, socket.CMSG_SPACE(array.array("i").itemsize)
+            )
+            if payload != b"F":
+                raise CuMemIPCUnsupportedError(
+                    "cuMem FD broker rejected the descriptor token or allocation"
+                )
+            for level, kind, data in ancillary:
+                if level == socket.SOL_SOCKET and kind == socket.SCM_RIGHTS:
+                    fds = array.array("i")
+                    fds.frombytes(data[: fds.itemsize])
+                    return int(fds[0])
+            raise CuMemIPCUnsupportedError("cuMem FD broker returned no handle")
+        except (FileNotFoundError, ConnectionRefusedError) as exc:
+            if time.monotonic() >= deadline:
+                raise CuMemIPCUnsupportedError(
+                    f"cannot reach cuMem FD broker {path} under configured root "
+                    f"{root}: {exc}. The exporter and LMCache server likely have "
+                    f"different mount namespaces; bind-mount one shared directory "
+                    f"at the same path and set {BROKER_DIR_ENV} on both containers"
+                ) from exc
+            time.sleep(0.05)
+        except OSError as exc:
+            raise CuMemIPCUnsupportedError(
+                f"cannot receive cuMem allocation handle from {path} under "
+                f"configured root {root}: {exc}"
+            ) from exc
+        finally:
+            sock.close()
+
+
+class CuMemAllocationImporter(Protocol):
+    def import_allocation(self, descriptor: CuMemAllocationDescriptor) -> Any: ...
+
+    def close_allocation(self, mapping: Any) -> None: ...
+
+
+class ImportedCuMemRegistry:
+    """Deduplicate imported aliases and own each mapping exactly once."""
+
+    def __init__(self, importer: CuMemAllocationImporter) -> None:
+        self._importer = importer
+        self._lock = threading.Lock()
+        self._entries: dict[str, tuple[CuMemAllocationDescriptor, Any, int]] = {}
+
+    def acquire(self, descriptor: CuMemAllocationDescriptor) -> Any:
+        if descriptor.protocol_version != 1 or descriptor.handle_type != "posix_fd":
+            raise ValueError("unsupported cuMem IPC descriptor")
+        with self._lock:
+            existing = self._entries.get(descriptor.allocation_id)
+            if existing is not None:
+                saved, mapping, refs = existing
+                if saved != descriptor:
+                    raise ValueError("incompatible duplicate cuMem descriptor")
+                self._entries[descriptor.allocation_id] = (saved, mapping, refs + 1)
+                return mapping
+            mapping = self._importer.import_allocation(descriptor)
+            self._entries[descriptor.allocation_id] = (descriptor, mapping, 1)
+            return mapping
+
+    def release(self, descriptor: CuMemAllocationDescriptor) -> None:
+        with self._lock:
+            existing = self._entries.get(descriptor.allocation_id)
+            if existing is None:
+                return
+            saved, saved_mapping, refs = existing
+            if saved != descriptor:
+                raise ValueError("incompatible cuMem descriptor release")
+            if refs > 1:
+                self._entries[descriptor.allocation_id] = (
+                    saved,
+                    saved_mapping,
+                    refs - 1,
+                )
+                return
+            # Keep the entry visible until close_allocation succeeds so a failed
+            # unmap/release cannot vanish from /status while still holding GPU memory.
+            self._importer.close_allocation(saved_mapping)
+            self._entries.pop(descriptor.allocation_id)
+
+    def refcount(self, descriptor: CuMemAllocationDescriptor) -> int:
+        with self._lock:
+            entry = self._entries.get(descriptor.allocation_id)
+            return 0 if entry is None else entry[2]
+
+    @property
+    def registration_count(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+    @property
+    def alias_refcount_total(self) -> int:
+        with self._lock:
+            return sum(refs for _, _, refs in self._entries.values())
+
+
+def _check_cuda(result: Any, operation: str) -> tuple[Any, ...]:
+    values = result if isinstance(result, tuple) else (result,)
+    if int(values[0]) != 0:
+        raise CuMemIPCUnsupportedError(f"{operation} failed: {values[0]}")
+    return tuple(values[1:])
+
+
+class ImportedCuMemMapping:
+    def __init__(self, ptr: int, size: int, handle: Any, device_index: int) -> None:
+        self.ptr = ptr
+        self.size = size
+        self.handle = handle
+        self.device_index = device_index
+        self._mapped = True
+        self._address_reserved = True
+        self._handle_open = True
+        self._closed = False
+
+    def as_torch_bytes(self):
+        import cupy
+        import torch
+
+        with cupy.cuda.Device(self.device_index):
+            memory = cupy.cuda.UnownedMemory(self.ptr, self.size, owner=self)
+            pointer = cupy.cuda.MemoryPointer(memory, 0)
+            raw = cupy.ndarray(self.size, dtype=cupy.uint8, memptr=pointer)
+        return torch.from_dlpack(raw)
+
+
+class CudaDriverAllocationImporter:
+    def _device_index(self, uuid: str) -> int:
+        import torch
+
+        matches = [
+            i
+            for i in range(torch.accelerator.device_count())
+            if str(torch.cuda.get_device_properties(i).uuid) == uuid
+        ]
+        if len(matches) != 1:
+            raise CuMemIPCUnsupportedError(
+                f"cuMem descriptor device UUID {uuid!r} is unavailable"
+            )
+        return matches[0]
+
+    def import_allocation(
+        self, descriptor: CuMemAllocationDescriptor
+    ) -> ImportedCuMemMapping:
+        import torch
+        from cuda.bindings import driver
+
+        device_index = self._device_index(descriptor.device_uuid)
+        fd = receive_fd(
+            descriptor.broker_path,
+            descriptor.broker_token,
+            descriptor.allocation_id,
+        )
+        ptr = None
+        handle = None
+        mapped = False
+        try:
+            with torch.accelerator.device_index(device_index):
+                torch.cuda.init()
+                (handle,) = _check_cuda(
+                    driver.cuMemImportFromShareableHandle(
+                        fd,
+                        driver.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR,
+                    ),
+                    "cuMemImportFromShareableHandle",
+                )
+                (ptr,) = _check_cuda(
+                    driver.cuMemAddressReserve(descriptor.allocation_size, 0, 0, 0),
+                    "cuMemAddressReserve",
+                )
+                _check_cuda(
+                    driver.cuMemMap(ptr, descriptor.allocation_size, 0, handle, 0),
+                    "cuMemMap",
+                )
+                mapped = True
+                access = driver.CUmemAccessDesc()
+                access.location.type = (
+                    driver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+                )
+                access.location.id = device_index
+                access.flags = (
+                    driver.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
+                )
+                _check_cuda(
+                    driver.cuMemSetAccess(ptr, descriptor.allocation_size, [access], 1),
+                    "cuMemSetAccess",
+                )
+            return ImportedCuMemMapping(
+                int(ptr), descriptor.allocation_size, handle, device_index
+            )
+        except BaseException:
+            if ptr is not None:
+                if mapped:
+                    driver.cuMemUnmap(ptr, descriptor.allocation_size)
+                driver.cuMemAddressFree(ptr, descriptor.allocation_size)
+            if handle is not None:
+                driver.cuMemRelease(handle)
+            raise
+        finally:
+            os.close(fd)
+
+    def close_allocation(self, mapping: ImportedCuMemMapping) -> None:
+        if mapping._closed:
+            return
+        import torch
+        from cuda.bindings import driver
+
+        with torch.accelerator.device_index(mapping.device_index):
+            torch.accelerator.synchronize(mapping.device_index)
+            if mapping._mapped:
+                _check_cuda(driver.cuMemUnmap(mapping.ptr, mapping.size), "cuMemUnmap")
+                mapping._mapped = False
+            if mapping._address_reserved:
+                _check_cuda(
+                    driver.cuMemAddressFree(mapping.ptr, mapping.size),
+                    "cuMemAddressFree",
+                )
+                mapping._address_reserved = False
+            if mapping._handle_open:
+                _check_cuda(driver.cuMemRelease(mapping.handle), "cuMemRelease")
+                mapping._handle_open = False
+        mapping._closed = True
+
+
+_broker_lock = threading.Lock()
+_broker: CuMemFDBroker | None = None
+_import_registry = ImportedCuMemRegistry(CudaDriverAllocationImporter())
+
+
+def get_fd_broker() -> CuMemFDBroker:
+    global _broker
+    with _broker_lock:
+        if _broker is None:
+            root = validate_broker_root(require_configured=True)
+            _broker = CuMemFDBroker(root)
+        return _broker
+
+
+def find_cumem_allocation(tensor: Any) -> tuple[int, int, Any] | None:
+    """Return exporter allocation metadata if tensor belongs to vLLM cuMem."""
+    try:
+        from vllm.device_allocator.cumem import CuMemAllocator
+    except (ImportError, AssertionError):
+        return None
+    allocator = CuMemAllocator.instance
+    if allocator is None:
+        return None
+    storage = tensor.untyped_storage()
+    storage_ptr = int(storage.data_ptr())
+    storage_end = storage_ptr + int(storage.nbytes())
+    matches = []
+    for base, data in allocator.pointer_to_data.items():
+        device, size, pointer, handle = data.handle
+        if (
+            not data.is_asleep
+            and int(base) == int(pointer)
+            and int(base) <= storage_ptr
+            and storage_end <= int(base) + int(size)
+        ):
+            matches.append((int(base), int(size), handle))
+    if len(matches) > 1:
+        raise CuMemIPCUnsupportedError("tensor matches multiple cuMem allocations")
+    return matches[0] if matches else None
+
+
+def export_cumem_allocation(
+    tensor: Any, allocation: tuple[int, int, Any]
+) -> tuple[CuMemAllocationDescriptor, CuMemFDLease, int]:
+    """Export one vLLM cuMem allocation and return descriptor/view offset."""
+    import torch
+    from cuda.bindings import driver
+
+    base, size, handle_holder = allocation
+    # vLLM keeps the generic allocation handle in heap storage so it can
+    # release/recreate the mapping later; its Python metadata exposes that
+    # storage address rather than the CUmemGenericAllocationHandle value.
+    handle = generic_handle_from_holder(handle_holder)
+    device_index = tensor.device.index
+    if device_index is None:
+        device_index = torch.accelerator.current_device_index()
+    with torch.accelerator.device_index(device_index):
+        (fd,) = _check_cuda(
+            driver.cuMemExportToShareableHandle(
+                handle,
+                driver.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR,
+                0,
+            ),
+            "cuMemExportToShareableHandle",
+        )
+    try:
+        device_uuid = str(torch.cuda.get_device_properties(device_index).uuid)
+        key = (device_uuid, base, size, int(handle))
+        lease = get_fd_broker().register(key, int(fd))
+    finally:
+        os.close(int(fd))
+    descriptor = CuMemAllocationDescriptor(
+        protocol_version=1,
+        allocation_id=lease.allocation_id,
+        device_uuid=device_uuid,
+        allocation_size=size,
+        broker_path=lease.broker_path,
+        broker_token=lease.broker_token,
+        handle_type="posix_fd",
+    )
+    return descriptor, lease, int(tensor.untyped_storage().data_ptr()) - base
+
+
+def acquire_imported_mapping(
+    descriptor: CuMemAllocationDescriptor,
+) -> ImportedCuMemMapping:
+    return _import_registry.acquire(descriptor)
+
+
+def release_imported_mapping(descriptor: CuMemAllocationDescriptor) -> None:
+    _import_registry.release(descriptor)
+
+
+def imported_registration_count() -> int:
+    return _import_registry.registration_count
+
+
+def imported_alias_refcount_total() -> int:
+    return _import_registry.alias_refcount_total
+
+
+def generic_handle_from_holder(handle_holder: Any) -> int:
+    """Dereference vLLM's heap-held CUmemGenericAllocationHandle."""
+    if not isinstance(handle_holder, int):
+        raise CuMemIPCUnsupportedError(
+            "chunked vLLM cuMem allocations are unsupported by protocol v1"
+        )
+    return int(ctypes.c_uint64.from_address(handle_holder).value)

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/v1/platform/cuda/ipc_wrapper.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/v1/platform/cuda/ipc_wrapper.py
@@ -1,0 +1,331 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CUDA IPC wrapper implementations.
+
+:class:`CudaIPCWrapper` handles tensors backed by PyTorch's caching
+allocator (vLLM default).  :class:`RawCudaIPCWrapper` handles tensors
+allocated outside PyTorch (e.g. TRT-LLM's ``cudaMalloc``'d pool).
+
+:class:`CudaIPCWrapper` is bound to ``device_type="cuda"`` via
+:attr:`~lmcache.v1.platform.cuda.CudaDeviceSpec.ipc_wrapper_cls`, so the
+multiprocess adapter dispatches to it via
+:func:`~lmcache.v1.platform.resolve_kv_wrapper_factory`.
+:class:`RawCudaIPCWrapper` is not exposed on the spec -- callers (the
+TRT-LLM adapter) instantiate it directly.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from builtins import ExceptionGroup
+from typing import ClassVar
+
+# Third Party
+import torch
+
+# First Party
+from lmcache import torch_device_type
+from lmcache.v1.platform.base.ipc_wrapper import DeviceIPCWrapper
+
+
+class CudaIPCWrapper(DeviceIPCWrapper):
+    #: ``torch.device.type`` this wrapper handles. Kept as a class-level
+    #: constant so external tooling / tests can introspect the binding.
+    device_type: ClassVar[str] = "cuda"
+
+    @classmethod
+    def wrap(cls, tensor: torch.Tensor) -> DeviceIPCWrapper:
+        """Factory used by
+        :func:`~lmcache.v1.platform.resolve_kv_wrapper_factory`.
+
+        Args:
+            tensor: A CUDA tensor backed by PyTorch's caching allocator.
+
+        Returns:
+            A new :class:`CudaIPCWrapper` wrapping ``tensor`` for the
+            multiprocess wire.
+        """
+        # vLLM's sleep-mode allocator uses CUDA VMM allocations. PyTorch does
+        # not own those allocations, so _share_cuda_ is invalid; export the
+        # underlying CUmemGenericAllocationHandle instead.
+        from lmcache.v1.platform.cuda.cumem_ipc import find_cumem_allocation
+
+        allocation = find_cumem_allocation(tensor)
+        if allocation is not None:
+            return CuMemCudaIPCWrapper(tensor, allocation)
+        return cls(tensor)
+
+    def __init__(self, tensor: torch.Tensor) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.kv_format.contiguity import (
+            attempt_permute_to_contiguous_view,
+        )
+
+        # Permute any non-contiguous view (e.g. vLLM's NHD-over-HND) so the
+        # shape/stride we encode across IPC reflects the physical layout.
+        # Offset is preserved by the wrapper's storage_offset field.
+        tensor = attempt_permute_to_contiguous_view(tensor)
+
+        storage = tensor.untyped_storage()
+        handle = storage._share_cuda_()
+
+        self.handle = handle
+        self.dtype = tensor.dtype
+        self.shape = tuple(tensor.shape)
+        self.stride = tuple(tensor.stride())
+        self.storage_offset = int(tensor.storage_offset())
+
+        device_index = tensor.device.index
+        self.device_uuid = self._get_device_uuid(device_index)
+
+    def to_tensor(self) -> torch.Tensor:
+        """
+        Note:
+            This function may break if the accelerator is not initialized.
+            We should call ``torch_dev.init()`` before using this function
+            (guarded by hasattr since not all backends expose init()).
+        """
+        device_index = self._get_device_index_from_uuid(self.device_uuid)
+
+        storage = torch.UntypedStorage._new_shared_cuda(  # noqa: SLF001
+            device_index, *self.handle[1:]
+        )
+
+        t = torch.empty(
+            (), device=f"{torch_device_type}:{device_index}", dtype=self.dtype
+        )
+        t.set_(storage, self.storage_offset, self.shape, self.stride)
+        return t
+
+
+class CuMemCudaIPCWrapper(DeviceIPCWrapper):
+    """Serializable view over a vLLM cuMem/VMM allocation.
+
+    The allocation's POSIX shareable handle is passed out-of-band with
+    SCM_RIGHTS. The wire descriptor carries only a capability token and view
+    metadata, so aliases map one physical allocation exactly once.
+    """
+
+    device_type: ClassVar[str] = "cuda"
+
+    def __init__(self, tensor: torch.Tensor, allocation) -> None:
+        from lmcache.v1.platform.cuda.cumem_ipc import (
+            export_cumem_allocation,
+            validate_tensor_view,
+        )
+
+        descriptor, lease, allocation_storage_offset = export_cumem_allocation(
+            tensor, allocation
+        )
+        try:
+            self.handle = descriptor
+            self.dtype = tensor.dtype
+            self.shape = tuple(tensor.shape)
+            self.stride = tuple(tensor.stride())
+            self.storage_offset = int(tensor.storage_offset())
+            self.device_uuid = descriptor.device_uuid
+            self.physical_storage_nbytes = int(tensor.untyped_storage().nbytes())
+            self.allocation_storage_offset_bytes = allocation_storage_offset
+            self._lease = lease
+            self._mapping = None
+            self._tensor = None
+            self._closed = False
+            validate_tensor_view(
+                allocation_size=descriptor.allocation_size,
+                storage_offset_bytes=allocation_storage_offset,
+                storage_nbytes=self.physical_storage_nbytes,
+                shape=self.shape,
+                stride=self.stride,
+                itemsize=tensor.element_size(),
+            )
+            self._validate_view_inside_storage(tensor.element_size())
+        except BaseException:
+            lease.close()
+            raise
+
+    def _validate_view_inside_storage(self, itemsize: int) -> None:
+        if self.storage_offset < 0:
+            raise ValueError("negative tensor storage offset")
+        if not self.shape or any(dim == 0 for dim in self.shape):
+            last = self.storage_offset
+        else:
+            last = self.storage_offset + sum(
+                (dim - 1) * step
+                for dim, step in zip(self.shape, self.stride, strict=True)
+            )
+        if (last + 1) * itemsize > self.physical_storage_nbytes:
+            raise ValueError("tensor view exceeds physical storage extent")
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # Exporter-only resources never cross the pickle/msgspec wire.
+        state["_lease"] = None
+        state["_mapping"] = None
+        state["_tensor"] = None
+        state["_closed"] = False
+        return state
+
+    def to_tensor(self) -> torch.Tensor:
+        if self._closed:
+            raise RuntimeError("cuMem IPC wrapper is closed")
+        if self._tensor is not None:
+            return self._tensor
+        from lmcache.v1.platform.cuda.cumem_ipc import (
+            acquire_imported_mapping,
+            validate_tensor_view,
+        )
+
+        itemsize = torch.empty((), dtype=self.dtype).element_size()
+        validate_tensor_view(
+            allocation_size=self.handle.allocation_size,
+            storage_offset_bytes=self.allocation_storage_offset_bytes,
+            storage_nbytes=self.physical_storage_nbytes,
+            shape=self.shape,
+            stride=self.stride,
+            itemsize=itemsize,
+        )
+        self._validate_view_inside_storage(itemsize)
+        mapping = acquire_imported_mapping(self.handle)
+        try:
+            raw = mapping.as_torch_bytes()
+            typed = raw.view(self.dtype)
+            absolute_offset = (
+                self.allocation_storage_offset_bytes + self.storage_offset * itemsize
+            )
+            tensor = torch.as_strided(
+                typed,
+                self.shape,
+                self.stride,
+                storage_offset=absolute_offset // itemsize,
+            )
+        except BaseException:
+            from lmcache.v1.platform.cuda.cumem_ipc import release_imported_mapping
+
+            release_imported_mapping(self.handle)
+            raise
+        self._mapping = mapping
+        self._tensor = tensor
+        return tensor
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._tensor = None
+        close_errors: list[BaseException] = []
+        if self._mapping is not None:
+            from lmcache.v1.platform.cuda.cumem_ipc import release_imported_mapping
+
+            try:
+                release_imported_mapping(self.handle)
+            except BaseException as exc:
+                close_errors.append(exc)
+            else:
+                self._mapping = None
+        if self._lease is not None:
+            try:
+                self._lease.close()
+            except BaseException as exc:
+                close_errors.append(exc)
+            else:
+                self._lease = None
+        self._closed = self._mapping is None and self._lease is None
+        if close_errors:
+            raise ExceptionGroup("CuMemCudaIPCWrapper.close failed", close_errors)
+
+
+class RawCudaIPCWrapper(DeviceIPCWrapper):
+    """IPC wrapper for CUDA tensors allocated outside PyTorch's caching
+    allocator.
+
+    PyTorch's ``UntypedStorage._share_cuda_()`` only works for tensors
+    backed by its own caching allocator. TRT-LLM publishes its KV pool
+    via ``at::for_blob`` over a ``cudaMalloc``'d buffer, which raises in
+    ``_share_cuda_()``. This subclass bypasses that path: it calls
+    ``cudaIpcGetMemHandle`` on the raw data pointer, then reconstructs
+    the tensor on the receiving side via ``cudaIpcOpenMemHandle`` plus
+    a CuPy ``UnownedMemory`` → DLPack → ``torch`` round-trip.
+
+    Sharing the ``DeviceIPCWrapper`` base (rather than introducing a
+    parallel class with its own msgspec ext code) is load-bearing —
+    msgspec does not support unions of custom ext-encoded types. With a
+    common base, ``KVCache = list[DeviceIPCWrapper]`` type-checks, the
+    single ext code 1 round-trips every wrapper, and pickle preserves
+    the concrete subclass identity through the wire so ``to_tensor``
+    dispatches correctly.
+    """
+
+    #: Same ``torch.device.type`` as ``CudaIPCWrapper``, but not exposed
+    #: on :attr:`~lmcache.v1.platform.cuda.CudaDeviceSpec.ipc_wrapper_cls`
+    #: -- callers (TRT-LLM adapter) instantiate it directly.
+    device_type: ClassVar[str] = "cuda"
+
+    def __init__(self, tensor: torch.Tensor) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import assert_contiguous
+
+        assert_contiguous(tensor)
+
+        try:
+            # Third Party
+            from cuda.bindings import runtime as cudart
+        except ImportError:
+            # Third Party
+            from cuda import cudart
+
+        data_ptr = tensor.data_ptr()
+        err, ipc_handle = cudart.cudaIpcGetMemHandle(data_ptr)
+        if err != cudart.cudaError_t.cudaSuccess:
+            raise RuntimeError(
+                f"cudaIpcGetMemHandle failed: {err} (ptr=0x{data_ptr:x})"
+            )
+
+        # Store only what's needed for reconstruction.
+        self._ipc_handle_reserved = bytes(ipc_handle.reserved)
+        self._nbytes = tensor.untyped_storage().nbytes()
+
+        # DeviceIPCWrapper interface fields. ``handle`` is unused —
+        # ``to_tensor`` is overridden to bypass it — but kept (None) so
+        # the base-class equality check has a value to compare.
+        self.handle = None
+        self.dtype = tensor.dtype
+        self.shape = tuple(tensor.shape)
+        self.stride = tuple(tensor.stride())
+        self.storage_offset = int(tensor.storage_offset())
+
+        device_index = tensor.device.index
+        self.device_uuid = self._get_device_uuid(device_index)
+
+    def to_tensor(self) -> torch.Tensor:
+        """Reconstruct the tensor in this process via raw CUDA IPC."""
+        # Third Party
+        import cupy
+
+        try:
+            # Third Party
+            from cuda.bindings import runtime as cudart
+        except ImportError:
+            # Third Party
+            from cuda import cudart
+
+        device_index = self._get_device_index_from_uuid(self.device_uuid)
+
+        handle = cudart.cudaIpcMemHandle_t()
+        handle.reserved = self._ipc_handle_reserved
+        err, ptr = cudart.cudaIpcOpenMemHandle(
+            handle, cudart.cudaIpcMemLazyEnablePeerAccess
+        )
+        if err != cudart.cudaError_t.cudaSuccess:
+            raise RuntimeError(f"cudaIpcOpenMemHandle failed: {err}")
+
+        # Wrap as a flat ``uint8`` CuPy array, DLPack to torch, then view
+        # as the original dtype/shape. ``uint8`` avoids dtype-conversion
+        # gaps (bfloat16, fp8 have no direct CuPy/NumPy equivalent without
+        # ml_dtypes).
+        with cupy.cuda.Device(device_index):
+            mem = cupy.cuda.UnownedMemory(ptr, self._nbytes, owner=self)
+            memptr = cupy.cuda.MemoryPointer(mem, 0)
+            cp_flat = cupy.ndarray(self._nbytes, dtype=cupy.uint8, memptr=memptr)
+
+        raw = torch.from_dlpack(cp_flat)
+        return raw.view(self.dtype).reshape(self.shape)

--- a/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/v1/platform/kv_wrap.py
+++ b/docker/glm53-flash/lmcache-d16-overlay/overlay/lmcache/v1/platform/kv_wrap.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Device-agnostic helpers that wrap worker KV caches for IPC transport.
+
+These helpers used to live under ``lmcache.integration.vllm`` for historical
+reasons, but they are engine-neutral: dispatch happens purely via
+:func:`resolve_kv_wrapper_factory` on ``tensor.device.type``. Keeping them
+here lets core transfer contexts (e.g. ``LMCacheDrivenTransferContext``) use
+them without importing the vLLM integration package.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Any
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.platform import resolve_kv_wrapper_factory
+
+logger = init_logger(__name__)
+
+
+def wrap_one_kv_cache(tensor: torch.Tensor) -> Any:
+    """Dispatch by ``tensor.device.type`` via the platform registry.
+
+    Concrete factories are supplied by the registered ``DeviceSpec`` objects,
+    so this call site stays free of if/elif chains and external accelerators
+    can provide their wrapper from an installed device-plugin wheel.
+    """
+    return resolve_kv_wrapper_factory(tensor.device.type)(tensor)
+
+
+def wrap_kv_caches(kv_caches: dict[str, torch.Tensor]) -> KVCache:
+    """Wrap every KV cache tensor for IPC transport.
+
+    Args:
+        kv_caches: Mapping from layer name to worker-owned KV cache tensor.
+
+    Returns:
+        The list of per-tensor IPC wrappers, ready for the msgspec wire.
+    """
+    # Emit a per-layer (name, shape, dtype) summary so the operator can
+    # verify the exact layer set & tensor geometry being shipped to the
+    # LMCache server, then the low-noise count of handles being wrapped.
+    kept_summary = [
+        (name, tuple(tensor.shape), str(tensor.dtype))
+        for name, tensor in kv_caches.items()
+    ]
+    logger.debug(
+        "KV cache transfer keeping %d layer(s) (name, shape, dtype):\n%s",
+        len(kept_summary),
+        "\n".join(
+            f"  [{i}] {name}  shape={shape}  dtype={dtype}"
+            for i, (name, shape, dtype) in enumerate(kept_summary)
+        ),
+    )
+    logger.info("Wrapping %d KV cache tensors for IPC", len(kv_caches))
+    # Per-iteration resource management: if wrapping the N-th tensor
+    # raises, ``shm_unlink`` whatever earlier iterations already
+    # registered with POSIX SHM so the named segments do not outlive
+    # the failed batch. CUDA wrappers do not own a named segment and
+    # are skipped via the duck-typed ``shm_name`` check.
+    wrappers: KVCache = []
+    try:
+        for tensor in kv_caches.values():
+            wrappers.append(wrap_one_kv_cache(tensor))
+    except BaseException:
+        _release_partial_kv_wrappers(wrappers)
+        raise
+    return wrappers
+
+
+def _release_partial_kv_wrappers(wrappers: list[Any]) -> None:
+    """Best-effort unlink of SHM segments owned by partially built wrappers.
+
+    Used by :func:`wrap_kv_caches` to roll back a half-finished batch
+    when a later iteration raises. Only POSIX-SHM-backed wrappers carry
+    a ``shm_name`` attribute, so other wrapper kinds (e.g. CUDA-IPC)
+    are silently skipped.
+    """
+    # First Party
+    from lmcache.v1.multiprocess.posix_shm import shm_unlink
+
+    for w in wrappers:
+        close = getattr(w, "close", None)
+        if close is not None:
+            try:
+                close()
+            except Exception:  # pragma: no cover - best effort
+                logger.debug("IPC wrapper close failed during rollback", exc_info=True)
+        name = getattr(w, "shm_name", None)
+        if name is None:
+            continue
+        try:
+            shm_unlink(name)
+        except Exception:  # pragma: no cover - best effort
+            logger.debug("shm_unlink failed during rollback", exc_info=True)

--- a/tests/v1/kv_connector/unit/test_lmcache_d16_transfer.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_d16_transfer.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import ast
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable, cast
+
+import pytest
+
+pytestmark = pytest.mark.cpu_test
+
+ROOT = Path(__file__).resolve().parents[4]
+TRANSFER = (
+    ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
+    "lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py"
+)
+CUMEM = (
+    ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
+    "lmcache/v1/platform/cuda/cumem_ipc.py"
+)
+IPC_WRAPPER = (
+    ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
+    "lmcache/v1/platform/cuda/ipc_wrapper.py"
+)
+
+
+def test_compressed_groups_select_production_safe_legacy_d2h() -> None:
+    tree = ast.parse(TRANSFER.read_text())
+    helper = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_object_group_requires_legacy_d2h"
+    )
+    namespace = {
+        "BaseCacheContext": object,
+        "logger": logging.getLogger(__name__),
+        "_production_lmcache_legacy_d2h_logged": False,
+    }
+    exec(
+        compile(
+            ast.fix_missing_locations(ast.Module(body=[helper], type_ignores=[])),
+            str(TRANSFER),
+            "exec",
+        ),
+        namespace,
+    )
+    requires_legacy = cast(
+        Callable[[Any, int], bool],
+        namespace["_object_group_requires_legacy_d2h"],
+    )
+
+    def context(tokens_per_block: int, slots_per_block: int):
+        return SimpleNamespace(
+            kv_layer_groups_manager=SimpleNamespace(
+                object_groups=[SimpleNamespace(kernel_group_indices=[0])],
+                kernel_groups=[
+                    SimpleNamespace(
+                        tokens_per_block=tokens_per_block,
+                        slots_per_block=slots_per_block,
+                    )
+                ],
+            )
+        )
+
+    assert requires_legacy(context(8, 4), 0)
+    assert not requires_legacy(context(4, 4), 0)
+    source = ast.unparse(
+        next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "transfer_kv_per_object_group"
+        )
+    )
+    assert "direction == lmcache_native.TransferDirection.D2H" in source
+    assert "_object_group_requires_legacy_d2h" in source
+
+
+def test_cumem_lifecycle_preserves_reusable_cuda_contexts() -> None:
+    source = CUMEM.read_text() + IPC_WRAPPER.read_text()
+    assert "cudaDeviceReset" not in source
+    assert "ImportedCuMemRegistry" in source
+    assert "release" in source
+    assert "close" in source

--- a/tests/v1/kv_connector/unit/test_lmcache_d16_transfer.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_d16_transfer.py
@@ -3,9 +3,10 @@
 
 import ast
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 import pytest
 
@@ -24,6 +25,83 @@ IPC_WRAPPER = (
     ROOT / "docker/glm53-flash/lmcache-d16-overlay/overlay/"
     "lmcache/v1/platform/cuda/ipc_wrapper.py"
 )
+
+
+def _load_transfer_function(name: str) -> Callable[..., Any]:
+    tree = ast.parse(TRANSFER.read_text())
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+    namespace = {
+        "BaseCacheContext": object,
+        "ObjectGroupInfo": object,
+        "Sequence": list,
+        "torch": SimpleNamespace(Tensor=object),
+    }
+    exec(
+        compile(
+            ast.fix_missing_locations(ast.Module(body=[function], type_ignores=[])),
+            str(TRANSFER),
+            "exec",
+        ),
+        namespace,
+    )
+    return cast(Callable[..., Any], namespace[name])
+
+
+def _sparse_transfer_context() -> SimpleNamespace:
+    manager = SimpleNamespace(
+        num_kernel_groups=2,
+        get_subchunk_sw_size_tokens=lambda group: 2304 if group == 0 else 9216,
+    )
+    return SimpleNamespace(
+        lmcache_tokens_per_chunk=9216,
+        kv_layer_groups_manager=manager,
+        calculate_num_blocks=lambda tokens, group: tokens
+        // (2304 if group == 0 else 9216),
+        stage_block_ids=lambda ids: ids,
+    )
+
+
+def test_sparse_transfer_uses_effective_sliding_window_block_counts() -> None:
+    effective_blocks = _load_transfer_function("effective_blocks_per_chunk")
+
+    assert effective_blocks(_sparse_transfer_context()) == [1, 1]
+
+
+def test_sparse_transfer_accepts_raw_and_exact_state_block_tables() -> None:
+    downsample = _load_transfer_function("downsample_and_stage_block_ids")
+    context = _sparse_transfer_context()
+    exact_ids = [[104, 108], [9, 10]]
+    raw_ids = [[1, 2, 3, 104, 5, 6, 7, 108], [9, 10]]
+
+    assert downsample(context, exact_ids, num_chunks=2) == exact_ids
+    assert downsample(context, raw_ids, num_chunks=2) == exact_ids
+
+    with pytest.raises(AssertionError, match="raw count 8 or reduced count 2"):
+        downsample(context, [[1, 2, 3], [9, 10]], num_chunks=2)
+
+
+def test_sparse_transfer_masks_mamba_after_block_normalization() -> None:
+    downsample = _load_transfer_function("downsample_and_stage_block_ids")
+    all_null_masks = _load_transfer_function("all_null_chunk_masks")
+    context = _sparse_transfer_context()
+    block_ids = [[0, 0, 0, 0, 0, 0, 0, 104], [9, 10]]
+
+    downsample(context, block_ids, num_chunks=2)
+    masks = all_null_masks(
+        block_ids,
+        [
+            SimpleNamespace(kernel_group_indices=[0]),
+            SimpleNamespace(kernel_group_indices=[1]),
+        ],
+        [1, 1],
+        num_chunks=2,
+    )
+
+    assert masks == [[True, False], [False, False]]
 
 
 def test_compressed_groups_select_production_safe_legacy_d2h() -> None:


### PR DESCRIPTION
## Summary

Adds the cuMem/CUDA-IPC lifecycle and sparse hybrid transfer normalization required by exact Mamba boundary-state caching.

### Behavior

- refcounted CUDA cuMem allocation import/export
- cross-process FD broker transport for all four ranks
- context-preserving unregister; no `cudaDeviceReset`
- rollback for partial imports and wrapper creation
- engine-driven store/retrieve cleanup
- production-safe legacy D2H routing for compressed logical geometry
- effective per-window block-count validation for store and retrieve
- accepts both raw full-chunk block tables and already-windowed exact-state tables
- normalizes before null-chunk masking so unavailable historical Mamba checkpoints are skipped, not copied
- native H2D and uncompressed native D2H remain available

Exact Mamba handoff and connector semantics are in #525. Separated object groups are enabled by #527.

## Why this update

The original D16 qualification was invalidated by delayed recurrent-state corruption. D22 demonstrated that transfer validation must use the same effective sliding-window geometry consumed by the kernels; requiring raw full-chunk Mamba counts rejects the correct one-checkpoint representation.

## Verification

- focused transfer normalization/lifecycle tests: reported in the latest branch commit
- `git diff --check`: clean
- D22 runtime: 60 L1 objects / 993,329,152 bytes after 131,041-token store; two concurrent requests reloaded 129,024 tokens each (258,048 total); coherent outputs and post-reload probe; no fatal runtime errors

Supersedes the transfer portion of closed umbrella PR #522.

## Duplicate-work note

This updates the existing focused transfer PR; it does not duplicate the scheduler-local prefix work in #403 or #482.

## AI assistance disclosure

AI assistance was used in preparing this contribution.

## Final D22 production receipt (2026-08-30)

The reviewed transfer stack is live with the rebuilt SM120 CUDA extension `ff81d0cc81720a0016d085c6cd88f704685162695814fe2e4454279bbc270db4`. Its pybind ABI exposes `block_stride_elems`, and the source includes the xword-alignment guard. Forced external reload transferred 119,808 tokens on each of four ranks with no transfer fault or corruption.
