### PR TITLE
perf(glm5next): parallelize C4 pool writes and bound visible pages

### DIFF
--- a/tests/models/test_glm5next_pooled_indexer.py
+++ b/tests/models/test_glm5next_pooled_indexer.py
@@ -124,10 +124,23 @@ def test_glm53_selector_prefill_lengths_do_not_require_attention_backend() -> No
         num_decode_tokens=1,
         prefill=None,
         prefill_query_lens_cpu=torch.tensor([3], dtype=torch.int32),
+        prefill_seq_lens_cpu=torch.tensor([8], dtype=torch.int32),
     )
 
     assert metadata.prefill is None
     assert metadata.prefill_query_lens_cpu.tolist() == [3]
+    assert metadata.prefill_seq_lens_cpu is not None
+    assert metadata.prefill_seq_lens_cpu.tolist() == [8]
+
+
+@pytest.mark.parametrize(
+    ("seq_len", "expected_pages"),
+    [(0, 1), (3, 1), (4, 1), (259, 1), (260, 2), (32768, 128)],
+)
+def test_glm53_active_index_pages_cover_completed_pools(
+    seq_len: int, expected_pages: int
+) -> None:
+    assert Glm5NextPooledIndexer._active_index_page_count(seq_len) == expected_pages
 
 
 def test_glm53_packed_c4_metadata_uses_parent_stride() -> None:
@@ -208,7 +221,8 @@ def test_glm53_decode_table_capacity_uses_batched_token_limit() -> None:
     indexer.max_tokens = 128
     indexer.max_seqs = 16
     indexer.max_model_len = 4096
