### PR TITLE
perf(glm5next): compact MTP prefill outputs before MoE

### DIFF
--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -695,6 +695,47 @@ def test_glm5next_b12x_mhc_builds_first_layer_broadcast_fn() -> None:
     assert layer.hc_attn_fn_broadcast.data_ptr() == broadcast_data_ptr
 
 
+def test_glm5next_mtp_compacts_outputs_after_attention_before_moe() -> None:
+    class Attention(torch.nn.Module):
+        def forward(self, hidden_states, positions):
+            return hidden_states + positions.unsqueeze(1)
+
+    class AddNorm(torch.nn.Module):
+        def forward(self, hidden_states, residual):
+            return hidden_states + residual, residual
+
+    class RecordingMLP(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.num_input_tokens = 0
+
+        def forward(self, hidden_states):
+            self.num_input_tokens = hidden_states.shape[0]
+            return hidden_states * 2
+
+    layer = Glm5NextDecoderLayer.__new__(Glm5NextDecoderLayer)
+    torch.nn.Module.__init__(layer)
+    layer.mhc = False
+    layer.is_mtp_layer = True
+    layer.input_layernorm = torch.nn.Identity()
+    layer.self_attn = Attention()
+    layer.post_attention_layernorm = AddNorm()
+    layer.mlp = RecordingMLP()
+
+    hidden_states = torch.arange(20, dtype=torch.float32).reshape(5, 4)
+    positions = torch.arange(5, dtype=torch.float32)
+    output_indices = torch.tensor([1, 4])
+
+    full_output, full_residual, _, _ = layer(positions, hidden_states)
+    compact_output, compact_residual, _, _ = layer(
+        positions, hidden_states, output_indices=output_indices
+    )
+
+    torch.testing.assert_close(compact_output, full_output[output_indices])
+    torch.testing.assert_close(compact_residual, full_residual[output_indices])
+    assert layer.mlp.num_input_tokens == output_indices.numel()
+
+
 def test_glm5next_dflash_contracts_completed_mhc_hidden_state() -> None:
     completed = torch.arange(24, dtype=torch.float32).reshape(2, 4, 3)
 

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -481,6 +481,7 @@ class Glm5NextDecoderLayer(nn.Module):
         residual: torch.Tensor | None = None,
         post: torch.Tensor | None = None,
         comb: torch.Tensor | None = None,
+        output_indices: torch.Tensor | None = None,
     ) -> tuple[
         torch.Tensor,
         torch.Tensor | None,
@@ -496,6 +497,16 @@ class Glm5NextDecoderLayer(nn.Module):
                 hidden_states=hidden_states,
                 positions=positions,
             )
+            if output_indices is not None:
+                if not self.is_mtp_layer:
+                    raise ValueError(
+                        "Selective decoder outputs are supported only for MTP layers."
+                    )
+                # Attention must process every prompt token because it owns the
+                # MTP MLA and sparse-index caches. Only request-tail outputs feed
+                # draft sampling, so compact the residual stream before the MoE.
+                attn_output = attn_output.index_select(0, output_indices)
+                residual = residual.index_select(0, output_indices)
             hidden_states, residual = self.post_attention_layernorm(
                 attn_output, residual=residual
             )

--- a/vllm/models/glm5next/nvidia/mtp.py
+++ b/vllm/models/glm5next/nvidia/mtp.py
@@ -87,6 +87,7 @@ class Glm5NextMultiTokenPredictorLayer(nn.Module):
         previous_hidden_states: torch.Tensor,
         inputs_embeds: torch.Tensor | None = None,
         spec_step_index: int = 0,
+        output_indices: torch.Tensor | None = None,
     ) -> torch.Tensor:
         assert inputs_embeds is not None
         aligned_embeds = inputs_embeds.masked_fill(positions.eq(0).unsqueeze(-1), 0)
