### PR TITLE
perf(glm5next): fuse and retune FWHT scaling

### DIFF
--- a/tests/models/test_glm5next_pooled_indexer.py
+++ b/tests/models/test_glm5next_pooled_indexer.py
@@ -10,15 +10,18 @@ import torch
 from torch import nn
 
 from vllm.models.deepseek_v4.nvidia.b12x_indexer import _flatten_index_cache
+from vllm.models.glm5next.nvidia.ops import glm_kpool
 from vllm.models.glm5next.nvidia.ops.glm_kpool import (
     expand_c4_block_table,
     expand_pool_ids,
+    fwht128_quant_fp8,
     gather_c4_block_table_rows,
     pool_seq_lens,
     update_decode_pools,
 )
 from vllm.models.glm5next.nvidia.pooled_indexer import Glm5NextPooledIndexer
 from vllm.platforms import current_platform
+from vllm.triton_utils import triton
 from vllm.v1.attention.backends.mla.b12x_mla_sparse import B12xMLASparseMetadata
 from vllm.v1.kv_cache_interface import MLAAttentionSpec
 
@@ -43,6 +46,113 @@ def _hadamard128(x: torch.Tensor) -> torch.Tensor:
         a, b = x[:, 0], x[:, 1]
         x = torch.stack((a + b, a - b), dim=1).reshape(128)
     return x / (128**0.5)
