### PR TITLE
perf(glm5next): replicate TP input embeddings

### DIFF
--- a/tests/kernels/core/test_fused_embed_norm.py
+++ b/tests/kernels/core/test_fused_embed_norm.py
@@ -1,11 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Unit tests for the replicated-embedding fused gather/norm kernels
-(``vllm.model_executor.layers.fused_embed_norm``).
+"""Unit tests for replicated-embedding fused gather/norm kernels.
 
-The guarantee: enabling ``VLLM_REPLICATE_EMBED`` (replicated table + fused
-kernels) must not change model outputs. The gathered residual is bit-exact and
-the fused norms match the unfused reference.
+Enabling ``VLLM_REPLICATE_EMBED`` must preserve every gathered embedding and
+match the unfused RMSNorm reference.
 """
 
 import pytest
@@ -15,8 +13,6 @@ from vllm.model_executor.layers.fused_embed_norm import (
     fused_embed_eh_norm,
     fused_embed_norm,
 )
-
-# The model-local (untouched) eh-norm the replicate path must match.
 from vllm.models.deepseek_v32.common.kernels import fused_eh_norm
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
@@ -59,17 +55,24 @@ def test_fused_embed_norm_matches_reference():
 @requires_cuda
 @torch.inference_mode()
 def test_fused_embed_eh_norm_matches_reference():
-    """MTP fusion (folded gather) is bit-exact vs gathering the embeds and
-    feeding the untouched model-local ``fused_eh_norm``."""
+    """The fused MTP gather/norm must preserve every embedding row."""
     set_random_seed(13)
     table = torch.randn(VOCAB, HIDDEN, dtype=DTYPE, device="cuda")
     ids = torch.randint(0, VOCAB, (NUM_TOKENS,), dtype=torch.int32, device="cuda")
     prev = torch.randn(NUM_TOKENS, HIDDEN, dtype=DTYPE, device="cuda")
+    positions = torch.arange(NUM_TOKENS, dtype=torch.int64, device="cuda")
     enorm_w = torch.randn(HIDDEN, dtype=DTYPE, device="cuda")
     hnorm_w = torch.randn(HIDDEN, dtype=DTYPE, device="cuda")
-    positions = torch.arange(NUM_TOKENS, device="cuda")  # includes pos 0
 
