### PR TITLE
perf(router): enable ll_bf16 on SM120

### DIFF
--- a/tests/kernels/test_gate_linear_rocm_dispatch.py
+++ b/tests/kernels/test_gate_linear_rocm_dispatch.py
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Platform-agnostic eligibility tests for GateLinear's fused router GEMM.
+"""Platform-agnostic eligibility tests for GateLinear router GEMMs.
 
 These assert the ``allow_cublas_router_gemm`` dispatch flag directly, so they
 run device-free by mocking the platform predicates. The flag decides whether
 the bf16xbf16->fp32 router GEMM uses ``torch.mm``'s fused out_dtype epilogue
 (one kernel) or falls back to a bf16 matmul plus a standalone bf16->fp32 copy.
 
-The ROCm branch is guarded on ``not bias`` because ``torch.mm`` has no bias
-term; a biased gate must fall back so the bias is not silently dropped.
+ROCm's fused ``torch.mm`` branch and SM120's CuTe branch are both guarded on
+``not bias`` so a biased gate cannot silently drop its bias term.
 """
 
 import torch
@@ -22,6 +22,7 @@ def _make_gate(
     *,
     is_rocm: bool,
     is_cuda: bool = False,
+    device_capability: tuple[int, int] | None = None,
     bias: bool = False,
     params_dtype: torch.dtype = torch.bfloat16,
     out_dtype: torch.dtype | None = torch.float32,
@@ -43,10 +44,17 @@ def _make_gate(
     platform = gate_linear_mod.current_platform
     monkeypatch.setattr(platform, "is_cuda", lambda: is_cuda)
     monkeypatch.setattr(platform, "is_rocm", lambda: is_rocm)
-    # Force the CUDA specialized-kernel gate off so ROCm eligibility is the
-    # only thing under test (these are the SM90/SM100 capability checks).
-    monkeypatch.setattr(platform, "is_device_capability", lambda *a, **k: False)
+    monkeypatch.setattr(
+        platform,
+        "is_device_capability",
+        lambda capability: capability == device_capability,
+    )
     monkeypatch.setattr(platform, "is_device_capability_family", lambda *a, **k: False)
+    if is_cuda and device_capability == (12, 0):
+        monkeypatch.setattr(
+            "vllm.model_executor.kernels.linear.cute_dsl.ll_bf16.is_available",
+            lambda: True,
+        )
 
     return GateLinear(
         input_size=2048,
@@ -96,3 +104,43 @@ def test_rocm_set_out_dtype_respects_bias_guard(monkeypatch):
     gate = _make_gate(monkeypatch, is_rocm=True, bias=True, out_dtype=None)
     gate.set_out_dtype(torch.float32)
     assert not gate.allow_cublas_router_gemm
+
+
+def test_sm120_enables_only_ll_bf16_router(monkeypatch):
+    gate = _make_gate(
+        monkeypatch,
+        is_rocm=False,
+        is_cuda=True,
+        device_capability=(12, 0),
+    )
+
+    assert gate.allow_ll_bf16_gemm
+    assert not gate.allow_specialized_router_gemm
+    assert not gate.allow_dsv3_router_gemm
+    assert not gate.allow_cublas_router_gemm
+
+
+def test_sm120_ll_bf16_respects_bias(monkeypatch):
+    gate = _make_gate(
+        monkeypatch,
+        is_rocm=False,
+        is_cuda=True,
+        device_capability=(12, 0),
+        bias=True,
+    )
+
+    assert not gate.allow_ll_bf16_gemm
+
+
+def test_sm120_set_out_dtype_enables_ll_bf16(monkeypatch):
+    gate = _make_gate(
+        monkeypatch,
+        is_rocm=False,
+        is_cuda=True,
+        device_capability=(12, 0),
+        out_dtype=None,
+    )
+
+    assert not gate.allow_ll_bf16_gemm
+    gate.set_out_dtype(torch.float32)
+    assert gate.allow_ll_bf16_gemm

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -58,8 +58,14 @@ class GateLinear(ReplicatedLinear):
     ):
         is_hopper = current_platform.is_device_capability((9, 0))
         is_blackwell = current_platform.is_device_capability_family(100)
+        is_blackwell_rtx = current_platform.is_device_capability((12, 0))
         can_use_specialized_kernels = (
             current_platform.is_cuda() and (is_hopper or is_blackwell) and not bias
+        )
+        self._can_use_ll_bf16 = (
+            current_platform.is_cuda()
+            and (is_hopper or is_blackwell or is_blackwell_rtx)
+            and not bias
         )
 
         # If fp32 compute is required and no specialized kernel is available,
@@ -133,7 +139,7 @@ class GateLinear(ReplicatedLinear):
         # 1. PDL support. Both dot-product and split-K kernels.
         # 2. Thread Block Clusters. Split-K kernel for cross-CTA reduction.
         self.allow_ll_bf16_gemm = False
-        if can_use_specialized_kernels:
+        if self._can_use_ll_bf16:
             from vllm.model_executor.kernels.linear.cute_dsl.ll_bf16 import (
                 is_available,
             )
@@ -165,7 +171,7 @@ class GateLinear(ReplicatedLinear):
             self.allow_cublas_router_gemm = self.weight.dtype == torch.bfloat16
 
         # out_dtype may start as None -> recompute eligibility here
-        if self.allow_specialized_router_gemm:
+        if self._can_use_ll_bf16:
             from vllm.model_executor.kernels.linear.cute_dsl.ll_bf16 import (
                 is_available,
             )


### PR DESCRIPTION
## Summary

- allow the existing CuTe `ll_bf16` router GEMM on exact SM120 devices
- keep SM120 excluded from the DSV3, FP32, BF16x3, and cuBLAS router gates
- retain dtype, bias, availability, output-type, and `M <= 16` guards

`ll_bf16` already supports the GLM-5.3 router shape; the change broadens only that backend's architecture eligibility, including deferred output-dtype setup.

## Isolated performance evidence

A historical source-locked TP4 single-request/context-zero A/B measured +2.01% end-to-end decode from this dispatch change. It used GLM-5.3-Flash-NVFP4 on four NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition GPUs, DCP1, 300 W per GPU, a persistent +6000 MHz memory-clock offset, ordinary model sampling, and 30-second sustained cells.

That experiment also enabled optional online dense MXFP8 conversion, so its absolute endpoints are intentionally omitted. This PR neither includes nor requires that numerical change. A matched no-online-MX current-head rerun remains required before assigning a clean isolated serving delta.

The qualified GLM path uses BF16 router weights and `force_fp32_compute=False`. This PR intentionally does not broaden `ll_bf16` to callers requesting forced FP32 computation; those callers retain FP32 weights and their existing fallback/specialized paths.

## Combined-stack integration qualification

The code-equivalent SM120 router dispatch was retained in the frozen quality-preserving deployment. This matrix qualifies the composition and is **not** isolated attribution to this PR.

Stack inventory:

- vLLM `ba494904b`, based on merged #537, including the code-equivalent merged MTP correctness fix #539, and containing code-equivalent versions of #542, #543, and #544
- B12X master `a45d3f7` plus code-equivalent versions of [B12X #261](https://github.com/local-inference-lab/b12x/pull/261) and [#262](https://github.com/local-inference-lab/b12x/pull/262) and the launch choices subsequently represented through typed policies in [#263](https://github.com/local-inference-lab/b12x/pull/263) and [#264](https://github.com/local-inference-lab/b12x/pull/264)
- the frozen image predates the final typed-policy plumbing in B12X #263/#264; those exact PR heads still require their own Linux/CUDA qualification
- the rejected 512-KiB PCIe all-reduce experiment is not present

Configuration: GLM-5.3-Flash-NVFP4, four Max-Q cards at TP4/DCP1, 300 W each, +6000 MHz memory offset, native B12X target W4A4, FP8 KV cache, CUDA graphs, one-million-token model length, maximum 32 sequences, 8192 batched tokens, online dense MXFP8 disabled, and probabilistic MTP3 with standard rejection (Marlin MXFP8 draft MoE and B12X draft attention).

`llm_decode_bench.py` ran 30-second sustained cells with ordinary model sampling, no temperature override, and an 8192-token output limit. All 35 cells completed without request errors or capacity limits:

| Context | C1 | C2 | C4 | C8 | C12 | C24 | C32 |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 0 | 251.7 | 384.8 | 555.8 | 808.9 | 995.7 | 1,341.3 | 1,615.6 |
| 16K | 227.8 | 373.0 | 552.1 | 806.8 | 970.9 | 1,359.0 | 1,642.4 |
| 32K | 224.1 | 366.7 | 545.4 | 814.6 | 994.0 | 1,372.8 | 1,612.9 |
| 64K | 220.7 | 370.1 | 556.2 | 796.0 | 982.7 | 1,340.4 | 1,636.1 |
| 128K | 245.3 | 374.6 | 542.5 | 811.5 | 952.0 | 1,298.3 | 1,553.8 |

The 251.7 tok/s C1 cell is retained as raw evidence, not promoted as a stable headline; same-stack C1 repeats were 218.3/221.7/225.3 tok/s. Acceptance-normalized verifier throughput was 92.0--95.7 steps/s at C1, 315.2--328.2 at C8, and 600.4--644.3 at C32.

The exact boot passed Estonia max C30/R30 30/30 and LAVD max C30/R30 30 exact / 0 near / 0 wrong with no token caps. Startup KV capacity was 4,592,497 tokens; exported capacity was 4,783,104 tokens. No eager or backend fallback was used.

## Correctness and current-head status

The selected router output was bitwise equal to the existing path. Device-free dispatch tests cover exact SM120 eligibility, the bias guard, deferred FP32 output selection, and exclusion of the other specialized backends. Static checks pass. Current-head pytest and a matched no-online-MX GPU A/B remain required before merge qualification.

## Portability

This is not GLM-specific. Compatible bias-free BF16 routers on exact SM120 with `M <= 16`, FP32 output, available CuTe kernels, and no forced-FP32 requirement can use the same path.

## AI assistance

OpenAI Codex assisted with implementation, tests, profiling analysis, benchmarking, and PR preparation. The commit includes a Codex co-author trailer. The human submitter reviewed the claims and remains responsible for the change.