@@ -99,7 +100,10 @@ class Glm5NextMultiTokenPredictorLayer(nn.Module):
         # its all-reduce, so no collective is needed here. The post-norm result
         # feeds both draft logits and the next recycled hidden state.
         hidden_states, residual, _, _ = self.mtp_block(
-            positions=positions, hidden_states=hidden_states, residual=None
+            positions=positions,
+            hidden_states=hidden_states,
+            residual=None,
+            output_indices=output_indices,
         )
         hidden_states, _ = self.shared_head.norm(hidden_states, residual=residual)
         return hidden_states, hidden_states
@@ -130,6 +134,7 @@ class Glm5NextMultiTokenPredictor(nn.Module):
         # Plain list for the per-propose lookup: ModuleDict[str(...)] builds a
         # string and hashes it on every draft step.
         self._mtp_layers = list(self.layers.values())
+        self._prefill_output_indices: torch.Tensor | None = None
         self.logits_processor = LogitsProcessor(config.vocab_size)
 
     def update_max_model_len(self, max_model_len: int) -> None:
@@ -171,6 +176,10 @@ class Glm5NextMultiTokenPredictor(nn.Module):
             if restore is not None:
                 restore()
 
+    def set_prefill_output_indices(self, output_indices: torch.Tensor | None) -> None:
+        """Select request-tail outputs after populating all MTP attention caches."""
+        self._prefill_output_indices = output_indices
+
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
@@ -191,6 +200,7 @@ class Glm5NextMultiTokenPredictor(nn.Module):
             previous_hidden_states,
             inputs_embeds,
             current_step_idx,
+            self._prefill_output_indices,
         )
 
     def compute_logits(

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -70,6 +70,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         self.prefill_cudagraph_manager: SpeculatorCudaGraphManager | None = None
         self.decode_cudagraph_manager: SpeculatorCudaGraphManager | None = None
         self.use_fused_multi_step_decode = False
+        self.prefill_outputs_are_compact = False
 
     def load_model(self, target_model: nn.Module) -> None:
         super().load_model(target_model)
@@ -513,7 +514,12 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             cudagraph_runtime_mode=cudagraph_runtime_mode,
             mm_inputs=mm_inputs,
         )
