### PR TITLE
feat(glm53): supervise vLLM and LMCache together

### DIFF
--- a/docker/glm53-flash/single-container/Dockerfile
+++ b/docker/glm53-flash/single-container/Dockerfile
@@ -8,6 +8,7 @@ COPY lmcache-d16-overlay/cumem_shareable_interposer.c /tmp/
 COPY single-container/vllm-startup-overlay/ /opt/glm53-vllm-startup-overlay/
 COPY single-container/serve_glm53_with_lmcache.py /usr/local/bin/
 COPY single-container/healthcheck_glm53_vllm.py /usr/local/bin/
+COPY single-container/glm53-logging.json /etc/vllm/glm53-logging.json
 
 RUN set -eux; \
     python_dir="$(/opt/venv/bin/python -c \

--- a/docker/glm53-flash/single-container/Dockerfile
+++ b/docker/glm53-flash/single-container/Dockerfile
@@ -1,0 +1,27 @@
+ARG BASE_IMAGE=glm53-jovian-lmcache:local
+FROM ${BASE_IMAGE}
+
+USER root
+
+COPY lmcache-d16-overlay/overlay/ /opt/glm53-lmcache-overlay/
+COPY lmcache-d16-overlay/cumem_shareable_interposer.c /tmp/
+COPY single-container/serve_glm53_with_lmcache.py /usr/local/bin/
+COPY single-container/healthcheck_glm53_vllm.py /usr/local/bin/
+
+RUN set -eux; \
+    python_dir="$(/opt/venv/bin/python -c \
+        'import sysconfig; print(sysconfig.get_paths()["purelib"])')"; \
+    cp -a /opt/glm53-lmcache-overlay/lmcache/. "${python_dir}/lmcache/"; \
+    cc -shared -fPIC -O2 -ldl /tmp/cumem_shareable_interposer.c \
+        -o /usr/local/lib/liblmcache-cumem-shareable.so; \
+    chmod 0755 /usr/local/bin/serve_glm53_with_lmcache.py \
+        /usr/local/bin/healthcheck_glm53_vllm.py; \
+    rm -rf /opt/glm53-lmcache-overlay /tmp/cumem_shareable_interposer.c
+
+ENV GLM53_LMCACHE_EXECUTABLE=/opt/venv/bin/lmcache \
+    GLM53_VLLM_EXECUTABLE=/opt/venv/bin/vllm \
+    LD_PRELOAD=/usr/local/lib/liblmcache-cumem-shareable.so
+
+ENTRYPOINT ["/usr/local/bin/serve_glm53_with_lmcache.py"]
+HEALTHCHECK --interval=30s --timeout=10s --start-period=3600s --retries=3 \
+    CMD ["/usr/local/bin/healthcheck_glm53_vllm.py"]

--- a/docker/glm53-flash/single-container/Dockerfile
+++ b/docker/glm53-flash/single-container/Dockerfile
@@ -5,6 +5,7 @@ USER root
 
 COPY lmcache-d16-overlay/overlay/ /opt/glm53-lmcache-overlay/
 COPY lmcache-d16-overlay/cumem_shareable_interposer.c /tmp/
+COPY single-container/vllm-startup-overlay/ /opt/glm53-vllm-startup-overlay/
 COPY single-container/serve_glm53_with_lmcache.py /usr/local/bin/
 COPY single-container/healthcheck_glm53_vllm.py /usr/local/bin/
 
@@ -12,11 +13,13 @@ RUN set -eux; \
     python_dir="$(/opt/venv/bin/python -c \
         'import sysconfig; print(sysconfig.get_paths()["purelib"])')"; \
     cp -a /opt/glm53-lmcache-overlay/lmcache/. "${python_dir}/lmcache/"; \
+    cp -a /opt/glm53-vllm-startup-overlay/vllm/. "${python_dir}/vllm/"; \
     cc -shared -fPIC -O2 -ldl /tmp/cumem_shareable_interposer.c \
         -o /usr/local/lib/liblmcache-cumem-shareable.so; \
     chmod 0755 /usr/local/bin/serve_glm53_with_lmcache.py \
         /usr/local/bin/healthcheck_glm53_vllm.py; \
-    rm -rf /opt/glm53-lmcache-overlay /tmp/cumem_shareable_interposer.c
+    rm -rf /opt/glm53-lmcache-overlay /opt/glm53-vllm-startup-overlay \
+        /tmp/cumem_shareable_interposer.c
 
 ENV GLM53_LMCACHE_EXECUTABLE=/opt/venv/bin/lmcache \
     GLM53_VLLM_EXECUTABLE=/opt/venv/bin/vllm \

--- a/docker/glm53-flash/single-container/README.md
+++ b/docker/glm53-flash/single-container/README.md
@@ -60,3 +60,8 @@ both children, starts LMCache first, gates vLLM on LMCache health, bounds vLLM
 readiness, forwards SIGTERM/SIGINT to both child process groups, and kills and
 reaps either sibling when the other exits. LMCache persistence and reload are
 not part of this recipe.
+
+LMCache is always launched with `--separate-object-groups`. Separation is
+mandatory for this hybrid recipe so full attention history and the one-chunk
+Mamba state use separate object semantics. The recipe depends on the
+exact-boundary and sparse-transfer updates in #525 and #526.

--- a/docker/glm53-flash/single-container/README.md
+++ b/docker/glm53-flash/single-container/README.md
@@ -72,9 +72,12 @@ such as Bifrost can report `usage.prompt_tokens_details.cached_tokens`. This
 changes cache accounting in API responses only; it does not change caching
 behavior.
 
-Both children default to `WARNING` through `VLLM_LOGGING_LEVEL` and
-`LMCACHE_LOG_LEVEL`. Explicit operator values such as `INFO` or `DEBUG` are
-preserved.
+LMCache defaults to `WARNING` through `LMCACHE_LOG_LEVEL`. vLLM defaults to a
+packaged logging config that keeps the general `vllm` namespace at `WARNING`
+while restoring the periodic request metrics and speculative-decoding metrics
+at `INFO`. An explicit `VLLM_LOGGING_CONFIG_PATH` or `VLLM_LOGGING_LEVEL`
+preserves the operator's vLLM logging choice without injecting the packaged
+config. Explicit `LMCACHE_LOG_LEVEL` values are also preserved.
 
 Immediately after vLLM readiness, the supervisor makes one bounded
 `GET /metrics` request to the readiness host and port. It reports the

--- a/docker/glm53-flash/single-container/README.md
+++ b/docker/glm53-flash/single-container/README.md
@@ -72,6 +72,18 @@ such as Bifrost can report `usage.prompt_tokens_details.cached_tokens`. This
 changes cache accounting in API responses only; it does not change caching
 behavior.
 
+Both children default to `WARNING` through `VLLM_LOGGING_LEVEL` and
+`LMCACHE_LOG_LEVEL`. Explicit operator values such as `INFO` or `DEBUG` are
+preserved.
+
+Immediately after vLLM readiness, the supervisor makes one bounded
+`GET /metrics` request to the readiness host and port. It reports the
+`vllm:cache_config_info` KV capacity as tokens, max-context concurrency, block
+size, and KV dtype. Concurrency falls back to capacity divided by an explicit
+`--max-model-len` when the metric omits it. Other labels are not logged.
+Unavailable, non-200, malformed, or oversized metrics produce one warning and
+do not interrupt serving.
+
 The image also installs startup-only vLLM fences around scheduler-realistic
 warmup stages and before FULL graph capture. They keep TP4/DCP4/MTP3 ranks
 aligned during capture without making steady-state serving synchronous.

--- a/docker/glm53-flash/single-container/README.md
+++ b/docker/glm53-flash/single-container/README.md
@@ -35,6 +35,7 @@ docker run --rm --restart=no --gpus all \
   --cp-kv-cache-interleave-size 4 \
   --mamba-cache-mode align \
   --enable-prefix-caching \
+  --enable-prompt-tokens-details \
   --enable-chunked-prefill \
   --dtype bfloat16 \
   --kv-cache-dtype fp8 \
@@ -65,6 +66,11 @@ LMCache is always launched with `--separate-object-groups`. Separation is
 mandatory for this hybrid recipe so full attention history and the one-chunk
 Mamba state use separate object semantics. The recipe depends on the
 exact-boundary and sparse-transfer updates in #525 and #526.
+
+The supervisor makes `--enable-prompt-tokens-details` mandatory so gateways
+such as Bifrost can report `usage.prompt_tokens_details.cached_tokens`. This
+changes cache accounting in API responses only; it does not change caching
+behavior.
 
 The image also installs startup-only vLLM fences around scheduler-realistic
 warmup stages and before FULL graph capture. They keep TP4/DCP4/MTP3 ranks

--- a/docker/glm53-flash/single-container/README.md
+++ b/docker/glm53-flash/single-container/README.md
@@ -65,3 +65,7 @@ LMCache is always launched with `--separate-object-groups`. Separation is
 mandatory for this hybrid recipe so full attention history and the one-chunk
 Mamba state use separate object semantics. The recipe depends on the
 exact-boundary and sparse-transfer updates in #525 and #526.
+
+The image also installs startup-only vLLM fences around scheduler-realistic
+warmup stages and before FULL graph capture. They keep TP4/DCP4/MTP3 ranks
+aligned during capture without making steady-state serving synchronous.

--- a/docker/glm53-flash/single-container/README.md
+++ b/docker/glm53-flash/single-container/README.md
@@ -1,0 +1,62 @@
+# GLM-5.3-Flash D16 single-container recipe
+
+Build vLLM from this branch with the repository CUDA image, ensuring
+FlashInfer 0.6.18 or newer is installed. Install LMCache 0.5.4, apply
+`../lmcache-d16-overlay`, rebuild its CUDA extension from the pinned source
+commit named there, and use that image as `BASE_IMAGE`:
+
+```bash
+docker build \
+  --build-arg BASE_IMAGE=glm53-jovian-lmcache:local \
+  -f docker/glm53-flash/single-container/Dockerfile \
+  -t glm53-d16:local docker/glm53-flash
+```
+
+The model must be the unchanged `zai-org/GLM-5.3-Flash` FP8 checkpoint.
+Its selective quantization configuration remains authoritative: MoE experts
+are FP8 while attention, KDA, and other excluded modules stay BF16.
+
+The qualified 4× RTX PRO 6000 Blackwell Max-Q launch is:
+
+```bash
+docker run --rm --restart=no --gpus all \
+  --shm-size=32g --ipc=host \
+  -v "$HOME/.cache/huggingface:/root/.cache/huggingface" \
+  -e CUTE_DSL_ARCH=sm_120a \
+  -e VLLM_ENABLE_PCIE_ALLREDUCE=1 \
+  -e VLLM_PCIE_ALLREDUCE_BACKEND=b12x \
+  -e GLM53_LMCACHE_L1_SIZE_GB=48 \
+  -e GLM53_LMCACHE_CHUNK_SIZE=9216 \
+  glm53-d16:local \
+  serve zai-org/GLM-5.3-Flash \
+  --served-model-name GLM-5.3-Flash \
+  --tensor-parallel-size 4 \
+  --decode-context-parallel-size 4 \
+  --cp-kv-cache-interleave-size 4 \
+  --mamba-cache-mode align \
+  --enable-prefix-caching \
+  --enable-chunked-prefill \
+  --dtype bfloat16 \
+  --kv-cache-dtype fp8 \
+  --quantization modelopt_mixed \
+  --attention-backend B12X \
+  --linear-backend b12x \
+  --moe-backend humming \
+  --load-format instanttensor \
+  --max-model-len 1048576 \
+  --max-num-seqs 4 \
+  --max-num-batched-tokens 32768 \
+  --kv-cache-memory-bytes 2952790016 \
+  --max-cudagraph-capture-size 32 \
+  --compilation-config '{"cudagraph_mode":"FULL"}' \
+  --speculative-config \
+  '{"method":"mtp","num_speculative_tokens":3,"moe_backend":"humming","attention_backend":"B12X"}' \
+  --kv-transfer-config \
+  '{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.mp.host":"127.0.0.1","lmcache.mp.port":5555}}'
+```
+
+The supervisor is PID 1. It creates a mode-0700 broker directory shared by
+both children, starts LMCache first, gates vLLM on LMCache health, bounds vLLM
+readiness, forwards SIGTERM/SIGINT to both child process groups, and kills and
+reaps either sibling when the other exits. LMCache persistence and reload are
+not part of this recipe.

--- a/docker/glm53-flash/single-container/glm53-logging.json
+++ b/docker/glm53-flash/single-container/glm53-logging.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "disable_existing_loggers": false,
+  "formatters": {
+    "vllm": {
+      "class": "vllm.logging_utils.NewLineFormatter",
+      "datefmt": "%m-%d %H:%M:%S",
+      "format": "%(levelname)s %(asctime)s [%(fileinfo)s:%(lineno)d] %(message)s"
+    }
+  },
+  "handlers": {
+    "vllm": {
+      "class": "logging.StreamHandler",
+      "formatter": "vllm",
+      "level": "INFO",
+      "stream": "ext://sys.stderr"
+    }
+  },
+  "loggers": {
+    "vllm": {
+      "handlers": [
+        "vllm"
+      ],
+      "level": "WARNING",
+      "propagate": false
+    },
+    "vllm.v1.metrics.loggers": {
+      "level": "INFO",
+      "propagate": true
+    },
+    "vllm.v1.spec_decode.metrics": {
+      "level": "INFO",
+      "propagate": true
+    }
+  }
+}

