### PR TITLE
fix(mtp): preserve position-zero embeddings

### DIFF
--- a/tests/kernels/core/test_fused_embed_norm.py
+++ b/tests/kernels/core/test_fused_embed_norm.py
@@ -1,11 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Unit tests for the replicated-embedding fused gather/norm kernels
-(``vllm.model_executor.layers.fused_embed_norm``).
+"""Unit tests for replicated-embedding fused gather/norm kernels.
 
-The guarantee: enabling ``VLLM_REPLICATE_EMBED`` (replicated table + fused
-kernels) must not change model outputs. The gathered residual is bit-exact and
-the fused norms match the unfused reference.
+Enabling ``VLLM_REPLICATE_EMBED`` must preserve every gathered embedding and
+match the unfused RMSNorm reference.
 """
 
 import pytest
@@ -15,8 +13,6 @@ from vllm.model_executor.layers.fused_embed_norm import (
     fused_embed_eh_norm,
     fused_embed_norm,
 )
-
-# The model-local (untouched) eh-norm the replicate path must match.
 from vllm.models.deepseek_v32.common.kernels import fused_eh_norm
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
@@ -59,17 +55,27 @@ def test_fused_embed_norm_matches_reference():
 @requires_cuda
 @torch.inference_mode()
 def test_fused_embed_eh_norm_matches_reference():
-    """MTP fusion (folded gather) is bit-exact vs gathering the embeds and
-    feeding the untouched model-local ``fused_eh_norm``."""
+    """The fused MTP gather/norm must preserve every embedding row."""
     set_random_seed(13)
     table = torch.randn(VOCAB, HIDDEN, dtype=DTYPE, device="cuda")
     ids = torch.randint(0, VOCAB, (NUM_TOKENS,), dtype=torch.int32, device="cuda")
     prev = torch.randn(NUM_TOKENS, HIDDEN, dtype=DTYPE, device="cuda")
+    positions = torch.arange(NUM_TOKENS, dtype=torch.int64, device="cuda")
     enorm_w = torch.randn(HIDDEN, dtype=DTYPE, device="cuda")
     hnorm_w = torch.randn(HIDDEN, dtype=DTYPE, device="cuda")
-    positions = torch.arange(NUM_TOKENS, device="cuda")  # includes pos 0
 
-    fused = fused_embed_eh_norm(positions, ids, table, prev, enorm_w, hnorm_w, EPS)
-    ref = fused_eh_norm(positions, table[ids.long()], prev, enorm_w, hnorm_w, EPS)
+    fused = fused_embed_eh_norm(ids, table, prev, enorm_w, hnorm_w, EPS)
+    local = fused_eh_norm(positions, table[ids.long()], prev, enorm_w, hnorm_w, EPS)
+    ref = torch.cat(
+        (
+            _rmsnorm(table[ids.long()], enorm_w, EPS).to(DTYPE),
+            _rmsnorm(prev, hnorm_w, EPS).to(DTYPE),
+        ),
+        dim=-1,
+    )
 
-    torch.testing.assert_close(fused, ref, atol=0.0, rtol=0.0)
+    # Both Triton paths implement the same operation and must remain bit-exact.
+    torch.testing.assert_close(fused, local, atol=0.0, rtol=0.0)
+    # PyTorch may reduce RMSNorm inputs in a different order. Compare against
+    # the independent reference at the precision promised by the BF16 output.
+    torch.testing.assert_close(fused.float(), ref.float(), atol=1e-3, rtol=1e-2)

--- a/tests/kernels/test_fused_deepseek_v32_norm_rope.py
+++ b/tests/kernels/test_fused_deepseek_v32_norm_rope.py
@@ -702,7 +702,7 @@ def test_fused_q_triton_supports_large_token_count():
 def test_fused_eh_norm(num_tokens: int):
     torch.manual_seed(4)
     dev = "cuda"
-    # Mix in a position-0 token to exercise the embeds-zeroing branch.
+    # Position zero is a live MTP token and must retain its embedding.
     pos = torch.arange(num_tokens, device=dev, dtype=torch.int64)
     pos[0] = 0
     embeds = torch.randn(num_tokens, HIDDEN, device=dev, dtype=torch.bfloat16)
@@ -712,7 +712,6 @@ def test_fused_eh_norm(num_tokens: int):
 
     out = K.fused_eh_norm(pos, embeds, prev, ew, hw, EPS)
 