+
+
+@pytest.mark.parametrize("rows", [1, 4, 5, 31, 32, 33, 128])
+def test_glm53_fused_fwht_weight_scaling_is_bitwise(rows: int) -> None:
+    device = _require_glm_gpu()
+    generator = torch.Generator(device=device).manual_seed(53 + rows)
+    query = torch.randn(
+        (rows, 128), generator=generator, dtype=torch.bfloat16, device=device
+    )
+    expected_query = torch.empty_like(query, dtype=torch.float8_e4m3fn)
+    expected_scales = torch.empty(rows, dtype=torch.float32, device=device)
+    actual_query = torch.empty_like(expected_query)
+    actual_scales = torch.empty_like(expected_scales)
+    legacy_query = torch.empty_like(expected_query)
+    legacy_scales = torch.empty_like(expected_scales)
+    initial_weights = torch.randn(
+        rows, generator=generator, dtype=torch.float32, device=device
+    )
+    expected_weights = initial_weights.clone()
+    actual_weights = initial_weights.clone()
+    legacy_weights = initial_weights.clone()
+
+    fwht128_quant_fp8(query, expected_query, expected_scales)
+    expected_weights.mul_(expected_scales)
+    expected_weights.mul_((128 * 32) ** -0.5)
+    fwht128_quant_fp8(
+        query,
+        actual_query,
+        actual_scales,
+        weights=actual_weights,
+    )
+    glm_kpool._fwht_quant_kernel[(triton.cdiv(rows, 32),)](
+        query,
+        legacy_query,
+        legacy_scales,
+        legacy_weights,
+        rows,
+        HEAD_DIM=128,
+        FP8_MAX=448.0,
+        BLOCK_R=32,
+        SCALE_WEIGHTS=True,
+        WEIGHT_NORM=(128 * 32) ** -0.5,
+        num_warps=2,
+    )
+
+    torch.testing.assert_close(actual_query, expected_query, rtol=0, atol=0)
+    torch.testing.assert_close(actual_scales, expected_scales, rtol=0, atol=0)
+    torch.testing.assert_close(actual_weights, expected_weights, rtol=0, atol=0)
+    torch.testing.assert_close(actual_query, legacy_query, rtol=0, atol=0)
+    torch.testing.assert_close(actual_scales, legacy_scales, rtol=0, atol=0)
+    torch.testing.assert_close(actual_weights, legacy_weights, rtol=0, atol=0)
+
+
+def test_glm53_fused_fwht_weight_scaling_graph_replays_live_inputs() -> None:
+    device = _require_glm_gpu()
+    rows = 33
+    generator = torch.Generator(device=device).manual_seed(5300)
+    query = torch.randn(
+        (rows, 128), generator=generator, dtype=torch.bfloat16, device=device
+    )
+    weights = torch.randn(rows, generator=generator, dtype=torch.float32, device=device)
+    query_out = torch.empty_like(query, dtype=torch.float8_e4m3fn)
+    scales = torch.empty(rows, dtype=torch.float32, device=device)
+
+    def transform() -> None:
+        fwht128_quant_fp8(query, query_out, scales, weights=weights)
+
+    transform()
+    device_module = torch.get_device_module(device)
+    graph = device_module.CUDAGraph()
+    with device_module.graph(graph):
+        transform()
+
+    query.copy_(
+        torch.randn(
+            query.shape,
+            generator=generator,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+    )
+    input_weights = torch.randn(
+        rows, generator=generator, dtype=torch.float32, device=device
+    )
+    weights.copy_(input_weights)
+    query_out.zero_()
+    scales.zero_()
+    graph.replay()
+    torch.accelerator.synchronize()
+
+    expected_query = torch.empty_like(query_out)
+    expected_scales = torch.empty_like(scales)
+    expected_weights = input_weights.clone()
+    fwht128_quant_fp8(query, expected_query, expected_scales)
+    expected_weights.mul_(expected_scales)
+    expected_weights.mul_((128 * 32) ** -0.5)
+    torch.testing.assert_close(query_out, expected_query, rtol=0, atol=0)
+    torch.testing.assert_close(scales, expected_scales, rtol=0, atol=0)
+    torch.testing.assert_close(weights, expected_weights, rtol=0, atol=0)
+
+    allocated = torch.accelerator.memory_allocated()
+    weights.copy_(input_weights)
+    graph.replay()
+    weights.copy_(input_weights)
+    graph.replay()
+    torch.accelerator.synchronize()
+    assert torch.accelerator.memory_allocated() == allocated
 
 
 def _pool_reference(

--- a/vllm/models/glm5next/nvidia/ops/glm_kpool.py
+++ b/vllm/models/glm5next/nvidia/ops/glm_kpool.py
@@ -40,10 +40,13 @@ def _fwht_quant_kernel(
     q,
     q_out,
     scale_out,
+    weights,
     rows,
     HEAD_DIM: tl.constexpr,
     FP8_MAX: tl.constexpr,
     BLOCK_R: tl.constexpr,
+    SCALE_WEIGHTS: tl.constexpr,
+    WEIGHT_NORM: tl.constexpr,
 ):
     pid = tl.program_id(0)
     row = pid * BLOCK_R + tl.arange(0, BLOCK_R)
@@ -74,14 +77,20 @@ def _fwht_quant_kernel(
         mask=row_mask[:, None],
     )
     tl.store(scale_out + row, scale, mask=row_mask)
+    if SCALE_WEIGHTS:
+        weight = tl.load(weights + row, mask=row_mask, other=0.0).to(tl.float32)
+        weight *= scale
+        weight *= WEIGHT_NORM
+        tl.store(weights + row, weight, mask=row_mask)
 
 
 def fwht128_quant_fp8(
     q: torch.Tensor,
     q_out: torch.Tensor,
     scale_out: torch.Tensor,
+    weights: torch.Tensor | None = None,
 ) -> None:
-    """Rotate and per-vector quantize contiguous BF16 rows into caller storage."""
+    """Rotate and quantize BF16 rows, optionally scaling their head weights."""
     if q.ndim != 2 or q.shape[1] != _HEAD_DIM or q.dtype != torch.bfloat16:
         raise ValueError("GLM index queries must be contiguous BF16 [rows, 128]")
     if not q.is_contiguous():
@@ -91,17 +100,26 @@ def fwht128_quant_fp8(
         raise ValueError("GLM FP8 query output must match the query shape")
     if scale_out.shape != (rows,) or scale_out.dtype != torch.float32:
         raise ValueError("GLM query scales must be FP32 [rows]")
+    if weights is not None and (
+        weights.shape != (rows,)
+        or weights.dtype != torch.float32
+        or not weights.is_contiguous()
+    ):
+        raise ValueError("GLM index head weights must be contiguous FP32 [rows]")
     if rows:
-        block_r = 32
+        block_r = 4
         _fwht_quant_kernel[(triton.cdiv(rows, block_r),)](
             q,
             q_out,
             scale_out,
+            weights if weights is not None else scale_out,
             rows,
             HEAD_DIM=_HEAD_DIM,
             FP8_MAX=_FP8_MAX,
             BLOCK_R=block_r,
-            num_warps=2,
+            SCALE_WEIGHTS=weights is not None,
+            WEIGHT_NORM=(_HEAD_DIM * 32) ** -0.5,
+            num_warps=1,
         )
 
 

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -384,9 +384,8 @@ class Glm5NextPooledIndexer(nn.Module):
             query.contiguous().view(-1, _INDEX_HEAD_DIM),
             q_fp8.view(-1, _INDEX_HEAD_DIM),
             q_scale.view(-1),
+            weights=weights.view(-1),
         )
-        weights.mul_(q_scale)
-        weights.mul_((_INDEX_HEAD_DIM * _INDEX_HEADS) ** -0.5)
 
         forward_context = get_forward_context()
         raw_metadata = forward_context.attn_metadata


### PR DESCRIPTION
## Summary

- apply GLM query scales and `1/sqrt(4096)` to index-head weights inside the existing FWHT/FP8 kernel, removing two pointwise launches per sparse layer
- retune that kernel from 32 rows/2 warps to 4 rows/1 warp for the measured SM120 workload

GLM-5.3 has 11 sparse indexers. The fused kernel preserves the existing two-operation order; the smaller CTA exposes more parallelism for the live 32-vector decode shape without changing row arithmetic.

## Isolated performance evidence

Historical isolated A/Bs used GLM-5.3-Flash-NVFP4 on four NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition GPUs at TP4/DCP1, 300 W per GPU, a persistent +6000 MHz memory-clock offset, context zero, ordinary model sampling, and 30-second sustained cells.

| Change | Kernel measurement | End-to-end delta |
|---|---:|---:|
| Fuse weight scaling | 15.6664 -> 9.8408 us | +0.740 tok/s (+0.45%) |
| 4-row/1-warp geometry | about 4.10 -> 2.05 us | +0.568 tok/s (+0.34%) |

Those A/Bs used an experimental integration stack that also enabled optional online dense MXFP8 conversion. This PR neither includes nor requires that numerical change, so absolute candidate endpoints are intentionally omitted. The table is isolated mechanism evidence, not a quality-preserving full-stack claim. The fusion removes 22 launches per generated token.

## Combined-stack integration qualification

Code-equivalent versions of both changes were retained in the frozen quality-preserving deployment. This matrix qualifies the composition and is **not** isolated attribution to this PR.

Stack inventory:

- vLLM `ba494904b`, based on merged #537, including the code-equivalent merged MTP correctness fix #539, and containing code-equivalent versions of #542, #543, and #544
- B12X master `a45d3f7` plus code-equivalent versions of [B12X #261](https://github.com/local-inference-lab/b12x/pull/261) and [#262](https://github.com/local-inference-lab/b12x/pull/262) and the launch choices subsequently represented through typed policies in [#263](https://github.com/local-inference-lab/b12x/pull/263) and [#264](https://github.com/local-inference-lab/b12x/pull/264)
- the frozen image predates the final typed-policy plumbing in B12X #263/#264; those exact PR heads still require their own Linux/CUDA qualification
- the rejected 512-KiB PCIe all-reduce experiment is not present

Configuration: GLM-5.3-Flash-NVFP4, four Max-Q cards at TP4/DCP1, 300 W each, +6000 MHz memory offset, native B12X target W4A4, FP8 KV cache, CUDA graphs, one-million-token model length, maximum 32 sequences, 8192 batched tokens, online dense MXFP8 disabled, and probabilistic MTP3 with standard rejection (Marlin MXFP8 draft MoE and B12X draft attention).

`llm_decode_bench.py` ran 30-second sustained cells with ordinary model sampling, no temperature override, and an 8192-token output limit. All 35 cells completed without request errors or capacity limits:

| Context | C1 | C2 | C4 | C8 | C12 | C24 | C32 |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 0 | 251.7 | 384.8 | 555.8 | 808.9 | 995.7 | 1,341.3 | 1,615.6 |
| 16K | 227.8 | 373.0 | 552.1 | 806.8 | 970.9 | 1,359.0 | 1,642.4 |
| 32K | 224.1 | 366.7 | 545.4 | 814.6 | 994.0 | 1,372.8 | 1,612.9 |
| 64K | 220.7 | 370.1 | 556.2 | 796.0 | 982.7 | 1,340.4 | 1,636.1 |
| 128K | 245.3 | 374.6 | 542.5 | 811.5 | 952.0 | 1,298.3 | 1,553.8 |

The 251.7 tok/s C1 cell is retained as raw evidence, not promoted as a stable headline; same-stack C1 repeats were 218.3/221.7/225.3 tok/s. Acceptance-normalized verifier throughput was 92.0--95.7 steps/s at C1, 315.2--328.2 at C8, and 600.4--644.3 at C32.

The exact boot passed Estonia max C30/R30 30/30 and LAVD max C30/R30 30 exact / 0 near / 0 wrong with no token caps. Startup KV capacity was 4,592,497 tokens; exported capacity was 4,783,104 tokens. No eager or backend fallback was used.

## Correctness and current-head status

Historical sweeps were bitwise exact in 216/216 fusion cases and 800/800 launch-geometry cases. Tests compare the fused output with the former separate multiplications and the 4-row geometry with the former 32-row launch across boundary counts; CUDA-graph coverage mutates live inputs and checks stable replay allocation. Static checks pass. A clean no-online-MX current-head GPU test and matched A/B remain required before merge qualification.

## Portability

This implementation is GLM5Next pooled-indexer-specific. The FWHT scaling technique is structurally reusable, but another model must match the transform/scaling contract and receive its own correctness and launch-geometry qualification.

## AI assistance

OpenAI Codex assisted with implementation, tests, profiling analysis, benchmarking, and PR preparation. The commit includes a Codex co-author trailer. The human submitter reviewed the claims and remains responsible for the change.
