### PR TITLE
perf(glm5next): accelerate DFlash prefill with FlashKDA checkpoints

### DIFF
--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers import mla as mla_layer
 from vllm.model_executor.layers.mamba.gdn import kimi_gdn_linear_attn
 from vllm.model_executor.layers.mamba.gdn.kimi_gdn_linear_attn import (
     KimiGatedDeltaNetAttention,
+    resolve_kda_prefill_backend,
 )
 from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptMixedPrecisionConfig,
@@ -461,7 +462,10 @@ def test_glm5next_moe_does_not_give_gate_to_runner(monkeypatch) -> None:
     assert "gate" not in factory_kwargs
 
 
-def test_glm5next_kda_splits_mixed_decode_prefill_batch(monkeypatch) -> None:
+@pytest.mark.parametrize("prefill_backend", ["triton", "flashkda"])
+def test_glm5next_kda_splits_mixed_decode_prefill_batch(
+    monkeypatch, prefill_backend: str
+) -> None:
     from vllm.models.kimi_k3.nvidia.ops.third_party import kda as kda_ops
     from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 
@@ -493,6 +497,12 @@ def test_glm5next_kda_splits_mixed_decode_prefill_batch(monkeypatch) -> None:
     layer.local_projection_size = 1
     layer.local_num_heads = 1
     layer.gate_lower_bound = -5.0
+    layer.kda_prefill_backend = prefill_backend
+    layer._flashkda_buffer_specs = (
+        ((1, 4, 1, 1), torch.float32),
+        ((1, 1, 1, 1), torch.float32),
+        ((1,), torch.uint8),
+    )
     layer.A_log = torch.ones(1)
     layer.dt_bias = torch.ones(1)
     layer._b12x_kda_plan = None
@@ -529,6 +539,21 @@ def test_glm5next_kda_splits_mixed_decode_prefill_batch(monkeypatch) -> None:
         calls["chunk_offsets"] = chunk_offsets
         return torch.full_like(q, 22), torch.full_like(initial_state, 33)
 
+    def fake_flashkda(
+        *, q, beta, initial_state, cu_seqlens, out, final_state, **kwargs
+    ):
+        calls["prefill_q_len"] = q.shape[1]
+        calls["prefill_query_start_loc"] = cu_seqlens.clone()
+        calls["prefill_beta"] = beta.clone()
+        out.fill_(22)
+        final_state.fill_(33)
+        return out, final_state
+
+    class FakeWorkspaceManager:
+        @staticmethod
+        def get_simultaneous(*specs):
+            return [torch.empty(shape, dtype=dtype) for shape, dtype in specs]
+
     def fake_gather(state, indices, has_initial_state):
         calls["prefill_state_indices"] = indices.clone()
         calls["prefill_has_initial_state"] = has_initial_state.clone()
@@ -542,6 +567,12 @@ def test_glm5next_kda_splits_mixed_decode_prefill_batch(monkeypatch) -> None:
     monkeypatch.setattr(kimi_gdn_linear_attn, "is_conv_state_dim_first", lambda: True)
     monkeypatch.setattr(kimi_gdn_linear_attn, "causal_conv1d_fn", fake_conv)
     monkeypatch.setattr(kimi_gdn_linear_attn, "gather_initial_states", fake_gather)
+    monkeypatch.setattr(kimi_gdn_linear_attn, "_flashkda_prefill", fake_flashkda)
+    monkeypatch.setattr(
+        kimi_gdn_linear_attn,
+        "current_workspace_manager",
+        lambda: FakeWorkspaceManager(),
+    )
     monkeypatch.setattr(kda_ops, "fused_recurrent_kda", fake_recurrent)
     monkeypatch.setattr(kda_ops, "chunk_kda_with_fused_gate", fake_chunk)
 
@@ -565,8 +596,11 @@ def test_glm5next_kda_splits_mixed_decode_prefill_batch(monkeypatch) -> None:
     assert torch.equal(
         calls["prefill_query_start_loc"], torch.tensor([0, 2], dtype=torch.int32)
     )
-    assert calls["chunk_indices"] is chunk_indices
-    assert calls["chunk_offsets"] is chunk_offsets
+    if prefill_backend == "triton":
+        assert calls["chunk_indices"] is chunk_indices
+        assert calls["chunk_offsets"] is chunk_offsets
+    else:
+        assert torch.equal(calls["prefill_beta"], torch.ones(1, 2, 1))
     assert torch.equal(
         calls["prefill_state_indices"], torch.tensor([3], dtype=torch.int32)
     )
@@ -574,6 +608,45 @@ def test_glm5next_kda_splits_mixed_decode_prefill_batch(monkeypatch) -> None:
     assert torch.equal(core_attn_out[:, :2], torch.full((1, 2, 1, 1), 11.0))
     assert torch.equal(core_attn_out[:, 2:], torch.full((1, 2, 1, 1), 22.0))
     assert torch.equal(layer.kv_cache[1][3], torch.full((1, 1, 1), 33.0))