--- a/docker/glm53-flash/single-container/healthcheck_glm53_vllm.py
+++ b/docker/glm53-flash/single-container/healthcheck_glm53_vllm.py
@@ -1,0 +1,61 @@
+#!/opt/venv/bin/python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Container healthcheck for the supervised vLLM endpoint."""
+
+from __future__ import annotations
+
+import http.client
+import os
+import sys
+from urllib.parse import urlsplit
+
+DEFAULT_URL = "http://127.0.0.1:8000/health"
+
+
+def main() -> int:
+    raw_url = os.environ.get("GLM53_VLLM_HEALTH_URL", DEFAULT_URL)
+    parsed = urlsplit(raw_url)
+    if (
+        parsed.scheme != "http"
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        print(f"invalid GLM53_VLLM_HEALTH_URL: {raw_url!r}", file=sys.stderr)
+        return 2
+    timeout_raw = os.environ.get("GLM53_VLLM_HEALTH_TIMEOUT_SECONDS", "5")
+    try:
+        timeout = float(timeout_raw)
+        if timeout <= 0:
+            raise ValueError
+    except ValueError:
+        print(
+            "GLM53_VLLM_HEALTH_TIMEOUT_SECONDS must be positive",
+            file=sys.stderr,
+        )
+        return 2
+
+    connection = http.client.HTTPConnection(
+        parsed.hostname, parsed.port or 80, timeout=timeout
+    )
+    try:
+        connection.request("GET", parsed.path or "/health")
+        response = connection.getresponse()
+        response.read()
+        if response.status != 200:
+            print(f"vLLM health returned HTTP {response.status}", file=sys.stderr)
+            return 1
+        return 0
+    except (OSError, http.client.HTTPException) as exc:
+        print(f"vLLM health request failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        connection.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker/glm53-flash/single-container/serve_glm53_with_lmcache.py
+++ b/docker/glm53-flash/single-container/serve_glm53_with_lmcache.py
@@ -94,10 +94,7 @@ DEFAULTS = {
     "GLM53_VLLM_HEALTH_POLL_SECONDS": "2",
 }
 HEALTHCHECK_ONLY_ENV = frozenset({"GLM53_VLLM_HEALTH_TIMEOUT_SECONDS"})
-CHILD_LOG_LEVEL_DEFAULTS = {
-    "VLLM_LOGGING_LEVEL": "WARNING",
-    "LMCACHE_LOG_LEVEL": "WARNING",
-}
+VLLM_LOGGING_CONFIG = "/etc/vllm/glm53-logging.json"
 METRICS_PATH = "/metrics"
 METRICS_TIMEOUT_SECONDS = 5.0
 METRICS_BODY_LIMIT_BYTES = 1 << 20
@@ -378,8 +375,12 @@ def child_environment(config: Config, environ: Mapping[str, str]) -> dict[str, s
     child_env = dict(environ)
     child_env["LMCACHE_CUMEM_BROKER_DIR"] = str(config.broker_dir)
     child_env["LMCACHE_MP_TRANSFER_MODE"] = config.transfer_mode
-    for name, level in CHILD_LOG_LEVEL_DEFAULTS.items():
-        child_env.setdefault(name, level)
+    child_env.setdefault("LMCACHE_LOG_LEVEL", "WARNING")
+    if (
+        "VLLM_LOGGING_CONFIG_PATH" not in environ
+        and "VLLM_LOGGING_LEVEL" not in environ
+    ):
+        child_env["VLLM_LOGGING_CONFIG_PATH"] = VLLM_LOGGING_CONFIG
     return child_env
 
 

--- a/docker/glm53-flash/single-container/serve_glm53_with_lmcache.py
+++ b/docker/glm53-flash/single-container/serve_glm53_with_lmcache.py
@@ -464,12 +464,23 @@ def _validate_executables(config: Config) -> None:
             raise ValueError(f"{name} executable is missing or not executable: {path}")
 
 
+def _with_prompt_tokens_details(vllm_args: Sequence[str]) -> list[str]:
+    flag = "--enable-prompt-tokens-details"
+    args = [arg for arg in vllm_args if arg != flag]
+    if flag in vllm_args:
+        args.insert(list(vllm_args).index(flag), flag)
+    else:
+        args.append(flag)
+    return args
+
+
 def supervise(vllm_args: Sequence[str], environ: Mapping[str, str]) -> int:
     config = load_config(environ)
     if not vllm_args or vllm_args[0] != "serve":
         raise ValueError(
             "vLLM arguments must use the supported form: serve MODEL [OPTIONS]"
         )
+    vllm_args = _with_prompt_tokens_details(vllm_args)
     _validate_executables(config)
     ensure_broker_directory(config.broker_dir)
     env = child_environment(config, environ)

--- a/docker/glm53-flash/single-container/serve_glm53_with_lmcache.py
+++ b/docker/glm53-flash/single-container/serve_glm53_with_lmcache.py
@@ -94,6 +94,16 @@ DEFAULTS = {
     "GLM53_VLLM_HEALTH_POLL_SECONDS": "2",
 }
 HEALTHCHECK_ONLY_ENV = frozenset({"GLM53_VLLM_HEALTH_TIMEOUT_SECONDS"})
+CHILD_LOG_LEVEL_DEFAULTS = {
+    "VLLM_LOGGING_LEVEL": "WARNING",
+    "LMCACHE_LOG_LEVEL": "WARNING",
+}
+METRICS_PATH = "/metrics"
+METRICS_TIMEOUT_SECONDS = 5.0
+METRICS_BODY_LIMIT_BYTES = 1 << 20
+CACHE_CONFIG_METRIC = "vllm:cache_config_info"
+METRIC_LABEL = re.compile(r'([A-Za-z_][A-Za-z0-9_]*)="((?:[^"\\]|\\.)*)"')
+CACHE_DTYPE = re.compile(r"[A-Za-z0-9_.+-]{1,32}")
 
 
 def _value(environ: Mapping[str, str], name: str) -> str:
@@ -364,9 +374,12 @@ def lmcache_argv(config: Config) -> list[str]:
 
 
 def child_environment(config: Config, environ: Mapping[str, str]) -> dict[str, str]:
+    """Build the environment shared by both sibling children."""
     child_env = dict(environ)
     child_env["LMCACHE_CUMEM_BROKER_DIR"] = str(config.broker_dir)
     child_env["LMCACHE_MP_TRANSFER_MODE"] = config.transfer_mode
+    for name, level in CHILD_LOG_LEVEL_DEFAULTS.items():
+        child_env.setdefault(name, level)
     return child_env
 
 
@@ -453,6 +466,110 @@ def _vllm_healthy(config: Config, timeout: float) -> bool:
         return False
     finally:
         connection.close()
+
+
+def _fetch_metrics(config: Config, timeout: float) -> str | None:
+    connection = http.client.HTTPConnection(
+        config.vllm_health_host,
+        config.vllm_health_port,
+        timeout=timeout,
+    )
+    try:
+        connection.request("GET", METRICS_PATH)
+        response = connection.getresponse()
+        body = response.read(METRICS_BODY_LIMIT_BYTES + 1)
+        if response.status != 200 or len(body) > METRICS_BODY_LIMIT_BYTES:
+            return None
+        return body.decode()
+    except (OSError, UnicodeError, http.client.HTTPException):
+        return None
+    finally:
+        connection.close()
+
+
+def _cache_config_labels(payload: str) -> dict[str, str]:
+    for line in payload.splitlines():
+        sample = line.strip()
+        if not sample.startswith(f"{CACHE_CONFIG_METRIC}{{"):
+            continue
+        end = sample.rfind("}")
+        if end < 0:
+            continue
+        body = sample[len(CACHE_CONFIG_METRIC) + 1 : end]
+        labels = {match[1]: match[2] for match in METRIC_LABEL.finditer(body)}
+        if labels:
+            return labels
+    return {}
+
+
+def _metric_integer(raw: str | None) -> int | None:
+    if raw is None or INTEGER.fullmatch(raw) is None:
+        return None
+    value = int(raw)
+    return value if value > 0 else None
+
+
+def _metric_number(raw: str | None) -> float | None:
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except ValueError:
+        return None
+    if not math.isfinite(value) or value <= 0:
+        return None
+    return value
+
+
+def _max_model_len(vllm_args: Sequence[str]) -> int | None:
+    flag = "--max-model-len"
+    for index, argument in enumerate(vllm_args):
+        if argument == flag and index + 1 < len(vllm_args):
+            candidate = vllm_args[index + 1]
+        elif argument.startswith(f"{flag}="):
+            candidate = argument.split("=", 1)[1]
+        else:
+            continue
+        value = _metric_integer(candidate)
+        if value is not None:
+            return value
+    return None
+
+
+def kv_pool_summary(payload: str, max_model_len: int | None = None) -> str | None:
+    """Summarize KV pool capacity from a vLLM Prometheus metrics payload."""
+    labels = _cache_config_labels(payload)
+    tokens = _metric_integer(labels.get("kv_cache_size_tokens"))
+    block_size = _metric_integer(labels.get("block_size"))
+    dtype = labels.get("cache_dtype", "")
+    if tokens is None or block_size is None or CACHE_DTYPE.fullmatch(dtype) is None:
+        return None
+    concurrency = _metric_number(labels.get("kv_cache_max_concurrency"))
+    if concurrency is None and max_model_len is not None:
+        concurrency = tokens / max_model_len
+    if concurrency is None:
+        return None
+    return (
+        f"KV pool: {tokens:,} tokens | max-context concurrency: {concurrency:.2f}x "
+        f"| block: {block_size} | dtype: {dtype}"
+    )
+
+
+def report_kv_pool(config: Config, vllm_args: Sequence[str]) -> None:
+    """Emit one KV pool capacity line, or one warning line if unavailable."""
+    payload = _fetch_metrics(config, METRICS_TIMEOUT_SECONDS)
+    summary = (
+        None if payload is None else kv_pool_summary(payload, _max_model_len(vllm_args))
+    )
+    if summary is None:
+        print(
+            "[glm53-lifecycle] WARNING KV pool capacity unavailable from "
+            f"{METRICS_PATH}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+    print(f"[glm53-lifecycle] {summary}", file=sys.stderr, flush=True)
 
 
 def _validate_executables(config: Config) -> None:
@@ -593,6 +710,7 @@ def supervise(vllm_args: Sequence[str], environ: Mapping[str, str]) -> int:
                     file=sys.stderr,
                     flush=True,
                 )
+                report_kv_pool(config, vllm_args)
                 break
             time.sleep(min(config.vllm_health_poll_seconds, max(0.0, remaining)))
 

--- a/docker/glm53-flash/single-container/serve_glm53_with_lmcache.py
+++ b/docker/glm53-flash/single-container/serve_glm53_with_lmcache.py
@@ -359,6 +359,7 @@ def lmcache_argv(config: Config) -> list[str]:
         config.eviction_policy,
         "--supported-transfer-mode",
         config.transfer_mode,
+        "--separate-object-groups",
     ]
 
 

--- a/docker/glm53-flash/single-container/serve_glm53_with_lmcache.py
+++ b/docker/glm53-flash/single-container/serve_glm53_with_lmcache.py
@@ -1,0 +1,633 @@
+#!/opt/venv/bin/python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""PID 1 supervisor for one-container GLM-5.3 vLLM and LMCache serving."""
+
+from __future__ import annotations
+
+import contextlib
+import http.client
+import math
+import os
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import regex as re
+
+LMCACHE_EXECUTABLE = "/opt/venv/bin/lmcache"
+VLLM_EXECUTABLE = "/opt/venv/bin/vllm"
+PREFIX = "GLM53_LMCACHE_"
+VLLM_PREFIX = "GLM53_VLLM_"
+INTEGER = re.compile(r"[0-9]+")
+IMMUTABLE_PROVENANCE_ENV = frozenset(
+    {
+        "GLM53_LMCACHE_ALIGNMENT_ABI_BASE_IMAGE_ID",
+        "GLM53_LMCACHE_DCP_BASE_IMAGE_ID",
+        "GLM53_LMCACHE_REGISTRATION_BASE_IMAGE_ID",
+    }
+)
+IMMUTABLE_BUILD_ENV = frozenset({"GLM53_VLLM_COMMIT"})
+
+
+@dataclass(frozen=True)
+class Config:
+    host: str
+    port: int
+    http_host: str
+    http_port: int
+    l1_size_gb: float
+    l1_init_size_gb: int
+    max_gpu_workers: int
+    max_cpu_workers: int
+    chunk_size: int
+    l1_align_bytes: int
+    eviction_trigger: float
+    eviction_ratio: float
+    eviction_policy: str
+    transfer_mode: str
+    startup_timeout_seconds: float
+    health_poll_seconds: float
+    shutdown_grace_seconds: float
+    vllm_health_url: str
+    vllm_health_host: str
+    vllm_health_port: int
+    vllm_health_path: str
+    vllm_startup_timeout_seconds: float
+    vllm_health_poll_seconds: float
+    broker_dir: Path
+    lmcache_executable: str
+    vllm_executable: str
+
+
+DEFAULTS = {
+    "GLM53_LMCACHE_HOST": "127.0.0.1",
+    "GLM53_LMCACHE_PORT": "5555",
+    "GLM53_LMCACHE_HTTP_HOST": "127.0.0.1",
+    "GLM53_LMCACHE_HTTP_PORT": "8080",
+    "GLM53_LMCACHE_L1_SIZE_GB": "48",
+    "GLM53_LMCACHE_L1_INIT_SIZE_GB": "20",
+    "GLM53_LMCACHE_MAX_GPU_WORKERS": "4",
+    "GLM53_LMCACHE_MAX_CPU_WORKERS": "8",
+    "GLM53_LMCACHE_CHUNK_SIZE": "9216",
+    "GLM53_LMCACHE_L1_ALIGN_BYTES": "16384",
+    "GLM53_LMCACHE_EVICTION_TRIGGER": "0.85",
+    "GLM53_LMCACHE_EVICTION_RATIO": "0.10",
+    "GLM53_LMCACHE_EVICTION_POLICY": "LRU",
+    "GLM53_LMCACHE_TRANSFER_MODE": "lmcache_driven",
+    "GLM53_LMCACHE_STARTUP_TIMEOUT_SECONDS": "600",
+    "GLM53_LMCACHE_HEALTH_POLL_SECONDS": "0.5",
+    "GLM53_LMCACHE_SHUTDOWN_GRACE_SECONDS": "30",
+    "GLM53_LMCACHE_CUMEM_BROKER_DIR": "/run/lmcache-cumem",
+    "GLM53_LMCACHE_EXECUTABLE": LMCACHE_EXECUTABLE,
+    "GLM53_VLLM_EXECUTABLE": VLLM_EXECUTABLE,
+    "GLM53_VLLM_HEALTH_URL": "http://127.0.0.1:8000/health",
+    "GLM53_VLLM_STARTUP_TIMEOUT_SECONDS": "3600",
+    "GLM53_VLLM_HEALTH_POLL_SECONDS": "2",
+}
+HEALTHCHECK_ONLY_ENV = frozenset({"GLM53_VLLM_HEALTH_TIMEOUT_SECONDS"})
+
+
+def _value(environ: Mapping[str, str], name: str) -> str:
+    value = environ.get(name, DEFAULTS[name])
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{name} must not be empty")
+    return value
+
+
+def _integer(
+    environ: Mapping[str, str],
+    name: str,
+    *,
+    minimum: int = 1,
+    maximum: int | None = None,
+) -> int:
+    raw = _value(environ, name)
+    if INTEGER.fullmatch(raw) is None:
+        raise ValueError(f"{name} must be a base-10 integer, got {raw!r}")
+    value = int(raw)
+    if value < minimum or (maximum is not None and value > maximum):
+        expected = f"{minimum}..{maximum}" if maximum is not None else f">= {minimum}"
+        raise ValueError(f"{name} must be {expected}, got {value}")
+    return value
+
+
+def _number(
+    environ: Mapping[str, str],
+    name: str,
+    *,
+    minimum_exclusive: float,
+    maximum_inclusive: float | None = None,
+) -> float:
+    raw = _value(environ, name)
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be numeric, got {raw!r}") from exc
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite, got {raw!r}")
+    if value <= minimum_exclusive:
+        raise ValueError(f"{name} must be > {minimum_exclusive}, got {value}")
+    if maximum_inclusive is not None and value > maximum_inclusive:
+        raise ValueError(f"{name} must be <= {maximum_inclusive}, got {value}")
+    return value
+
+
+def _host(environ: Mapping[str, str], name: str) -> str:
+    value = _value(environ, name)
+    if any(character.isspace() or ord(character) < 32 for character in value):
+        raise ValueError(f"{name} must be a host without whitespace")
+    return value
+
+
+def _choice(environ: Mapping[str, str], name: str, choices: set[str]) -> str:
+    value = _value(environ, name)
+    if value not in choices:
+        raise ValueError(f"{name} must be one of {sorted(choices)}, got {value!r}")
+    return value
+
+
+def _executable(environ: Mapping[str, str], name: str) -> str:
+    value = _value(environ, name)
+    if not os.path.isabs(value):
+        raise ValueError(f"{name} must be an absolute path, got {value!r}")
+    return value
+
+
+def _http_url(environ: Mapping[str, str], name: str) -> tuple[str, str, int, str]:
+    raw = _value(environ, name)
+    if any(character.isspace() or ord(character) < 32 for character in raw):
+        raise ValueError(f"{name} must not contain whitespace or control characters")
+    try:
+        parsed = urlsplit(raw)
+        host = parsed.hostname
+        parsed_port = parsed.port
+        port = 80 if parsed_port is None else parsed_port
+    except (UnicodeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a valid HTTP URL, got {raw!r}") from exc
+    if (
+        parsed.scheme != "http"
+        or not host
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or not parsed.path
+        or not parsed.path.startswith("/")
+        or port < 1
+        or port > 65535
+    ):
+        raise ValueError(
+            f"{name} must be an HTTP URL with a valid host, port, and path, got {raw!r}"
+        )
+    return raw, host, port, parsed.path
+
+
+def load_config(environ: Mapping[str, str]) -> Config:
+    """Load and strictly validate the complete supervisor environment."""
+    unknown = sorted(
+        name
+        for name in environ
+        if name.startswith((PREFIX, VLLM_PREFIX))
+        and name not in DEFAULTS
+        and name not in HEALTHCHECK_ONLY_ENV
+        and name not in IMMUTABLE_BUILD_ENV
+        and name not in IMMUTABLE_PROVENANCE_ENV
+    )
+    if unknown:
+        if unknown[0].startswith(PREFIX):
+            raise ValueError(
+                f"unknown GLM53 LMCache environment variable: {unknown[0]}"
+            )
+        raise ValueError(f"unknown GLM53 runtime environment variable: {unknown[0]}")
+
+    l1_size = _number(environ, "GLM53_LMCACHE_L1_SIZE_GB", minimum_exclusive=0)
+    l1_init = _integer(environ, "GLM53_LMCACHE_L1_INIT_SIZE_GB")
+    if l1_init > l1_size:
+        raise ValueError(
+            "GLM53_LMCACHE_L1_INIT_SIZE_GB must not exceed "
+            f"GLM53_LMCACHE_L1_SIZE_GB ({l1_size:g}), got {l1_init}"
+        )
+    align = _integer(environ, "GLM53_LMCACHE_L1_ALIGN_BYTES")
+    if align & (align - 1):
+        raise ValueError(
+            f"GLM53_LMCACHE_L1_ALIGN_BYTES must be a power of two, got {align}"
+        )
+    vllm_health_url, vllm_health_host, vllm_health_port, vllm_health_path = _http_url(
+        environ, "GLM53_VLLM_HEALTH_URL"
+    )
+
+    return Config(
+        host=_host(environ, "GLM53_LMCACHE_HOST"),
+        port=_integer(environ, "GLM53_LMCACHE_PORT", maximum=65535),
+        http_host=_host(environ, "GLM53_LMCACHE_HTTP_HOST"),
+        http_port=_integer(environ, "GLM53_LMCACHE_HTTP_PORT", maximum=65535),
+        l1_size_gb=l1_size,
+        l1_init_size_gb=l1_init,
+        max_gpu_workers=_integer(environ, "GLM53_LMCACHE_MAX_GPU_WORKERS"),
+        max_cpu_workers=_integer(environ, "GLM53_LMCACHE_MAX_CPU_WORKERS"),
+        chunk_size=_integer(environ, "GLM53_LMCACHE_CHUNK_SIZE"),
+        l1_align_bytes=align,
+        eviction_trigger=_number(
+            environ,
+            "GLM53_LMCACHE_EVICTION_TRIGGER",
+            minimum_exclusive=0,
+            maximum_inclusive=1,
+        ),
+        eviction_ratio=_number(
+            environ,
+            "GLM53_LMCACHE_EVICTION_RATIO",
+            minimum_exclusive=0,
+            maximum_inclusive=1,
+        ),
+        eviction_policy=_choice(
+            environ,
+            "GLM53_LMCACHE_EVICTION_POLICY",
+            {"LRU", "IsolatedLRU", "noop"},
+        ),
+        transfer_mode=_choice(
+            environ,
+            "GLM53_LMCACHE_TRANSFER_MODE",
+            {"lmcache_driven", "engine_driven", "auto"},
+        ),
+        startup_timeout_seconds=_number(
+            environ,
+            "GLM53_LMCACHE_STARTUP_TIMEOUT_SECONDS",
+            minimum_exclusive=0,
+        ),
+        health_poll_seconds=_number(
+            environ,
+            "GLM53_LMCACHE_HEALTH_POLL_SECONDS",
+            minimum_exclusive=0,
+        ),
+        shutdown_grace_seconds=_number(
+            environ,
+            "GLM53_LMCACHE_SHUTDOWN_GRACE_SECONDS",
+            minimum_exclusive=0,
+        ),
+        vllm_health_url=vllm_health_url,
+        vllm_health_host=vllm_health_host,
+        vllm_health_port=vllm_health_port,
+        vllm_health_path=vllm_health_path,
+        vllm_startup_timeout_seconds=_number(
+            environ,
+            "GLM53_VLLM_STARTUP_TIMEOUT_SECONDS",
+            minimum_exclusive=0,
+        ),
+        vllm_health_poll_seconds=_number(
+            environ,
+            "GLM53_VLLM_HEALTH_POLL_SECONDS",
+            minimum_exclusive=0,
+        ),
+        broker_dir=Path(_value(environ, "GLM53_LMCACHE_CUMEM_BROKER_DIR")),
+        lmcache_executable=_executable(environ, "GLM53_LMCACHE_EXECUTABLE"),
+        vllm_executable=_executable(environ, "GLM53_VLLM_EXECUTABLE"),
+    )
+
+
+def ensure_broker_directory(path: Path) -> None:
+    """Create and verify a private, writable, non-symlink broker directory."""
+    if not path.is_absolute():
+        raise ValueError(f"cuMem broker directory must be absolute, got {path}")
+    try:
+        before = path.lstat()
+    except FileNotFoundError:
+        path.mkdir(parents=True, mode=0o700)
+        before = path.lstat()
+    if stat.S_ISLNK(before.st_mode):
+        raise ValueError(f"cuMem broker directory must not be a symlink: {path}")
+    if not stat.S_ISDIR(before.st_mode):
+        raise ValueError(f"cuMem broker path is not a directory: {path}")
+
+    descriptor = os.open(path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        os.fchmod(descriptor, 0o700)
+        current = os.fstat(descriptor)
+        if stat.S_IMODE(current.st_mode) != 0o700:
+            raise ValueError(f"could not set cuMem broker directory mode 0700: {path}")
+        with tempfile.NamedTemporaryFile(dir=path):
+            pass
+    except OSError as exc:
+        raise ValueError(
+            f"cuMem broker directory is not writable: {path}: {exc}"
+        ) from exc
+    finally:
+        os.close(descriptor)
+
+
+def _display_number(value: float) -> str:
+    return f"{value:g}"
+
+
+def lmcache_argv(config: Config) -> list[str]:
+    return [
+        config.lmcache_executable,
+        "server",
+        "--host",
+        config.host,
+        "--port",
+        str(config.port),
+        "--http-host",
+        config.http_host,
+        "--http-port",
+        str(config.http_port),
+        "--l1-size-gb",
+        _display_number(config.l1_size_gb),
+        "--l1-init-size-gb",
+        str(config.l1_init_size_gb),
+        "--l1-align-bytes",
+        str(config.l1_align_bytes),
+        "--max-gpu-workers",
+        str(config.max_gpu_workers),
+        "--max-cpu-workers",
+        str(config.max_cpu_workers),
+        "--chunk-size",
+        str(config.chunk_size),
+        "--eviction-trigger-watermark",
+        _display_number(config.eviction_trigger),
+        "--eviction-ratio",
+        _display_number(config.eviction_ratio),
+        "--eviction-policy",
+        config.eviction_policy,
+        "--supported-transfer-mode",
+        config.transfer_mode,
+    ]
+
+
+def child_environment(config: Config, environ: Mapping[str, str]) -> dict[str, str]:
+    child_env = dict(environ)
+    child_env["LMCACHE_CUMEM_BROKER_DIR"] = str(config.broker_dir)
+    child_env["LMCACHE_MP_TRANSFER_MODE"] = config.transfer_mode
+    return child_env
+
+
+def _normalized_status(returncode: int) -> int:
+    return 128 + abs(returncode) if returncode < 0 else returncode
+
+
+def _group_exists(process: subprocess.Popen[object]) -> bool:
+    try:
+        os.killpg(process.pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def _signal_group(process: subprocess.Popen[object], signum: int) -> None:
+    with contextlib.suppress(ProcessLookupError):
+        os.killpg(process.pid, signum)
+
+
+def _stop_processes(
+    processes: Sequence[subprocess.Popen[object]], grace_seconds: float
+) -> None:
+    for process in processes:
+        _signal_group(process, signal.SIGTERM)
+    deadline = time.monotonic() + grace_seconds
+    while time.monotonic() < deadline:
+        for process in processes:
+            process.poll()
+        if all(not _group_exists(process) for process in processes):
+            break
+        time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+    for process in processes:
+        if _group_exists(process):
+            _signal_group(process, signal.SIGKILL)
+    for process in processes:
+        try:
+            process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            print(
+                f"[glm53-lifecycle] child process group {process.pid} did not reap",
+                file=sys.stderr,
+                flush=True,
+            )
+
+
+def _health_host(host: str) -> str:
+    if host == "0.0.0.0":
+        return "127.0.0.1"
+    if host == "::":
+        return "::1"
+    return host
+
+
+def _healthy(config: Config, timeout: float) -> bool:
+    connection = http.client.HTTPConnection(
+        _health_host(config.http_host), config.http_port, timeout=timeout
+    )
+    try:
+        connection.request("GET", "/healthcheck")
+        response = connection.getresponse()
+        response.read()
+        return response.status == 200
+    except (OSError, http.client.HTTPException):
+        return False
+    finally:
+        connection.close()
+
+
+def _vllm_healthy(config: Config, timeout: float) -> bool:
+    connection = http.client.HTTPConnection(
+        config.vllm_health_host,
+        config.vllm_health_port,
+        timeout=timeout,
+    )
+    try:
+        connection.request("GET", config.vllm_health_path)
+        response = connection.getresponse()
+        response.read()
+        return response.status == 200
+    except (OSError, http.client.HTTPException):
+        return False
+    finally:
+        connection.close()
+
+
+def _validate_executables(config: Config) -> None:
+    for name, path in (
+        ("LMCache", config.lmcache_executable),
+        ("vLLM", config.vllm_executable),
+    ):
+        if not os.path.isfile(path) or not os.access(path, os.X_OK):
+            raise ValueError(f"{name} executable is missing or not executable: {path}")
+
+
+def supervise(vllm_args: Sequence[str], environ: Mapping[str, str]) -> int:
+    config = load_config(environ)
+    if not vllm_args or vllm_args[0] != "serve":
+        raise ValueError(
+            "vLLM arguments must use the supported form: serve MODEL [OPTIONS]"
+        )
+    _validate_executables(config)
+    ensure_broker_directory(config.broker_dir)
+    env = child_environment(config, environ)
+    children: list[subprocess.Popen[object]] = []
+    received_signal: int | None = None
+
+    def forward(signum: int, _frame: object) -> None:
+        nonlocal received_signal
+        if received_signal is None:
+            received_signal = signum
+            print(
+                f"[glm53-lifecycle] received signal {signum}; stopping children",
+                file=sys.stderr,
+                flush=True,
+            )
+        for child in children:
+            _signal_group(child, signum)
+
+    previous = {
+        signum: signal.signal(signum, forward)
+        for signum in (signal.SIGTERM, signal.SIGINT)
+    }
+    try:
+        print("[glm53-lifecycle] starting LMCache", file=sys.stderr, flush=True)
+        lmcache = subprocess.Popen(
+            lmcache_argv(config),
+            env=env,
+            start_new_session=True,
+        )
+        children.append(lmcache)
+
+        deadline = time.monotonic() + config.startup_timeout_seconds
+        while True:
+            if received_signal is not None:
+                _stop_processes(children, config.shutdown_grace_seconds)
+                return 128 + received_signal
+            lmcache_status = lmcache.poll()
+            if lmcache_status is not None:
+                print(
+                    "[glm53-lifecycle] LMCache exited before healthcheck "
+                    f"(status={_normalized_status(lmcache_status)})",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                return _normalized_status(lmcache_status) or 1
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                print(
+                    "[glm53-lifecycle] LMCache healthcheck timed out after "
+                    f"{config.startup_timeout_seconds:g}s",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                _stop_processes(children, config.shutdown_grace_seconds)
+                return 1
+            if _healthy(config, min(1.0, remaining)):
+                break
+            time.sleep(min(config.health_poll_seconds, max(0.0, remaining)))
+
+        print(
+            "[glm53-lifecycle] LMCache healthy; starting vLLM",
+            file=sys.stderr,
+            flush=True,
+        )
+        vllm = subprocess.Popen(
+            [config.vllm_executable, *vllm_args],
+            env=env,
+            start_new_session=True,
+        )
+        children.append(vllm)
+
+        deadline = time.monotonic() + config.vllm_startup_timeout_seconds
+        while True:
+            if received_signal is not None:
+                _stop_processes(children, config.shutdown_grace_seconds)
+                return 128 + received_signal
+            vllm_status = vllm.poll()
+            if vllm_status is not None:
+                print(
+                    "[glm53-lifecycle] vLLM exited before readiness "
+                    f"(status={_normalized_status(vllm_status)}); stopping LMCache",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                _stop_processes([lmcache], config.shutdown_grace_seconds)
+                return _normalized_status(vllm_status)
+            lmcache_status = lmcache.poll()
+            if lmcache_status is not None:
+                print(
+                    "[glm53-lifecycle] LMCache exited during vLLM startup "
+                    f"(status={_normalized_status(lmcache_status)}); stopping vLLM",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                _stop_processes([vllm], config.shutdown_grace_seconds)
+                return _normalized_status(lmcache_status) or 1
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                print(
+                    "[glm53-lifecycle] vLLM readiness timed out after "
+                    f"{config.vllm_startup_timeout_seconds:g}s",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                _stop_processes(children, config.shutdown_grace_seconds)
+                return 1
+            if _vllm_healthy(config, min(1.0, remaining)):
+                print(
+                    "[glm53-lifecycle] vLLM healthy; entering steady-state supervision",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                break
+            time.sleep(min(config.vllm_health_poll_seconds, max(0.0, remaining)))
+
+        while True:
+            if received_signal is not None:
+                _stop_processes(children, config.shutdown_grace_seconds)
+                return 128 + received_signal
+            vllm_status = vllm.poll()
+            if vllm_status is not None:
+                print(
+                    f"[glm53-lifecycle] vLLM exited (status="
+                    f"{_normalized_status(vllm_status)}); stopping LMCache",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                _stop_processes([lmcache], config.shutdown_grace_seconds)
+                return _normalized_status(vllm_status)
+            lmcache_status = lmcache.poll()
+            if lmcache_status is not None:
+                print(
+                    "[glm53-lifecycle] LMCache exited while vLLM was running "
+                    f"(status={_normalized_status(lmcache_status)}); stopping vLLM",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                _stop_processes([vllm], config.shutdown_grace_seconds)
+                return _normalized_status(lmcache_status) or 1
+            time.sleep(min(config.health_poll_seconds, 0.1))
+    finally:
+        _stop_processes(children, config.shutdown_grace_seconds)
+        for signum, handler in previous.items():
+            signal.signal(signum, handler)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        return supervise(
+            list(sys.argv[1:] if argv is None else argv),
+            os.environ,
+        )
+    except ValueError as exc:
+        print(f"[glm53-lifecycle] configuration error: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"[glm53-lifecycle] startup error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker/glm53-flash/single-container/vllm-startup-overlay/vllm/v1/worker/gpu/warmup.py
+++ b/docker/glm53-flash/single-container/vllm-startup-overlay/vllm/v1/worker/gpu/warmup.py
@@ -1,0 +1,431 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Callable
+from contextlib import AbstractContextManager, nullcontext
+from typing import Any
+
+import numpy as np
+import torch
+
+from vllm import PoolingParams, SamplingParams
+from vllm.distributed.parallel_state import get_tp_group
+from vllm.logger import init_logger
+from vllm.multimodal.inputs import MultiModalFeatureSpec, PlaceholderRange
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core.sched.output import (
+    CachedRequestData,
+    GrammarOutput,
+    NewRequestData,
+    SchedulerOutput,
+)
+from vllm.v1.kv_cache_interface import CrossAttentionSpec, KVCacheSpec, MambaSpec
+from vllm.v1.request import Request
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+
+logger = init_logger(__name__)
+
+
+def _reserved_block_count(
+    num_tokens: int,
+    kvcache_spec: KVCacheSpec,
+    *,
+    num_lookahead_tokens: int,
+    max_model_len: int,
+    max_encoder_len: int,
+) -> int:
+    """Number of blocks the scheduler would hold for a request of `num_tokens`.
+
+    Warmup hand-builds its `SchedulerOutput`s, so it must reserve what
+    `KVCacheManager.allocate_slots` reserves: the token range plus
+    `num_lookahead_tokens`, where the speculator writes the KV of its drafts.
+    """
+    if isinstance(kvcache_spec, CrossAttentionSpec):
+        # Cross-attention blocks cover the encoder sequence only.
+        return cdiv(max_encoder_len, kvcache_spec.block_size)
+    num_speculative_blocks = 0
+    if isinstance(kvcache_spec, MambaSpec):
+        # MambaManager appends speculative running-state blocks in every cache
+        # mode; align mode sizes from the uncapped, lookahead-free token range.
+        num_speculative_blocks = kvcache_spec.num_speculative_blocks
+        if kvcache_spec.mamba_cache_mode == "align":
+            return cdiv(num_tokens, kvcache_spec.block_size) + num_speculative_blocks
+    num_tokens = min(num_tokens + num_lookahead_tokens, max_model_len)
+    return cdiv(num_tokens, kvcache_spec.block_size) + num_speculative_blocks
+
+
+def _warmup_block_counter(
+    model_runner: GPUModelRunner,
+) -> Callable[[int, KVCacheSpec], int]:
+    """Bind `_reserved_block_count` to `model_runner`'s reservation policy."""
+    num_lookahead_tokens = model_runner.vllm_config.num_lookahead_tokens
+    max_model_len = model_runner.max_model_len
+    max_encoder_len = getattr(model_runner.model_state, "max_encoder_len", 0)
+
+    def block_count(num_tokens: int, kvcache_spec: KVCacheSpec) -> int:
+        return _reserved_block_count(
+            num_tokens,
+            kvcache_spec,
+            num_lookahead_tokens=num_lookahead_tokens,
+            max_model_len=max_model_len,
+            max_encoder_len=max_encoder_len,
+        )
+
+    return block_count
+
+
+def run_mixed_prefill_decode_warmup(
+    model_runner: GPUModelRunner,
+    worker_execute_model: Callable[[SchedulerOutput], Any],
+    worker_sample_tokens: Callable[[GrammarOutput | None], Any],
+    num_tokens: int,
+    *,
+    mixed_step_context: AbstractContextManager[object] | None = None,
+    req_id_prefix: str = "_v2_mixed_warmup",
+) -> bool:
+    """Run a V2 mixed prefill+decode step through normal scheduler inputs."""
+    if model_runner.is_pooling_model or model_runner.max_num_reqs < 2 or num_tokens < 3:
+        return False
+
+    decode_req_id = f"{req_id_prefix}_decode_"
+    prefill_req_id = f"{req_id_prefix}_prefill_"
+    decode_prompt_len = 2
+    decode_scheduled_tokens = 1
+    prefill_len = num_tokens - decode_scheduled_tokens
+    decode_token_ids = list(range(decode_prompt_len))
+    prefill_token_ids = list(range(prefill_len))
+
+    kv_cache_groups = model_runner.kv_cache_config.kv_cache_groups
+    num_kv_cache_groups = len(kv_cache_groups)
+    block_count = _warmup_block_counter(model_runner)
+    kv_cache_specs = [g.kv_cache_spec for g in kv_cache_groups]
+    decode_prefill_block_counts = [
+        block_count(decode_prompt_len, s) for s in kv_cache_specs
+    ]
+    decode_block_counts = [
+        block_count(decode_prompt_len + decode_scheduled_tokens, s)
+        for s in kv_cache_specs
+    ]
+    decode_block_deltas = [
+        decode - prefill
+        for decode, prefill in zip(decode_block_counts, decode_prefill_block_counts)
+    ]
+    prefill_block_counts = [block_count(prefill_len, s) for s in kv_cache_specs]
+    required_blocks = sum(decode_block_counts) + sum(prefill_block_counts)
+    if model_runner.kv_cache_config.num_blocks <= required_blocks:
+        logger.warning(
+            "Skipping V2 mixed prefill+decode warmup because only %d KV blocks "
+            "are available for %d required warmup blocks.",
+            model_runner.kv_cache_config.num_blocks,
+            required_blocks,
+        )
+        return False
+
+    next_block_id = 1
+
+    def _alloc_blocks(num_blocks: int) -> list[int]:
+        nonlocal next_block_id
+        block_ids = list(range(next_block_id, next_block_id + num_blocks))
+        next_block_id += num_blocks
+        return block_ids
+
+    sampling_params = SamplingParams(max_tokens=2, temperature=0.0)
+
+    decode_prefill_output = SchedulerOutput.make_empty()
+    decode_prefill_output.scheduled_new_reqs = [
+        NewRequestData(
+            req_id=decode_req_id,
+            prompt_token_ids=decode_token_ids,
+            mm_features=[],
+            sampling_params=sampling_params,
+            pooling_params=None,
+            block_ids=tuple(_alloc_blocks(n) for n in decode_prefill_block_counts),
+            num_computed_tokens=0,
+            lora_request=None,
+            prefill_token_ids=decode_token_ids,
+        ),
+    ]
+    decode_prefill_output.num_scheduled_tokens = {
+        decode_req_id: decode_prompt_len,
+    }
+    decode_prefill_output.total_num_scheduled_tokens = decode_prompt_len
+    decode_prefill_output.num_common_prefix_blocks = [0] * num_kv_cache_groups
+
+    decode_new_blocks = tuple(_alloc_blocks(n) for n in decode_block_deltas)
+    cached_decode_req = CachedRequestData.make_empty()
+    cached_decode_req.req_ids = [decode_req_id]
+    cached_decode_req.num_computed_tokens = [decode_prompt_len]
+    cached_decode_req.num_output_tokens = [1]
+    cached_decode_req.new_block_ids = [
+        decode_new_blocks if any(decode_block_deltas) else None
+    ]
+
+    mixed_output = SchedulerOutput.make_empty()
+    mixed_output.scheduled_cached_reqs = cached_decode_req
+    mixed_output.scheduled_new_reqs = [
+        NewRequestData(
+            req_id=prefill_req_id,
+            prompt_token_ids=prefill_token_ids,
+            mm_features=[],
+            sampling_params=sampling_params,
+            pooling_params=None,
+            block_ids=tuple(_alloc_blocks(n) for n in prefill_block_counts),
+            num_computed_tokens=0,
+            lora_request=None,
+            prefill_token_ids=prefill_token_ids,
+        ),
+    ]
+    mixed_output.num_scheduled_tokens = {
+        decode_req_id: decode_scheduled_tokens,
+        prefill_req_id: prefill_len,
+    }
+    mixed_output.total_num_scheduled_tokens = num_tokens
+    mixed_output.num_common_prefix_blocks = [0] * num_kv_cache_groups
+
+    cleanup_output = SchedulerOutput.make_empty()
+    cleanup_output.finished_req_ids = {decode_req_id, prefill_req_id}
+
+    context = mixed_step_context or nullcontext()
+    model_runner.kv_connector.set_disabled(True)
+    try:
+        worker_execute_model(decode_prefill_output)
+        worker_sample_tokens(None)
+        with context:
+            worker_execute_model(mixed_output)
+            worker_sample_tokens(None)
+        worker_execute_model(cleanup_output)
+    finally:
+        model_runner.kv_connector.set_disabled(False)
+    return True
+
+
+@torch.inference_mode()
+def warmup_kernels(
+    model_runner: GPUModelRunner,
+    worker_execute_model: Callable[[SchedulerOutput], Any],
+    worker_sample_tokens: Callable[[GrammarOutput | None], Any],
+) -> None:
+    """Run scheduler-realistic prefill and decode steps to JIT compile kernels.
+
+    We must call the provided worker's execute_model for pipeline parallel
+    coordination.
+    """
+    if model_runner.vllm_config.is_mm_encoder_only:
+        return
+
+    num_spec_steps = model_runner.num_speculative_steps
+    decode_query_len = model_runner.decode_query_len
+    # Use decode_query_len + 1 tokens so the prefill batch's per-request query
+    # length exceeds decode_query_len, preventing it from being misclassified as
+    # a uniform decode batch.
+    prompt_len = decode_query_len + 1
+    prompt_token_ids = list(range(prompt_len))
+    # Upper bound on the decode steps built in `decode_steps` below.
+    num_decode_steps = 1
+    if not model_runner.is_pooling_model:
+        num_decode_steps = 5 if num_spec_steps > 0 else 3
+    # Size the block allocation for the worst case: every request advancing
+    # decode_query_len tokens on every decode step.
+    decode_len = prompt_len + num_decode_steps * decode_query_len
+
+    kv_cache_groups = model_runner.kv_cache_config.kv_cache_groups
+    num_kv_cache_groups = len(kv_cache_groups)
+
+    # Encoder-decoder models: give each warmup request a dummy encoder input so
+    # cross-attention warms up over a realistic, non-empty key sequence.
+    # The dummy mm_feature is registered in the encoder cache and only its encoder
+    # length is read (not the inputs themselves); the encoder itself is not scheduled.
+    max_encoder_len = getattr(model_runner.model_state, "max_encoder_len", 0)
+    warmup_mm_features: list[MultiModalFeatureSpec] = []
+    if model_runner.is_encoder_decoder and max_encoder_len:
+        warmup_mm_features = [
+            MultiModalFeatureSpec(
+                data=None,
+                modality="",
+                identifier="_warmup_encoder",
+                mm_position=PlaceholderRange(offset=0, length=max_encoder_len),
+            )
+        ]
+
+    # Compute per-request block counts for each KV cache group.
+    block_count = _warmup_block_counter(model_runner)
+    kv_cache_specs = [g.kv_cache_spec for g in kv_cache_groups]
+    prefill_block_counts = [block_count(prompt_len, s) for s in kv_cache_specs]
+    decode_block_counts = [block_count(decode_len, s) for s in kv_cache_specs]
+    max_blocks_per_req = sum(decode_block_counts)
+
+    num_reqs = min(
+        model_runner.scheduler_config.max_num_seqs,
+        model_runner.scheduler_config.max_num_batched_tokens
+        // max(prompt_len, decode_query_len),
+    )
+    if max_blocks_per_req > 0:
+        # Reserve block 0 (null block) and ensure we have enough blocks.
+        # Encoder-only models allocate no KV blocks, so this cap doesn't apply.
+        num_reqs = min(
+            num_reqs,
+            max(1, (model_runner.kv_cache_config.num_blocks - 1) // max_blocks_per_req),
+        )
+
+    req_ids = [f"_warmup_{i}_" for i in range(num_reqs)]
+
+    # SamplingParams exercising all sampling features.
+    if model_runner.is_pooling_model:
+        sampling_params = None
+        pooling_task = model_runner.model_config.get_pooling_task(
+            model_runner.get_supported_tasks()
+        )
+        pooling_params = PoolingParams(task=pooling_task)
+        pooling_params.verify(model_runner.model_config)
+    else:
+        sampling_params = SamplingParams.for_sampler_warmup()
+        pooling_params = None
+
+    # Assign distinct block IDs per request per group. 0 null block, start from 1.
+    next_block_id = 1
+
+    def _alloc_blocks(num_blocks: int) -> list[int]:
+        nonlocal next_block_id
+        return list(range(next_block_id, next_block_id := next_block_id + num_blocks))
+
+    # The KV-block zeroing kernel is driven by the scheduler's
+    # new_block_ids_to_zero, so none of the steps below reach it.
+    if model_runner.kv_block_zeroer is not None:
+        model_runner.kv_block_zeroer.warmup(model_runner.kv_cache_config.num_blocks)
+
+    # Step 1: Prefill all requests with 1 + decode_query_len prompt tokens each.
+    new_reqs = [
+        NewRequestData.from_request(
+            Request(
+                req_ids[i],
+                prompt_token_ids,
+                sampling_params,
+                pooling_params,
+                mm_features=warmup_mm_features,
+            ),
+            block_ids=tuple(_alloc_blocks(n) for n in prefill_block_counts),
+            prefill_token_ids=prompt_token_ids,
+        )
+        for i in range(num_reqs)
+    ]
+
+    prefill_output = SchedulerOutput.make_empty()
+    prefill_output.scheduled_new_reqs = new_reqs
+    prefill_output.num_scheduled_tokens = {rid: prompt_len for rid in req_ids}
+    prefill_output.total_num_scheduled_tokens = prompt_len * num_reqs
+    prefill_output.num_common_prefix_blocks = [0] * num_kv_cache_groups
+
+    def _fence() -> None:
+        torch.accelerator.synchronize()
+        get_tp_group().barrier()
+
+    # Disable KV connector for warmup run.
+    model_runner.kv_connector.set_disabled(True)
+    _fence()
+    worker_execute_model(prefill_output)
+    _fence()
+
+    if not model_runner.is_pooling_model:
+        # Warm up sampler and perform a decode step for non-pooling models.
+
+        grammar_output = None
+        if model_runner.is_last_pp_rank:
+            # Build a GrammarOutput to exercise the structured output bitmask
+            # kernel during the prefill step.
+            vocab_size = model_runner.model_config.get_vocab_size()
+            bitmask_width = (vocab_size + 31) // 32
+            grammar_bitmask = np.full(
+                (len(req_ids), bitmask_width), fill_value=-1, dtype=np.int32
+            )
+            grammar_output = GrammarOutput(
+                structured_output_request_ids=req_ids, grammar_bitmask=grammar_bitmask
+            )
+
+        worker_sample_tokens(grammar_output)
+        _fence()
+
+        # Per-request state carried across the decode steps.
+        req_computed = [prompt_len] * num_reqs
+        req_blocks = [list(prefill_block_counts) for _ in range(num_reqs)]
+
+        def _run_decode_step(indices: list[int], spec_flags: list[bool]) -> None:
+            """Decode `indices`, spec-decoding the ones flagged in `spec_flags`."""
+            cached_req_data = CachedRequestData.make_empty()
+            cached_req_data.req_ids = [req_ids[i] for i in indices]
+            cached_req_data.num_computed_tokens = [req_computed[i] for i in indices]
+            cached_req_data.num_output_tokens = [1] * len(indices)
+            cached_req_data.new_block_ids = []
+
+            step_num_scheduled_tokens: dict[str, int] = {}
+            step_spec_tokens: dict[str, list[int]] = {}
+            for i, use_spec in zip(indices, spec_flags):
+                num_tokens = decode_query_len if use_spec else 1
+                after = req_computed[i] + num_tokens
+                deltas = [
+                    block_count(after, spec) - held
+                    for spec, held in zip(kv_cache_specs, req_blocks[i])
+                ]
+                cached_req_data.new_block_ids.append(
+                    tuple(_alloc_blocks(n) for n in deltas) if any(deltas) else None
+                )
+                req_blocks[i] = [
+                    held + delta for held, delta in zip(req_blocks[i], deltas)
+                ]
+                step_num_scheduled_tokens[req_ids[i]] = num_tokens
+                if use_spec:
+                    step_spec_tokens[req_ids[i]] = [0] * num_spec_steps
+
+            decode_output = SchedulerOutput.make_empty()
+            decode_output.scheduled_cached_reqs = cached_req_data
+            decode_output.num_scheduled_tokens = step_num_scheduled_tokens
+            decode_output.scheduled_spec_decode_tokens = step_spec_tokens
+            decode_output.total_num_scheduled_tokens = sum(
+                step_num_scheduled_tokens.values()
+            )
+            decode_output.num_common_prefix_blocks = [0] * num_kv_cache_groups
+
+            _fence()
+            worker_execute_model(decode_output)
+            _fence()
+            worker_sample_tokens(None)
+            _fence()
+
+            for i, use_spec in zip(indices, spec_flags):
+                req_computed[i] += decode_query_len if use_spec else 1
+
+        all_indices = list(range(num_reqs))
+        use_spec_decode = num_spec_steps > 0
+
+        # Decode steps to warm, as (request indices, per-request spec flag).
+        # Under spec decoding the scheduler drops requests the drafter proposed
+        # nothing for, so warm each batch shape with and without draft tokens.
+        decode_steps: list[tuple[list[int], list[bool]]] = [
+            (all_indices, [use_spec_decode] * num_reqs),
+        ]
+        if num_reqs >= 2:
+            # Mixed spec / non-spec: GDN and KDA reclassify the non-spec decode
+            # as a prefill and split the batch into spec/non-spec token indices.
+            decode_steps.append(([0, 1], [use_spec_decode, False]))
+            if use_spec_decode:
+                # Exercise the model paths that split a batch by whether each
+                # request received draft tokens.
+                decode_steps.append(([0, 1], [False, False]))
+        if num_reqs > 1:
+            decode_steps.append(([0], [use_spec_decode]))
+            if use_spec_decode:
+                decode_steps.append(([0], [False]))
+        elif use_spec_decode:
+            decode_steps.append(([0], [False]))
+
+        for step_indices, step_spec_flags in decode_steps:
+            _run_decode_step(step_indices, step_spec_flags)
+
+    # Clean up - process finish_req_ids.
+    cleanup_output = SchedulerOutput.make_empty()
+    cleanup_output.finished_req_ids = set(req_ids)
+    _fence()
+    worker_execute_model(cleanup_output)
+    _fence()
+    model_runner.kv_connector.set_disabled(False)
+    torch.accelerator.synchronize()
+    get_tp_group().barrier()

--- a/docker/glm53-flash/single-container/vllm-startup-overlay/vllm/v1/worker/gpu_worker.py
+++ b/docker/glm53-flash/single-container/vllm-startup-overlay/vllm/v1/worker/gpu_worker.py
@@ -1,0 +1,1459 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""A GPU worker class."""
+
+import gc
+import os
+import time
+from collections.abc import Callable
+from contextlib import AbstractContextManager, contextmanager, nullcontext
+from datetime import timedelta
+from types import NoneType
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import regex as re
+import torch
+import torch.nn as nn
+
+import vllm.envs as envs
+from vllm.config import CUDAGraphMode, VllmConfig, set_current_vllm_config
+from vllm.config.compilation import CompilationMode
+from vllm.device_allocator import get_mem_allocator_instance
+from vllm.distributed import (
+    ensure_model_parallel_initialized,
+    init_distributed_environment,
+    set_custom_all_reduce,
+)
+from vllm.distributed.ec_transfer import (
+    ensure_ec_transfer_initialized,
+    ensure_ec_transfer_shutdown,
+)
+from vllm.distributed.eplb.eplb_utils import override_envs_for_eplb
+from vllm.distributed.kv_transfer import (
+    ensure_kv_transfer_initialized,
+    ensure_kv_transfer_shutdown,
+    get_kv_transfer_group,
+    has_kv_transfer_group,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorHandshakeMetadata,
+)
+from vllm.distributed.parallel_state import (
+    Handle,
+    checkpoint_prepare_distributed_state,
+    checkpoint_restore_distributed_state,
+    get_pp_group,
+    get_tp_group,
+)
+from vllm.distributed.weight_transfer import (
+    WeightTransferEngine,
+    WeightTransferEngineFactory,
+)
+from vllm.logger import init_logger
+from vllm.lora.request import LoRARequest
+from vllm.model_executor.warmup.kernel_warmup import kernel_warmup
+from vllm.multimodal.gpu_ipc_memory import reserve_mm_ipc_gpu_memory
+from vllm.platforms import current_platform
+from vllm.profiler.wrapper import (
+    CudaProfilerWrapper,
+    ProtonProfilerWrapper,
+    TorchProfilerWrapper,
+)
+from vllm.sequence import IntermediateTensors
+from vllm.tasks import SupportedTask
+from vllm.tracing import instrument
+from vllm.utils.gc_utils import freeze_gc_heap, maybe_attach_gc_debug_callback
+from vllm.utils.gpu_sync_debug import enable_gpu_sync_check, with_gpu_sync_check
+from vllm.utils.mem_constants import GiB_bytes
+from vllm.utils.mem_utils import MemorySnapshot, format_gib, memory_profiling
+from vllm.utils.torch_utils import set_random_seed, set_torch_threads_for_runtime
+from vllm.v1.attention.backends.utils import record_kv_cache_layout
+from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
+from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
+from vllm.v1.outputs import (
+    AsyncModelRunnerOutput,
+    DraftTokenIds,
+    ModelRunnerOutput,
+)
+from vllm.v1.utils import compute_iteration_details, report_usage_stats
+from vllm.v1.worker.sentinel.gpu_worker_sentinel import WorkerSentinel
+from vllm.v1.worker.startup_plan import (
+    maybe_apply_startup_plan,
+    maybe_save_startup_plan,
+)
+from vllm.v1.worker.utils import is_residual_scattered_for_sp
+from vllm.v1.worker.worker_base import CompilationTimes, WorkerBase
+from vllm.v1.worker.workspace import init_workspace_manager
+
+from ...model_executor.model_loader import TensorizerLoader
+from .gpu.warmup import warmup_kernels
+from .utils import request_memory
+
+logger = init_logger(__name__)
+
+
+def _num_workspace_lanes(vllm_config: VllmConfig, use_v2_model_runner: bool) -> int:
+    spec_config = vllm_config.speculative_config
+    return (
+        2
+        if use_v2_model_runner and spec_config is not None and spec_config.use_dspark()
+        else 1
+    )
+
+
+if TYPE_CHECKING:
+    from vllm.device_allocator.sleep_mode_backend import SleepModeBackend
+    from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+
+class AsyncIntermediateTensors(IntermediateTensors):
+    """IntermediateTensors with lazy comm synchronization"""
+
+    def __init__(
+        self,
+        tensors: dict[str, torch.Tensor],
+        comm_handles: list[Handle] | None = None,
+        comm_postprocess: list[Callable[[], None]] | None = None,
+    ) -> None:
+        super().__init__(tensors)
+        self._comm_handles = comm_handles
+        self._comm_postprocess = comm_postprocess
+        self._comm_waited = False
+
+    def wait_for_comm(self) -> None:
+        if self._comm_waited:
+            return
+        if self._comm_handles:
+            for handle in self._comm_handles:
+                handle.wait()
+        if self._comm_postprocess:
+            for fn in self._comm_postprocess:
+                fn()
+        self._comm_waited = True
+
+    def __getattribute__(self, name: str):
+        # ensure `.tensors` is ready before use
+        if name == "tensors" and not object.__getattribute__(self, "_comm_waited"):
+            object.__getattribute__(self, "wait_for_comm")()
+        return object.__getattribute__(self, name)
+
+
+class Worker(WorkerBase):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        local_rank: int,
+        rank: int,
+        distributed_init_method: str,
+        is_driver_worker: bool = False,
+    ):
+        super().__init__(
+            vllm_config=vllm_config,
+            local_rank=local_rank,
+            rank=rank,
+            distributed_init_method=distributed_init_method,
+            is_driver_worker=is_driver_worker,
+        )
+
+        # configure float32 matmul precision according to vLLM env.
+        precision = envs.VLLM_FLOAT32_MATMUL_PRECISION
+        torch.set_float32_matmul_precision(precision)
+
+        from vllm.distributed.elastic_ep.elastic_execute import ElasticEPScalingExecutor
+
+        self.elastic_ep_executor = ElasticEPScalingExecutor(self)
+        self.worker_sentinel: WorkerSentinel | None = None
+        if self.parallel_config.enable_fault_tolerance:
+            self.worker_sentinel = WorkerSentinel(worker=self)
+        # Buffers saved before sleep
+        self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
+        self._sleep_saved_draft_buffers: dict[str, torch.Tensor] = {}
+
+        # Weight transfer engine is created in `load_model` once the model
+        # is available, since the engine needs a reference to the model.
+        self.weight_transfer_engine: WeightTransferEngine | None = None
+        self._weight_update_active = False
+        self._weight_update_is_draft = False
+
+        # Worker profiler. Enabled and configured through profiler_config.
+        # Profiler wrapper is created lazily in profile() when start is called,
+        # so we have all the information needed for proper trace naming.
+        self.profiler: Any | None = None
+        self.profiler_config = vllm_config.profiler_config
+
+        self.use_v2_model_runner = vllm_config.use_v2_model_runner
+        # pending non-blocking PP send work from the previous iteration
+        self._pp_send_work: list[Handle] = []
+
+        # Resolved lazily on first sleep/wake; persists worker-process state.
+        self._sleep_mode_backend: SleepModeBackend | None = None
+
+    def _get_sleep_mode_backend(self) -> "SleepModeBackend":
+        if self._sleep_mode_backend is None:
+            from vllm.device_allocator.sleep_mode_backend import (
+                SleepModeBackendFactory,
+            )
+
+            self._sleep_mode_backend = SleepModeBackendFactory.create_backend(
+                self.vllm_config.model_config
+            )
+        return self._sleep_mode_backend
+
+    def sleep(self, level: int = 1) -> None:
+        torch.accelerator.synchronize()
+        free_bytes_before_sleep = torch.accelerator.get_memory_info()[0]
+
+        # Save the buffers before level 2 sleep
+        if level == 2:
+            model = self.model_runner.model
+            self._sleep_saved_buffers = {
+                name: buffer.cpu().clone() for name, buffer in model.named_buffers()
+            }
+            draft = self.get_draft_model()
+            if draft is not None:
+                self._sleep_saved_draft_buffers = {
+                    name: buffer.cpu().clone() for name, buffer in draft.named_buffers()
+                }
+
+        self._get_sleep_mode_backend().suspend(level)
+
+        torch.accelerator.synchronize()
+        deadline = time.monotonic() + (5.0 if current_platform.is_rocm() else 0)
+        while True:
+            free_bytes_after_sleep, total = torch.accelerator.get_memory_info()
+            freed_bytes = free_bytes_after_sleep - free_bytes_before_sleep
+            if freed_bytes >= 0 or time.monotonic() >= deadline:
+                break
+            time.sleep(0.1)
+
+        used_bytes = total - free_bytes_after_sleep
+        assert freed_bytes >= 0, "Memory usage increased after sleeping."
+        logger.info(
+            "Sleep mode freed %s GiB memory, %s GiB memory is still in use.",
+            format_gib(freed_bytes),
+            format_gib(used_bytes),
+        )
+
+    def wake_up(self, tags: list[str] | None = None) -> None:
+        self._get_sleep_mode_backend().resume(tags)
+
+        # Restore the buffers after level 2 sleep
+        wake_weights = tags is None or "weights" in tags
+        if wake_weights and len(self._sleep_saved_buffers):
+            model = self.model_runner.model
+            for name, buffer in model.named_buffers():
+                if name in self._sleep_saved_buffers:
+                    buffer.data.copy_(self._sleep_saved_buffers[name].data)
+            self._sleep_saved_buffers = {}
+
+        if wake_weights and len(self._sleep_saved_draft_buffers):
+            draft = self.get_draft_model()
+            if draft is not None:
+                for name, buffer in draft.named_buffers():
+                    if name in self._sleep_saved_draft_buffers:
+                        buffer.data.copy_(self._sleep_saved_draft_buffers[name].data)
+            self._sleep_saved_draft_buffers = {}
+
+        if tags is None or "kv_cache" in tags:
+            self.model_runner.post_kv_cache_wake_up()
+
+    def checkpoint_prepare(self) -> None:
+        checkpoint_prepare_distributed_state()
+
+    def checkpoint_restore(self) -> None:
+        checkpoint_restore_distributed_state()
+
+    def _maybe_get_memory_pool_context(self, tag: str) -> AbstractContextManager:
+        if (
+            current_platform.is_cuda_alike()
+            and not self.vllm_config.model_config.enable_cumem_allocator
+        ):
+            return nullcontext()
+
+        if (
+            current_platform.is_xpu()
+            and not self.vllm_config.model_config.enable_sleep_mode
+        ):
+            return nullcontext()
+
+        if current_platform.is_cpu():
+            return nullcontext()
+
+        allocator = get_mem_allocator_instance()
+        if tag == "weights":
+            assert allocator.get_current_usage() == 0, (
+                "CuMem allocator can only be used for one instance per process."
+            )
+        return allocator.use_memory_pool(tag=tag)
+
+    @contextmanager
+    def _scoped_allocator_max_split(self, max_split_size_mb: int):
+        """Temporarily set max_split_size_mb to reduce allocator fragmentation at the
+        cost of more cudaMalloc calls (negligible in practice). Restores the original
+        value on exit."""
+        if not current_platform.is_cuda():
+            yield
+            return
+
+        conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
+        match = re.search(r"max_split_size_mb:(\d+)", conf)
+        original_value = match.group(1) if match else None
+
+        torch._C._accelerator_setAllocatorSettings(
+            f"max_split_size_mb:{max_split_size_mb}"
+        )
+        try:
+            yield
+        finally:
+            # PyTorch defaults to SIZE_MAX (no limit).
+            _SIZE_MAX_MB = (2**64 - 1) // (1024 * 1024)
+            restore = original_value if original_value else str(_SIZE_MAX_MB)
+            torch._C._accelerator_setAllocatorSettings(f"max_split_size_mb:{restore}")
+
+    @instrument(span_name="Init device")
+    def init_device(self):
+        if self.device_config.device_type == "cuda":
+            # This env var set by Ray causes exceptions with graph building.
+            os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)
+            parallel_config = self.parallel_config
+            if (
+                parallel_config.distributed_executor_backend
+                not in ("ray", "external_launcher")
+                and parallel_config.data_parallel_backend != "ray"
+                and parallel_config.nnodes_within_dp == 1
+            ):
+                # Use local DP rank if available, otherwise use global DP rank.
+                dp_local_rank = self.parallel_config.data_parallel_rank_local
+                if dp_local_rank is None:
+                    dp_local_rank = self.parallel_config.data_parallel_index
+
+                tp_pp_world_size = (
+                    self.parallel_config.pipeline_parallel_size
+                    * self.parallel_config.tensor_parallel_size
+                )
+
+                # DP_LOCAL_RANK * TP_PP_WORLD_SIZE + TP_LOCAL_RANK
+                self.local_rank += dp_local_rank * tp_pp_world_size
+
+            # Publish the logical-to-physical mapping for topology queries
+            # such as NIC affinity and P2P checks.
+            assigned_physical_gpu_ids = parallel_config.assigned_physical_gpu_ids
+            if assigned_physical_gpu_ids is not None:
+                from vllm.platforms.interface import set_assigned_physical_gpu_ids
+
+                set_assigned_physical_gpu_ids(assigned_physical_gpu_ids)
+                assert self.local_rank < len(assigned_physical_gpu_ids), (
+                    f"local_rank {self.local_rank} is out of bounds for "
+                    f"assigned_physical_gpu_ids {assigned_physical_gpu_ids}"
+                )
+                # NOTE(patch pr45026): local_world_size is derived from
+                # parallel_config.nnodes, which is only set for the "mp"
+                # multi-node backend. With the "ray"/"external_launcher"
+                # backends nnodes stays 1, so local_world_size collapses to
+                # the full world_size and this check wrongly fires on
+                # cross-node deployments. assigned_physical_gpu_ids is already
+                # per-node and the local_rank bound above fully validates the
+                # mapping for these backends, so skip the check for them.
+                if parallel_config.distributed_executor_backend not in (
+                    "ray",
+                    "external_launcher",
+                ):
+                    assert self.parallel_config.local_world_size <= len(
+                        assigned_physical_gpu_ids
+                    ), (
+                        f"local_world_size ({self.parallel_config.local_world_size})"
+                        " exceeds assigned_physical_gpu_ids count "
+                        f"({len(assigned_physical_gpu_ids)})"
+                    )
+            else:
+                assert self.local_rank < torch.accelerator.device_count(), (
+                    f"DP adjusted local rank {self.local_rank} is out of "
+                    f"bounds for {torch.accelerator.device_count()} devices."
+                )
+
+            visible_device_index = (
+                current_platform.logical_device_id_to_visible_device_id(self.local_rank)
+            )
+            self.device = torch.device(f"cuda:{visible_device_index}")
+            torch.accelerator.set_device_index(self.device)
+
+            current_platform.check_if_supports_dtype(self.model_config.dtype)
+
+            # Initialize the distributed environment BEFORE taking
+            # memory snapshot
+            # This ensures NCCL buffers are allocated before we measure
+            # available memory
+            init_worker_distributed_environment(
+                self.vllm_config,
+                self.rank,
+                self.distributed_init_method,
+                self.local_rank,
+                current_platform.dist_backend,
+            )
+
+            if self.use_v2_model_runner:
+                logger.info_once("Using V2 Model Runner")
+
+            # Set random seed.
+            set_random_seed(self.model_config.seed)
+
+            # Now take memory snapshot after NCCL is initialized
+            gc.collect()
+            torch.accelerator.empty_cache()
+
+            # take current memory snapshot
+            self.init_snapshot = init_snapshot = MemorySnapshot(device=self.device)
+            self.requested_memory = request_memory(init_snapshot, self.cache_config)
+            logger.debug("worker init memory snapshot: %r", self.init_snapshot)
+            logger.debug(
+                "worker requested memory: %sGiB", format_gib(self.requested_memory)
+            )
+        else:
+            raise RuntimeError(f"Unsupported device type: {self.device_config.device}")
+
+        # DSpark target and draft CUDA graphs retain workspace views concurrently.
+        num_ubatches = 2 if self.vllm_config.parallel_config.enable_dbo else 1
+        init_workspace_manager(
+            self.device,
+            num_ubatches,
+            _num_workspace_lanes(self.vllm_config, self.use_v2_model_runner),
+        )
+
+        # Construct the model runner
+        if self.use_v2_model_runner:
+            if self.vllm_config.is_mm_encoder_only:
+                from vllm.v1.worker.mm_encoder_model_runner import (
+                    MMEncoderModelRunner as GPUModelRunnerV2,
+                )
+            else:
+                from vllm.v1.worker.gpu.model_runner import (  # type: ignore[assignment]
+                    GPUModelRunner as GPUModelRunnerV2,
+                )
+
+            # HACK(woosuk): This is a temporary fix to avoid type errors.
+            self.model_runner: GPUModelRunner = GPUModelRunnerV2(  # type: ignore
+                self.vllm_config, self.device
+            )
+        else:
+            from vllm.v1.worker.gpu_model_runner import (
+                GPUModelRunner as GPUModelRunnerV1,
+            )
+
+            self.model_runner = GPUModelRunnerV1(self.vllm_config, self.device)
+
+        if self.rank == 0:
+            # If usage stat is enabled, collect relevant info.
+            report_usage_stats(self.vllm_config)
+
+    def handle_ft_command(self, ft_request):
+        assert self.worker_sentinel is not None
+        return self.worker_sentinel.handle_command(ft_request)
+
+    # FIXME(youkaichao & ywang96): Use TorchDispatchMode instead of memory pool
+    # to hijack tensor allocation.
+    def load_model(self, *, load_dummy_weights: bool = False) -> None:
+        with (
+            self._maybe_get_memory_pool_context(tag="weights"),
+            set_current_vllm_config(self.vllm_config),
+            # 20 MiB is the minimum PyTorch allows for max_split_size_mb.
+            self._scoped_allocator_max_split(max_split_size_mb=20),
+        ):
+            self.model_runner.load_model(load_dummy_weights=load_dummy_weights)
+
+        if self.vllm_config.weight_transfer_config is not None:
+            self.weight_transfer_engine = WeightTransferEngineFactory.create_engine(
+                self.vllm_config.weight_transfer_config,
+                self.vllm_config,
+                self.device,
+                self.model_runner.get_model(),
+            )
+
+    def update_config(self, overrides: dict[str, Any]) -> None:
+        self.model_runner.update_config(overrides)
+
+    def reload_weights(self, *args, **kwargs) -> None:
+        with set_current_vllm_config(self.vllm_config):
+            self.model_runner.reload_weights(*args, **kwargs)
+
+    @torch.inference_mode()
+    def determine_available_memory(self) -> int:
+        """Profiles the peak memory usage of the model to determine how much
+        memory can be used for KV cache without OOMs.
+
+        The engine will first conduct a profiling of the existing memory usage.
+        Then, it calculates the free memory that can be used for KV cache in
+        bytes.
+
+        Tip:
+            You may limit the usage of GPU memory
+            by adjusting the `gpu_memory_utilization` parameter.
+        """
+        maybe_apply_startup_plan(self)
+
+        if kv_cache_memory_bytes := self.cache_config.kv_cache_memory_bytes:
+            # still need a profile run which compiles the model for
+            # max_num_batched_tokens
+            self.model_runner.profile_run()
+
+            msg = (
+                f"Initial free memory {format_gib(self.init_snapshot.free_memory)} "
+                f"GiB, reserved {format_gib(kv_cache_memory_bytes)} GiB memory for "
+                "KV Cache as specified by kv_cache_memory_bytes config and "
+                "skipped memory profiling. This does not respect the "
+                "gpu_memory_utilization config. Only use kv_cache_memory_bytes "
+                "config when you want manual control of KV cache memory "
+                "size. If OOM'ed, check the difference of initial free "
+                "memory between the current run and the previous run "
+                "where kv_cache_memory_bytes is suggested and update it "
+                "correspondingly."
+            )
+            logger.info(msg)
+            return reserve_mm_ipc_gpu_memory(
+                kv_cache_memory_bytes,
+                self.model_config.multimodal_config,
+                getattr(self.parallel_config, "_api_process_count", 1),
+            )
+
+        # Execute a forward pass with dummy inputs to profile the memory usage
+        # of the model.
+        with memory_profiling(
+            self.init_snapshot,
+            weights_memory=int(self.model_runner.model_memory_usage),
+        ) as profile_result:
+            self.model_runner.profile_run()
+
+        # Profile CUDA graph memory if graphs will be captured.
+        # ROCm is included: #44825 moved the profiler to
+        # torch.accelerator.get_memory_info (reliable on ROCm, as used by
+        # the AMD-CI mem tests), and graph_pool_handle resolves to the same
+        # torch.cuda handle the live capture path already uses on ROCm.
+        # XPU stays excluded (see #39977).
+        cudagraph_memory_estimate = 0
+        if (
+            current_platform.is_cuda_alike()
+            and self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
+        ):
+            cudagraph_memory_estimate = self.model_runner.profile_cudagraph_memory()
+
+        # Respect the opt-in flag as originally designed.
+        cudagraph_memory_estimate_applied = (
+            cudagraph_memory_estimate
+            if envs.VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS
+            else 0
+        )
+
+        self.total_consumed = profile_result.total_consumed
+        self.peak_activation_memory = (
+            profile_result.transient_peak_headroom + cudagraph_memory_estimate_applied
+        )
+        self.cudagraph_memory_estimate = cudagraph_memory_estimate
+
+        free_gpu_memory = profile_result.after_profile.free_memory
+        # NOTE(woosuk): Here we assume that the other processes using the same
+        # GPU did not change their memory usage during the profiling.
+        assert self.init_snapshot.free_memory >= free_gpu_memory, (
+            "Error in memory profiling. "
+            f"Initial free memory {format_gib(self.init_snapshot.free_memory)} GiB, "
+            f"current free memory {format_gib(free_gpu_memory)} GiB. "
+            "This happens when other processes sharing the same container "
+            "release GPU memory while vLLM is profiling during initialization. "
+            "To fix this, ensure consistent GPU memory allocation or "
+            "isolate vLLM in its own container."
+        )
+        self.available_kv_cache_memory_bytes = (
+            self.requested_memory
+            - profile_result.non_kv_cache_memory
+            - cudagraph_memory_estimate_applied
+        )
+
+        unrequested_memory = self.init_snapshot.free_memory - self.requested_memory
+        logger.debug(
+            "Initial free memory: %s GiB; Requested memory: %f (util), %s GiB",
+            format_gib(self.init_snapshot.free_memory),
+            self.cache_config.gpu_memory_utilization,
+            format_gib(self.requested_memory),
+        )
+        logger.debug(
+            "Free memory after profiling: %s GiB (total), %s GiB (within requested)",
+            format_gib(free_gpu_memory),
+            format_gib(free_gpu_memory - unrequested_memory),
+        )
+        logger.debug(profile_result)
+        logger.info_once(
+            "Available KV cache memory: %s GiB",
+            format_gib(self.available_kv_cache_memory_bytes),
+        )
+
+        if cudagraph_memory_estimate > 0:
+            total_mem = self.init_snapshot.total_memory
+            current_util = self.cache_config.gpu_memory_utilization
+            cg_util_delta = cudagraph_memory_estimate / total_mem
+            if envs.VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS:
+                equiv_util = round(current_util - cg_util_delta, 4)
+                suggested_util = min(
+                    round(current_util + cg_util_delta, 4),
+                    1.0,
+                )
+                logger.info(
+                    "CUDA graph memory profiling is enabled (default since "
+                    "v0.21.0). The current --gpu-memory-utilization=%.4f is "
+                    "equivalent to --gpu-memory-utilization=%.4f without "
+                    "CUDA graph memory profiling. To maintain the same "
+                    "effective KV cache size as before, increase "
+                    "--gpu-memory-utilization to %.4f. To disable, set "
+                    "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0.",
+                    current_util,
+                    equiv_util,
+                    suggested_util,
+                )
+            else:
+                suggested_util = min(
+                    round(current_util + cg_util_delta, 4),
+                    1.0,
+                )
+                logger.warning(
+                    "CUDA graph memory profiling is disabled "
+                    "(VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0). "
+                    "Without it, CUDA graph memory is not accounted for "
+                    "during KV cache allocation, which may require lowering "
+                    "--gpu-memory-utilization to avoid OOM. Consider "
+                    "re-enabling it (the default as of v0.21.0) and increasing "
+                    "--gpu-memory-utilization from %.4f to %.4f.",
+                    current_util,
+                    suggested_util,
+                )
+
+        return reserve_mm_ipc_gpu_memory(
+            int(self.available_kv_cache_memory_bytes),
+            self.model_config.multimodal_config,
+            getattr(self.parallel_config, "_api_process_count", 1),
+        )
+
+    def get_kv_connector_handshake_metadata(
+        self,
+    ) -> dict[tuple[int, int], KVConnectorHandshakeMetadata] | None:
+        """Get KV connector metadata from this worker if available.
+
+        Returned dict is keyed by `(pp_rank, tp_rank)`.
+        """
+
+        if not has_kv_transfer_group():
+            return None
+
+        connector = get_kv_transfer_group()
+        # Return None for connectors that don't need to exchange handshake
+        # metadata across workers.
+        if (metadata := connector.get_handshake_metadata()) is None:
+            return None
+
+        pp_rank = get_pp_group().rank_in_group
+        tp_rank = get_tp_group().rank_in_group
+        return {(pp_rank, tp_rank): metadata}
+
+    def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
+        return self.model_runner.get_kv_cache_spec()
+
+    def update_max_model_len(self, max_model_len: int) -> None:
+        """Update max_model_len after auto-fit to GPU memory.
+        This is called when max_model_len=-1 is used and the engine
+        automatically determines the maximum context length that fits
+        in GPU memory. Workers need to update their cached max_model_len
+        to match the engine's decision.
+        """
+        self.model_config.max_model_len = max_model_len
+        if self.model_runner is not None:
+            self.model_runner.update_max_model_len(max_model_len)
+        logger.debug("Updated max_model_len to %d", max_model_len)
+
+    @instrument(span_name="Allocate KV cache")
+    def initialize_from_config(self, kv_cache_config: KVCacheConfig) -> None:
+        """Allocate GPU KV cache with the specified kv_cache_config."""
+
+        # Update local config with adjusted num blocks after profiling,
+        # so that it's available to the warmup stage.
+        self.cache_config.num_gpu_blocks = kv_cache_config.num_blocks
+
+        # Adopt the engine core's layout; workers spawned after resolution
+        # (e.g. elastic EP scale-up) only see it through the config.
+        if kv_cache_config.kv_cache_layout is not None:
+            record_kv_cache_layout(self.cache_config, kv_cache_config.kv_cache_layout)
+
+        # Init kv cache connector here, because it requires
+        # `kv_cache_config`.
+        # NOTE(Kuntai): This need to be done before `initialize_kv_cache`,
+        # because `initialize_kv_cache` will inject kv cache groups not
+        # related to kv cache connector (e.g. kv cache sharing layers).
+        ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
+
+        with self._maybe_get_memory_pool_context(tag="kv_cache"):
+            self.model_runner.initialize_kv_cache(kv_cache_config)
+
+        if self.model_config.enable_return_routed_experts:
+            self.model_runner.init_routed_experts_capturer()
+
+        # Build KV-zero metadata outside the CuMem pool so the bookkeeping
+        # GPU tensors (seg_addrs, block-id buffers) use the standard PyTorch
+        # allocator and are not discarded during sleep/wake cycles.
+        if kv_cache_config.needs_kv_cache_zeroing and hasattr(
+            self.model_runner, "_init_kv_zero_meta"
+        ):
+            self.model_runner._init_kv_zero_meta()
+
+    @instrument(span_name="Warmup (GPU)")
+    def compile_or_warm_up_model(self) -> CompilationTimes:
+        warmup_sizes: list[int] = []
+
+        if self.vllm_config.compilation_config.mode == CompilationMode.VLLM_COMPILE:
+            # warm up sizes that are not in cudagraph capture sizes,
+            # but users still want to compile for better performance,
+            # e.g. for the max-num-batched token size in chunked prefill.
+            compile_sizes = self.vllm_config.compilation_config.compile_sizes
+            warmup_sizes = compile_sizes.copy() if compile_sizes is not None else []  # type: ignore[assignment]
+            cg_capture_sizes: list[int] = []
+
+            if self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
+                cg_sizes = self.vllm_config.compilation_config.cudagraph_capture_sizes
+                cg_capture_sizes = [] if cg_sizes is None else cg_sizes
+                warmup_sizes = [x for x in warmup_sizes if x not in cg_capture_sizes]
+
+            compile_ranges = self.vllm_config.compilation_config.get_compile_ranges()
+            # For each compile_range, if none of the batch sizes
+            # in warmup_sizes or cudagraph_capture_sizes are in the range,
+            # add the end of the range to ensure compilation/warmup.
+            all_sizes = set(cg_capture_sizes)
+            all_sizes.update([x for x in warmup_sizes if isinstance(x, int)])
+            for compile_range in compile_ranges:
+                if not any(x in compile_range for x in all_sizes):
+                    warmup_sizes.append(compile_range.end)
+
+        # We skip EPLB here since we don't want to record dummy metrics
+        for size in sorted(warmup_sizes, reverse=True):
+            logger.info("Compile and warming up model for size %d", size)
+            self.model_runner._dummy_run(size, skip_eplb=True, remove_lora=False)
+        self.model_runner.maybe_remove_all_loras(self.model_runner.lora_config)
+
+        # Warmup and tune the kernels used during model execution before
+        # cuda graph capture.
+        kernel_warmup(self)
+        # Warmup launches are asynchronous and can finish at different times
+        # across TP/DCP ranks. FULL capture begins with a device synchronize;
+        # entering it while peer ranks still mutate shared distributed buffers
+        # can leave captured pointers invalid. Fence startup work only; serving
+        # remains fully asynchronous.
+        torch.accelerator.synchronize()
+        get_tp_group().barrier()
+
+        cuda_graph_memory_bytes = 0
+        if not self.model_config.enforce_eager:
+            cuda_graph_memory_bytes = self.model_runner.capture_model()
+
+        # Compare actual vs estimated CUDA graph memory (if we did profiling)
+        if (
+            hasattr(self, "cudagraph_memory_estimate")
+            and self.cudagraph_memory_estimate > 0
+        ):
+            GiB = lambda b: round(b / GiB_bytes, 2)
+            diff = abs(cuda_graph_memory_bytes - self.cudagraph_memory_estimate)
+            logger.info(
+                "CUDA graph pool memory: %s GiB (actual), %s GiB (estimated), "
+                "difference: %s GiB (%.1f%%).",
+                GiB(cuda_graph_memory_bytes),
+                GiB(self.cudagraph_memory_estimate),
+                GiB(diff),
+                100 * diff / max(cuda_graph_memory_bytes, 1),
+            )
+
+        if self.cache_config.kv_cache_memory_bytes is None and hasattr(
+            self, "peak_activation_memory"
+        ):
+            # Suggests optimal kv cache memory size if we rely on
+            # memory_profiling to guess the kv cache memory size which
+            # provides peak_activation_memory and a few other memory
+            # consumption. `memory_profiling` does not consider
+            # CUDAGraph memory size and may not utilize all gpu memory.
+            # Users may want fine-grained control to specify kv cache
+            # memory size.
+
+            # empirically observed that the memory profiling may
+            # slightly underestimate the memory consumption.
+            # So leave a small buffer (=150MiB) to avoid OOM.
+            redundancy_buffer_memory = 150 * (1 << 20)
+
+            non_kv_cache_memory = (
+                self.total_consumed
+                + self.peak_activation_memory
+                + cuda_graph_memory_bytes
+            )
+            kv_cache_memory_bytes_to_gpu_limit = (
+                self.init_snapshot.free_memory
+                - non_kv_cache_memory
+                - redundancy_buffer_memory
+            )
+            kv_cache_memory_bytes_to_requested_limit = (
+                int(self.requested_memory)
+                - non_kv_cache_memory
+                - redundancy_buffer_memory
+            )
+
+            msg = (
+                f"Free memory on device "
+                f"({format_gib(self.init_snapshot.free_memory)}/"
+                f"{format_gib(self.init_snapshot.total_memory)} GiB) on startup. "
+                f"Desired GPU memory utilization is "
+                f"({self.cache_config.gpu_memory_utilization}, "
+                f"{format_gib(self.requested_memory)} GiB). "
+                f"Actual usage is {format_gib(self.total_consumed)} "
+                f"GiB for consumed memory (weights + non-torch), "
+                f"{format_gib(self.peak_activation_memory)} GiB "
+                f"for peak activation, and {format_gib(cuda_graph_memory_bytes)} "
+                f"GiB for CUDAGraph memory. Replace gpu_memory_utilization "
+                f"config with `--kv-cache-memory="
+                f"{kv_cache_memory_bytes_to_requested_limit}` "
+                f"({format_gib(kv_cache_memory_bytes_to_requested_limit)} GiB) to fit "
+                f"into requested memory, or `--kv-cache-memory="
+                f"{kv_cache_memory_bytes_to_gpu_limit}` "
+                f"({format_gib(kv_cache_memory_bytes_to_gpu_limit)} GiB) to fully "
+                f"utilize gpu memory. Current kv cache memory in use is "
+                f"{format_gib(self.available_kv_cache_memory_bytes)} GiB."
+            )
+
+            logger.info(msg)
+
+            maybe_save_startup_plan(self, kv_cache_memory_bytes_to_requested_limit)
+
+        if self.use_v2_model_runner:
+            # V2: Run full execute_model + sample_tokens to JIT compile triton kernels.
+            warmup_kernels(self.model_runner, self.execute_model, self.sample_tokens)
+        elif get_pp_group().is_last_rank:
+            # V1: Warm up sampler and preallocate memory buffer for logits and other
+            # sampling related tensors of max possible shape to avoid memory
+            # fragmentation issue.
+            # NOTE: This is called after `capture_model` on purpose to prevent
+            # memory buffers from being cleared by `torch.accelerator.empty_cache`.
+            max_num_reqs = min(
+                self.scheduler_config.max_num_seqs,
+                self.scheduler_config.max_num_batched_tokens,
+            )
+
+            # We skip EPLB here since we don't want to record dummy metrics
+            hidden_states, last_hidden_states = self.model_runner._dummy_run(
+                num_tokens=max_num_reqs,
+                skip_eplb=True,
+                cudagraph_runtime_mode=CUDAGraphMode.NONE,
+            )
+            if self.model_runner.is_pooling_model:
+                self.model_runner._dummy_pooler_run(hidden_states)
+            else:
+                self.model_runner._dummy_sampler_run(hidden_states=last_hidden_states)
+
+        # Reset the seed to ensure that the random state is not affected by
+        # the model initialization and profiling.
+        set_random_seed(self.model_config.seed)
+
+        # Eagerly trigger inductor's once-per-process lazy inits during
+        # warmup (rather than on a later compile cache-miss at runtime).
+        c_config = self.compilation_config
+        if c_config.mode != CompilationMode.NONE and c_config.backend == "inductor":
+            from vllm.compilation.compiler_interface import (
+                trigger_inductor_lazy_init,
+            )
+
+            trigger_inductor_lazy_init(self.device)
+
+        # All warmup is done — start monitoring for unexpected JIT
+        # compilations that would cause latency spikes during inference.
+        from vllm.utils.jit_monitor import activate as activate_jit_monitor
+
+        activate_jit_monitor(
+            mode=self.observability_config.jit_monitor_mode,
+            verbose=self.observability_config.jit_monitor_verbose,
+        )
+
+        # Freeze the worker heap so the GC won't scan static objects
+        # (model weights, KV caches, CUDA graphs) during inference.
+        freeze_gc_heap()
+        maybe_attach_gc_debug_callback()
+
+        # Warmup / first-compile is done — activate the `VLLM_GPU_SYNC_CHECK`
+        # gate so subsequent `execute_model` / `sample_tokens` calls enforce it.
+        enable_gpu_sync_check()
+
+        # Startup is done; steady-state serving gets no benefit from torch
+        # intra-op parallelism.
+        set_torch_threads_for_runtime()
+
+        return CompilationTimes(
+            language_model=self.compilation_config.compilation_time,
+            encoder=self.compilation_config.encoder_compilation_time,
+        )
+
+    def reset_mm_cache(self) -> None:
+        self.model_runner.reset_mm_cache()
+
+    def reset_encoder_cache(self) -> None:
+        self.model_runner.reset_encoder_cache()
+
+    def get_model(self) -> nn.Module:
+        return self.model_runner.get_model()
+
+    def get_draft_model(self) -> nn.Module | None:
+        return self.model_runner.get_draft_model()
+
+    def supports_draft_weight_updates(self) -> bool:
+        engine = self.weight_transfer_engine
+        speculative_config = self.speculative_config
+        get_draft_model = getattr(self.model_runner, "get_draft_model", None)
+        return (
+            engine is not None
+            and engine.supports_draft_weight_update
+            and callable(get_draft_model)
+            and get_draft_model() is not None
+            and speculative_config is not None
+            and speculative_config.draft_model_config is not None
+        )
+
+    def _set_draft_weight_update_target(self) -> None:
+        assert self.weight_transfer_engine is not None
+
+        draft_model = self.get_draft_model()
+        if draft_model is None:
+            raise RuntimeError(
+                "Draft model weight update requested, but no draft model is configured."
+            )
+
+        speculative_config = self.speculative_config
+        if speculative_config is None or speculative_config.draft_model_config is None:
+            raise RuntimeError(
+                "Draft model weight update requested, but no draft model "
+                "config is configured."
+            )
+
+        self.weight_transfer_engine.set_weight_update_target(
+            draft_model, speculative_config.draft_model_config
+        )
+
+    def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
+        return self.model_runner.get_supported_tasks()
+
+    def get_compilation_match_table(self) -> dict[str, int]:
+        from vllm.compilation.passes.vllm_inductor_pass import get_match_table
+
+        return get_match_table()
+
+    def get_encoder_timing_stats(self) -> dict[str, dict[str, float | int]]:
+        """Get encoder timing stats from model runner."""
+        return self.model_runner.get_encoder_timing_stats()
+
+    def annotate_profile(self, scheduler_output):
+        # add trace annotation so that we can easily distinguish
+        # context/generation request numbers in each iteration.
+        # A context request is a request that has not yet generated any tokens
+        if not self.profiler:
+            return nullcontext()
+
+        self.profiler.step()
+        if not self.profiler.is_running:
+            return nullcontext()
+
+        iteration_details = compute_iteration_details(scheduler_output)
+
+        if self.vllm_config.profiler_config.detailed_trace_annotation:
+            # Compute roofline-model metrics per request, split by phase
+            # (context vs generation). These help estimate compute and
+            # memory intensity from the trace.
+            #
+            # Per-request quantities:
+            #   query_len = number of scheduled (new) tokens for this request
+            #   seq_len   = total sequence length (computed + scheduled tokens)
+            #
+            # Aggregated across requests in each phase
+            # (ctx_=context, gen_=generation):
+            #   seq_len_sum = sum of seq_len   (total KV length)
+            #   qq_compute  = sum of query_len*query_len
+            #                 (proxy for QK^T compute cost)
+            #   qk_compute  = sum of query_len*seq_len
+            #                 (proxy for QK^T compute cost for decode and
+            #                  chunked prefill)
+            #   total_scheduled_tokens = scheduled tokens across all requests
+            ctx_seq_len_sum = 0
+            ctx_qq_compute = 0
+            ctx_qk_compute = 0
+            gen_seq_len_sum = 0
+            gen_qq_compute = 0
+            gen_qk_compute = 0
+            total_scheduled_tokens = 0
+
+            # Build a map of req_id -> num_computed_tokens for all requests
+            new_req_ids = {
+                new_req.req_id for new_req in scheduler_output.scheduled_new_reqs
+            }
+            num_computed_tokens_ids = {
+                new_req.req_id: new_req.num_computed_tokens
+                for new_req in scheduler_output.scheduled_new_reqs
+            }
+            for req_id, num_computed_tokens in zip(
+                scheduler_output.scheduled_cached_reqs.req_ids,
+                scheduler_output.scheduled_cached_reqs.num_computed_tokens,
+            ):
+                num_computed_tokens_ids[req_id] = num_computed_tokens
+
+            # Accumulate per-phase metrics
+            for req_id, num_tokens in scheduler_output.num_scheduled_tokens.items():
+                query_len = num_tokens
+                total_scheduled_tokens += query_len
+                seq_len = num_computed_tokens_ids.get(req_id, 0) + query_len
+                if (
+                    scheduler_output.scheduled_cached_reqs.is_context_phase(req_id)
+                    or req_id in new_req_ids
+                ):
+                    ctx_seq_len_sum += seq_len
+                    ctx_qq_compute += query_len * query_len
+                    ctx_qk_compute += query_len * seq_len
+                else:
+                    gen_seq_len_sum += seq_len
+                    gen_qq_compute += query_len * query_len
+                    gen_qk_compute += query_len * seq_len
+            annotation = "".join(
+                [
+                    "execute_",
+                    str(total_scheduled_tokens),
+                    "_context_",
+                    str(iteration_details.num_ctx_requests),
+                    "(sq",
+                    str(iteration_details.num_ctx_tokens),
+                    "sk",
+                    str(ctx_seq_len_sum),
+                    "sqsq",
+                    str(ctx_qq_compute),
+                    "sqsk",
+                    str(ctx_qk_compute),
+                    ")_generation_",
+                    str(iteration_details.num_generation_requests),
+                    "(sq",
+                    str(iteration_details.num_generation_tokens),
+                    "sk",
+                    str(gen_seq_len_sum),
+                    "sqsq",
+                    str(gen_qq_compute),
+                    "sqsk",
+                    str(gen_qk_compute),
+                    ")",
+                ]
+            )
+        else:
+            annotation = "".join(
+                [
+                    "execute_context_",
+                    str(iteration_details.num_ctx_requests),
+                    "(",
+                    str(iteration_details.num_ctx_tokens),
+                    ")",
+                    "_generation_",
+                    str(iteration_details.num_generation_requests),
+                    "(",
+                    str(iteration_details.num_generation_tokens),
+                    ")",
+                ]
+            )
+        return self.profiler.annotate_context_manager(annotation)
+
+    @torch.inference_mode()
+    @with_gpu_sync_check
+    def sample_tokens(
+        self, grammar_output: "GrammarOutput | None"
+    ) -> ModelRunnerOutput | AsyncModelRunnerOutput:
+        return self.model_runner.sample_tokens(grammar_output)
+
+    @torch.inference_mode()
+    @with_gpu_sync_check
+    def execute_model(
+        self, scheduler_output: "SchedulerOutput"
+    ) -> ModelRunnerOutput | AsyncModelRunnerOutput | None:
+        # ensure any previous non-blocking PP sends are complete
+        if self._pp_send_work:
+            for handle in self._pp_send_work:
+                handle.wait()
+            self._pp_send_work = []
+
+        intermediate_tensors = None
+        forward_pass = scheduler_output.total_num_scheduled_tokens > 0
+        num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
+        all_gather_tensors = {}
+        compilation_config = self.vllm_config.compilation_config
+        parallel_config = self.vllm_config.parallel_config
+
+        if (
+            parallel_config.pipeline_parallel_size > 1
+            and compilation_config.pass_config.enable_sp
+            and forward_pass
+        ):
+            # currently only supported by V1 GPUModelRunner
+            assert not self.use_v2_model_runner
+            num_scheduled_tokens_np = np.array(
+                list(scheduler_output.num_scheduled_tokens.values()),
+                dtype=np.int32,
+            )
+            # TODO(lucas): This is pretty gross; ideally we should only ever call
+            # `_determine_batch_execution_and_padding` once (will get called again
+            # in `execute_model`) but this requires a larger refactor of PP.
+            _, batch_desc, _, _, _ = (
+                self.model_runner._determine_batch_execution_and_padding(
+                    num_tokens=num_scheduled_tokens,
+                    num_reqs=len(num_scheduled_tokens_np),
+                    num_scheduled_tokens_np=num_scheduled_tokens_np,
+                    max_num_scheduled_tokens=num_scheduled_tokens_np.max(),
+                    use_cascade_attn=False,  # TODO(lucas): Handle cascade attention
+                )
+            )
+            all_gather_tensors = {
+                "residual": not is_residual_scattered_for_sp(
+                    self.vllm_config, batch_desc.num_tokens
+                )
+            }
+
+        if forward_pass and not get_pp_group().is_first_rank:
+            tensor_dict, comm_handles, comm_postprocess = (
+                get_pp_group().irecv_tensor_dict(
+                    all_gather_group=get_tp_group(),
+                    all_gather_tensors=all_gather_tensors,
+                )
+            )
+            assert tensor_dict is not None
+            intermediate_tensors = AsyncIntermediateTensors(
+                tensor_dict,
+                comm_handles=comm_handles,
+                comm_postprocess=comm_postprocess,
+            )
+
+        with self.annotate_profile(scheduler_output):
+            output = self.model_runner.execute_model(
+                scheduler_output, intermediate_tensors
+            )
+            if (
+                self.use_v2_model_runner
+                and self.model_runner.is_pooling_model
+                and output is None
+            ):
+                output = self.model_runner.pool()  # type: ignore
+            if isinstance(
+                output, ModelRunnerOutput | AsyncModelRunnerOutput | NoneType
+            ):
+                return output
+
+        assert isinstance(output, IntermediateTensors)
+        parallel_config = self.vllm_config.parallel_config
+        assert (
+            parallel_config.distributed_executor_backend != "external_launcher"
+            and not get_pp_group().is_last_rank
+        )
+
+        # launch non-blocking send of intermediate tensors
+        self._pp_send_work = get_pp_group().isend_tensor_dict(
+            output.tensors,
+            all_gather_group=get_tp_group(),
+            all_gather_tensors=all_gather_tensors,
+        )
+
+        return None
+
+    def take_draft_token_ids(self) -> DraftTokenIds | None:
+        return self.model_runner.take_draft_token_ids()
+
+    def profile(self, is_start: bool = True, profile_prefix: str | None = None):
+        # Check if profiling is enabled
+        if self.profiler_config is None or self.profiler_config.profiler is None:
+            raise RuntimeError(
+                "Profiling is not enabled. Please set --profiler-config to enable "
+                "profiling. Example: "
+                "'--profiler-config.profiler=torch --profiler-config.torch_profiler_dir"
+                "=YOUR_DIR_PATH_TO_DUMP_TRACE'"
+            )
+
+        if is_start:
+            profiler_type = self.profiler_config.profiler
+            # Generate the trace name by combining prefix with comprehensive rank suffix
+            from vllm.distributed.utils import get_worker_rank_suffix
+
+            rank_suffix = get_worker_rank_suffix(global_rank=self.rank)
+
+            # Build the full trace name
+            if profile_prefix:
+                trace_name = f"{profile_prefix}_{rank_suffix}"
+            else:
+                trace_name = rank_suffix
+
+            # Create the profiler wrapper only on the first start call
+            if self.profiler is None:
+                if profiler_type == "torch":
+                    self.profiler = TorchProfilerWrapper(
+                        self.profiler_config,
+                        worker_name=trace_name,
+                        local_rank=self.local_rank,
+                        activities=["CPU", "CUDA"],
+                    )
+                    logger.debug(
+                        "Starting torch profiler with trace name: %s", trace_name
+                    )
+                elif profiler_type == "cuda":
+                    self.profiler = CudaProfilerWrapper(self.profiler_config)
+                    logger.debug("Starting CUDA profiler")
+                elif profiler_type == "proton":
+                    self.profiler = ProtonProfilerWrapper(
+                        self.profiler_config, worker_name=trace_name
+                    )
+                    logger.debug(
+                        "Starting Proton profiler with trace name: %s", trace_name
+                    )
+                else:
+                    # Config validation should prevent this code being reached
+                    raise ValueError(
+                        f"Invalid profiler value of {self.profiler_config.profiler}"
+                    )
+
+            self.profiler.start()
+        else:
+            if self.profiler is None:
+                logger.warning("Profiler was not started, nothing to stop.")
+                return
+            try:
+                self.profiler.stop()
+            finally:
+                if self.profiler_config.profiler == "proton":
+                    # Proton output names are fixed when the wrapper is constructed.
+                    # Recreate it so the next profile_prefix is honored.
+                    self.profiler = None
+
+    def execute_dummy_batch(self) -> None:
+        num_tokens = getattr(self.model_runner, "uniform_decode_query_len", 1)
+        self.model_runner._dummy_run(num_tokens, uniform_decode=True)
+
+    def add_lora(self, lora_request: LoRARequest) -> bool:
+        return self.model_runner.add_lora(lora_request)
+
+    def remove_lora(self, lora_id: int) -> bool:
+        return self.model_runner.remove_lora(lora_id)
+
+    def list_loras(self) -> set[int]:
+        return self.model_runner.list_loras()
+
+    def pin_lora(self, lora_id: int) -> bool:
+        return self.model_runner.pin_lora(lora_id)
+
+    def check_health(self) -> None:
+        # worker will always be healthy as long as it's running.
+        return
+
+    def save_sharded_state(
+        self,
+        path: str,
+        pattern: str | None = None,
+        max_size: int | None = None,
+    ) -> None:
+        from vllm.model_executor.model_loader import ShardedStateLoader
+
+        ShardedStateLoader.save_model(
+            self.model_runner.model,
+            path,
+            pattern=pattern,
+            max_size=max_size,
+        )
+
+    def save_tensorized_model(self, tensorizer_config: "TensorizerConfig") -> None:
+        TensorizerLoader.save_model(
+            self.get_model(),
+            tensorizer_config=tensorizer_config,
+            model_config=self.model_config,
+        )
+
+    def _check_weight_transfer_engine(self) -> None:
+        if self.weight_transfer_engine is None:
+            raise RuntimeError(
+                "Weight transfer not configured. "
+                "Please set weight_transfer_config to enable weight transfer."
+            )
+
+    def init_weight_transfer_engine(self, init_info: dict) -> None:
+        """
+        Initialize weight transfer mechanism.
+        For NCCL backend, this creates a process group with the trainer.
+
+        Args:
+            init_info: Dictionary containing backend-specific initialization info
+        """
+        self._check_weight_transfer_engine()
+        assert self.weight_transfer_engine is not None
+        # Parse dict into backend-specific typed dataclass
+        typed_init_info = self.weight_transfer_engine.parse_init_info(init_info)
+        self.weight_transfer_engine.init_transfer_engine(typed_init_info)
+
+    def start_weight_update(self) -> None:
+        """
+        Start a new weight update session.
+
+        Delegates engine-specific preparation (e.g. layerwise reload setup) to
+        the configured weight transfer engine. The worker only tracks that a
+        session is active.
+        """
+        with set_current_vllm_config(self.vllm_config):
+            self._start_weight_update()
+
+    def start_draft_weight_update(self) -> None:
+        """
+        Like start_weight_update, but retargets the engine at the speculative
+        draft model for this session.
+        """
+        with set_current_vllm_config(self.vllm_config):
+            self._start_weight_update(is_draft=True)
+
+    def _start_weight_update(self, is_draft: bool = False) -> None:
+        self._check_weight_transfer_engine()
+        assert self.weight_transfer_engine is not None
+
+        if is_draft and not self.weight_transfer_engine.supports_draft_weight_update:
+            raise RuntimeError(
+                f"{type(self.weight_transfer_engine).__name__} does not support "
+                "draft model weight updates."
+            )
+
+        if self._weight_update_active:
+            raise RuntimeError(
+                "start_weight_update called while a weight update is already "
+                "active. Call finish_weight_update first."
+            )
+
+        try:
+            if is_draft:
+                self._set_draft_weight_update_target()
+            self.weight_transfer_engine.start_weight_update()
+        except BaseException:
+            self.weight_transfer_engine.reset_weight_update_target()
+            raise
+        self._weight_update_active = True
+        self._weight_update_is_draft = is_draft
+
+    def update_weights(self, update_info: dict) -> None:
+        """
+        Receive one weight update chunk from the trainer.
+
+        start_weight_update must be called before update_weights and
+        finish_weight_update must be called after all chunks have been sent.
+        Every chunk loads into whichever model the session's start_weight_update
+        / start_draft_weight_update call selected.
+
+        Args:
+            update_info: Dictionary containing backend-specific update info
+        """
+        self._check_weight_transfer_engine()
+        assert self.weight_transfer_engine is not None
+
+        if not self._weight_update_active:
+            raise RuntimeError(
+                "start_weight_update must be called before update_weights."
+            )
+
+        with set_current_vllm_config(self.vllm_config):
+            try:
+                self.weight_transfer_engine.update_weights(update_info)
+            except BaseException:
+                self._weight_update_active = False
+                self.weight_transfer_engine.reset_weight_update_target()
+                raise
+
+    def finish_weight_update(self) -> None:
+        """Finish the current weight update session."""
+        self._check_weight_transfer_engine()
+        assert self.weight_transfer_engine is not None
+
+        if not self._weight_update_active:
+            raise RuntimeError(
+                "finish_weight_update called without a matching start_weight_update."
+            )
+
+        with set_current_vllm_config(self.vllm_config):
+            self.weight_transfer_engine.finish_weight_update()
+            self.weight_transfer_engine.reset_weight_update_target()
+            self._weight_update_active = False
+
+        # Weight transfer bypasses GPUModelRunner.reload_weights().
+        if not self._weight_update_is_draft:
+            self.model_runner.reset_lora_state()
+
+    def shutdown(self) -> None:
+        gc.unfreeze()
+
+        # has_kv_transfer_group can be None during interpreter shutdown.
+        if ensure_kv_transfer_shutdown is not None:
+            ensure_kv_transfer_shutdown()
+        if ensure_ec_transfer_shutdown is not None:
+            ensure_ec_transfer_shutdown()
+        if self.profiler is not None:
+            self.profiler.shutdown()
+
+        if weight_transfer_engine := getattr(self, "weight_transfer_engine", None):
+            weight_transfer_engine.shutdown()
+
+        self.elastic_ep_executor.shutdown()
+
+        # Release GPU resources held by the model runner so that memory
+        # can be reclaimed when running in-process
+        if model_runner := getattr(self, "model_runner", None):
+            model_runner.shutdown()
+
+        # Release kept-alive cumem pools while the pluggable allocator wrappers
+        # and callbacks are still alive, so MemPool teardown is not deferred to
+        # interpreter finalization (pytorch/pytorch#145168).
+        if current_platform.is_cuda_alike():
+            from vllm.device_allocator.cumem import CuMemAllocator
+
+            if CuMemAllocator.instance is not None:
+                CuMemAllocator.instance.release_pools()
+
+    def elastic_ep_execute(self, execute_method: str, *args, **kwargs):
+        return self.elastic_ep_executor.execute(execute_method, *args, **kwargs)
+
+
+def init_worker_distributed_environment(
+    vllm_config: VllmConfig,
+    rank: int,
+    distributed_init_method: str | None = None,
+    local_rank: int = -1,
+    backend: str = "nccl",
+) -> None:
+    """Initialize the distributed environment."""
+    parallel_config = vllm_config.parallel_config
+    from vllm.model_executor.determinism.batch_invariant import init_batch_invariance
+
+    init_batch_invariance()
+    override_envs_for_eplb(
+        parallel_config,
+        moe_backend=getattr(vllm_config.kernel_config, "moe_backend", None),
+    )
+    set_custom_all_reduce(not parallel_config.disable_custom_all_reduce)
+
+    init_method = distributed_init_method or "env://"
+
+    timeout = None
+    if parallel_config.distributed_timeout_seconds is not None:
+        timeout = timedelta(seconds=parallel_config.distributed_timeout_seconds)
+
+    init_distributed_environment(
+        parallel_config.world_size,
+        rank,
+        init_method,
+        local_rank,
+        backend,
+        timeout,
+    )
+
+    ensure_model_parallel_initialized(
+        parallel_config.tensor_parallel_size,
+        parallel_config.pipeline_parallel_size,
+        parallel_config.prefill_context_parallel_size,
+        parallel_config.decode_context_parallel_size,
+    )
+
+    # Init ec connector here before KV caches init
+    # NOTE: We do not init KV caches for Encoder-only instance in EPD disagg mode
+    ensure_ec_transfer_initialized(vllm_config)

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -14,8 +14,8 @@ PyNvVideoCodec==2.0.4
 # flashinfer-cubin is not on PyPI since 0.6.14; setup.py excludes it from
 # install_requires so the published wheel does not carry an unresolvable pin
 --extra-index-url https://flashinfer.ai/whl/
-flashinfer-python==0.6.17
-flashinfer-cubin==0.6.17
+flashinfer-python==0.6.18
+flashinfer-cubin==0.6.18
 apache-tvm-ffi==0.1.11
 tilelang==0.1.12
 nvidia-cudnn-frontend>=1.19.1

--- a/tests/entrypoints/unit_tests/test_glm53_single_container.py
+++ b/tests/entrypoints/unit_tests/test_glm53_single_container.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib.util
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.cpu_test
+
+ROOT = Path(__file__).resolve().parents[3]
+SUPERVISOR = ROOT / "docker/glm53-flash/single-container/serve_glm53_with_lmcache.py"
+RECIPE = ROOT / "docker/glm53-flash/single-container/README.md"
+CUDA_REQUIREMENTS = ROOT / "requirements/cuda.txt"
+
+
+def _load_supervisor():
+    spec = importlib.util.spec_from_file_location("glm53_supervisor", SUPERVISOR)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_single_container_defaults_match_qualified_geometry(tmp_path) -> None:
+    supervisor = _load_supervisor()
+    lmcache = tmp_path / "lmcache"
+    vllm = tmp_path / "vllm"
+    lmcache.touch(mode=0o755)
+    vllm.touch(mode=0o755)
+    broker = tmp_path / "broker"
+    config = supervisor.load_config(
+        {
+            "GLM53_LMCACHE_EXECUTABLE": str(lmcache),
+            "GLM53_VLLM_EXECUTABLE": str(vllm),
+            "GLM53_LMCACHE_CUMEM_BROKER_DIR": str(broker),
+        }
+    )
+
+    assert config.chunk_size == 9216
+    assert config.l1_size_gb == 48
+    assert config.max_gpu_workers == 4
+    supervisor.ensure_broker_directory(broker)
+    assert stat.S_IMODE(broker.stat().st_mode) == 0o700
+    assert supervisor.child_environment(config, {})["LMCACHE_CUMEM_BROKER_DIR"] == str(
+        broker
+    )
+
+
+def test_single_container_rejects_unknown_runtime_variable() -> None:
+    supervisor = _load_supervisor()
+    with pytest.raises(ValueError, match="unknown GLM53"):
+        supervisor.load_config({"GLM53_LMCACHE_UNSAFE_OPTION": "1"})
+
+
+def test_single_container_recipe_preserves_qualified_d16_contract() -> None:
+    recipe = RECIPE.read_text()
+    requirements = CUDA_REQUIREMENTS.read_text()
+
+    assert "flashinfer-python==0.6.18" in requirements
+    assert "flashinfer-cubin==0.6.18" in requirements
+    for argument in (
+        "--tensor-parallel-size 4",
+        "--decode-context-parallel-size 4",
+        "--cp-kv-cache-interleave-size 4",
+        "--quantization modelopt_mixed",
+        "--attention-backend B12X",
+        "--linear-backend b12x",
+        "--max-model-len 1048576",
+        "--max-num-seqs 4",
+        "--max-num-batched-tokens 32768",
+        '"cudagraph_mode":"FULL"',
+        '"num_speculative_tokens":3',
+    ):
+        assert argument in recipe
+
+
+def test_lmcache_failure_prevents_vllm_start(tmp_path) -> None:
+    supervisor = _load_supervisor()
+    marker = tmp_path / "vllm-started"
+    lmcache = tmp_path / "lmcache"
+    lmcache.write_text("#!/bin/sh\nexit 7\n")
+    lmcache.chmod(0o755)
+    vllm = tmp_path / "vllm"
+    vllm.write_text(f"#!/bin/sh\ntouch '{marker}'\n")
+    vllm.chmod(0o755)
+
+    status = supervisor.supervise(
+        ["serve", "model"],
+        {
+            "GLM53_LMCACHE_EXECUTABLE": str(lmcache),
+            "GLM53_VLLM_EXECUTABLE": str(vllm),
+            "GLM53_LMCACHE_CUMEM_BROKER_DIR": str(tmp_path / "broker"),
+            "GLM53_LMCACHE_STARTUP_TIMEOUT_SECONDS": "1",
+            "GLM53_LMCACHE_HEALTH_POLL_SECONDS": "0.01",
+            "GLM53_LMCACHE_SHUTDOWN_GRACE_SECONDS": "0.1",
+        },
+    )
+
+    assert status == 7
+    assert not marker.exists()

--- a/tests/entrypoints/unit_tests/test_glm53_single_container.py
+++ b/tests/entrypoints/unit_tests/test_glm53_single_container.py
@@ -15,12 +15,23 @@ ROOT = Path(__file__).resolve().parents[3]
 SUPERVISOR = ROOT / "docker/glm53-flash/single-container/serve_glm53_with_lmcache.py"
 RECIPE = ROOT / "docker/glm53-flash/single-container/README.md"
 DOCKERFILE = ROOT / "docker/glm53-flash/single-container/Dockerfile"
-VLLM_OVERLAY = (
-    ROOT / "docker/glm53-flash/single-container/vllm-startup-overlay/vllm"
-)
+VLLM_OVERLAY = ROOT / "docker/glm53-flash/single-container/vllm-startup-overlay/vllm"
 GPU_WORKER = VLLM_OVERLAY / "v1/worker/gpu_worker.py"
 GPU_WARMUP = VLLM_OVERLAY / "v1/worker/gpu/warmup.py"
 CUDA_REQUIREMENTS = ROOT / "requirements/cuda.txt"
+METRICS_SAMPLE = (
+    "# HELP vllm:cache_config_info Information of the LLMEngine CacheConfig\n"
+    "# TYPE vllm:cache_config_info gauge\n"
+    'vllm:cache_config_info{block_size="2304",cache_dtype="fp8_e4m3",'
+    'enable_prefix_caching="True",gpu_memory_utilization="0.9",'
+    'kv_cache_max_concurrency="1.4728683471679688",'
+    'kv_cache_size_tokens="1544414",num_gpu_blocks="670",'
+    'swap_space_bytes="4294967296"} 1.0\n'
+)
+KV_POOL_SUMMARY = (
+    "KV pool: 1,544,414 tokens | max-context concurrency: 1.47x "
+    "| block: 2304 | dtype: fp8_e4m3"
+)
 
 
 def _load_supervisor():
@@ -41,9 +52,7 @@ def _function(tree: ast.AST, name: str) -> ast.FunctionDef:
 
 
 def _call_name(statement: ast.stmt) -> str | None:
-    if not isinstance(statement, ast.Expr) or not isinstance(
-        statement.value, ast.Call
-    ):
+    if not isinstance(statement, ast.Expr) or not isinstance(statement.value, ast.Call):
         return None
     return ast.unparse(statement.value.func)
 
@@ -114,9 +123,28 @@ def test_single_container_defaults_match_qualified_geometry(tmp_path) -> None:
     ]
     supervisor.ensure_broker_directory(broker)
     assert stat.S_IMODE(broker.stat().st_mode) == 0o700
-    assert supervisor.child_environment(config, {})["LMCACHE_CUMEM_BROKER_DIR"] == str(
-        broker
+    child_env = supervisor.child_environment(config, {})
+    assert child_env["LMCACHE_CUMEM_BROKER_DIR"] == str(broker)
+    assert child_env["VLLM_LOGGING_LEVEL"] == "WARNING"
+    assert child_env["LMCACHE_LOG_LEVEL"] == "WARNING"
+
+
+def test_single_container_preserves_child_log_level_overrides(tmp_path) -> None:
+    supervisor = _load_supervisor()
+    config = supervisor.load_config(
+        {"GLM53_LMCACHE_CUMEM_BROKER_DIR": str(tmp_path / "broker")}
     )
+
+    child_env = supervisor.child_environment(
+        config,
+        {
+            "VLLM_LOGGING_LEVEL": "DEBUG",
+            "LMCACHE_LOG_LEVEL": "INFO",
+        },
+    )
+
+    assert child_env["VLLM_LOGGING_LEVEL"] == "DEBUG"
+    assert child_env["LMCACHE_LOG_LEVEL"] == "INFO"
 
 
 def test_single_container_rejects_unknown_runtime_variable() -> None:
@@ -148,6 +176,121 @@ def test_single_container_keeps_one_prompt_tokens_details_flag() -> None:
     )
 
     assert args == ["serve", "model", flag, "--port", "8000"]
+
+
+def test_kv_pool_summary_reports_only_capacity_fields() -> None:
+    supervisor = _load_supervisor()
+
+    summary = supervisor.kv_pool_summary(METRICS_SAMPLE)
+
+    assert summary == KV_POOL_SUMMARY
+    for unrelated in (
+        "gpu_memory_utilization",
+        "num_gpu_blocks",
+        "swap_space_bytes",
+        "enable_prefix_caching",
+        "0.9",
+    ):
+        assert unrelated not in summary
+
+
+def test_kv_pool_summary_falls_back_to_max_model_len() -> None:
+    supervisor = _load_supervisor()
+    without_concurrency = METRICS_SAMPLE.replace(
+        'kv_cache_max_concurrency="1.4728683471679688",', ""
+    )
+
+    assert supervisor.kv_pool_summary(without_concurrency) is None
+    assert supervisor.kv_pool_summary(without_concurrency, 1048576) == KV_POOL_SUMMARY
+    assert (
+        supervisor._max_model_len(["serve", "model", "--max-model-len", "1048576"])
+        == 1048576
+    )
+    assert (
+        supervisor._max_model_len(["serve", "model", "--max-model-len=1048576"])
+        == 1048576
+    )
+    assert supervisor._max_model_len(["serve", "model"]) is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "",
+        "# HELP vllm:cache_config_info Information of the LLMEngine CacheConfig\n",
+        'vllm:cache_config_info{block_size="2304"} 1.0\n',
+        'vllm:cache_config_info{kv_cache_size_tokens="many",block_size="2304",'
+        'cache_dtype="fp8_e4m3",kv_cache_max_concurrency="1.47"} 1.0\n',
+        'vllm:cache_config_info{kv_cache_size_tokens="1544414",block_size="0",'
+        'cache_dtype="fp8_e4m3",kv_cache_max_concurrency="1.47"} 1.0\n',
+        'vllm:cache_config_info{kv_cache_size_tokens="1544414",block_size="2304",'
+        'cache_dtype="",kv_cache_max_concurrency="1.47"} 1.0\n',
+        'vllm:cache_config_info{kv_cache_size_tokens="1544414",block_size="2304",'
+        'cache_dtype="fp8_e4m3",kv_cache_max_concurrency="nan"} 1.0\n',
+        'vllm:cache_config_info{kv_cache_size_tokens="1544414",block_size="2304",'
+        'cache_dtype="fp8_e4m3",kv_cache_max_concurrency="1.47"\n',
+        "<html><body>404 not found</body></html>\n",
+    ],
+)
+def test_kv_pool_summary_rejects_malformed_metrics(payload) -> None:
+    supervisor = _load_supervisor()
+
+    assert supervisor.kv_pool_summary(payload) is None
+
+
+@pytest.mark.parametrize(
+    ("status", "body"),
+    [
+        (503, b"unavailable"),
+        (200, b"x" * ((1 << 20) + 1)),
+        (200, b"\xff"),
+    ],
+)
+def test_metrics_response_failures_return_none(
+    tmp_path, monkeypatch, status, body
+) -> None:
+    supervisor = _load_supervisor()
+    config = supervisor.load_config(
+        {"GLM53_LMCACHE_CUMEM_BROKER_DIR": str(tmp_path / "broker")}
+    )
+
+    class Response:
+        def read(self, amount: int) -> bytes:
+            assert amount == supervisor.METRICS_BODY_LIMIT_BYTES + 1
+            return body[:amount]
+
+    class Connection:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def request(self, method: str, path: str) -> None:
+            assert (method, path) == ("GET", "/metrics")
+
+        def getresponse(self) -> Response:
+            response = Response()
+            response.status = status
+            return response
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(supervisor.http.client, "HTTPConnection", Connection)
+
+    assert supervisor._fetch_metrics(config, 5.0) is None
+
+
+def test_unavailable_metrics_warn_once(monkeypatch, capsys, tmp_path) -> None:
+    supervisor = _load_supervisor()
+    config = supervisor.load_config(
+        {"GLM53_LMCACHE_CUMEM_BROKER_DIR": str(tmp_path / "broker")}
+    )
+    monkeypatch.setattr(supervisor, "_fetch_metrics", lambda *_args: None)
+
+    supervisor.report_kv_pool(config, ["serve", "model"])
+
+    stderr = capsys.readouterr().err
+    assert stderr.count("WARNING KV pool capacity unavailable from /metrics") == 1
+    assert "KV pool:" not in stderr
 
 
 def test_single_container_recipe_preserves_qualified_d16_contract() -> None:
@@ -217,9 +360,7 @@ def test_scheduler_warmup_stages_are_rank_fenced() -> None:
 
 
 def test_kernel_warmup_is_fenced_before_full_graph_capture() -> None:
-    method = _function(
-        ast.parse(GPU_WORKER.read_text()), "compile_or_warm_up_model"
-    )
+    method = _function(ast.parse(GPU_WORKER.read_text()), "compile_or_warm_up_model")
     calls = sorted(
         (node.lineno, node.col_offset, ast.unparse(node))
         for node in ast.walk(method)
@@ -309,3 +450,49 @@ def test_supervisor_launches_vllm_with_prompt_tokens_details(
         "8000",
         "--enable-prompt-tokens-details",
     ]
+
+
+def test_supervisor_fetches_metrics_once_after_readiness(tmp_path, monkeypatch) -> None:
+    supervisor = _load_supervisor()
+    lmcache = tmp_path / "lmcache"
+    vllm = tmp_path / "vllm"
+    lmcache.touch(mode=0o755)
+    vllm.touch(mode=0o755)
+    events: list[str] = []
+
+    class Process:
+        pid = 1
+
+        def __init__(self, argv: list[str], **_kwargs: object) -> None:
+            self.is_vllm = argv[0] == str(vllm)
+
+        def poll(self) -> int | None:
+            if self.is_vllm and "metrics" in events:
+                return 0
+            return None
+
+    def readiness(*_args) -> bool:
+        events.append("readiness")
+        return True
+
+    def fetch_metrics(*_args) -> str:
+        events.append("metrics")
+        return METRICS_SAMPLE
+
+    monkeypatch.setattr(supervisor.subprocess, "Popen", Process)
+    monkeypatch.setattr(supervisor, "_healthy", lambda *_args: True)
+    monkeypatch.setattr(supervisor, "_vllm_healthy", readiness)
+    monkeypatch.setattr(supervisor, "_fetch_metrics", fetch_metrics)
+    monkeypatch.setattr(supervisor, "_stop_processes", lambda *_args: None)
+
+    status = supervisor.supervise(
+        ["serve", "model", "--max-model-len=1048576"],
+        {
+            "GLM53_LMCACHE_EXECUTABLE": str(lmcache),
+            "GLM53_VLLM_EXECUTABLE": str(vllm),
+            "GLM53_LMCACHE_CUMEM_BROKER_DIR": str(tmp_path / "broker"),
+        },
+    )
+
+    assert status == 0
+    assert events == ["readiness", "metrics"]

--- a/tests/entrypoints/unit_tests/test_glm53_single_container.py
+++ b/tests/entrypoints/unit_tests/test_glm53_single_container.py
@@ -3,7 +3,9 @@
 
 import ast
 import importlib.util
+import json
 import stat
+import subprocess
 import sys
 from pathlib import Path
 
@@ -15,6 +17,7 @@ ROOT = Path(__file__).resolve().parents[3]
 SUPERVISOR = ROOT / "docker/glm53-flash/single-container/serve_glm53_with_lmcache.py"
 RECIPE = ROOT / "docker/glm53-flash/single-container/README.md"
 DOCKERFILE = ROOT / "docker/glm53-flash/single-container/Dockerfile"
+LOGGING_CONFIG = ROOT / "docker/glm53-flash/single-container/glm53-logging.json"
 VLLM_OVERLAY = ROOT / "docker/glm53-flash/single-container/vllm-startup-overlay/vllm"
 GPU_WORKER = VLLM_OVERLAY / "v1/worker/gpu_worker.py"
 GPU_WARMUP = VLLM_OVERLAY / "v1/worker/gpu/warmup.py"
@@ -125,11 +128,13 @@ def test_single_container_defaults_match_qualified_geometry(tmp_path) -> None:
     assert stat.S_IMODE(broker.stat().st_mode) == 0o700
     child_env = supervisor.child_environment(config, {})
     assert child_env["LMCACHE_CUMEM_BROKER_DIR"] == str(broker)
-    assert child_env["VLLM_LOGGING_LEVEL"] == "WARNING"
+    assert child_env["VLLM_LOGGING_CONFIG_PATH"] == supervisor.VLLM_LOGGING_CONFIG
+    assert "VLLM_LOGGING_LEVEL" not in child_env
     assert child_env["LMCACHE_LOG_LEVEL"] == "WARNING"
 
 
-def test_single_container_preserves_child_log_level_overrides(tmp_path) -> None:
+@pytest.mark.parametrize("level", ["INFO", "DEBUG"])
+def test_vllm_log_level_override_prevents_default_config(tmp_path, level) -> None:
     supervisor = _load_supervisor()
     config = supervisor.load_config(
         {"GLM53_LMCACHE_CUMEM_BROKER_DIR": str(tmp_path / "broker")}
@@ -138,13 +143,78 @@ def test_single_container_preserves_child_log_level_overrides(tmp_path) -> None:
     child_env = supervisor.child_environment(
         config,
         {
-            "VLLM_LOGGING_LEVEL": "DEBUG",
+            "VLLM_LOGGING_LEVEL": level,
             "LMCACHE_LOG_LEVEL": "INFO",
         },
     )
 
-    assert child_env["VLLM_LOGGING_LEVEL"] == "DEBUG"
+    assert child_env["VLLM_LOGGING_LEVEL"] == level
+    assert "VLLM_LOGGING_CONFIG_PATH" not in child_env
     assert child_env["LMCACHE_LOG_LEVEL"] == "INFO"
+
+
+def test_vllm_logging_config_override_is_preserved(tmp_path) -> None:
+    supervisor = _load_supervisor()
+    config = supervisor.load_config(
+        {"GLM53_LMCACHE_CUMEM_BROKER_DIR": str(tmp_path / "broker")}
+    )
+    custom_config = "/operator/logging.json"
+
+    child_env = supervisor.child_environment(
+        config, {"VLLM_LOGGING_CONFIG_PATH": custom_config}
+    )
+
+    assert child_env["VLLM_LOGGING_CONFIG_PATH"] == custom_config
+    assert "VLLM_LOGGING_LEVEL" not in child_env
+    assert child_env["LMCACHE_LOG_LEVEL"] == "WARNING"
+
+
+def test_packaged_logging_config_selects_only_periodic_metrics() -> None:
+    config = json.loads(LOGGING_CONFIG.read_text())
+    loggers = config["loggers"]
+    info_loggers = {
+        name for name, settings in loggers.items() if settings["level"] == "INFO"
+    }
+
+    assert config["handlers"]["vllm"]["level"] == "INFO"
+    assert loggers["vllm"] == {
+        "handlers": ["vllm"],
+        "level": "WARNING",
+        "propagate": False,
+    }
+    assert info_loggers == {
+        "vllm.v1.metrics.loggers",
+        "vllm.v1.spec_decode.metrics",
+    }
+    for name in info_loggers:
+        assert "handlers" not in loggers[name]
+        assert loggers[name]["propagate"] is True
+
+
+def test_packaged_logging_config_emits_selected_info_once() -> None:
+    script = """
+import json
+import logging
+import logging.config
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as config_file:
+    logging.config.dictConfig(json.load(config_file))
+logging.getLogger("vllm.other").info("hidden-info")
+logging.getLogger("vllm.other").warning("general-warning")
+logging.getLogger("vllm.v1.metrics.loggers").info("request-metrics")
+logging.getLogger("vllm.v1.spec_decode.metrics").info("spec-metrics")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(LOGGING_CONFIG)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "hidden-info" not in result.stderr
+    for message in ("general-warning", "request-metrics", "spec-metrics"):
+        assert result.stderr.count(message) == 1
 
 
 def test_single_container_rejects_unknown_runtime_variable() -> None:
@@ -318,6 +388,10 @@ def test_single_container_recipe_preserves_qualified_d16_contract() -> None:
 def test_docker_installs_startup_fences_into_vllm_package() -> None:
     dockerfile = DOCKERFILE.read_text()
 
+    assert (
+        "COPY single-container/glm53-logging.json "
+        "/etc/vllm/glm53-logging.json" in dockerfile
+    )
     assert (
         "COPY single-container/vllm-startup-overlay/ "
         "/opt/glm53-vllm-startup-overlay/" in dockerfile

--- a/tests/entrypoints/unit_tests/test_glm53_single_container.py
+++ b/tests/entrypoints/unit_tests/test_glm53_single_container.py
@@ -43,6 +43,39 @@ def test_single_container_defaults_match_qualified_geometry(tmp_path) -> None:
     assert config.chunk_size == 9216
     assert config.l1_size_gb == 48
     assert config.max_gpu_workers == 4
+    assert supervisor.lmcache_argv(config) == [
+        str(lmcache),
+        "server",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "5555",
+        "--http-host",
+        "127.0.0.1",
+        "--http-port",
+        "8080",
+        "--l1-size-gb",
+        "48",
+        "--l1-init-size-gb",
+        "20",
+        "--l1-align-bytes",
+        "16384",
+        "--max-gpu-workers",
+        "4",
+        "--max-cpu-workers",
+        "8",
+        "--chunk-size",
+        "9216",
+        "--eviction-trigger-watermark",
+        "0.85",
+        "--eviction-ratio",
+        "0.1",
+        "--eviction-policy",
+        "LRU",
+        "--supported-transfer-mode",
+        "lmcache_driven",
+        "--separate-object-groups",
+    ]
     supervisor.ensure_broker_directory(broker)
     assert stat.S_IMODE(broker.stat().st_mode) == 0o700
     assert supervisor.child_environment(config, {})["LMCACHE_CUMEM_BROKER_DIR"] == str(

--- a/tests/entrypoints/unit_tests/test_glm53_single_container.py
+++ b/tests/entrypoints/unit_tests/test_glm53_single_container.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import ast
 import importlib.util
 import stat
 import sys
@@ -13,6 +14,12 @@ pytestmark = pytest.mark.cpu_test
 ROOT = Path(__file__).resolve().parents[3]
 SUPERVISOR = ROOT / "docker/glm53-flash/single-container/serve_glm53_with_lmcache.py"
 RECIPE = ROOT / "docker/glm53-flash/single-container/README.md"
+DOCKERFILE = ROOT / "docker/glm53-flash/single-container/Dockerfile"
+VLLM_OVERLAY = (
+    ROOT / "docker/glm53-flash/single-container/vllm-startup-overlay/vllm"
+)
+GPU_WORKER = VLLM_OVERLAY / "v1/worker/gpu_worker.py"
+GPU_WARMUP = VLLM_OVERLAY / "v1/worker/gpu/warmup.py"
 CUDA_REQUIREMENTS = ROOT / "requirements/cuda.txt"
 
 
@@ -23,6 +30,35 @@ def _load_supervisor():
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _function(tree: ast.AST, name: str) -> ast.FunctionDef:
+    return next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+
+
+def _call_name(statement: ast.stmt) -> str | None:
+    if not isinstance(statement, ast.Expr) or not isinstance(
+        statement.value, ast.Call
+    ):
+        return None
+    return ast.unparse(statement.value.func)
+
+
+def _statement_lists(node: ast.AST):
+    for _, value in ast.iter_fields(node):
+        if isinstance(value, list):
+            statements = [item for item in value if isinstance(item, ast.stmt)]
+            if statements:
+                yield statements
+            for item in value:
+                if isinstance(item, ast.AST):
+                    yield from _statement_lists(item)
+        elif isinstance(value, ast.AST):
+            yield from _statement_lists(value)
 
 
 def test_single_container_defaults_match_qualified_geometry(tmp_path) -> None:
@@ -109,6 +145,68 @@ def test_single_container_recipe_preserves_qualified_d16_contract() -> None:
         '"num_speculative_tokens":3',
     ):
         assert argument in recipe
+
+
+def test_docker_installs_startup_fences_into_vllm_package() -> None:
+    dockerfile = DOCKERFILE.read_text()
+
+    assert (
+        "COPY single-container/vllm-startup-overlay/ "
+        "/opt/glm53-vllm-startup-overlay/" in dockerfile
+    )
+    assert (
+        'cp -a /opt/glm53-vllm-startup-overlay/vllm/. "${python_dir}/vllm/";'
+        in dockerfile
+    )
+    assert GPU_WORKER.is_file()
+    assert GPU_WARMUP.is_file()
+
+
+def test_scheduler_warmup_stages_are_rank_fenced() -> None:
+    warmup = _function(ast.parse(GPU_WARMUP.read_text()), "warmup_kernels")
+    fence = _function(warmup, "_fence")
+    assert [_call_name(statement) for statement in fence.body] == [
+        "torch.accelerator.synchronize",
+        "get_tp_group().barrier",
+    ]
+
+    stage_counts = {"worker_execute_model": 0, "worker_sample_tokens": 0}
+    for statements in _statement_lists(warmup):
+        for index, statement in enumerate(statements):
+            stage = _call_name(statement)
+            if stage not in stage_counts:
+                continue
+            stage_counts[stage] += 1
+            assert _call_name(statements[index + 1]) == "_fence"
+            if stage == "worker_execute_model":
+                assert _call_name(statements[index - 1]) == "_fence"
+
+    assert stage_counts == {"worker_execute_model": 3, "worker_sample_tokens": 2}
+    direct_calls = [
+        _call_name(statement) for statement in warmup.body if _call_name(statement)
+    ]
+    assert direct_calls[-2:] == [
+        "torch.accelerator.synchronize",
+        "get_tp_group().barrier",
+    ]
+
+
+def test_kernel_warmup_is_fenced_before_full_graph_capture() -> None:
+    method = _function(
+        ast.parse(GPU_WORKER.read_text()), "compile_or_warm_up_model"
+    )
+    calls = sorted(
+        (node.lineno, node.col_offset, ast.unparse(node))
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call)
+    )
+    call_sources = [source for _, _, source in calls]
+
+    warmup = call_sources.index("kernel_warmup(self)")
+    sync = call_sources.index("torch.accelerator.synchronize()", warmup)
+    barrier = call_sources.index("get_tp_group().barrier()", sync)
+    capture = call_sources.index("self.model_runner.capture_model()", barrier)
+    assert warmup < sync < barrier < capture
 
 
 def test_lmcache_failure_prevents_vllm_start(tmp_path) -> None:

--- a/tests/entrypoints/unit_tests/test_glm53_single_container.py
+++ b/tests/entrypoints/unit_tests/test_glm53_single_container.py
@@ -125,6 +125,31 @@ def test_single_container_rejects_unknown_runtime_variable() -> None:
         supervisor.load_config({"GLM53_LMCACHE_UNSAFE_OPTION": "1"})
 
 
+def test_single_container_appends_prompt_tokens_details_flag() -> None:
+    supervisor = _load_supervisor()
+
+    args = supervisor._with_prompt_tokens_details(["serve", "model", "--port", "8000"])
+
+    assert args == [
+        "serve",
+        "model",
+        "--port",
+        "8000",
+        "--enable-prompt-tokens-details",
+    ]
+
+
+def test_single_container_keeps_one_prompt_tokens_details_flag() -> None:
+    supervisor = _load_supervisor()
+    flag = "--enable-prompt-tokens-details"
+
+    args = supervisor._with_prompt_tokens_details(
+        ["serve", "model", flag, "--port", "8000", flag]
+    )
+
+    assert args == ["serve", "model", flag, "--port", "8000"]
+
+
 def test_single_container_recipe_preserves_qualified_d16_contract() -> None:
     recipe = RECIPE.read_text()
     requirements = CUDA_REQUIREMENTS.read_text()
@@ -233,3 +258,54 @@ def test_lmcache_failure_prevents_vllm_start(tmp_path) -> None:
 
     assert status == 7
     assert not marker.exists()
+
+
+def test_supervisor_launches_vllm_with_prompt_tokens_details(
+    tmp_path, monkeypatch
+) -> None:
+    supervisor = _load_supervisor()
+    lmcache = tmp_path / "lmcache"
+    vllm = tmp_path / "vllm"
+    lmcache.touch(mode=0o755)
+    vllm.touch(mode=0o755)
+    launched: list[list[str]] = []
+
+    class Process:
+        pid = 1
+
+        def __init__(self, argv: list[str], **_kwargs: object) -> None:
+            launched.append(argv)
+
+        def poll(self) -> int | None:
+            return 0 if self is vllm_process else None
+
+    def popen(argv: list[str], **kwargs: object) -> Process:
+        nonlocal vllm_process
+        process = Process(argv, **kwargs)
+        if argv[0] == str(vllm):
+            vllm_process = process
+        return process
+
+    vllm_process: Process | None = None
+    monkeypatch.setattr(supervisor.subprocess, "Popen", popen)
+    monkeypatch.setattr(supervisor, "_healthy", lambda *_args: True)
+    monkeypatch.setattr(supervisor, "_stop_processes", lambda *_args: None)
+
+    status = supervisor.supervise(
+        ["serve", "model", "--port", "8000"],
+        {
+            "GLM53_LMCACHE_EXECUTABLE": str(lmcache),
+            "GLM53_VLLM_EXECUTABLE": str(vllm),
+            "GLM53_LMCACHE_CUMEM_BROKER_DIR": str(tmp_path / "broker"),
+        },
+    )
+
+    assert status == 0
+    assert launched[1] == [
+        str(vllm),
+        "serve",
+        "model",
+        "--port",
+        "8000",
+        "--enable-prompt-tokens-details",
+    ]


### PR DESCRIPTION
## Summary

Packages the verified GLM-5.3 vLLM + LMCache topology as one supervised lifecycle feature and enables the hybrid object separation required by exact Mamba state caching.

### Behavior

- LMCache starts first and health-gates vLLM
- PID-1 supervisor owns both sibling process groups
- bounded vLLM startup health gate catches live-parent/dead-worker wedges
- either child exiting terminates the other
- SIGTERM/SIGINT forwarding and bounded cleanup
- private shared broker directory
- `--separate-object-groups` is mandatory for the GLM hybrid recipe
- exact-1M TP4/DCP4/MTP3/B12X launch recipe
- pinned qualified FlashInfer 0.6.18 pair
- `--enable-prompt-tokens-details` injected exactly once so gateways can report cached prompt tokens

Exact Mamba boundary semantics are in #525; sparse transfer normalization is in #526.

## Why object separation is required

Attention stores full prefix history. Align-mode Mamba retains exact recurrent checkpoints only at committed boundaries. Combining them into one full-attention object group either requires nonexistent historical Mamba states or stores stale positional state. Separate object groups preserve full attention objects while allowing all-null historical Mamba objects to be skipped and exact retained checkpoints to be stored.

## Verification

- focused lifecycle/config tests: reported in the latest branch commit
- `git diff --check`: clean
- production D22 single-container deployment: exact 1M, TP4/DCP4/MTP3/FULL graphs, four CUDA-IPC mappings, 128k external reload correctness, healthy endpoint, restart count 0
- backend measured 96.13% effective cached prompt share; vLLM now exposes `usage.prompt_tokens_details.cached_tokens` for Bifrost accounting on the next deployment

Supersedes the lifecycle portion of closed umbrella PR #522.

## Duplicate-work note

This updates the existing lifecycle submission; no new overlapping PR is opened.

## AI assistance disclosure

AI assistance was used for implementation and tests. Devin Kuhn reviewed and directed the behavior.

## Final D22 production receipt (2026-08-30)

The supervised one-container lifecycle is live on image `sha256:b73579097f4d68b52c20f7996cbd8f03a27e51bf3109e60ea5cda81105122aab`, healthy with restart count 0. LMCache registered four CUDA-IPC allocations and separated recurrent/attention object groups. `--enable-prompt-tokens-details` is injected exactly once: a forced external reload reported `cached_tokens: 119,808`, and a repeated request through the existing Bifrost route reported `cached_tokens` / `cached_read_tokens: 27,648` without any Bifrost mutation.

Fleet-owned immutable deployment receipt: Apple-Federal-Credit-Union/fleet-infra#309.