-    fused = fused_embed_eh_norm(positions, ids, table, prev, enorm_w, hnorm_w, EPS)
-    ref = fused_eh_norm(positions, table[ids.long()], prev, enorm_w, hnorm_w, EPS)
+    fused = fused_embed_eh_norm(ids, table, prev, enorm_w, hnorm_w, EPS)
+    local = fused_eh_norm(positions, table[ids.long()], prev, enorm_w, hnorm_w, EPS)
+    ref = torch.cat(
+        (
+            _rmsnorm(table[ids.long()], enorm_w, EPS).to(DTYPE),
+            _rmsnorm(prev, hnorm_w, EPS).to(DTYPE),
+        ),
+        dim=-1,
+    )
 
     torch.testing.assert_close(fused, ref, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(local, ref, atol=0.0, rtol=0.0)

--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -36,6 +36,7 @@ from vllm.models.glm5next.nvidia.model import (
 from vllm.models.glm5next.nvidia.mtp import (
     Glm5NextMTP,
     Glm5NextMultiTokenPredictor,
+    Glm5NextMultiTokenPredictorLayer,
 )
 from vllm.transformers_utils.configs.glm5_next import (
     Glm5NextConfig,
@@ -185,6 +186,104 @@ def test_glm5next_mtp_selects_only_draft_checkpoint_weights() -> None:
         "model.layers.45.",
         "layers.45.",
     )
+
+
+def test_glm5next_mtp_preserves_position_zero_embedding() -> None:
+    class CaptureProjection(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.inputs: torch.Tensor | None = None
+
+        def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+            self.inputs = inputs
+            return inputs
+
+    class IdentityBlock(torch.nn.Module):
+        def forward(
+            self,
+            *,
+            positions: torch.Tensor,
+            hidden_states: torch.Tensor,
+            residual: torch.Tensor | None,
+        ) -> tuple[torch.Tensor, torch.Tensor, None, None]:
+            return hidden_states, torch.zeros_like(hidden_states), None, None
+
+    class IdentityHead(torch.nn.Module):
+        def norm(
+            self, hidden_states: torch.Tensor, residual: torch.Tensor
+        ) -> tuple[torch.Tensor, None]:
+            return hidden_states, None
+
+    layer = Glm5NextMultiTokenPredictorLayer.__new__(Glm5NextMultiTokenPredictorLayer)
+    torch.nn.Module.__init__(layer)
+    projection = CaptureProjection()
+    layer.enorm = torch.nn.Identity()
+    layer.hnorm = torch.nn.Identity()
+    layer.eh_proj = projection
+    layer.mtp_block = IdentityBlock()
+    layer.shared_head = IdentityHead()
+
+    inputs_embeds = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    previous_hidden_states = torch.zeros_like(inputs_embeds)
+    layer(
+        input_ids=torch.tensor([1, 2]),
+        positions=torch.tensor([0, 1]),
+        previous_hidden_states=previous_hidden_states,
+        inputs_embeds=inputs_embeds,
+    )
+
+    assert projection.inputs is not None
+    torch.testing.assert_close(projection.inputs[:, :2], inputs_embeds)
+
+
+def test_glm5next_mtp_replicated_embedding_defers_lookup() -> None:
+    captured: dict[str, object] = {}
+
+    class FailingEmbedding(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.zeros(8, 4))
+
+        def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+            raise AssertionError(
+                "replicated lookup must be fused into MTP normalization"
+            )
+
+    class RecordingLayer(torch.nn.Module):
+        def forward(
+            self,
+            input_ids: torch.Tensor,
+            positions: torch.Tensor,
+            previous_hidden_states: torch.Tensor,
+            inputs_embeds: torch.Tensor | None = None,
+            spec_step_index: int = 0,
+            embed_table: torch.Tensor | None = None,
+        ) -> torch.Tensor:
+            captured.update(
+                inputs_embeds=inputs_embeds,
+                spec_step_index=spec_step_index,
+                embed_table=embed_table,
+            )
+            return previous_hidden_states
+
+    predictor = Glm5NextMultiTokenPredictor.__new__(Glm5NextMultiTokenPredictor)
+    torch.nn.Module.__init__(predictor)
+    predictor.num_mtp_layers = 1
+    predictor.embed_tokens = FailingEmbedding()
+    predictor.replicated_embed = True
+    predictor._mtp_layers = [RecordingLayer()]
+    previous_hidden_states = torch.ones(2, 4)
+
+    result = predictor(
+        torch.tensor([1, 2]),
+        torch.tensor([3, 4]),
+        previous_hidden_states,
+    )
+
+    assert result is previous_hidden_states
+    assert captured["inputs_embeds"] is None
+    assert captured["spec_step_index"] == 0
+    assert captured["embed_table"] is predictor.embed_tokens.weight
 
 
 def test_glm5next_mixed_precision_reaches_mla_projections(monkeypatch) -> None:

--- a/vllm/model_executor/layers/fused_embed_norm.py
+++ b/vllm/model_executor/layers/fused_embed_norm.py
@@ -8,10 +8,8 @@ the full on-rank table unlocks --
 
   * ``fused_embed_norm``: gather + a chained RMSNorm (e.g. the first decoder
     layer's ``input_layernorm``), and
-  * ``fused_embed_eh_norm``: gather + pos-0 zeroing + enorm/hnorm + cat, the
-    embed/previous-hidden input norm for a speculative (MTP/eagle) depth layer
-    (the replicated-table analogue of the model-local ``fused_eh_norm``, which
-    takes precomputed embeds).
+  * ``fused_embed_eh_norm``: gather + enorm/hnorm + cat, the
+    embed/previous-hidden input norm for a speculative (MTP/eagle) depth layer.
 
 Self-contained (no model-local imports) so it can live under ``layers/``.
 """
@@ -152,7 +150,6 @@ def fused_embed_norm(
 
 @triton.jit
 def _fused_embed_eh_norm_kernel(
-    pos_ptr,
     ids_ptr,  # [T] token ids
     table_ptr,  # [V, H] embedding table (full vocab, replicated on-rank)
     table_stride,
@@ -166,19 +163,17 @@ def _fused_embed_eh_norm_kernel(
     H: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
-    """MTP input fusion with a folded embedding gather: gather
-    ``table[ids]``, zero it at position 0, RMSNorm(embed) with enorm and
-    RMSNorm(prev_hidden) with hnorm, written side-by-side into ``out`` ([N, 2H])
-    ready for the eh_proj GEMM. Replaces embedding lookup + where + 2x RMSNorm +
-    cat. Requires the full table on-rank (replicated embedding)."""
+    """MTP input fusion with a folded embedding gather: gather ``table[ids]``,
+    RMSNorm(embed) with enorm, and RMSNorm(prev_hidden) with hnorm, written
+    side-by-side into ``out`` ([N, 2H]) ready for the eh_proj GEMM. Requires the
+    full table on-rank (replicated embedding).
+    """
     tok = tl.program_id(0)
     off = tl.arange(0, BLOCK)
     mask = off < H
 
-    pos = tl.load(pos_ptr + tok)
     row = tl.load(ids_ptr + tok).to(tl.int64)
     e = tl.load(table_ptr + row * table_stride + off, mask=mask, other=0.0)
-    e = tl.where(pos == 0, 0.0, e.to(tl.float32))
     ew = tl.load(enorm_w_ptr + off, mask=mask)
     e_normed = _rms_norm(e, ew, eps, H)
     tl.store(out_ptr + tok * out_stride + off, e_normed, mask=mask)
@@ -191,7 +186,6 @@ def _fused_embed_eh_norm_kernel(
 
 # MTP fusion
 def fused_embed_eh_norm(
-    positions: torch.Tensor,
     input_ids: torch.Tensor,
     embed_table: torch.Tensor,
     previous_hidden: torch.Tensor,
@@ -199,22 +193,20 @@ def fused_embed_eh_norm(
     hnorm_w: torch.Tensor,
     eps: float,
 ) -> torch.Tensor:
-    """Fused ``cat([enorm(masked embed_table[ids]), hnorm(prev_hidden)])`` -> [N, 2H].
+    """Fused ``cat([enorm(embed_table[ids]), hnorm(prev_hidden)])`` -> [N, 2H].
 
     Folds the embedding row gather into the MTP eh-norm launch; requires the full
-    table on-rank (replicated embedding). Bit-exact vs gathering ``embed_table[
-    input_ids]`` and passing it to the model-local ``fused_eh_norm``.
+    table on-rank (replicated embedding).
     """
     assert previous_hidden.ndim == 2 and embed_table.ndim == 2
     n, h = previous_hidden.shape
-    assert positions.shape == (n,) and input_ids.view(-1).shape == (n,)
+    assert input_ids.view(-1).shape == (n,)
     assert embed_table.shape[1] == h, (embed_table.shape, h)
     assert enorm_w.shape == (h,) and hnorm_w.shape == (h,)
     out = torch.empty(
         n, 2 * h, dtype=previous_hidden.dtype, device=previous_hidden.device
     )
     _fused_embed_eh_norm_kernel[(n,)](
-        positions,
         input_ids,
         embed_table,
         embed_table.stride(0),

--- a/vllm/models/deepseek_v32/common/kernels.py
+++ b/vllm/models/deepseek_v32/common/kernels.py
@@ -981,16 +981,15 @@ def _fused_eh_norm_kernel(
     H: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
-    """MTP input fusion: zero embeds at position 0, RMSNorm(embeds) with enorm
-    and RMSNorm(prev_hidden) with hnorm, written side-by-side into ``out``
-    ([N, 2H]) ready for the eh_proj GEMM. Replaces where + 2x RMSNorm + cat."""
+    """MTP input fusion: RMSNorm(embeds) with enorm and RMSNorm(prev_hidden)
+    with hnorm, written side-by-side into ``out`` ([N, 2H]) ready for the
+    eh_proj GEMM. Replaces 2x RMSNorm + cat.
+    """
     tok = tl.program_id(0)
     off = tl.arange(0, BLOCK)
     mask = off < H
 
-    pos = tl.load(pos_ptr + tok)
     e = tl.load(embeds_ptr + tok * embeds_stride + off, mask=mask, other=0.0)
-    e = tl.where(pos == 0, 0.0, e.to(tl.float32))
     ew = tl.load(enorm_w_ptr + off, mask=mask)
     e_normed = _rms_norm(e, ew, eps, H)
     tl.store(out_ptr + tok * out_stride + off, e_normed, mask=mask)
@@ -1009,7 +1008,7 @@ def fused_eh_norm(
     hnorm_w: torch.Tensor,
     eps: float,
 ) -> torch.Tensor:
-    """Returns cat([enorm(masked embeds), hnorm(prev_hidden)]) -> [N, 2H]."""
+    """Returns cat([enorm(embeds), hnorm(prev_hidden)]) -> [N, 2H]."""
     n, h = inputs_embeds.shape
     out = torch.empty(n, 2 * h, dtype=inputs_embeds.dtype, device=inputs_embeds.device)
     _fused_eh_norm_kernel[(n,)](

--- a/vllm/models/deepseek_v32/nvidia/mtp.py
+++ b/vllm/models/deepseek_v32/nvidia/mtp.py
@@ -97,13 +97,10 @@ class DeepseekV32MultiTokenPredictorLayer(nn.Module):
         embed_table: torch.Tensor | None = None,
         spec_step_index: int = 0,
     ) -> torch.Tensor:
-        # Fused zero pos-0 + enorm(embeds) + hnorm(prev) + cat -> [N, 2H]. With a
-        # replicated table the caller passes ``embed_table`` so the embedding
-        # lookup is folded in too (fused_embed_eh_norm); otherwise the embeds are
-        # precomputed and go through the model-local fused_eh_norm.
+        # Fold the embedding lookup into the norm when the full table is
+        # available on-rank; otherwise use the precomputed embeddings.
         if embed_table is not None:
             eh_input = fused_embed_eh_norm(
-                positions,
                 input_ids,
                 embed_table,
                 previous_hidden_states,

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -17,6 +17,7 @@ from vllm.distributed import (
 )
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul, SiluAndMulWithClamp
+from vllm.model_executor.layers.fused_embed_norm import make_input_embedding
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEFactory,
     GateLinear,
@@ -47,10 +48,7 @@ from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
     MXFP8_VALUE_DTYPE,
     dequant_mxfp8_to_bf16,
 )
-from vllm.model_executor.layers.vocab_parallel_embedding import (
-    ParallelLMHead,
-    VocabParallelEmbedding,
-)
+from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
@@ -708,10 +706,11 @@ class Glm5NextModel(nn.Module, EagleModelMixin):
             pool_topk_indices_buffer = None
 
         if get_pp_group().is_first_rank:
-            self.embed_tokens = VocabParallelEmbedding(
+            self.embed_tokens = make_input_embedding(
                 config.vocab_size,
                 config.hidden_size,
                 prefix=f"{prefix}.embed_tokens",
+                tie_word_embeddings=getattr(config, "tie_word_embeddings", False),
             )
         else:
             self.embed_tokens = PPMissingLayer()

--- a/vllm/models/glm5next/nvidia/mtp.py
+++ b/vllm/models/glm5next/nvidia/mtp.py
@@ -7,14 +7,16 @@ import torch
 import torch.nn as nn
 
 from vllm.config import VllmConfig
+from vllm.model_executor.layers.fused_embed_norm import (
+    fused_embed_eh_norm,
+    has_full_vocab_on_rank,
+    make_input_embedding,
+)
 from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
-from vllm.model_executor.layers.vocab_parallel_embedding import (
-    VocabParallelEmbedding,
-)
 from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
@@ -87,13 +89,23 @@ class Glm5NextMultiTokenPredictorLayer(nn.Module):
         previous_hidden_states: torch.Tensor,
         inputs_embeds: torch.Tensor | None = None,
         spec_step_index: int = 0,
+        embed_table: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        assert inputs_embeds is not None
-        aligned_embeds = inputs_embeds.masked_fill(positions.eq(0).unsqueeze(-1), 0)
-        eh_input = torch.cat(
-            (self.enorm(aligned_embeds), self.hnorm(previous_hidden_states)),
-            dim=-1,
-        )
+        if embed_table is not None:
+            eh_input = fused_embed_eh_norm(
+                input_ids,
+                embed_table,
+                previous_hidden_states,
+                self.enorm.weight,
+                self.hnorm.weight,
+                self.enorm.variance_epsilon,
+            )
+        else:
+            assert inputs_embeds is not None
+            eh_input = torch.cat(
+                (self.enorm(inputs_embeds), self.hnorm(previous_hidden_states)),
+                dim=-1,
+            )
         hidden_states = self.eh_proj(eh_input)
         # Fuse the residual add and final RMSNorm. Glm5NextMoE already performs
         # its all-reduce, so no collective is needed here. The post-norm result
@@ -122,11 +134,13 @@ class Glm5NextMultiTokenPredictor(nn.Module):
                 )
             }
         )
-        self.embed_tokens = VocabParallelEmbedding(
+        self.embed_tokens = make_input_embedding(
             config.vocab_size,
             config.hidden_size,
             prefix=maybe_prefix(prefix, "embed_tokens"),
+            tie_word_embeddings=getattr(config, "tie_word_embeddings", False),
         )
+        self.replicated_embed = has_full_vocab_on_rank(self.embed_tokens)
         # Plain list for the per-propose lookup: ModuleDict[str(...)] builds a
         # string and hashes it on every draft step.
         self._mtp_layers = list(self.layers.values())
@@ -182,15 +196,20 @@ class Glm5NextMultiTokenPredictor(nn.Module):
         inputs_embeds: torch.Tensor | None = None,
         spec_step_idx: int = 0,
     ) -> torch.Tensor:
+        embed_table = None
         if inputs_embeds is None:
-            inputs_embeds = self.embed_tokens(input_ids)
+            if self.replicated_embed:
+                embed_table = self.embed_tokens.weight
+            else:
+                inputs_embeds = self.embed_tokens(input_ids)
         current_step_idx = spec_step_idx % self.num_mtp_layers
         return self._mtp_layers[current_step_idx](
             input_ids,
             positions,
             previous_hidden_states,
             inputs_embeds,
-            current_step_idx,
+            spec_step_index=current_step_idx,
+            embed_table=embed_table,
         )
 
     def compute_logits(


### PR DESCRIPTION
## TL;DR

Port upstream replicated-embedding infrastructure and a known MTP correctness invariant into Jovian's GLM5Next stack, with custom integration and regression tests.

## Purpose

### Problem and source

GLM5Next constructs its target and multi-token-prediction (MTP) input embeddings directly as vocabulary-parallel embeddings. The existing `VLLM_REPLICATE_EMBED` implementation therefore does not apply to GLM5Next, and tensor-parallel execution performs one target embedding all-reduce plus one embedding all-reduce for each MTP draft position.

The shared replicated gather/normalization helper and the `deepseek_v32` model, both present upstream, also mask the embedding at position zero. MTP first-pass input IDs are shifted while positions remain unchanged, so that row contains a live token rather than padding. The local GLM5Next path inherits that behavior. All three require the position-zero contract proposed for other upstream model paths by vllm-project/vllm#49938.

- Target repository: https://github.com/local-inference-lab/vllm
- Target branch: `dev/jovian-judgement`
- Exact base: `0b67266a0f37d6146a8403fb8482403c62f412d5`
- Proposed head: `0dbcfcc411a4573e87ff6699cb0570139bdfecb3`
- Result tree: `84a43c68995c2a336e4b0622c506691877c608bc`
- Binary/full-index diff SHA-256: `817a567ff03c676e82b6d347eae0e83fff6936f9d8b702e9d9f79d08f66e7062`
- Community wiki commit reviewed: `local-inference-lab/rtx6kpro@0a27155d6b71e726d66233db9dd7f79dfec51a4a`
- Contribution-method source reviewed: local-inference-lab/rtx6kpro#89 at `0a825d7dc19d95f4d360f6f5441463a41e9b7290` (open; no files from it are vendored here)
- Public runbook/evidence URL: N/A — the DGX Spark campaign artifacts are local and must be packaged or uploaded before this draft is marked ready
- Related issue: https://github.com/vllm-project/vllm/issues/33299
- Related upstream PRs: https://github.com/vllm-project/vllm/pull/48484 and https://github.com/vllm-project/vllm/pull/49938

### Resulting behavior

With `VLLM_REPLICATE_EMBED=1`, each tensor-parallel rank stores the complete GLM5Next target/MTP input embedding table. The target model performs a local gather. The MTP path folds its local gather into the existing embedding/hidden-state normalization kernel. At static MTP width 3, the intended observable result is removal of one target embedding collective and three draft embedding collectives per target step.

Without the flag, GLM5Next retains vocabulary-parallel embedding placement. Position zero is preserved in both the local and replicated MTP normalization paths because it contains a shifted live token.

Status: research-only draft. Source-level checks pass. The final diff has not received a controlled GPU or endpoint A/B.

### Technical reason

`VocabParallelEmbedding` masks rows outside each rank's vocabulary shard and all-reduces the partial result. `make_input_embedding` already supports disabling that sharding behind `VLLM_REPLICATE_EMBED`; GLM5Next only needs to use the existing factory and route the complete MTP table into the existing fused gather/normalization kernel.

The position-zero mask is incompatible with the proposer contract: first-pass token IDs are shifted before the draft forward while the positions tensor is not. Removing the mask preserves the embedding selected by the shifted token ID and keeps replicated and non-replicated paths equivalent.

### Changes

- Construct GLM5Next target and MTP embeddings through `make_input_embedding`.
- Detect when the MTP embedding contains the complete vocabulary and defer its lookup to `fused_embed_eh_norm`.
- Preserve position-zero embeddings in the upstream-shared replicated helper and `deepseek_v32` paths and in the local GLM5Next path.
- Update every affected call site after removing the now-unused `positions` argument from `fused_embed_eh_norm`.
- Add regressions for the position-zero invariant and deferred replicated MTP lookup.

### Inherited work and attribution

- vllm-project/vllm#48484, head `48c7e71ec070ce0314fd91842ab820c6947db910`, merged as `2687fec6ef744f7d8ac174303e9a2ee6fe8d7153`: Jee Jee Li (`@jeejeelee`) introduced `VLLM_REPLICATE_EMBED`, the shared factory, and fused embedding/normalization kernels. This PR extends that implementation to GLM5Next.
- vllm-project/vllm#49938, head `876250e0664f0b1e22fca89bb6423b9bfb1177e5`: `@2019598399` owns the general upstream position-zero correction. That PR does not cover `deepseek_v32`, the replicated helper introduced by #48484, or GLM5Next. Commit `b86deddf46bac5f6f1d0d1c773eb816aa2dbfe7f` applies the same invariant to those paths; it is not presented as an independent discovery.
- Research commits `777dfcb67db643f97bdd93d243717e67056f41ac` and `fd5ac24edac7c4a144dc174e593c32e38cdd5792` are superseded by the focused series in this branch. The current commits retain Jason Cook's sign-off and record OpenAI Codex assistance.

### Reviewed alternatives and exclusions

| Reference | Disposition | Reason |
|---|---|---|
| `708ce63711f7dea0b579ed231956649800da472e` B12X MTP vocabulary-plan preparation | Rejected | Its isolated saving was 0.136 ms per MTP3 step and its endpoint effect was below measurement resolution. It is excluded so the PR asks one technical question. |
| vllm-project/vllm#49938 | Inherited/coordinate | It establishes the general position-zero contract but does not touch upstream `deepseek_v32`, the shared replicated helper from #48484, or the local GLM5Next model. Reconcile overlapping changes if equivalent fixes land before merge. |
| Fusing the target gather with its first normalization | Out of scope | A local replicated target gather removes the target embedding collective without another model-specific forward-path change. |
| TP2 and pipeline-parallel enablement | Out of scope | Neither is required to establish the TP4 GLM5Next behavior; both need separate memory/correctness qualification. |

### Compatibility impact

- Interfaces/flags/defaults: replication remains opt-in through the existing `VLLM_REPLICATE_EMBED` flag; the internal `fused_embed_eh_norm` signature drops an unused `positions` argument and every affected caller is migrated.
- Models/formats: GLM5Next gains the replicated path. The position-zero correction also affects the upstream-shared `deepseek_v32` MTP path. Tied word embeddings remain unsupported with replication at tensor parallelism greater than one.
- Hardware/topology: code is tensor-parallel-degree agnostic. Only four DGX Spark GB10 ranks at TP4 have historical measurements. TP2 is Not tested.
- Cache/graph state: the historical TP4 candidate added 951,582,720 bytes (907.5 MiB) per rank; configured KV capacity remained 2,464,487 tokens. The final diff is Not tested on GPU.
- Upgrade/downgrade: disabling the flag restores vocabulary-parallel placement. The position-zero correction is unconditional because it follows the MTP input contract.

### Claim and evidence ledger

| Claim | Status | Evidence | Rivals or validity limits |
|---|---|---|---|
| The final source routes GLM5Next through the existing replicated-embedding factory and defers the full-table MTP lookup to the fused kernel. | Demonstrated | Source diff plus focused tests: 42 passed, 2 GPU tests skipped. | No final GPU execution. |
| Position zero contains a live shifted MTP token and must be preserved. | Demonstrated | vllm-project/vllm#33299, upstream draft #49938, and the new local/replicated regression tests. | Model families with a different proposer contract would require separate analysis. |
| The historical candidate removed four embedding all-reduces at MTP width 3. | Demonstrated for the historical candidate only | Candidate/control profiler traces; collective count changed by four. | The historical candidate also prepared a B12X vocabulary plan. The final diff has not been profiled. |
| The final diff improves C1 target steps/s. | Hypothesis | A confounded historical candidate measured +3.09%; no final-diff A/B exists. | Vocabulary-plan confounder, server-state independence not established, thermal/clock drift, acceptance movement, and the newer Jovian base. |
| TP4 replication adds 907.5 MiB per rank without reducing the configured KV capacity. | Demonstrated for the historical candidate only | Runtime allocation and KV-capacity observations on candidate `fd5ac24ed`. | Not repeated on the final base; other TP degrees and memory policies are Not tested. |
| Model quality is unchanged. | Speculation | A 30-item MMLU-Pro smoke had 27/30 for both compared systems with no answer flips. | Different speculative systems were compared; 30 items are not a powered model evaluation. |

## Test Plan

### Source checks

Run the focused model/kernel tests, applicable pre-commit hooks, and diff whitespace validation listed under Test Result.

### Required final-diff GPU and endpoint comparison

This comparison is Not tested and remains a gate before the draft is marked ready.

- Question: Does `VLLM_REPLICATE_EMBED=1` remove the four expected collectives and improve low-concurrency GLM5Next MTP3 target-step latency without a material acceptance, quality, or capacity regression?
- Experimental unit: one independently started, warmed, and inspected TP4 server instance.
- Candidate: head `0dbcfcc411a4573e87ff6699cb0570139bdfecb3` with `VLLM_REPLICATE_EMBED=1`.
- Control: the same commit, image, model, B12X revision, launch settings, and benchmark workload with `VLLM_REPLICATE_EMBED=0`.
- Changed variable: `VLLM_REPLICATE_EMBED` only.
- Held constant: image bytes, source/component revisions, four-host TP4 topology, model snapshot, MTP width, scheduler/cache/graph settings, benchmark commit/overlay, prompt, context, concurrency, temperature, duration, and warmup.
- Nuisance variables: independent server state, JIT/cache state, clocks, thermals, background load, RoCE state, and run order.
- Rivals: ordinary restart variation, acceptance changes, hidden environment drift, or a missing flag inside the container.
- Design: two balanced blocks, `ABBA` and `BAAB`, with a fresh server start for every letter; four independent server units per arm. Verify the effective container environment before every candidate measurement.
- Primary measurement: C1, zero-context, static-MTP3 target steps/s over 180 seconds after a 20-second decode warmup.
- Secondary measurements: physical step time, collective count/time, raw tokens/s, accepted tokens/step and per-position acceptance, TTFT, incremental memory, and KV capacity.
- Stopping rule: stop after the predeclared eight server units regardless of outcome. Preserve failures and invalid runs; do not replace them silently.
- Exclusions: only predeclared startup or instrumentation failures. Record the failed unit and reason before any rerun.
- Prediction: the candidate trace lacks four embedding all-reduces and has lower target-step time.
- Falsification condition: the performance claim remains unsupported if the collective count does not change, the paired step-rate effect is not consistently positive beyond repeated-control variation, or acceptance/capacity regressions offset the latency effect.
- Quality gate: run the pinned full evaluation selected for GLM5Next, not only the 30-item smoke, and report any answer flips separately from acceptance.

## Test Result

### Current rebased branch

```bash
/home/jasonc/sparks-glm53-lowcon/.venv/bin/python -m pytest \
  tests/models/test_glm5next_model.py \
  tests/kernels/core/test_fused_embed_norm.py -q
```

**Conditions:** head `0dbcfcc411a4573e87ff6699cb0570139bdfecb3` on the local `perf/glm53-replicated-embed` worktree.  
**Experimental unit:** one local source-test process.  
**Measurement:** focused public test files; no outcome-dependent exclusions.  
**Result:** 42 passed, 2 skipped in 15.03 seconds. The two Triton tests skipped because the local vLLM environment could not initialize the CUDA/NVML platform.
**Conclusion:** CPU-exercisable GLM model contracts pass. GPU kernel behavior on the final diff is Not tested.  
**Critical validity threats:** the skipped tests cover the fused Triton kernels.

```bash
/home/jasonc/sparks-glm53-lowcon/.venv/bin/pre-commit run --files \
  tests/kernels/core/test_fused_embed_norm.py \
  tests/models/test_glm5next_model.py \
  vllm/model_executor/layers/fused_embed_norm.py \
  vllm/models/deepseek_v32/common/kernels.py \
  vllm/models/deepseek_v32/nvidia/mtp.py \
  vllm/models/glm5next/nvidia/model.py \
  vllm/models/glm5next/nvidia/mtp.py
```

**Result:** all applicable hooks passed, including Ruff, mypy, SPDX, forbidden-import, and configuration checks.

```bash
git diff --check origin/dev/jovian-judgement...HEAD
```

**Result:** passed.

### Historical TP4 candidate: exploratory evidence only

**Conditions:** four physical NVIDIA DGX Spark GB10 hosts, one GPU per host, TP4 over RoCE v2; GLM-5.3-Flash NVFP4; static MTP width 3; B12X `501ffb9a9b118009b8ea2ea20b8d43f57ba4f221`; driver 580.173.02; CUDA 13.0; PyTorch 2.13.0. Control vLLM was `a4b6044a1399c9b9f87e73ba76e9fd363949cd17`. Candidate vLLM was `fd5ac24edac7c4a144dc174e593c32e38cdd5792`. Benchmark base was `42c38fdd0476cf86940268f4e098581e5b61542e` plus overlay SHA-256 `baf0811c7e58dfd070dfa68018b3f5c5759263cabf4289612e5c1b54fbf73aff`.

**Experimental unit:** an independently started server should be the unit. Whether each of the two collections per arm used an independent server start is `UNKNOWN — needs verification`; treat within-server collections as subsamples.

**Measurement:** C1, zero context, temperature 0, 8,192 maximum tokens, 180-second sustained decode after a 20-second warmup. Timestamp order was control, candidate, candidate, control (`ABBA`). Collection stopped after two runs per arm. An earlier candidate pair was excluded because the Compose environment failed to pass `VLLM_REPLICATE_EMBED`; the invalid artifacts remain recorded in `repembed-abba-invalidation-20260830.json`.

| Arm | Run 1 steps/s | Run 2 steps/s | Mean | Within-arm range |
|---|---:|---:|---:|---:|
| Control | 12.9875 | 12.9268 | 12.9571 | 0.0607 (0.47% of mean) |
| Research candidate | 13.3636 | 13.3505 | 13.3570 | 0.0130 (0.10% of mean) |

**Result:** candidate-control mean difference was +0.3999 target steps/s (+3.09%). Raw tokens/s changed +1.59%; accepted tokens/step changed -1.45%; TTFT changed +4.85%. A profile window lacked four embedding all-reduces and was 3.41 ms shorter on CPU step time. The candidate also contained the excluded B12X vocabulary-plan preparation change.

**Conclusion:** exploratory system comparison only. It demonstrates that the historical candidate trace omitted the expected collectives, but it does not identify the final PR's latency effect. No uncertainty interval is justified from two possibly non-independent collections. The final-diff performance claim remains unsupported pending the predeclared comparison above.

**Critical validity threats:** two changed code paths, unverified server-instance independence, only two collections per arm, sampled rather than locked clocks, mixed acceptance movement, and a different Jovian base from this PR.

Raw evidence identities:

| Artifact | SHA-256 |
|---|---|
| `final-control-fd5ac24eda-critical-c1-180s-20260830.json` | `94d0283d92ed772eeeb0d7b841418e3348d51e182091f524aeffde2282147b8a` |
| `final-candidate-fd5ac24eda-critical-c1-180s-20260830.json` | `365f59ccb2af3adc4d08f44d285a03eed7f3d5ec05520eb38cbbdfc28ada4816` |
| `final-candidate-fd5ac24eda-critical-c1-repeat2-180s-20260830.json` | `afe198f366640cd719b25821c9d0ff476f96e673f9b7919640d3e526cc73b71b` |
| `final-control-fd5ac24eda-critical-c1-repeat2-180s-20260830.json` | `e79c800fc8588e2f589d74303ae3ea9b1090c6c93a4eeb3cf8c1460fd8be2b38` |
| `repembed-abba-invalidation-20260830.json` | `4a1e7a28e8cc0c349f0d5148f3d2a5fac3d997ffa417d81339fd152d9718e4ff` |
| `glm53-lowcon-final-report-20260830.json` | `450d4647ec64a7f196b7e00480186df206b49a55e19c060d44822e2e7287c379` |

Historical correctness checks:

- `python /bench/check_glm53_fused_embed_zero.py`: passed on the historical candidate image on `maxwell`; output SHA-256 `d608cfda827456482fd83719875506c6641893532230e06ef4ae865f4246ce1b`.
- Target and MTP checkpoint embedding tensors were bit-identical before aliasing: SHA-256 `4f7aecd51589ce7879d0ae48a5a1ed25750e4e94d2abe2d14c9526e5ce5641d6`.
- A 30-item MMLU-Pro smoke scored 27/30 for both compared systems with no answer flips. This is not a full model evaluation.

## Duplicate-work check

No open PR matching GLM5Next replicated input embeddings was found in either `vllm-project/vllm` or `local-inference-lab/vllm`. Searches covered `glm5next replicated embedding`, `VLLM_REPLICATE_EMBED`, and the exact proposed subject.

Upstream draft vllm-project/vllm#49938 owns the general position-zero correction, but its file scope does not include `fused_embed_norm.py` or `deepseek_v32`. As of upstream `main` commit `b2dc864bb668da328aee8a8b0b72a0ad13c82252`, those paths still mask position zero, and `vllm/models/glm5next` is absent. This PR applies the #49938 invariant to the missing upstream-shared paths and adds the local GLM5Next replication path. If equivalent changes reach upstream or Jovian first, the overlapping hunks in `b86deddf46bac5f6f1d0d1c773eb816aa2dbfe7f` must be reconciled or dropped.

## Limitations and non-goals

- Known: the final diff has no controlled GPU or endpoint performance result and no public evidence package.
- Untested: final-diff GPU kernels, final-diff memory/KV capacity, TP2, pipeline parallelism, tied word embeddings, dynamic speculation, and a full pinned quality evaluation.
- Unsupported: tied word embeddings with `VLLM_REPLICATE_EMBED=1` at tensor parallelism greater than one, as enforced by the existing factory.
- Non-goals: vocabulary-projection planning, local vocabulary argmax, pipeline-parallel enablement, and high-concurrency throughput tuning.
- Publication gate: the human submitter must review every changed line, rerun the relevant tests, understand the evidence limits, and be able to defend the change end to end.

## AI assistance

This draft PR and its code were developed with OpenAI Codex assistance. It remains a draft while final-diff GPU/performance evidence and human review are outstanding. Before marking it ready for review, the human submitter must review every changed line, rerun the relevant tests, and be able to defend the change end to end.
