### PR TITLE
perf(glm5next): checkpoint target GDN state for MTP prefill

### DIFF
--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -173,6 +173,33 @@ def test_dflash_checkpoint_keeps_intermediate_chunks_aligned_and_joins_prompt_ta
     )
 
 
+def test_glm_mtp_checkpoint_joins_unaligned_prompt_tail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Target GDN checkpointing does not add an MTP target-only tail step.
+
+    GLM-5.3 MTP stores draft MLA KV independently from the target GDN state.
+    The EAGLE cache-group policy remains responsible for dropping and replaying
+    the lookahead-dependent draft tail during prefix-cache lookup.
+    """
+    block_size = 512
+    prompt_len = 32320
+    (request,) = create_requests(1, num_tokens=prompt_len, block_size=ATTN_BLOCK_SIZE)
+    monkeypatch.setattr(sys.modules[__name__], "MAMBA_BLOCK_SIZE", block_size)
+
+    request.num_computed_tokens = 7 * 4096
+    assert (
+        _split(
+            request,
+            prompt_len - request.num_computed_tokens,
+            use_eagle=True,
+            num_prefill_checkpoint_blocks=1,
+            allow_speculative_checkpoints=True,
+        )
+        == 3648
+    )
+
+
 def _run_chunked_prefill(
     manager: KVCacheManager, request: Request, budgets: list[int]
 ) -> dict[int, int]:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -344,14 +344,24 @@ class Scheduler(SchedulerInterface):
         self.need_mamba_block_aligned_split = (
             self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
         )
+        glm5_next_mtp_has_independent_draft_state = (
+            speculative_config is not None
+            and speculative_config.method == "mtp"
+            and speculative_config.draft_model_config is not None
+            and "Glm5NextMTPModel"
+            in (speculative_config.draft_model_config.hf_config.architectures or ())
+        )
         self.mamba_has_prefill_checkpoint_blocks = (
             self.has_mamba_layers
-            # DFlash's external draft has no recurrent state. The target GDN
-            # backend can therefore publish its internal prefill checkpoint
-            # without changing the drafter's cache contract.
+            # DFlash and GLM-5.3 MTP keep draft attention state independently
+            # from the target GDN recurrent state. Publishing a target GDN
+            # checkpoint therefore does not mutate draft KV. Prefix-cache
+            # lookup still drops and re-prefills the lookahead-dependent MTP
+            # draft tail through the EAGLE group policy.
             and (
                 not self.use_eagle
                 or (speculative_config is not None and speculative_config.use_dflash())
+                or glm5_next_mtp_has_independent_draft_state
             )
             and all(
                 not isinstance(group.kv_cache_spec, MambaSpec)


### PR DESCRIPTION
## Purpose and status

Status: **implemented and qualified** for GLM-5.3 MTP align-mode prefill.

GLM-5.3 MTP stores draft MLA KV independently from the target model's gated
delta network (GDN) recurrent state. The generic EAGLE scheduler disables
intermediate recurrent-state checkpoints because most speculative models must
replay a lookahead-dependent draft tail. Applying that blanket policy to
`Glm5NextMTPModel` also discards a valid target GDN checkpoint and can schedule
an additional target-only forward at an unaligned prompt tail.

This pull request permits target GDN checkpoint publication only when the MTP
draft architecture is `Glm5NextMTPModel`. Prefix-cache lookup continues to
drop and replay the lookahead-dependent draft tail through the existing EAGLE
cache-group policy. Other MTP architectures retain the generic scheduler
behavior.

## Correctness contract

- The target GDN checkpoint contains target recurrent state only.
- Draft MLA KV remains independently owned and is not checkpointed by this
  path.
- EAGLE prefix-cache lookup still invalidates the draft lookahead tail.
- Non-GLM MTP and EAGLE architectures do not enable the exception.

## Performance evidence

Hardware was four stock-clock NVIDIA RTX PRO 6000 Blackwell Workstation
Edition GPUs (physical devices 4-7), TP4/DCP1, B12X target attention, B12X
NVFP4 W4A4 MoE, B12X linear kernels and PCIe all-reduce, FlashKDA prefill,
MTP3 with B12X attention and Humming MoE, full CUDA graphs, FP8 target KV,
512-token target/recurrent cache blocks and `max_num_batched_tokens=4096`.
Each row is the median of three cold completion requests with one output token.

| Exact prompt length | Scheduler | Median TTFT | Prefill throughput |
|---:|---|---:|---:|
| 32,320 | Generic EAGLE policy | 2.26366 s | 14,277.7 tok/s |
| 32,320 | GLM target GDN checkpoint | 2.18174 s | 14,813.9 tok/s |
| 32,770 | Generic EAGLE policy | 2.28408 s | 14,347.1 tok/s |
| 32,770 | GLM target GDN checkpoint | 2.28757 s | 14,325.3 tok/s |

The 32,320-token request crosses a checkpoint boundary with an unaligned
3,648-token prompt tail. Reusing the target checkpoint removes one redundant
target-only forward and improves throughput by 3.75%. The 32,770-token request
does not expose that redundant schedule and remains neutral within 0.2%.

## Validation

```text
.venv/bin/python -m pytest -q \
  tests/v1/core/test_mamba_align_chunk_split.py \
  tests/models/test_glm5next_model.py \
  tests/v1/core/test_kv_cache_utils.py
181 passed
```

All pre-commit hooks for the changed files pass, including Ruff and mypy. The
scheduler unit test constructs the 32,320-token boundary case and verifies that
the remaining 3,648 prompt tokens join the checkpointed target tail instead of
forming a separate target-only step.

Six deterministic serving cases in the complete GLM-5.3 MTP stack selected
identical tokens between DCP1 and TP4/DCP4 full-CKV execution. The largest
selected-token log-probability delta was 0.00896.

## Relationship to open work

This pull request is stacked on #535, which defines independent target MLA and
recurrent-state page geometry. PR #530 provides FlashKDA target prefill and
#517 provides DCP full-CKV target selection. Those pull requests do not alter
the MTP scheduler's recurrent-checkpoint eligibility.

AI assistance was used to implement, test, benchmark, and prepare this pull
request. The submitted behavior and evidence were reviewed against the source
and runtime logs by the human submitter.