-    indexer.indexer_op = SimpleNamespace(max_model_len=0)
+    indexer.dcp_world_size = 1
+    indexer.indexer_op = SimpleNamespace(max_model_len=4096 // 4)
 
     indexer.bind_main_kv_cache(main)
 

--- a/tests/models/test_glm5next_pooled_indexer.py
+++ b/tests/models/test_glm5next_pooled_indexer.py
@@ -468,7 +468,7 @@ def test_glm53_decode_tail_completes_the_same_pool_as_prefill() -> None:
     torch.testing.assert_close(actual_scale, expected_scale.reshape(1), rtol=0, atol=0)
 
 
-def test_glm53_decode_writer_matches_batched_prefill_writer() -> None:
+def test_glm53_decode_writer_matches_parallel_prefill_writer() -> None:
     device = _require_glm_gpu()
     generator = torch.Generator(device=device).manual_seed(56)
     key = torch.randn(
@@ -496,9 +496,13 @@ def test_glm53_decode_writer_matches_batched_prefill_writer() -> None:
         key,
         gate,
         ape,
-        torch.tensor([-1, -1, -1, 0, -1, -1, -1, 1], device=device),
+        torch.tensor([-1, -1, -1, 3, -1, -1, -1, 7], device=device),
         torch.arange(8, dtype=torch.int64, device=device),
         1,
+        num_decode_requests=0,
+        max_query_len=8,
+        model_block_size=256,
+        parent_stride_pages=1,
     )
     for position in range(8):
         update_decode_pools(
@@ -510,16 +514,125 @@ def test_glm53_decode_writer_matches_batched_prefill_writer() -> None:
             gate[position : position + 1],
             ape,
             torch.tensor(
-                [position // 4 if position % 4 == 3 else -1],
+                [position if position % 4 == 3 else -1],
                 dtype=torch.int64,
                 device=device,
             ),
             torch.tensor([position], dtype=torch.int64, device=device),
             1,
+            model_block_size=256,
+            parent_stride_pages=1,
         )
 
     assert torch.equal(decode_cache, prefill_cache)
     assert torch.equal(decode_tail, prefill_tail)
+
+
+def test_glm53_parallel_prefill_preserves_boundary_tail_and_state_slots() -> None:
+    device = _require_glm_gpu()
+    generator = torch.Generator(device=device).manual_seed(5304)
+    key = torch.randn(
+        (10, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    gate = torch.randn(
+        (10, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    ape = torch.randn(
+        (4, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    initial_tail = torch.randn(
+        (2, 2, 4, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    sequential_tail = initial_tail.clone()
+    parallel_tail = initial_tail.clone()
+    sequential_cache = torch.zeros((2, 64, 132), dtype=torch.uint8, device=device)
+    parallel_cache = torch.zeros_like(sequential_cache)
+    state_slots = torch.tensor([1, 0], dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 5, 10], dtype=torch.int32, device=device)
+    positions = torch.tensor(
+        [4099, 4100, 4101, 4102, 4103, 4099, 4100, 4101, 4102, 4103],
+        dtype=torch.int64,
+        device=device,
+    )
+    slot_mapping = torch.tensor(
+        [3, -1, -1, -1, 7, 259, -1, -1, -1, 263],
+        dtype=torch.int64,
+        device=device,
+    )
+    common = dict(model_block_size=256, parent_stride_pages=1)
+
+    update_decode_pools(
+        sequential_cache,
+        sequential_tail,
+        state_slots,
+        query_start_loc,
+        key,
+        gate,
+        ape,
+        slot_mapping,
+        positions,
+        2,
+        **common,
+    )
+    update_decode_pools(
+        parallel_cache,
+        parallel_tail,
+        state_slots,
+        query_start_loc,
+        key,
+        gate,
+        ape,
+        slot_mapping,
+        positions,
+        2,
+        num_decode_requests=0,
+        max_query_len=5,
+        **common,
+    )
+
+    assert torch.equal(parallel_cache, sequential_cache)
+    assert torch.equal(parallel_tail, sequential_tail)
+
+
+def test_glm53_parallel_prefill_ignores_invalid_dummy_slots() -> None:
+    device = _require_glm_gpu()
+    generator = torch.Generator(device=device).manual_seed(5305)
+    key = torch.randn(
+        (8, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    gate = torch.randn(
+        (8, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    ape = torch.randn(
+        (4, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    cache = torch.zeros((1, 64, 132), dtype=torch.uint8, device=device)
+    initial_tail = torch.randn(
+        (1, 2, 4, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    tail = initial_tail.clone()
+
+    update_decode_pools(
+        cache,
+        tail,
+        torch.zeros(1, dtype=torch.int32, device=device),
+        torch.tensor([0, 8], dtype=torch.int32, device=device),
+        key,
+        gate,
+        ape,
+        torch.full((8,), -1, dtype=torch.int64, device=device),
+        torch.zeros(8, dtype=torch.int64, device=device),
+        1,
+        num_decode_requests=0,
+        max_query_len=8,
+        model_block_size=256,
+        parent_stride_pages=1,
+    )
+
+    assert torch.count_nonzero(cache).item() == 0
+    torch.testing.assert_close(tail[0, 0, 0], key[-1])
+    torch.testing.assert_close(tail[0, 1, 0], gate[-1])
+    assert torch.equal(tail[:, :, 1:], initial_tail[:, :, 1:])
 
 
 def test_glm53_tail_state_isolated_between_requests() -> None:

--- a/vllm/models/glm5next/nvidia/ops/glm_kpool.py
+++ b/vllm/models/glm5next/nvidia/ops/glm_kpool.py
@@ -251,6 +251,195 @@ def _decode_update_kernel(
         tl.store(tail + base + tail_stride_1 + dim, current_gate, mask=dim_mask)
 
 
+@triton.jit
+def _prefill_pool_kernel(
+    cache_fp8,
+    cache_fp32,
+    tail,
+    state_slots,
+    query_start_loc,
+    key,
+    gate,
+    ape,
+    slot_mapping,
+    positions,
+    request_offset,
+    page_stride_bytes,
+    model_block_size,
+    parent_stride_pages,
+    tail_stride_0,
+    tail_stride_1,
+    tail_stride_2,
+    key_stride_0,
+    gate_stride_0,
+    ape_stride_0,
+    PAGE_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    request = request_offset + tl.program_id(0)
+    pool_ordinal = tl.program_id(1)
+    state_slot = tl.load(state_slots + request).to(tl.int64)
+    start = tl.load(query_start_loc + request).to(tl.int64)
+    end = tl.load(query_start_loc + request + 1).to(tl.int64)
+    has_rows = end > start
+    first_position = tl.load(positions + start, mask=has_rows, other=0).to(tl.int64)
+    first_physical_slot = first_position % POOL_SIZE
+    first_completion = start + (POOL_SIZE - 1 - first_physical_slot)
+    completion_row = first_completion + pool_ordinal * POOL_SIZE
+    write_pool = has_rows & (completion_row < end) & (state_slot >= 0)
+    completion_position = tl.load(
+        positions + completion_row, mask=write_pool, other=-1
+    ).to(tl.int64)
+    write_pool &= completion_position % POOL_SIZE == POOL_SIZE - 1
+    main_cache_location = tl.load(
+        slot_mapping + completion_row, mask=write_pool, other=-1
+    ).to(tl.int64)
+    write_pool &= main_cache_location >= 0
+    parent_page = main_cache_location // model_block_size
+    model_page_offset = main_cache_location - parent_page * model_block_size
+    pool_offset = model_page_offset // POOL_SIZE
+    child_page = pool_offset // PAGE_SIZE
+    child_offset = pool_offset - child_page * PAGE_SIZE
+    cache_location = (
+        parent_page * parent_stride_pages + child_page
+    ) * PAGE_SIZE + child_offset
+
+    dim = tl.arange(0, BLOCK_D)
+    dim_mask = dim < HEAD_DIM
+    maximum = tl.full((BLOCK_D,), -float("inf"), tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        source_row = completion_row - (POOL_SIZE - 1 - slot)
+        from_current_chunk = source_row >= start
+        tail_offset = (
+            state_slot * tail_stride_0 + tail_stride_1 + slot * tail_stride_2 + dim
+        )
+        current_score = tl.load(
+            gate + source_row * gate_stride_0 + dim,
+            mask=dim_mask & write_pool & from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        previous_score = tl.load(
+            tail + tail_offset,
+            mask=dim_mask & write_pool & ~from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        score = tl.where(from_current_chunk, current_score, previous_score)
+        score += tl.load(
+            ape + slot * ape_stride_0 + dim,
+            mask=dim_mask & write_pool,
+            other=0.0,
+        ).to(tl.float32)
+        maximum = tl.maximum(maximum, score)
+
+    numerator = tl.zeros((BLOCK_D,), tl.float32)
+    denominator = tl.zeros((BLOCK_D,), tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        source_row = completion_row - (POOL_SIZE - 1 - slot)
+        from_current_chunk = source_row >= start
+        tail_offset = state_slot * tail_stride_0 + slot * tail_stride_2 + dim
+        current_value = tl.load(
+            key + source_row * key_stride_0 + dim,
+            mask=dim_mask & write_pool & from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        previous_value = tl.load(
+            tail + tail_offset,
+            mask=dim_mask & write_pool & ~from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        value = tl.where(from_current_chunk, current_value, previous_value)
+        current_score = tl.load(
+            gate + source_row * gate_stride_0 + dim,
+            mask=dim_mask & write_pool & from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        previous_score = tl.load(
+            tail + tail_offset + tail_stride_1,
+            mask=dim_mask & write_pool & ~from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        score = tl.where(from_current_chunk, current_score, previous_score)
+        score += tl.load(
+            ape + slot * ape_stride_0 + dim,
+            mask=dim_mask & write_pool,
+            other=0.0,
+        ).to(tl.float32)
+        weight = tl.exp(score - maximum)
+        numerator += value * weight
+        denominator += weight
+
+    pooled = numerator / tl.maximum(denominator, 1e-20)
+    _write_pool(
+        cache_fp8,
+        cache_fp32,
+        cache_location,
+        pooled,
+        dim,
+        dim_mask,
+        write_pool,
+        page_stride_bytes,
+        PAGE_SIZE,
+        HEAD_DIM,
+        FP8_MAX,
+    )
+
+
+@triton.jit
+def _prefill_tail_kernel(
+    tail,
+    state_slots,
+    query_start_loc,
+    key,
+    gate,
+    positions,
+    request_offset,
+    tail_stride_0,
+    tail_stride_1,
+    tail_stride_2,
+    key_stride_0,
+    gate_stride_0,
+    HEAD_DIM: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    request = request_offset + tl.program_id(0)
+    state_slot = tl.load(state_slots + request).to(tl.int64)
+    start = tl.load(query_start_loc + request).to(tl.int64)
+    end = tl.load(query_start_loc + request + 1).to(tl.int64)
+    last_row = end - 1
+    has_rows = end > start
+    last_position = tl.load(positions + last_row, mask=has_rows, other=0).to(tl.int64)
+    last_physical_slot = last_position % POOL_SIZE
+    dim = tl.arange(0, BLOCK_D)
+    dim_mask = (dim < HEAD_DIM) & has_rows & (state_slot >= 0)
+    for slot in tl.static_range(0, POOL_SIZE):
+        distance = (last_physical_slot - slot + POOL_SIZE) % POOL_SIZE
+        source_row = last_row - distance
+        source_in_chunk = source_row >= start
+        source_position = tl.load(
+            positions + source_row,
+            mask=has_rows & source_in_chunk,
+            other=-1,
+        ).to(tl.int64)
+        write_slot = dim_mask & source_in_chunk & (source_position % POOL_SIZE == slot)
+        value = tl.load(
+            key + source_row * key_stride_0 + dim,
+            mask=write_slot,
+            other=0.0,
+        )
+        score = tl.load(
+            gate + source_row * gate_stride_0 + dim,
+            mask=write_slot,
+            other=0.0,
+        )
+        tail_offset = state_slot * tail_stride_0 + slot * tail_stride_2 + dim
+        tl.store(tail + tail_offset, value, mask=write_slot)
+        tl.store(tail + tail_offset + tail_stride_1, score, mask=write_slot)
+
+
 def update_decode_pools(
     kv_cache: torch.Tensor,
     tail: torch.Tensor,
@@ -263,10 +452,18 @@ def update_decode_pools(
     positions: torch.Tensor,
     num_requests: int,
     *,
+    num_decode_requests: int | None = None,
+    max_query_len: int | None = None,
     model_block_size: int | None = None,
     parent_stride_pages: int | None = None,
 ) -> None:
-    """Update raw tails and write every newly completed FP8 pool."""
+    """Update request tails and write every newly completed FP8 C4 pool.
+
+    Decode and speculative-decode requests retain ordered row processing. Prefill
+    requests use one program per completed pool and a separate final-tail update;
+    their positions must be consecutive within each request, as required by the
+    packed GLM MLA cache contract.
+    """
     if num_requests <= 0:
         return
     page_size = int(kv_cache.shape[1])
@@ -287,7 +484,17 @@ def update_decode_pools(
     assert parent_stride_pages is not None
     if parent_stride_pages <= 0:
         raise ValueError("GLM parent_stride_pages must be positive")
-    _decode_update_kernel[(num_requests,)](
+    if num_decode_requests is None:
+        num_decode_requests = num_requests
+    if not 0 <= num_decode_requests <= num_requests:
+        raise ValueError("GLM decode request count exceeds the request batch")
+    num_prefill_requests = num_requests - num_decode_requests
+    if num_prefill_requests and not packed_main_slots:
+        raise ValueError("parallel GLM prefill requires packed main-cache slots")
+    if num_prefill_requests and (max_query_len is None or max_query_len <= 0):
+        raise ValueError("parallel GLM prefill requires a positive max_query_len")
+
+    common_args = (
         kv_cache.view(torch.float8_e4m3fn),
         kv_cache.view(torch.float32),
         tail,
@@ -307,14 +514,49 @@ def update_decode_pools(
         int(key.stride(0)),
         int(gate.stride(0)),
         int(ape.stride(0)),
+    )
+    common_meta = dict(
         PAGE_SIZE=page_size,
         HEAD_DIM=_HEAD_DIM,
         POOL_SIZE=_POOL_SIZE,
         FP8_MAX=_FP8_MAX,
         BLOCK_D=128,
-        PACKED_MAIN_SLOTS=packed_main_slots,
         num_warps=4,
     )
+    if num_decode_requests:
+        _decode_update_kernel[(num_decode_requests,)](
+            *common_args,
+            PACKED_MAIN_SLOTS=packed_main_slots,
+            **common_meta,
+        )
+    if num_prefill_requests:
+        assert max_query_len is not None
+        _prefill_pool_kernel[
+            (num_prefill_requests, triton.cdiv(max_query_len, _POOL_SIZE))
+        ](
+            *common_args[:10],
+            num_decode_requests,
+            *common_args[10:],
+            **common_meta,
+        )
+        _prefill_tail_kernel[(num_prefill_requests,)](
+            tail,
+            state_slots,
+            query_start_loc,
+            key,
+            gate,
+            positions,
+            num_decode_requests,
+            int(tail.stride(0)),
+            int(tail.stride(1)),
+            int(tail.stride(2)),
+            int(key.stride(0)),
+            int(gate.stride(0)),
+            HEAD_DIM=_HEAD_DIM,
+            POOL_SIZE=_POOL_SIZE,
+            BLOCK_D=128,
+            num_warps=4,
+        )
 
 
 @triton.jit

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -430,6 +430,8 @@ class Glm5NextPooledIndexer(nn.Module):
             main_metadata.slot_mapping[:rows],
             positions,
             num_reqs,
+            num_decode_requests=num_decodes,
+            max_query_len=int(main_metadata.max_query_len),
             model_block_size=self.block_size,
             parent_stride_pages=self._parent_stride_pages,
         )

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -261,6 +261,12 @@ class Glm5NextPooledIndexer(nn.Module):
         return math.ceil(max_model_len / (block_size * dcp_world_size))
 
     @staticmethod
+    def _active_index_page_count(seq_len: int) -> int:
+        """Return FP8 C4 pages that can contain completed visible pools."""
+        completed_pools = seq_len // _POOL_SIZE
+        return max(1, math.ceil(completed_pools / _INDEX_PAGE_SIZE))
+
+    @staticmethod
     def _index_cache_view(
         main_cache: torch.Tensor,
     ) -> tuple[torch.Tensor, int, int]:
@@ -482,15 +488,35 @@ class Glm5NextPooledIndexer(nn.Module):
 
         if decode_rows < live_rows:
             query_lens_cpu = main_metadata.prefill_query_lens_cpu
-            if query_lens_cpu is None:
+            request_seq_lens_cpu = main_metadata.prefill_seq_lens_cpu
+            if query_lens_cpu is None or request_seq_lens_cpu is None:
                 raise RuntimeError("GLM selector prefill metadata is incomplete")
+            if len(query_lens_cpu) != len(request_seq_lens_cpu):
+                raise RuntimeError(
+                    "GLM selector prefill request metadata has inconsistent lengths"
+                )
             row_start = decode_rows
             for local_request, query_len in enumerate(query_lens_cpu.tolist()):
                 row_end = row_start + int(query_len)
                 request = num_decodes + local_request
-                shared_table = self._pool_block_table[request : request + 1].expand(
-                    int(query_len), -1
-                )
+                if self.dcp_world_size == 1:
+                    active_pages = self._active_index_page_count(
+                        int(request_seq_lens_cpu[local_request])
+                    )
+                    if active_pages > int(self._pool_block_table.shape[1]):
+                        raise RuntimeError(
+                            "GLM selector visible C4 pages exceed table capacity: "
+                            f"active={active_pages}, "
+                            f"capacity={int(self._pool_block_table.shape[1])}"
+                        )
+                    request_table = self._pool_block_table[
+                        request : request + 1, :active_pages
+                    ]
+                else:
+                    # DCP pool ownership is interleaved across ranks, so a global
+                    # sequence length does not define a contiguous local prefix.
+                    request_table = self._pool_block_table[request : request + 1]
+                shared_table = request_table.expand(int(query_len), -1)
                 self.indexer_op.run_paged_topk(
                     q=q_fp8[row_start:row_end],
                     weights=weights[row_start:row_end],

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -291,6 +291,7 @@ class B12xMLASparseMetadata(AttentionMetadata):
     prefill_max_seq_len: int = 0
     prefill: MLACommonPrefillMetadata | None = None
     prefill_query_lens_cpu: torch.Tensor | None = None
+    prefill_seq_lens_cpu: torch.Tensor | None = None
     block_size: int = 64
     topk_tokens: int = 2048
     cp_kv_cache_interleave_size: int = 1
@@ -524,6 +525,14 @@ class B12xMLASparseMetadataBuilder(
             metadata.prefill_query_lens_cpu = torch.diff(
                 common.query_start_loc_cpu[prefill_start:prefill_end]
             )
+            seq_lens_cpu_source = (
+                common.seq_lens_cpu_upper_bound
+                if common.seq_lens_cpu_upper_bound is not None
+                else common.seq_lens_cpu
+            )
+            metadata.prefill_seq_lens_cpu = seq_lens_cpu_source[
+                prefill_start : prefill_start + metadata.num_prefills
+            ].clone()
         (
             metadata.selector_state_slot_ids,
             metadata.selector_state_is_fresh,


### PR DESCRIPTION
## Result

Status: **implemented and qualified** for packed GLM5Next C4 prefill.

Completed four-token C4 pools are written by independent Triton programs, and
one request-scoped program persists the incomplete tail needed by a later
chunk. Decode and speculative-decode rows retain ordered processing.

For non-DCP prefill, candidate selection receives only the C4 pages that can
contain completed visible pools. DCP keeps the full local page table because
global pool ownership is interleaved and a global sequence length does not
define a contiguous rank-local prefix.

## Technical reason

Assigning an entire 4,080-token request to one program serializes roughly
1,020 independent completed-pool writes. The separated writer exposes those
pools as parallel programs while preserving the request tail at chunk
boundaries. Restricting non-DCP selection to visible pages prevents the paged
selector from scanning graph-capacity padding that cannot contain a completed
pool.

## Operation contract and compatibility

- Parallel prefill requires packed main-cache slot mappings and consecutive
  positions within each request.
- Decode and speculative-decode rows use the ordered writer.
- Negative state slots and dummy cache slots do not write cache or tail state.
- The final request tail preserves keys and gates that a subsequent chunk
  needs to complete a C4 pool.
- DCP page ownership and candidate remapping are unchanged.
- Cache quantization, page addressing, top-k value, and public cache layouts
  are unchanged.

## Review-stack boundary

This pull request is based on #531, which caches immutable B12X C4 plans while
rebinding live tensors and caller-owned workspace. Its diff contains only the
parallel pool writer, visible-page calculation, adapter wiring, and associated
tests.

## Validation

Source base: `perf/glm53-b12x-c4-plan-reuse-20260830` at
`b8edca554d21e0fbe17a40e182bea6545ab1901b`.

```bash
CUDA_VISIBLE_DEVICES=0 B12X_GLM53_GPU_TEST=1 \
  /opt/venv/bin/python -B -m pytest -q \
  tests/models/test_glm5next_pooled_indexer.py \
  -k "active_index_pages or decode_writer_matches_parallel_prefill_writer or parallel_prefill_preserves_boundary_tail_and_state_slots or parallel_prefill_ignores_invalid_dummy_slots"
```

The cases cover visible-page boundaries, ordered-versus-parallel output,
partial pools crossing a chunk boundary, recurrent-state slot isolation, and
invalid scheduler padding slots.
Result: 9 passed, 15 deselected.

The source-locked TP4/DCP4 integration at vLLM
`3609a3db498698314bdc44920cad9f2d25796eb9` and B12X composition
`6255090a03b12c3f7d552102a02fac0b542fb8c9` completed model loading, memory
profiling, graph capture, and the 32k standalone-prefill workloads with
`max_num_batched_tokens=4096`. The B12X composition contains #259 and #260 over
`master@fc1d4b68f7a5b0cfdb88bf06abccd869f5c589d5`. This establishes
integration compatibility; it does not attribute total serving throughput to
this pull request alone.

## AI assistance disclosure

AI assistance was used to implement and test the kernels, qualify the composed
runtime, and prepare this pull-request description.