-    masked = torch.where(pos.unsqueeze(-1) == 0, torch.zeros_like(embeds), embeds)
-    ref = torch.cat([rms_norm(masked, ew), rms_norm(prev, hw)], dim=-1)
+    ref = torch.cat([rms_norm(embeds, ew), rms_norm(prev, hw)], dim=-1)
     assert out.shape == (num_tokens, 2 * HIDDEN)
     assert_bf16(out, ref, "eh_norm")

--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -36,6 +36,7 @@ from vllm.models.glm5next.nvidia.model import (
 from vllm.models.glm5next.nvidia.mtp import (
     Glm5NextMTP,
     Glm5NextMultiTokenPredictor,
+    Glm5NextMultiTokenPredictorLayer,
 )
 from vllm.transformers_utils.configs.glm5_next import (
     Glm5NextConfig,
@@ -185,6 +186,55 @@ def test_glm5next_mtp_selects_only_draft_checkpoint_weights() -> None:
         "model.layers.45.",
         "layers.45.",
     )
+
+
+def test_glm5next_mtp_preserves_position_zero_embedding() -> None:
+    class CaptureProjection(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.inputs: torch.Tensor | None = None
+
+        def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+            self.inputs = inputs
+            return inputs
+
+    class IdentityBlock(torch.nn.Module):
+        def forward(
+            self,
+            *,
+            positions: torch.Tensor,
+            hidden_states: torch.Tensor,
+            residual: torch.Tensor | None,
+            output_indices: torch.Tensor | None = None,
+        ) -> tuple[torch.Tensor, torch.Tensor, None, None]:
+            return hidden_states, torch.zeros_like(hidden_states), None, None
+
+    class IdentityHead(torch.nn.Module):
+        def norm(
+            self, hidden_states: torch.Tensor, residual: torch.Tensor
+        ) -> tuple[torch.Tensor, None]:
+            return hidden_states, None
+
+    layer = Glm5NextMultiTokenPredictorLayer.__new__(Glm5NextMultiTokenPredictorLayer)
+    torch.nn.Module.__init__(layer)
+    projection = CaptureProjection()
+    layer.enorm = torch.nn.Identity()
+    layer.hnorm = torch.nn.Identity()
+    layer.eh_proj = projection
+    layer.mtp_block = IdentityBlock()
+    layer.shared_head = IdentityHead()
+
+    inputs_embeds = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    previous_hidden_states = torch.zeros_like(inputs_embeds)
+    layer(
+        input_ids=torch.tensor([1, 2]),
+        positions=torch.tensor([0, 1]),
+        previous_hidden_states=previous_hidden_states,
+        inputs_embeds=inputs_embeds,
+    )
+
+    assert projection.inputs is not None
+    torch.testing.assert_close(projection.inputs[:, :2], inputs_embeds)
 
 
 def test_glm5next_mixed_precision_reaches_mla_projections(monkeypatch) -> None:

--- a/vllm/model_executor/layers/fused_embed_norm.py
+++ b/vllm/model_executor/layers/fused_embed_norm.py
@@ -8,10 +8,8 @@ the full on-rank table unlocks --
 
   * ``fused_embed_norm``: gather + a chained RMSNorm (e.g. the first decoder
     layer's ``input_layernorm``), and
-  * ``fused_embed_eh_norm``: gather + pos-0 zeroing + enorm/hnorm + cat, the
-    embed/previous-hidden input norm for a speculative (MTP/eagle) depth layer
-    (the replicated-table analogue of the model-local ``fused_eh_norm``, which
-    takes precomputed embeds).
+  * ``fused_embed_eh_norm``: gather + enorm/hnorm + cat, the
+    embed/previous-hidden input norm for a speculative (MTP/eagle) depth layer.
 
 Self-contained (no model-local imports) so it can live under ``layers/``.
 """
@@ -152,7 +150,6 @@ def fused_embed_norm(
 
 @triton.jit
 def _fused_embed_eh_norm_kernel(
-    pos_ptr,
     ids_ptr,  # [T] token ids
     table_ptr,  # [V, H] embedding table (full vocab, replicated on-rank)
     table_stride,
@@ -166,19 +163,17 @@ def _fused_embed_eh_norm_kernel(
     H: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
-    """MTP input fusion with a folded embedding gather: gather
-    ``table[ids]``, zero it at position 0, RMSNorm(embed) with enorm and
-    RMSNorm(prev_hidden) with hnorm, written side-by-side into ``out`` ([N, 2H])
-    ready for the eh_proj GEMM. Replaces embedding lookup + where + 2x RMSNorm +
-    cat. Requires the full table on-rank (replicated embedding)."""
+    """MTP input fusion with a folded embedding gather: gather ``table[ids]``,
+    RMSNorm(embed) with enorm, and RMSNorm(prev_hidden) with hnorm, written
+    side-by-side into ``out`` ([N, 2H]) ready for the eh_proj GEMM. Requires the
+    full table on-rank (replicated embedding).
+    """
     tok = tl.program_id(0)
     off = tl.arange(0, BLOCK)
     mask = off < H
 
-    pos = tl.load(pos_ptr + tok)
     row = tl.load(ids_ptr + tok).to(tl.int64)
     e = tl.load(table_ptr + row * table_stride + off, mask=mask, other=0.0)
-    e = tl.where(pos == 0, 0.0, e.to(tl.float32))
     ew = tl.load(enorm_w_ptr + off, mask=mask)
     e_normed = _rms_norm(e, ew, eps, H)
     tl.store(out_ptr + tok * out_stride + off, e_normed, mask=mask)
@@ -191,7 +186,6 @@ def _fused_embed_eh_norm_kernel(
 
 # MTP fusion
 def fused_embed_eh_norm(
-    positions: torch.Tensor,
     input_ids: torch.Tensor,
     embed_table: torch.Tensor,
     previous_hidden: torch.Tensor,
@@ -199,22 +193,20 @@ def fused_embed_eh_norm(
     hnorm_w: torch.Tensor,
     eps: float,
 ) -> torch.Tensor:
-    """Fused ``cat([enorm(masked embed_table[ids]), hnorm(prev_hidden)])`` -> [N, 2H].
+    """Fused ``cat([enorm(embed_table[ids]), hnorm(prev_hidden)])`` -> [N, 2H].
 
     Folds the embedding row gather into the MTP eh-norm launch; requires the full
-    table on-rank (replicated embedding). Bit-exact vs gathering ``embed_table[
-    input_ids]`` and passing it to the model-local ``fused_eh_norm``.
+    table on-rank (replicated embedding).
     """
     assert previous_hidden.ndim == 2 and embed_table.ndim == 2
     n, h = previous_hidden.shape
-    assert positions.shape == (n,) and input_ids.view(-1).shape == (n,)
+    assert input_ids.view(-1).shape == (n,)
     assert embed_table.shape[1] == h, (embed_table.shape, h)
     assert enorm_w.shape == (h,) and hnorm_w.shape == (h,)
     out = torch.empty(
         n, 2 * h, dtype=previous_hidden.dtype, device=previous_hidden.device
     )
     _fused_embed_eh_norm_kernel[(n,)](
-        positions,
         input_ids,
         embed_table,
         embed_table.stride(0),

--- a/vllm/models/deepseek_v32/common/kernels.py
+++ b/vllm/models/deepseek_v32/common/kernels.py
@@ -981,16 +981,15 @@ def _fused_eh_norm_kernel(
     H: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
-    """MTP input fusion: zero embeds at position 0, RMSNorm(embeds) with enorm
-    and RMSNorm(prev_hidden) with hnorm, written side-by-side into ``out``
-    ([N, 2H]) ready for the eh_proj GEMM. Replaces where + 2x RMSNorm + cat."""
+    """MTP input fusion: RMSNorm(embeds) with enorm and RMSNorm(prev_hidden)
+    with hnorm, written side-by-side into ``out`` ([N, 2H]) ready for the
+    eh_proj GEMM. Replaces 2x RMSNorm + cat.
+    """
     tok = tl.program_id(0)
     off = tl.arange(0, BLOCK)
     mask = off < H
 
-    pos = tl.load(pos_ptr + tok)
     e = tl.load(embeds_ptr + tok * embeds_stride + off, mask=mask, other=0.0)
-    e = tl.where(pos == 0, 0.0, e.to(tl.float32))
     ew = tl.load(enorm_w_ptr + off, mask=mask)
     e_normed = _rms_norm(e, ew, eps, H)
     tl.store(out_ptr + tok * out_stride + off, e_normed, mask=mask)
@@ -1009,7 +1008,7 @@ def fused_eh_norm(
     hnorm_w: torch.Tensor,
     eps: float,
 ) -> torch.Tensor:
-    """Returns cat([enorm(masked embeds), hnorm(prev_hidden)]) -> [N, 2H]."""
+    """Returns cat([enorm(embeds), hnorm(prev_hidden)]) -> [N, 2H]."""
     n, h = inputs_embeds.shape
     out = torch.empty(n, 2 * h, dtype=inputs_embeds.dtype, device=inputs_embeds.device)
     _fused_eh_norm_kernel[(n,)](

--- a/vllm/models/deepseek_v32/nvidia/mtp.py
+++ b/vllm/models/deepseek_v32/nvidia/mtp.py
@@ -97,13 +97,10 @@ class DeepseekV32MultiTokenPredictorLayer(nn.Module):
         embed_table: torch.Tensor | None = None,
         spec_step_index: int = 0,
     ) -> torch.Tensor:
-        # Fused zero pos-0 + enorm(embeds) + hnorm(prev) + cat -> [N, 2H]. With a
-        # replicated table the caller passes ``embed_table`` so the embedding
-        # lookup is folded in too (fused_embed_eh_norm); otherwise the embeds are
-        # precomputed and go through the model-local fused_eh_norm.
+        # Fold the embedding lookup into the norm when the full table is
+        # available on-rank; otherwise use the precomputed embeddings.
         if embed_table is not None:
             eh_input = fused_embed_eh_norm(
-                positions,
                 input_ids,
                 embed_table,
                 previous_hidden_states,

--- a/vllm/models/glm5next/nvidia/mtp.py
+++ b/vllm/models/glm5next/nvidia/mtp.py
@@ -89,9 +89,8 @@ class Glm5NextMultiTokenPredictorLayer(nn.Module):
         spec_step_index: int = 0,
     ) -> torch.Tensor:
         assert inputs_embeds is not None
-        aligned_embeds = inputs_embeds.masked_fill(positions.eq(0).unsqueeze(-1), 0)
         eh_input = torch.cat(
-            (self.enorm(aligned_embeds), self.hnorm(previous_hidden_states)),
+            (self.enorm(inputs_embeds), self.hnorm(previous_hidden_states)),
             dim=-1,
         )
         hidden_states = self.eh_proj(eh_input)


### PR DESCRIPTION
## Status

Implemented and qualified.

## Behavior

MTP input normalization preserves the embedding row for tokens at absolute position zero in the GLM-5.3 predictor, the repository-specific DeepSeek-v3.2 fused norm, and the replicated embedding fused norm.

## Technical reason

The first MTP pass shifts token IDs while retaining their absolute positions. Position zero therefore identifies a live shifted token, not padding. Zeroing that row changes the predictor input and violates the speculative-decoding input contract.

## Compatibility

- The change affects MTP predictor inputs only.
- The vocabulary-parallel and replicated-embedding implementations now implement the same normalization contract.
- No embedding-table replication or `VLLM_REPLICATE_EMBED` policy change is included.
- DFlash speculative decoding is unaffected.

## Validation

- `CUDA_VISIBLE_DEVICES=4`: 47 tests passed across `tests/kernels/core/test_fused_embed_norm.py`, `tests/kernels/test_fused_deepseek_v32_norm_rope.py::test_fused_eh_norm`, and `tests/models/test_glm5next_model.py`.
- Both Triton paths are required to agree bit-for-bit.
- Triton output is checked against an independent PyTorch RMSNorm reference at BF16 precision.
- All changed-file pre-commit checks passed.

## Provenance

The operation contract is adapted from `vllm-project/vllm@876250e0664f0b1e22fca89bb6423b9bfb1177e5` and applied to the repository-specific GLM-5.3 and DeepSeek-v3.2 implementations. The commit records both the upstream author and the local adaptation author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multi-token prediction so embeddings at position zero are preserved instead of being cleared.
  * Updated fused embedding and normalization paths to process position-zero embeddings correctly.
  * Improved consistency between optimized and reference normalization behavior.

* **Tests**
  * Added regression coverage confirming position-zero embeddings remain intact.
  * Expanded validation against independent fp32 RMSNorm results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->