-        sample_hidden_states = last_hidden_states[last_token_indices]
+        if self.prefill_outputs_are_compact:
+            sample_hidden_states = last_hidden_states[:num_reqs]
+            feedback_hidden_states = hidden_states[:num_reqs]
+        else:
+            sample_hidden_states = last_hidden_states[last_token_indices]
+            feedback_hidden_states = hidden_states[last_token_indices]
 
         self.draft_tokens[:num_reqs, 0] = self.sample_draft(
             sample_hidden_states,
@@ -527,7 +533,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         if last_hidden_states is hidden_states:
             self.hidden_states[:num_reqs] = sample_hidden_states
         else:
-            self.hidden_states[:num_reqs] = hidden_states[last_token_indices]
+            self.hidden_states[:num_reqs] = feedback_hidden_states
         if self.mrope_positions is not None:
             assert self.mrope_positions_scratch is not None
             compact_mrope_positions(

--- a/vllm/v1/worker/gpu/spec_decode/mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/mtp/speculator.py
@@ -36,6 +36,9 @@ class MTPSpeculator(AutoRegressiveSpeculator):
         self.rollback_qsa_interval_starts = hasattr(
             draft_model.model, "snapshot_qsa_interval_starts"
         ) and hasattr(draft_model.model, "restore_qsa_interval_starts")
+        self.prefill_outputs_are_compact = hasattr(
+            draft_model.model, "set_prefill_output_indices"
+        )
         return draft_model
 
     def on_prefill_begin(self, num_reqs: int) -> None:
@@ -43,6 +46,10 @@ class MTPSpeculator(AutoRegressiveSpeculator):
         # midway cannot leave reuse mode on.
         if self.share_mtp_topk_indices:
             self.model.model.set_skip_topk(False)
+        if self.prefill_outputs_are_compact:
+            self.model.model.set_prefill_output_indices(
+                self.last_token_indices[:num_reqs]
+            )
 
     def on_prefill_end(self, num_reqs: int) -> None:
         # Step 0 (prefill) wrote topk indices for every query token in the
@@ -50,6 +57,8 @@ class MTPSpeculator(AutoRegressiveSpeculator):
         # steps 1+ can reuse them from the shared buffer.
         if self.share_mtp_topk_indices and self.num_speculative_steps > 1:
             self.model.model.compact_topk_indices(self.last_token_indices[:num_reqs])
+        if self.prefill_outputs_are_compact:
+            self.model.model.set_prefill_output_indices(None)
 
     def on_multi_step_decode_begin(self, num_reqs: int) -> None:
         if self.rollback_qsa_interval_starts:


### PR DESCRIPTION
## Purpose and status

Status: **implemented and qualified** for GLM-5.3 MTP prefill.

The GLM-5.3 MTP attention layer must process every prompt token because it
owns draft MLA KV and sparse-index state. Only one tail row per request feeds
the first draft proposal, but the existing forward also sends every prompt row
through the MTP MoE and shared output head.

This pull request keeps the full attention input, then compacts the residual
stream to the request-tail rows before post-attention normalization, MoE and
the shared output head. The MTP speculator consumes the already compact rows
and clears the selection after prefill. Capability detection keeps every other
autoregressive draft model on its existing full-row contract.

## Correctness contract

- MTP attention always receives all scheduled prompt rows.
- Draft MLA KV and sparse-index caches are populated exactly as before.
- Only rows selected by `last_token_indices` enter the prefill MoE and logits
  path.
- Multi-step decode clears the selector and retains its existing row layout.

## Performance evidence

Hardware was four stock-clock NVIDIA RTX PRO 6000 Blackwell Workstation
Edition GPUs (physical devices 4-7), TP4/DCP1, B12X target attention, B12X
NVFP4 W4A4 MoE, B12X linear kernels and PCIe all-reduce, FlashKDA prefill,
MTP3 with B12X attention and Humming MoE, full CUDA graphs, FP8 target KV,
512-token target/recurrent cache blocks and `max_num_batched_tokens=4096`.

An exact 32,770-token cold completion prompt was repeated three times per arm:

| MTP prefill output | Median TTFT | Prefill throughput |
|---|---:|---:|
| Full prompt rows through MTP MoE | 2.30193 s | 14,235.9 tok/s |
| Request-tail rows through MTP MoE | 2.24851 s | 14,574.1 tok/s |

Selective output saved 53.4 ms and improved throughput by 2.38%. A 30-second
CC1 decode check retained approximately 90 target steps/s; the optimization is
disabled after prefill and is not intended to alter decode throughput.

The complete TP4/DCP4 full-CKV stack measured 12,846 tok/s median across three
32k runs with the selective path enabled.

## Model-output validation

Six deterministic serving cases covering short prompts, an unaligned long
prompt and multiple generated tokens selected identical token IDs and text
between full-row and selective execution. The maximum selected-token
log-probability delta was 0.01357. Repeating the full-row reference against
itself produced a larger maximum delta of 0.02853, so the observed floating
point movement is within ordinary repeated-run drift for this stack.

The same six cases selected identical tokens between DCP1 and TP4/DCP4
full-CKV execution; the maximum selected-token log-probability delta was
0.00896.

## Tests

```text
.venv/bin/python -m pytest -q \
  tests/v1/core/test_mamba_align_chunk_split.py \
  tests/models/test_glm5next_model.py \
  tests/v1/core/test_kv_cache_utils.py
181 passed
```

All pre-commit hooks for the changed files pass, including Ruff and mypy. The
model unit test verifies that compact execution is numerically equal to
selecting the same rows from full execution and that the MTP MoE receives only
the selected row count.

## Relationship to open work

This pull request is stacked on the GLM-5.3 target-GDN checkpoint branch. The
checkpoint commit controls scheduler boundaries; this pull request removes
discarded MTP MoE work inside each scheduled prefill forward. PR #530 provides
the FlashKDA target prefill path, and #517 provides DCP full-CKV target
selection. Neither changes MTP post-attention row selection.

No open local-inference-lab/vllm or vllm-project/vllm pull request implements
this GLM-5.3 selective post-attention MTP contract.

AI assistance was used to implement, test, benchmark, and prepare this pull
request. The submitted behavior and evidence were reviewed against the source
and runtime logs by the human submitter.