+
+
+@pytest.mark.parametrize(
+    ("configured", "supported", "expected"),
+    [
+        ("auto", True, "flashkda"),
+        ("auto", False, "triton"),
+        ("flashkda", True, "flashkda"),
+        ("triton", True, "triton"),
+    ],
+)
+def test_glm5next_kda_prefill_backend_resolution(
+    monkeypatch, configured: str, supported: bool, expected: str
+) -> None:
+    monkeypatch.setattr(
+        kimi_gdn_linear_attn,
+        "is_flashkda_supported",
+        lambda *args: supported,
+    )
+
+    assert (
+        resolve_kda_prefill_backend(configured, 128, torch.bfloat16, -5.0) == expected
+    )
+
+
+def test_glm5next_explicit_flashkda_rejects_unsupported_layer(monkeypatch) -> None:
+    monkeypatch.setattr(
+        kimi_gdn_linear_attn,
+        "is_flashkda_supported",
+        lambda *args: False,
+    )
+
+    with pytest.raises(RuntimeError, match="FlashKDA requires"):
+        resolve_kda_prefill_backend("flashkda", 64, torch.float16, None)
+
+
+def test_glm5next_kda_prefill_backend_rejects_unknown_name() -> None:
+    with pytest.raises(ValueError, match="Unsupported KDA prefill backend"):
+        resolve_kda_prefill_backend("unknown", 128, torch.bfloat16, -5.0)
 
 
 def test_glm5next_alone_opts_into_b12x_kda_decode() -> None:

--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -501,6 +501,7 @@ def test_glm5next_kda_splits_mixed_decode_prefill_batch(
     layer._flashkda_buffer_specs = (
         ((1, 4, 1, 1), torch.float32),
         ((1, 1, 1, 1), torch.float32),
+        ((1, 1, 1, 1), torch.float32),
         ((1,), torch.uint8),
     )
     layer.A_log = torch.ones(1)

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -123,11 +123,13 @@ GDN_BUILD_TEST_CASES = {
 def _create_gdn_builder(
     num_speculative_tokens: int = 0,
     full_cuda_graph: bool = False,
+    num_prefill_checkpoint_blocks: int = 0,
 ) -> GDNAttentionMetadataBuilder:
     """Create a GDNAttentionMetadataBuilder with minimal config."""
     vllm_config = create_vllm_config(
         model_name="Qwen/Qwen3.5-0.8B",
         block_size=BLOCK_SIZE,
+        max_num_batched_tokens=4096,
     )
     if full_cuda_graph:
         vllm_config.compilation_config.cudagraph_mode = CUDAGraphMode.FULL_AND_PIECEWISE
@@ -140,6 +142,7 @@ def _create_gdn_builder(
         block_size=BLOCK_SIZE,
         shapes=((16, 64),),
         dtypes=(torch.float16,),
+        num_prefill_checkpoint_blocks=num_prefill_checkpoint_blocks,
     )
     return GDNAttentionMetadataBuilder(
         kv_cache_spec=mamba_spec,
@@ -258,6 +261,67 @@ def test_full_cudagraph_spec_metadata_uses_request_count():
 def test_gdn_block_table_reuse_supports_regular_and_spec_decode() -> None:
     assert _create_gdn_builder().supports_update_block_table
     assert _create_gdn_builder(num_speculative_tokens=2).supports_update_block_table
+
+
+def test_gdn_prefill_checkpoint_targets_crossed_cache_boundary() -> None:
+    builder = _create_gdn_builder(num_prefill_checkpoint_blocks=1)
+    builder.vllm_config.cache_config.mamba_cache_mode = "align"
+    batch = BatchSpec(seq_lens=[33], query_lens=[33])
+    common = create_common_attn_metadata(
+        batch,
+        BLOCK_SIZE,
+        DEVICE,
+        arange_block_indices=True,
+    ).replace(is_prefilling=torch.tensor([True]))
+
+    metadata = builder.build(common_prefix_len=0, common_attn_metadata=common)
+
+    assert metadata.prefill_checkpoint is not None
+    torch.testing.assert_close(
+        metadata.prefill_checkpoint.checkpoint_offsets,
+        torch.tensor([32], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        metadata.prefill_checkpoint.request_rows,
+        torch.tensor([0], dtype=torch.int64),
+    )
+    torch.testing.assert_close(
+        metadata.prefill_checkpoint.block_table_columns,
+        torch.tensor([1], dtype=torch.int64),
+    )
+    torch.testing.assert_close(
+        metadata.prefill_checkpoint.state_indices,
+        torch.tensor([1], dtype=torch.int32),
+    )
+
+
+def test_gdn_prefill_checkpoint_refreshes_reused_block_table() -> None:
+    builder = _create_gdn_builder(num_prefill_checkpoint_blocks=1)
+    builder.vllm_config.cache_config.mamba_cache_mode = "align"
+    batch = BatchSpec(seq_lens=[33], query_lens=[33])
+    common = create_common_attn_metadata(
+        batch,
+        BLOCK_SIZE,
+        DEVICE,
+        arange_block_indices=True,
+    ).replace(is_prefilling=torch.tensor([True]))
+    metadata = builder.build(common_prefix_len=0, common_attn_metadata=common)
+    replacement_block_table = torch.tensor(
+        [[101, 102, 103]],
+        dtype=torch.int32,
+    )
+
+    updated = builder.update_block_table(
+        metadata,
+        replacement_block_table,
+        torch.zeros(33, dtype=torch.int64),
+    )
+
+    assert updated.prefill_checkpoint is not None
+    torch.testing.assert_close(
+        updated.prefill_checkpoint.state_indices,
+        torch.tensor([102], dtype=torch.int32),
+    )
 
 
 def test_gdn_update_block_table_uses_current_builders_graph_buffers() -> None:

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -8,6 +8,7 @@ the wrong offset, and a later chunk crossing that boundary publishes it anyway.
 Requests resuming from it then restore a truncated state (#43559).
 """
 
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -82,6 +83,7 @@ def _split(
     use_eagle: bool = True,
     partial_hit: bool = False,
     num_prefill_checkpoint_blocks: int = 0,
+    allow_speculative_checkpoints: bool = False,
 ) -> int:
     """Call the real `Scheduler._mamba_block_aligned_split` on a stub self."""
     stub = SimpleNamespace(
@@ -93,7 +95,8 @@ def _split(
         mamba_partial_cache_hit=partial_hit,
         hash_block_size=ATTN_BLOCK_SIZE,
         mamba_has_prefill_checkpoint_blocks=(
-            num_prefill_checkpoint_blocks > 0 and not use_eagle
+            num_prefill_checkpoint_blocks > 0
+            and (not use_eagle or allow_speculative_checkpoints)
         ),
     )
     return Scheduler._mamba_block_aligned_split(stub, request, num_new_tokens)
@@ -126,6 +129,48 @@ def test_internal_checkpoint_split(
         mamba_manager = manager.coordinator.single_type_managers[MAMBA_GROUP_ID]
         blocks = mamba_manager.req_to_blocks[request.request_id]
         assert all(not block.is_null for block in blocks)  # checkpoint + running state
+
+
+def test_dflash_checkpoint_keeps_intermediate_chunks_aligned_and_joins_prompt_tail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DFlash reserves unaligned draft slots but can checkpoint the prompt tail.
+
+    Intermediate chunks still end on the recurrent cache grid. Once a chunk
+    reaches the prompt end, the internal checkpoint preserves the crossed
+    boundary and the scheduler need not emit a one-token target forward.
+    """
+    block_size = 16
+    prompt_len = 32321
+    (request,) = create_requests(1, num_tokens=prompt_len, block_size=block_size)
+    # Model a resumed request whose replay range extends one token past the
+    # prompt. This is the case in which prefill_end alone would floor 17 to 16.
+    request.append_output_token_ids([1, 2])
+    monkeypatch.setattr(sys.modules[__name__], "MAMBA_BLOCK_SIZE", block_size)
+
+    request.num_computed_tokens = 0
+    assert (
+        _split(
+            request,
+            4089,
+            use_eagle=True,
+            num_prefill_checkpoint_blocks=1,
+            allow_speculative_checkpoints=True,
+        )
+        == 4080
+    )
+
+    request.num_computed_tokens = 32304
+    assert (
+        _split(
+            request,
+            17,
+            use_eagle=True,
+            num_prefill_checkpoint_blocks=1,
+            allow_speculative_checkpoints=True,
+        )
+        == 17
+    )
 
 
 def _run_chunked_prefill(

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -26,6 +26,7 @@ from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 from vllm.utils.b12x import get_b12x_gdn_decode, get_b12x_scratch_buffers
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+from vllm.v1.worker.workspace import current_workspace_manager
 
 from ...linear import (
     ColumnParallelLinear,
@@ -43,6 +44,81 @@ from ..ops.gather_initial_states import gather_initial_states
 
 # Empirical lower bound for the KDA gate to avoid numerical underflow.
 _KDA_GATE_LOGBOUND_MIN = -5.0
+
+
+def is_flashkda_supported(
+    head_dim: int,
+    dtype: torch.dtype,
+    lower_bound: float | None,
+) -> bool:
+    """Return whether FlashKDA supports the layer's prefill contract."""
+    if not current_platform.is_cuda():
+        return False
+    capability = current_platform.get_device_capability()
+    return (
+        capability is not None
+        and capability.major in (9, 10, 12)
+        and head_dim == 128
+        and dtype == torch.bfloat16
+        and lower_bound is not None
+    )
+
+
+def _flashkda_prefill(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: float,
+    initial_state: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    out: torch.Tensor,
+    final_state: torch.Tensor,
+    workspace: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run packed bounded-gate KDA prefill into caller-owned buffers."""
+    import vllm._flashkda_C  # noqa: F401
+
+    torch.ops._flashkda_C.fwd(
+        q.contiguous(),
+        k.contiguous(),
+        v.contiguous(),
+        g.contiguous(),
+        beta,
+        q.shape[-1] ** -0.5,
+        out,
+        workspace,
+        A_log.contiguous(),
+        dt_bias.view(-1, q.shape[-1]).contiguous(),
+        lower_bound,
+        initial_state.contiguous(),
+        final_state,
+        cu_seqlens.contiguous(),
+    )
+    return out, final_state
+
+
+def resolve_kda_prefill_backend(
+    backend: str,
+    head_dim: int,
+    dtype: torch.dtype,
+    lower_bound: float | None,
+) -> str:
+    """Resolve the packed KDA prefill implementation for one server."""
+    if backend not in ("auto", "triton", "flashkda"):
+        raise ValueError(f"Unsupported KDA prefill backend: {backend}")
+    supported = is_flashkda_supported(head_dim, dtype, lower_bound)
+    if backend == "flashkda" and not supported:
+        raise RuntimeError(
+            "FlashKDA requires CUDA SM90/SM10x/SM12x, bfloat16, "
+            "head_dim=128, and a bounded KDA gate."
+        )
+    if supported and backend != "triton":
+        return "flashkda"
+    return "triton"
 
 
 def a_log_weight_loader(
@@ -285,11 +361,34 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             if isinstance(additional_config, dict)
             else "auto"
         )
-        backend = "triton" if backend == "auto" else backend
-        assert backend == "triton", (
-            "The shared Kimi GDN layer only supports the Triton KDA "
-            f"prefill backend, got {backend!r}."
+        self.kda_prefill_backend = resolve_kda_prefill_backend(
+            backend,
+            self.head_dim,
+            vllm_config.model_config.dtype,
+            self.gate_lower_bound,
         )
+        self._flashkda_buffer_specs: (
+            tuple[tuple[tuple[int, ...], torch.dtype], ...] | None
+        ) = None
+        if self.kda_prefill_backend == "flashkda":
+            max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+            max_sequences = vllm_config.scheduler_config.max_num_seqs
+            heads, head_dim = self.local_num_heads, self.head_dim
+            import vllm._flashkda_C  # noqa: F401
+
+            workspace_size = torch.ops._flashkda_C.get_workspace_size(
+                max_tokens,
+                heads,
+                max_sequences,
+            )
+            self._flashkda_buffer_specs = (
+                ((1, max_tokens, heads, head_dim), self.model_config.dtype),
+                (
+                    (max_sequences, heads, head_dim, head_dim),
+                    self.get_state_dtype()[1],
+                ),
+                ((workspace_size,), torch.uint8),
+            )
         if not self.use_full_rank_gate:
             self.g_a_proj = ReplicatedLinear(
                 self.hidden_size,
@@ -871,25 +970,54 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                     prefill_state_indices,
                     prefill_has_initial_state,
                 )
-                (
-                    core_attn_out_non_spec,
-                    last_recurrent_state,
-                ) = chunk_kda_with_fused_gate(
-                    q=q_ns,
-                    k=k_ns,
-                    v=v_ns,
-                    raw_g=g1_ns,
-                    raw_beta=beta_ns,
-                    A_log=self.A_log,
-                    g_bias=self.dt_bias,
-                    lower_bound=self.gate_lower_bound,
-                    initial_state=initial_state,
-                    output_final_state=True,
-                    use_qk_l2norm_in_kernel=True,
-                    cu_seqlens=prefill_query_start_loc,
-                    chunk_indices=m.chunk_indices,
-                    chunk_offsets=m.chunk_offsets,
-                )
+                if self.kda_prefill_backend == "flashkda":
+                    assert self.gate_lower_bound is not None
+                    assert self._flashkda_buffer_specs is not None
+                    assert prefill_query_start_loc is not None
+                    workspace_out, final_state, workspace = (
+                        current_workspace_manager().get_simultaneous(
+                            *self._flashkda_buffer_specs
+                        )
+                    )
+                    flashkda_out = workspace_out[:, : q_ns.shape[1]]
+                    (
+                        core_attn_out_non_spec,
+                        last_recurrent_state,
+                    ) = _flashkda_prefill(
+                        q=q_ns,
+                        k=k_ns,
+                        v=v_ns,
+                        g=g1_ns,
+                        beta=beta_ns,
+                        A_log=self.A_log,
+                        dt_bias=self.dt_bias,
+                        lower_bound=self.gate_lower_bound,
+                        initial_state=initial_state,
+                        cu_seqlens=prefill_query_start_loc,
+                        out=flashkda_out,
+                        final_state=final_state[: initial_state.shape[0]],
+                        workspace=workspace,
+                    )
+                else:
+                    (
+                        core_attn_out_non_spec,
+                        last_recurrent_state,
+                    ) = chunk_kda_with_fused_gate(
+                        q=q_ns,
+                        k=k_ns,
+                        v=v_ns,
+                        raw_g=g1_ns,
+                        raw_beta=beta_ns,
+                        A_log=self.A_log,
+                        g_bias=self.dt_bias,
+                        lower_bound=self.gate_lower_bound,
+                        initial_state=initial_state,
+                        output_final_state=True,
+                        use_qk_l2norm_in_kernel=True,
+                        cu_seqlens=prefill_query_start_loc,
+                        chunk_indices=m.chunk_indices,
+                        chunk_offsets=m.chunk_offsets,
+                    )
                 # Init cache
                 recurrent_state[prefill_state_indices] = last_recurrent_state
 

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Callable
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -24,8 +25,11 @@ from vllm.model_executor.utils import set_weight_attrs
 from vllm.platforms import current_platform
 from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
+from vllm.triton_utils import tl, triton
 from vllm.utils.b12x import get_b12x_gdn_decode, get_b12x_scratch_buffers
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+from vllm.v1.kv_cache_interface import MambaSpec
 from vllm.v1.worker.workspace import current_workspace_manager
 
 from ...linear import (
@@ -78,6 +82,8 @@ def _flashkda_prefill(
     out: torch.Tensor,
     final_state: torch.Tensor,
     workspace: torch.Tensor,
+    checkpoint_state: torch.Tensor | None = None,
+    checkpoint_offsets: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Run packed bounded-gate KDA prefill into caller-owned buffers."""
     import vllm._flashkda_C  # noqa: F401
@@ -97,8 +103,76 @@ def _flashkda_prefill(
         initial_state.contiguous(),
         final_state,
         cu_seqlens.contiguous(),
+        checkpoint_state,
+        checkpoint_offsets.contiguous() if checkpoint_offsets is not None else None,
     )
     return out, final_state
+
+
+@triton.jit
+def _store_cache_checkpoints_kernel(
+    x_ptr,
+    conv_state_ptr,
+    recurrent_checkpoint_ptr,
+    recurrent_state_ptr,
+    query_start_loc_ptr,
+    checkpoint_offsets_ptr,
+    checkpoint_state_indices_ptr,
+    x_stride_0: tl.constexpr,
+    x_stride_1: tl.constexpr,
+    state_stride_0: tl.constexpr,
+    state_stride_1: tl.constexpr,
+    state_stride_2: tl.constexpr,
+    checkpoint_stride_0: tl.constexpr,
+    recurrent_state_stride_0: tl.constexpr,
+    checkpoint_offset_stride: tl.constexpr,
+    STATE_LEN: tl.constexpr,
+    WIDTH: tl.constexpr,
+    RECURRENT_ROW_SIZE: tl.constexpr,
+    NULL_STATE_IDX: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Store FlashKDA recurrent and convolution state at an internal boundary."""
+    seq_idx = tl.program_id(0)
+    cols = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    seq_idx_i64 = seq_idx.to(tl.int64)
+    cols_i64 = cols.to(tl.int64)
+    state_idx = tl.load(checkpoint_state_indices_ptr + seq_idx_i64)
+    state_idx_i64 = state_idx.to(tl.int64)
+    checkpoint_offset = tl.load(
+        checkpoint_offsets_ptr + seq_idx_i64 * checkpoint_offset_stride
+    )
+    valid_checkpoint = (state_idx != NULL_STATE_IDX) & (checkpoint_offset > 0)
+    valid_conv = (
+        (cols < WIDTH * STATE_LEN) & valid_checkpoint & (checkpoint_offset >= STATE_LEN)
+    )
+    width_idx = cols // STATE_LEN
+    history_idx = cols % STATE_LEN
+    checkpoint_end = tl.load(query_start_loc_ptr + seq_idx_i64) + checkpoint_offset
+    token_idx = checkpoint_end.to(tl.int64) - STATE_LEN + history_idx.to(tl.int64)
+    values = tl.load(
+        x_ptr + token_idx * x_stride_0 + width_idx.to(tl.int64) * x_stride_1,
+        mask=valid_conv,
+    )
+    tl.store(
+        conv_state_ptr
+        + state_idx_i64 * state_stride_0
+        + width_idx.to(tl.int64) * state_stride_1
+        + history_idx.to(tl.int64) * state_stride_2,
+        values,
+        mask=valid_conv,
+    )
+
+    valid_recurrent = (cols < RECURRENT_ROW_SIZE) & valid_checkpoint
+    recurrent = tl.load(
+        recurrent_checkpoint_ptr + seq_idx_i64 * checkpoint_stride_0 + cols_i64,
+        mask=valid_recurrent,
+    )
+    tl.store(
+        recurrent_state_ptr + state_idx_i64 * recurrent_state_stride_0 + cols_i64,
+        recurrent,
+        mask=valid_recurrent,
+    )
 
 
 def resolve_kda_prefill_backend(
@@ -254,6 +328,14 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             num_spec=self.num_spec,
         )
 
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> MambaSpec:
+        spec = super().get_kv_cache_spec(vllm_config)
+        assert isinstance(spec, MambaSpec)
+        return replace(
+            spec,
+            num_prefill_checkpoint_blocks=int(self.kda_prefill_backend == "flashkda"),
+        )
+
     def __init__(
         self,
         config: KimiLinearConfig,
@@ -383,6 +465,10 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             )
             self._flashkda_buffer_specs = (
                 ((1, max_tokens, heads, head_dim), self.model_config.dtype),
+                (
+                    (max_sequences, heads, head_dim, head_dim),
+                    self.get_state_dtype()[1],
+                ),
                 (
                     (max_sequences, heads, head_dim, head_dim),
                     self.get_state_dtype()[1],
@@ -758,6 +844,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             return
         assert isinstance(attn_metadata_narrowed, GDNAttentionMetadata)
         m = attn_metadata_narrowed
+        prefill_checkpoint = m.prefill_checkpoint
         has_initial_state = m.has_initial_state
         non_spec_query_start_loc = m.non_spec_query_start_loc
         non_spec_state_indices_tensor = m.non_spec_state_indices_tensor
@@ -892,6 +979,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 q_ns, k_ns, v_ns = mixed_qkv_ns.split(
                     self.local_projection_size, dim=-1
                 )
+                prefill_mixed_qkv = mixed_qkv_ns
 
                 # Packed prefill conv would require copying V solely to make
                 # it dense for KDA. Separate calls accept the strided inputs
@@ -934,6 +1022,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 if split_non_spec:
                     assert non_spec_query_start_loc is not None
                     nd_tok = m.num_decode_tokens
+                    prefill_mixed_qkv = prefill_mixed_qkv[nd_tok:]
                     core_attn_out_decode, _ = fused_recurrent_kda(
                         q=q_ns[:, :nd_tok],
                         k=k_ns[:, :nd_tok],
@@ -974,30 +1063,93 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                     assert self.gate_lower_bound is not None
                     assert self._flashkda_buffer_specs is not None
                     assert prefill_query_start_loc is not None
-                    workspace_out, final_state, workspace = (
+                    workspace_out, final_state, checkpoint_state, workspace = (
                         current_workspace_manager().get_simultaneous(
                             *self._flashkda_buffer_specs
                         )
                     )
                     flashkda_out = workspace_out[:, : q_ns.shape[1]]
-                    (
-                        core_attn_out_non_spec,
-                        last_recurrent_state,
-                    ) = _flashkda_prefill(
-                        q=q_ns,
-                        k=k_ns,
-                        v=v_ns,
-                        g=g1_ns,
-                        beta=beta_ns,
-                        A_log=self.A_log,
-                        dt_bias=self.dt_bias,
-                        lower_bound=self.gate_lower_bound,
-                        initial_state=initial_state,
-                        cu_seqlens=prefill_query_start_loc,
-                        out=flashkda_out,
-                        final_state=final_state[: initial_state.shape[0]],
-                        workspace=workspace,
-                    )
+                    if prefill_checkpoint is not None:
+                        assert prefill_query_start_loc is not None
+                        num_sequences = initial_state.shape[0]
+                        assert prefill_checkpoint.checkpoint_offsets.shape == (
+                            num_sequences,
+                        )
+                        final_state = final_state[:num_sequences]
+                        checkpoint_state = checkpoint_state[:num_sequences]
+                        _flashkda_prefill(
+                            q=q_ns,
+                            k=k_ns,
+                            v=v_ns,
+                            g=g1_ns,
+                            beta=beta_ns,
+                            A_log=self.A_log,
+                            dt_bias=self.dt_bias,
+                            lower_bound=self.gate_lower_bound,
+                            initial_state=initial_state,
+                            cu_seqlens=prefill_query_start_loc,
+                            out=flashkda_out,
+                            final_state=final_state,
+                            workspace=workspace,
+                            checkpoint_state=checkpoint_state,
+                            checkpoint_offsets=(prefill_checkpoint.checkpoint_offsets),
+                        )
+                        core_attn_out_non_spec = flashkda_out
+                        last_recurrent_state = final_state
+
+                        state_len = conv_state.shape[-1]
+                        width = prefill_mixed_qkv.shape[-1]
+                        recurrent_row_size = checkpoint_state[0].numel()
+                        store_block_size = 256
+                        _store_cache_checkpoints_kernel[
+                            (
+                                prefill_checkpoint.checkpoint_offsets.numel(),
+                                triton.cdiv(
+                                    max(width * state_len, recurrent_row_size),
+                                    store_block_size,
+                                ),
+                            )
+                        ](
+                            prefill_mixed_qkv,
+                            conv_state,
+                            checkpoint_state,
+                            recurrent_state,
+                            prefill_query_start_loc,
+                            prefill_checkpoint.checkpoint_offsets,
+                            prefill_checkpoint.state_indices,
+                            prefill_mixed_qkv.stride(0),
+                            prefill_mixed_qkv.stride(1),
+                            conv_state.stride(0),
+                            conv_state.stride(1),
+                            conv_state.stride(2),
+                            checkpoint_state.stride(0),
+                            recurrent_state.stride(0),
+                            prefill_checkpoint.checkpoint_offsets.stride(0),
+                            state_len,
+                            width,
+                            recurrent_row_size,
+                            NULL_BLOCK_ID,
+                            store_block_size,
+                        )
+                    else:
+                        (
+                            core_attn_out_non_spec,
+                            last_recurrent_state,
+                        ) = _flashkda_prefill(
+                            q=q_ns,
+                            k=k_ns,
+                            v=v_ns,
+                            g=g1_ns,
+                            beta=beta_ns,
+                            A_log=self.A_log,
+                            dt_bias=self.dt_bias,
+                            lower_bound=self.gate_lower_bound,
+                            initial_state=initial_state,
+                            cu_seqlens=prefill_query_start_loc,
+                            out=flashkda_out,
+                            final_state=final_state[: initial_state.shape[0]],
+                            workspace=workspace,
+                        )
                 else:
                     (
                         core_attn_out_non_spec,

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -39,6 +39,22 @@ class GDNAttentionBackend(AttentionBackend):
 
 
 @dataclass
+class GDNPrefillCheckpointMetadata:
+    """One recurrent-state checkpoint inside each packed prefill sequence.
+
+    ``checkpoint_offsets`` are relative to the corresponding packed query.
+    ``request_rows`` and ``block_table_columns`` identify the cache slots that
+    receive the checkpoint, allowing metadata reuse to refresh physical block
+    IDs from a replacement block table.
+    """
+
+    checkpoint_offsets: torch.Tensor
+    state_indices: torch.Tensor
+    request_rows: torch.Tensor
+    block_table_columns: torch.Tensor
+
+
+@dataclass
 class GDNAttentionMetadata:
     num_prefills: int
     num_prefill_tokens: int
@@ -83,6 +99,8 @@ class GDNAttentionMetadata:
     # groups whose state block tables differ.
     num_reqs: int = 0
     seq_lens: torch.Tensor | None = None
+
+    prefill_checkpoint: GDNPrefillCheckpointMetadata | None = None
 
 
 class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]):
@@ -449,6 +467,76 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         else:
             has_initial_state = None
 
+        prefill_checkpoint = None
+        if (
+            num_prefills > 0
+            and self.kv_cache_spec.num_prefill_checkpoint_blocks > 0
+            and self.vllm_config.cache_config.mamba_cache_mode == "align"
+        ):
+            # FlashKDA can materialize one state at a cache-block boundary
+            # without splitting the target-model forward. Only prefill rows
+            # participate, in the same order as prefill_query_start_loc.
+            assert m.seq_lens_cpu_upper_bound is not None
+            all_query_lens = query_start_loc_cpu.diff().tolist()
+            if spec_sequence_masks_cpu is None:
+                request_rows = list(range(num_decodes, num_decodes + num_prefills))
+            else:
+                request_rows = [
+                    row
+                    for row in (~spec_sequence_masks_cpu).nonzero().flatten().tolist()
+                    if all_query_lens[row] > 0
+                ]
+            assert len(request_rows) == num_prefills
+
+            seq_lens = m.seq_lens_cpu_upper_bound.tolist()
+            block_size = self.kv_cache_spec.block_size
+            checkpoint_offsets: list[int] = []
+            checkpoint_columns: list[int] = []
+            for row in request_rows:
+                query_len = all_query_lens[row]
+                seq_len = seq_lens[row]
+                offset = seq_len // block_size * block_size - (seq_len - query_len)
+                valid = (
+                    seq_len % block_size != 0
+                    and 0 < offset < query_len
+                    # FlashKDA checkpoint outputs are produced on its
+                    # 16-token recurrence boundary.
+                    and offset % 16 == 0
+                )
+                checkpoint_offsets.append(offset if valid else 0)
+                checkpoint_columns.append(seq_len // block_size - 1 if valid else -1)
+
+            if any(checkpoint_offsets):
+                checkpoint_offsets_tensor = async_tensor_h2d(
+                    checkpoint_offsets,
+                    dtype=torch.int32,
+                    device=query_start_loc.device,
+                )
+                request_rows_tensor = async_tensor_h2d(
+                    request_rows,
+                    dtype=torch.int64,
+                    device=query_start_loc.device,
+                )
+                checkpoint_columns_tensor = async_tensor_h2d(
+                    checkpoint_columns,
+                    dtype=torch.int64,
+                    device=query_start_loc.device,
+                )
+                checkpoint_state_indices = m.block_table_tensor[
+                    request_rows_tensor, checkpoint_columns_tensor
+                ]
+                checkpoint_state_indices = torch.where(
+                    checkpoint_columns_tensor >= 0,
+                    checkpoint_state_indices,
+                    NULL_BLOCK_ID,
+                )
+                prefill_checkpoint = GDNPrefillCheckpointMetadata(
+                    checkpoint_offsets=checkpoint_offsets_tensor,
+                    state_indices=checkpoint_state_indices,
+                    request_rows=request_rows_tensor,
+                    block_table_columns=checkpoint_columns_tensor,
+                )
+
         # Function code counted on either presency non-spec decode or spec decode,
         # but not both.
         assert not (num_decodes > 0 and num_spec_decodes > 0), (
@@ -555,6 +643,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             token_chunk_offset_ptr=token_chunk_offset_ptr,
             num_reqs=m.num_reqs,
             seq_lens=m.seq_lens,
+            prefill_checkpoint=prefill_checkpoint,
         )
         return attn_metadata
 
@@ -589,6 +678,22 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 prefill_state_indices = non_spec_state_indices[metadata.num_decodes :]
             else:
                 prefill_state_indices = non_spec_state_indices
+
+        prefill_checkpoint = metadata.prefill_checkpoint
+        if prefill_checkpoint is not None:
+            checkpoint_state_indices = blk_table[
+                prefill_checkpoint.request_rows,
+                prefill_checkpoint.block_table_columns,
+            ]
+            checkpoint_state_indices = torch.where(
+                prefill_checkpoint.block_table_columns >= 0,
+                checkpoint_state_indices,
+                NULL_BLOCK_ID,
+            )
+            prefill_checkpoint = replace(
+                prefill_checkpoint,
+                state_indices=checkpoint_state_indices,
+            )
 
         spec_sequence_masks = metadata.spec_sequence_masks
         spec_token_indx = metadata.spec_token_indx
@@ -677,6 +782,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_query_start_loc=spec_query_start_loc,
             non_spec_query_start_loc=non_spec_query_start_loc,
             num_accepted_tokens=num_accepted_tokens,
+            prefill_checkpoint=prefill_checkpoint,
         )
 
     def build_for_cudagraph_capture(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -346,8 +346,13 @@ class Scheduler(SchedulerInterface):
         )
         self.mamba_has_prefill_checkpoint_blocks = (
             self.has_mamba_layers
-            # TODO: support spec decoding
-            and not self.use_eagle
+            # DFlash's external draft has no recurrent state. The target GDN
+            # backend can therefore publish its internal prefill checkpoint
+            # without changing the drafter's cache contract.
+            and (
+                not self.use_eagle
+                or (speculative_config is not None and speculative_config.use_dflash())
+            )
             and all(
                 not isinstance(group.kv_cache_spec, MambaSpec)
                 or group.kv_cache_spec.num_prefill_checkpoint_blocks > 0
@@ -446,7 +451,20 @@ class Scheduler(SchedulerInterface):
         # aligned. Exempt: the prompt's last chunk, whose slot decode advances
         # to the boundary. A block too wide for one chunk advances sub-block
         # and re-aligns at the next boundary.
-        if end < prefill_end and not use_internal_checkpoint:
+        checkpoint_covers_prompt_tail = (
+            use_internal_checkpoint and end >= request.num_prompt_tokens
+        )
+        if (
+            end < prefill_end
+            and not checkpoint_covers_prompt_tail
+            and (
+                not use_internal_checkpoint
+                # DFlash reserves draft input slots, so its target-token budget
+                # is not necessarily block aligned. Keep intermediate target
+                # chunks aligned; only the prompt tail uses the checkpoint.
+                or self.use_eagle
+            )
+        ):
             max_prefill_tokens = self.max_num_scheduled_tokens
             long_prefill_threshold = self.scheduler_config.long_prefill_token_threshold
             if long_prefill_threshold > 0:


### PR DESCRIPTION
## Result

Status: **implemented and qualified** for GLM-5.3-Flash DFlash2 serving.

Supported GLM gated-delta-net layers use FlashKDA for packed prefill. FlashKDA
publishes recurrent and convolution state at crossed cache boundaries, which
allows DFlash to finish an unaligned prompt tail in the same target forward.
The packed Triton implementation remains available as an explicit control and
as the automatic fallback for unsupported geometry.

## Operation contract and compatibility

- FlashKDA prefill requires CUDA SM90, SM100, or SM120, BF16 values, a
  128-element head dimension, and a bounded KDA gate.
- Unsupported automatic selection retains Triton. Unsupported explicit
  FlashKDA selection fails during model construction.
- Internal tail checkpoints require `mamba_cache_mode=align` and a
  FlashKDA-backed Mamba cache specification.
- DFlash can consume the tail checkpoint because its external draft model has
  no target GDN recurrent state. Other speculative methods retain aligned
  intermediate target chunks unless they declare the same checkpoint contract.
- Checkpoint address arithmetic uses 64-bit indices and strides. CUDA-graph
  metadata reuse refreshes the physical checkpoint block ID from the active
  block table.
- Decode KDA selection, B12X sparse attention, B12X MoE, B12X linear, DFlash
  draft attention, and non-GLM behavior are unchanged.

## Review-stack boundary

This pull request is based on #533, which preserves replicated DFlash cache
geometry under DCP. Its diff contains only FlashKDA backend selection,
recurrent-state checkpoint publication, DFlash prompt-tail consumption, and
associated tests.

The source-locked composed head is
`3609a3db498698314bdc44920cad9f2d25796eb9`, and its Git tree is
`9ab7295e7dc0531514b54587b2187a74881e20c5`.

## Validation

The composed runtime used:

- vLLM base
  `dev/jovian-judgement@0b67266a0f37d6146a8403fb8482403c62f412d5`;
- vLLM head `3609a3db498698314bdc44920cad9f2d25796eb9`;
- B12X composition `6255090a03b12c3f7d552102a02fac0b542fb8c9`, containing
  #259 and #260 over
  `master@fc1d4b68f7a5b0cfdb88bf06abccd869f5c589d5`;
- target checkpoint
  `local-inference-lab/GLM-5.3-Flash-NVFP4@520de24eabf507659eaef7c70f14fd584527facc`;
- draft checkpoint
  `local-inference-lab/GLM-5.3-Flash-DFlash2-MXFP8@b6d33aa93fc1ac5b23a88251a1c0ce0bfe2ad17c`;
- physical RTX PRO 6000 Blackwell GPUs 4, 5, 6, and 7; TP4; DCP4;
  FP8 target KV; automatic draft KV; seven draft tokens; full target and draft
  CUDA graphs; and `max_num_batched_tokens=4096`.

Correctness and startup validation:

- GLM5Next model, aligned chunk splitting, and GDN metadata tests: 99 passed.
- Six deterministic serving cases covered short, 32,768-token, concurrent, and
  shared-prefix requests. FlashKDA and Triton selected identical tokens and
  text; the maximum selected-token log-probability difference was
  `0.008707568`.
- The TP4/DCP4 runtime completed cache allocation, target graph capture,
  DFlash2 graph capture, deterministic requests, and the 32k standalone
  prefill workload with 32,320 measured prompt tokens.

FlashKDA component qualification used TP4/DCP1, exact token-ID prompts from
32,312 through 32,327 tokens, three cold-prefix repetitions per length, one
output token, and a 4,096-token scheduler batch limit:

| 32k prompt set | FlashKDA checkpoint | Triton control | Difference |
| --- | ---: | ---: | ---: |
| All 16 lengths | 12,537 tok/s | 11,262 tok/s | +11.33% |
| Fifteen unaligned lengths | 12,498 tok/s | 11,211 tok/s | +11.48% |
| Aligned length 32,320 | 13,134 tok/s | 12,023 tok/s | +9.24% |

The final TP4/DCP4 DFlash2 integration disables full-CKV gathering because its
adjacent A/B was neutral to negative for that speculative mode. The
source-locked community image has digest
`sha256:1cb556807752cff49ec3383e193a7ffb4f0ccf5e58aa9c08996417899d536fe7`.
After its dedicated JIT cache was populated, three 30-second 32k measurements
produced 9,523, 9,551, and 9,534 prompt tok/s, with a median of 9,534 tok/s.
The preceding source-equivalent composition produced 9,551, 9,493, and 9,493
prompt tok/s, with a median of 9,493 tok/s. The client-side difference is
+0.43%, which establishes performance parity rather than a speedup attributable
to the B12X pull-request revisions.

## Duplicate-work check

- `local-inference-lab/vllm#495` changes server-stable GLM KDA decode routing;
  it does not implement packed prefill checkpoint publication.
- `vllm-project/vllm#53614` manages Kimi-K3 partial-prefix checkpoint hashes;
  it does not implement the GLM-5.3 DFlash prompt-tail contract.

No open pull request in `local-inference-lab/vllm` implements the same GLM
DFlash FlashKDA tail-checkpoint contract.

## AI assistance disclosure

AI assistance was used for implementation, failure isolation, profiling,
tests, benchmarking, duplicate analysis, and pull-request preparation. Human
review of every changed line and ownership of the recurrent-state contract are
required before merge.
