### PR TITLE
perf(glm5next): split target and recurrent cache pages

### DIFF
--- a/tests/v1/core/test_contiguous_kv_packing.py
+++ b/tests/v1/core/test_contiguous_kv_packing.py
@@ -104,6 +104,15 @@ class TestDensePacking:
             list(g2),
         ]
 
+    def test_glm53_split_env_does_not_pad_other_mla_models(self, monkeypatch):
+        groups, _, _ = _mixed_page_groups()
+        expected = _expected_bytes_per_block(groups)
+        assert expected % (64 * 132) != 0
+
+        monkeypatch.setenv("VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE", "512")
+
+        assert _get_kv_cache_bytes_per_block(groups) == expected
+
     def test_layers_within_a_group_are_dense(self):
         groups, _, _ = _mixed_page_groups()
         pages = _pages(groups)

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2313,6 +2313,55 @@ def test_group_dcp_replicated_dflash_with_hybrid_mla_target():
     assert groups[-1].kv_cache_spec.dcp_replicated is True
 
 
+def test_glm5next_split_cache_preserves_physical_pages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Split GLM-5.3 cache groups retain their independent page geometry."""
+    target = MLAAttentionSpec(
+        block_size=512,
+        num_kv_heads=1,
+        head_size=528,
+        dtype=torch.uint8,
+        cache_dtype_str="fp8",
+        model_version="glm5_next",
+        page_tail_bytes_per_token=33,
+    )
+    recurrent = MambaSpec(
+        block_size=512,
+        shapes=((585728,),),
+        dtypes=(torch.bfloat16,),
+        mamba_cache_mode="align",
+    )
+    assert target.page_size_bytes == 287232
+    assert recurrent.page_size_bytes == 1171456
+
+    monkeypatch.setenv("VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE", "512")
+    groups = get_kv_cache_groups(
+        _grouping_config(),
+        {"model.target": target, "model.recurrent": recurrent},
+    )
+
+    pages = {
+        layer_name: group.kv_cache_spec.page_size_bytes
+        for group in groups
+        for layer_name in group.layer_names
+    }
+    assert pages == {
+        "model.target": target.page_size_bytes,
+        "model.recurrent": recurrent.page_size_bytes,
+    }
+
+    c4_index_page_bytes = 64 * 132
+    expected_pool_stride = (
+        (recurrent.page_size_bytes + c4_index_page_bytes - 1)
+        // c4_index_page_bytes
+        * c4_index_page_bytes
+    )
+    assert kv_cache_utils._get_kv_cache_bytes_per_block(groups) == (
+        expected_pool_stride
+    )
+
+
 def new_indexer_mla_spec(block_size=16):
     # Sparse-attention indexer k_cache: an MLAAttentionSpec with a much smaller
     # page size than the main MLA attention (uint8, small head), so their pages

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -807,6 +807,53 @@ class Platform:
         model_config = vllm_config.model_config
         parallel_config = vllm_config.parallel_config
 
+        split_target_block_size = os.getenv("VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE")
+        if split_target_block_size is not None:
+            if model_config.architecture != "Glm5NextForConditionalGeneration":
+                raise ValueError(
+                    "VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE is supported only for "
+                    "Glm5NextForConditionalGeneration."
+                )
+            target_block_size = int(split_target_block_size)
+            split_mamba_block_size = int(
+                os.getenv(
+                    "VLLM_GLM53_SPLIT_MAMBA_BLOCK_SIZE",
+                    split_target_block_size,
+                )
+            )
+            if target_block_size <= 0 or target_block_size % 64 != 0:
+                raise ValueError(
+                    "VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE must be a positive "
+                    "multiple of 64."
+                )
+            if (
+                split_mamba_block_size <= 0
+                or split_mamba_block_size % target_block_size != 0
+            ):
+                raise ValueError(
+                    "VLLM_GLM53_SPLIT_MAMBA_BLOCK_SIZE must be a positive "
+                    "multiple of VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE."
+                )
+            if cache_config.mamba_cache_mode != "align":
+                raise ValueError(
+                    "Split GLM-5.3 target and recurrent-state pages require "
+                    "mamba_cache_mode='align'."
+                )
+
+            # The target MLA cache and recurrent-state cache use independent
+            # physical pages. Their token block sizes remain scheduler-visible,
+            # so the recurrent block must be a multiple of the target block.
+            cache_config.block_size = target_block_size
+            cache_config.mamba_block_size = split_mamba_block_size
+            cache_config.mamba_page_size_padded = None
+            logger.warning(
+                "Using split GLM-5.3 cache pages: target block size %d tokens, "
+                "recurrent-state block size %d tokens.",
+                target_block_size,
+                split_mamba_block_size,
+            )
+            return
+
         if cache_config.cache_dtype == "auto":
             kv_cache_dtype = model_config.dtype
         else:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1282,6 +1282,14 @@ def _get_per_layer_spec(
     return spec
 
 
+def _contains_glm5_next_mla(kv_cache_specs: Iterable[KVCacheSpec]) -> bool:
+    """Return whether the cache specifications contain GLM-5.3 target MLA."""
+    return any(
+        isinstance(spec, MLAAttentionSpec) and spec.model_version == "glm5_next"
+        for spec in kv_cache_specs
+    )
+
+
 def _get_kv_cache_bytes_per_block(
     kv_cache_groups: list[KVCacheGroupSpec],
 ) -> int:
@@ -1294,7 +1302,15 @@ def _get_kv_cache_bytes_per_block(
         for group in kv_cache_groups
     )
     assert bytes_per_block > 0
-    if os.getenv("VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE") is not None:
+    contains_glm5_next_mla = _contains_glm5_next_mla(
+        _get_per_layer_spec(group, layer_name)
+        for group in kv_cache_groups
+        for layer_name in group.layer_names
+    )
+    if (
+        os.getenv("VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE") is not None
+        and contains_glm5_next_mla
+    ):
         # GLM-5.3 stores two 64-row by 132-byte FP8 C4 index pages in the
         # target MLA page tail when the target block contains 512 tokens.
         # The block-outermost pool stride must preserve the index-page unit
@@ -1911,9 +1927,9 @@ def get_kv_cache_groups(
     }
 
     split_target_block_size = os.getenv("VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE")
-    is_glm5_next_split_cache = split_target_block_size is not None and any(
-        isinstance(spec, MLAAttentionSpec) and spec.model_version == "glm5_next"
-        for spec in filtered_spec.values()
+    is_glm5_next_split_cache = (
+        split_target_block_size is not None
+        and _contains_glm5_next_mla(filtered_spec.values())
     )
     if is_glm5_next_split_cache:
         if hidden_specs:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1294,6 +1294,13 @@ def _get_kv_cache_bytes_per_block(
         for group in kv_cache_groups
     )
     assert bytes_per_block > 0
+    if os.getenv("VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE") is not None:
+        # GLM-5.3 stores two 64-row by 132-byte FP8 C4 index pages in the
+        # target MLA page tail when the target block contains 512 tokens.
+        # The block-outermost pool stride must preserve the index-page unit
+        # even when a larger recurrent-state group determines pool capacity.
+        glm_c4_index_page_bytes = 64 * 132
+        bytes_per_block = round_up(bytes_per_block, glm_c4_index_page_bytes)
     return bytes_per_block
 
 
@@ -1902,6 +1909,36 @@ def get_kv_cache_groups(
         for k, v in kv_cache_spec.items()
         if not isinstance(v, HiddenStateCacheSpec)
     }
+
+    split_target_block_size = os.getenv("VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE")
+    is_glm5_next_split_cache = split_target_block_size is not None and any(
+        isinstance(spec, MLAAttentionSpec) and spec.model_version == "glm5_next"
+        for spec in filtered_spec.values()
+    )
+    if is_glm5_next_split_cache:
+        if hidden_specs:
+            raise ValueError(
+                "Split GLM-5.3 cache pages do not support hidden-state cache layers."
+            )
+        if not any(isinstance(spec, MambaSpec) for spec in filtered_spec.values()):
+            raise ValueError(
+                "Split GLM-5.3 cache pages require recurrent-state cache layers."
+            )
+        # Preserve the target MLA and recurrent-state physical page sizes.
+        # The block-outermost layout packs each group's pages independently,
+        # while the hybrid coordinator handles their token block sizes.
+        groups = _get_kv_cache_groups_uniform_page_size(filtered_spec)
+        logger.warning(
+            "Keeping split GLM-5.3 cache groups with physical page sizes %s.",
+            sorted(
+                {
+                    _get_per_layer_spec(group, layer_name).page_size_bytes
+                    for group in groups
+                    for layer_name in group.layer_names
+                }
+            ),
+        )
+        return groups
 
     # Prefer preserving each layer's cache semantics. If physical pages cannot
     # be unified, try a supported allocation-only fallback before failing.


### PR DESCRIPTION
## Purpose and status

Status: **implemented and qualified** for opt-in GLM-5.3 align-mode serving.

GLM-5.3 stores sparse MLA KV and gated-delta recurrent state in independent
physical allocations. The generic hybrid-page alignment promotes the target
MLA block from 256 to 2304 tokens so one MLA page can contain a GDN state page.
That promotion is unnecessary for the block-outermost cache layout and makes
the packed C4 and GDN prefill kernels operate on an inefficient token geometry.

This pull request adds an explicit split-page contract:

- `VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE` selects the target MLA token block;
- `VLLM_GLM53_SPLIT_MAMBA_BLOCK_SIZE` independently selects the recurrent-state
  token block and must be a multiple of the target block;
- both values require `Glm5NextForConditionalGeneration` and
  `mamba_cache_mode=align`;
- cache grouping preserves the target and recurrent physical page sizes; and
- the pool stride is rounded to the 64-row by 132-byte C4 index-page unit so
  model-owned C4 page tails remain correctly addressed.

Other architectures and servers that do not set the environment variable use
the existing hybrid cache planner unchanged.

## Compatibility and capacity

The qualified setting is target 512 tokens and recurrent state 512 tokens.
The MTP3 DCP1 server retained 1,265,215 local KV tokens, or 4.83 concurrent
262,144-token requests. The automatic 2304-token unified layout reported
4,412,757 tokens. The lower capacity is an explicit opt-in tradeoff caused by
retaining independent group allocations; the configured 262,144-token model
length remains supported.

## Performance evidence

Hardware was four stock-clock NVIDIA RTX PRO 6000 Blackwell Workstation
Edition GPUs (physical devices 4-7), TP4/DCP1, B12X target attention, B12X
NVFP4 W4A4 MoE, B12X linear kernels and PCIe all-reduce, FlashKDA prefill,
MTP3 with B12X attention and Humming MoE, full CUDA graphs, FP8 target KV,
`max_num_batched_tokens=4096`, and an exact 32,770-token cold prompt. Each row
is the median of three runs.

| Cache geometry | 32k prefill |
|---|---:|
| Automatic unified target block 2304 | 10,595 tok/s |
| Split target 512, recurrent 2048 | 13,084 tok/s |
| Split target 512, recurrent 512 | 13,830 tok/s |

The 512/512 geometry is 30.5% faster than automatic 2304-token alignment and
5.7% faster than retaining a 2048-token recurrent block.

The same 512/512 implementation was also qualified in the complete PR stack:

- MTP3 TP4/DCP4 full-CKV prefill: 12,846 tok/s median across three 32k runs;
- DFlash2 TP4/DCP4 full-CKV prefill: 12,999 tok/s versus 9,858 tok/s with
  rank-local target KV selection; and
- six deterministic DCP1/DCP4 serving cases selected identical tokens. The
  largest selected-token log-probability delta was 0.01365.

## Tests

```text
.venv/bin/python -m pytest -q \
  tests/v1/core/test_mamba_align_chunk_split.py \
  tests/models/test_glm5next_model.py \
  tests/v1/core/test_kv_cache_utils.py
181 passed
```

All pre-commit hooks for the changed files pass, including Ruff and mypy.

The cache-group unit test constructs a 287,232-byte target page and a
1,171,456-byte DFlash recurrent page, verifies that grouping preserves both,
and checks the C4-aligned pool stride. Runtime qualification also covered the
1,122,304-byte MTP recurrent page.

## Relationship to open work

This pull request is stacked on #530. PR #533 preserves the replicated DFlash
draft-cache partition under DCP, while this pull request defines independent
physical target and recurrent-state pages. PR #517 consumes the resulting
target cache groups for full-CKV DCP prefill. None of those pull requests
implements split target/GDN page geometry.

AI assistance was used to implement, test, benchmark, and prepare this pull
request. The submitted behavior and evidence were reviewed against the source
and runtime logs by the human submitter.
