### PR TITLE
Fix prefill cadence for non-DP engines

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -339,11 +339,10 @@ def test_schedule_partial_requests():
 
 @pytest.mark.parametrize("has_running", [True, False])
 def test_schedule_prefills_gating(has_running: bool):
-    """DP prefill-balancing gate: when `throttle_prefills` is True, a new
-    WAITING (prefill) request is deferred ONLY if this rank has running work to
-    protect. With no running requests, the prefill is admitted regardless (so a
-    throttled step is never wasted as a dummy), and running/decode requests are
-    unaffected. Once the cadence allows prefills again, the request is admitted.
+    """When `throttle_prefills` is True, a new waiting prefill request is
+    deferred only if this engine has running decode work to protect. With no
+    running request, the prefill is admitted so a throttled step is not wasted.
+    Once the cadence allows prefills again, the request is admitted.
     """
     scheduler = create_scheduler(max_num_seqs=16, max_num_batched_tokens=8192)
 
@@ -463,10 +462,11 @@ def test_throttle_prefills_defers_remote_kv_resume_with_local_prefill():
 
 
 def test_throttle_defers_inflight_prefill_chunk():
-    """DP prefill balancing throttles ALL prefill compute on a throttled step,
-    not just new admissions: an in-progress (chunked) prefill already in the
-    running queue is also deferred, so the step runs decode-only, while a
-    separate decode keeps being scheduled."""
+    """A throttled step defers all prefill compute, not just new admissions.
+
+    An in-progress chunked prefill in the running queue is deferred so the step
+    runs decode-only while a separate decode request remains scheduled.
+    """
     scheduler = create_scheduler(
         max_num_seqs=16, max_num_batched_tokens=50, enable_chunked_prefill=True
     )

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -384,6 +384,36 @@ def test_schedule_prefills_gating(has_running: bool):
     assert any(r.req_id == "new0" for r in output.scheduled_new_reqs)
 
 
+def test_throttle_prefills_admits_work_when_decode_is_temporarily_ineligible():
+    """Prefill runs instead of an empty step while async decode waits for its
+    pipeline-parallel scheduling slot.
+    """
+    scheduler = create_scheduler(max_num_seqs=16, max_num_batched_tokens=8192)
+
+    (decode_req,) = create_requests(num_requests=1, num_tokens=8, req_ids=["decode"])
+    scheduler.add_request(decode_req)
+    output = scheduler.schedule()
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["decode"],
+            req_id_to_index={"decode": 0},
+            sampled_token_ids=[[0]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+    decode_req.next_decode_eligible_step = scheduler.current_step + 2
+
+    (prefill_req,) = create_requests(num_requests=1, num_tokens=8, req_ids=["prefill"])
+    scheduler.add_request(prefill_req)
+    output = scheduler.schedule(throttle_prefills=True)
+
+    assert "decode" not in output.num_scheduled_tokens
+    assert "prefill" in output.num_scheduled_tokens
+
+
 def _setup_remote_kv_resume(num_prompt_tokens: int, matched_tokens: int):
     """Drive a remote-KV request `r2` to the resume point (async load complete)
     while another request `r1` is already decoding, so the step is throttle-

--- a/tests/v1/engine/test_iteration_logging.py
+++ b/tests/v1/engine/test_iteration_logging.py
@@ -4,6 +4,8 @@
 import time
 from types import SimpleNamespace
 
+import pytest
+
 from vllm.v1.engine import EngineCoreOutputs
 from vllm.v1.engine.core import EngineCore
 from vllm.v1.metrics.stats import SchedulerIterationDetails, SchedulerStats
@@ -104,3 +106,19 @@ def test_non_dp_prefill_schedule_interval_uses_scheduler_step():
     engine.vllm_config.scheduler_config.prefill_schedule_interval = 1
     engine.scheduler.current_step = 3
     assert not EngineCore._should_throttle_prefills(engine)
+
+
+@pytest.mark.parametrize("current_step", [None, -1, True, 1.5])
+def test_non_dp_prefill_schedule_interval_validates_scheduler_step(current_step):
+    scheduler = SimpleNamespace()
+    if current_step is not None:
+        scheduler.current_step = current_step
+    engine = SimpleNamespace(
+        vllm_config=SimpleNamespace(
+            scheduler_config=SimpleNamespace(prefill_schedule_interval=4)
+        ),
+        scheduler=scheduler,
+    )
+
+    with pytest.raises(RuntimeError, match="scheduler.current_step"):
+        EngineCore._should_throttle_prefills(engine)

--- a/tests/v1/engine/test_iteration_logging.py
+++ b/tests/v1/engine/test_iteration_logging.py
@@ -86,3 +86,21 @@ def test_attach_iteration_details_falls_back_to_client_zero_without_outputs():
     assert set(outputs) == {0}
     assert outputs[0].scheduler_stats is not None
     assert outputs[0].scheduler_stats.iteration_details == iteration_details
+
+
+def test_non_dp_prefill_schedule_interval_uses_scheduler_step():
+    engine = SimpleNamespace(
+        vllm_config=SimpleNamespace(
+            scheduler_config=SimpleNamespace(prefill_schedule_interval=4)
+        ),
+        scheduler=SimpleNamespace(current_step=0),
+    )
+
+    expected_by_completed_step = (False, True, True, True, False)
+    for completed_step, expected in enumerate(expected_by_completed_step):
+        engine.scheduler.current_step = completed_step
+        assert EngineCore._should_throttle_prefills(engine) is expected
+
+    engine.vllm_config.scheduler_config.prefill_schedule_interval = 1
+    engine.scheduler.current_step = 3
+    assert not EngineCore._should_throttle_prefills(engine)

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -141,9 +141,8 @@ class SchedulerConfig:
     (the default) disables the watermark."""
 
     prefill_schedule_interval: int = Field(default=1, ge=1)
-    """For data-parallel deployments, only admit new prefill requests
-    once every N engine steps, aligned across DP ranks, to better balance
-    per-step forward-pass times."""
+    """Schedule prefill work once every N engine steps while decode requests
+    are running. Data-parallel engines align the cadence across DP ranks."""
 
     async_scheduling: bool | None = None
     """If set to False, disable async scheduling. Async scheduling helps to

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -36,6 +36,9 @@ class PauseState(enum.IntEnum):
 
 
 class SchedulerInterface(ABC):
+    current_step: int
+    """Number of scheduling decisions completed by this scheduler."""
+
     @abstractmethod
     def __init__(
         self,
@@ -71,10 +74,10 @@ class SchedulerInterface(ABC):
         preparing inputs to the model.
 
         Args:
-            throttle_prefills: DP prefill balancing. When True (set by the DP
-                engine core on non-cadence-aligned steps), new prefill compute is
-                deferred to a later step so prefills stay aligned across DP ranks;
-                automatically overridden when the rank is saturated.
+            throttle_prefills: When True, defer prefill compute while decode
+                requests are running. Engine cores use this signal on
+                non-cadence steps. A saturated prefill queue overrides the signal
+                so queued requests continue to make progress.
 
         Returns:
             A SchedulerOutput object containing information about the scheduled

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -37,7 +37,12 @@ class PauseState(enum.IntEnum):
 
 class SchedulerInterface(ABC):
     current_step: int
-    """Number of scheduling decisions completed by this scheduler."""
+    """Number of scheduling decisions completed by this scheduler.
+
+    Implementations initialize this counter to zero and increment it exactly
+    once at the start of every ``schedule`` call. Engine-level prefill cadence
+    reads the counter before the next scheduling decision.
+    """
 
     @abstractmethod
     def __init__(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -557,11 +557,18 @@ class Scheduler(SchedulerInterface):
 
         self.kv_cache_manager.new_step_starts()
 
-        # On a throttled cadence step, defer all prefill compute unless the
-        # prefill queue is saturated.
+        # On a throttled cadence step, defer prefill compute only when this
+        # decision can schedule decode work. Pipeline-parallel async requests
+        # can be temporarily ineligible; admitting prefill in that case avoids
+        # an empty model-executor step.
+        has_eligible_decode = any(
+            not request.is_prefill_chunk
+            and self.current_step >= request.next_decode_eligible_step
+            for request in self.running
+        )
         defer_prefills = (
             throttle_prefills and not self.prefill_capacity_bound
-        ) and any(not r.is_prefill_chunk for r in self.running)
+        ) and has_eligible_decode
 
         # First, schedule the RUNNING requests.
         req_index = 0

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -557,8 +557,8 @@ class Scheduler(SchedulerInterface):
 
         self.kv_cache_manager.new_step_starts()
 
-        # DP prefill balancing: on a throttled (non-cadence-aligned) step, defer
-        # all prefill compute unless saturated.
+        # On a throttled cadence step, defer all prefill compute unless the
+        # prefill queue is saturated.
         defer_prefills = (
             throttle_prefills and not self.prefill_capacity_bound
         ) and any(not r.is_prefill_chunk for r in self.running)
@@ -593,8 +593,8 @@ class Scheduler(SchedulerInterface):
                 continue
 
             if defer_prefills and request.is_prefill_chunk:
-                # DP prefill balancing: defer this in-progress prefill chunk to a
-                # cadence-aligned step; decodes still run to fill this step.
+                # Defer this in-progress chunk to a cadence-aligned step;
+                # decodes still run to fill this step.
                 req_index += 1
                 continue
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -590,9 +590,16 @@ class EngineCore:
             eco.scheduler_stats.iteration_details = iteration_details
 
     def _should_throttle_prefills(self) -> bool:
-        """Whether to defer new prefills this step (DP prefill balancing).
-        Overridden by the DP engine core; never throttles otherwise."""
-        return False
+        """Defer prefills on non-cadence steps in a non-DP engine.
+
+        ``Scheduler.current_step`` counts completed scheduling decisions. A
+        value divisible by the configured interval therefore releases prefill
+        work on the next decision, including the first decision after startup.
+        The data-parallel engine overrides this method with a counter that is
+        synchronized across DP ranks.
+        """
+        interval = self.vllm_config.scheduler_config.prefill_schedule_interval
+        return interval > 1 and self.scheduler.current_step % interval != 0
 
     def step(self) -> tuple[dict[int, EngineCoreOutputs], bool]:
         """Schedule, execute, and make output.

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -599,7 +599,20 @@ class EngineCore:
         synchronized across DP ranks.
         """
         interval = self.vllm_config.scheduler_config.prefill_schedule_interval
-        return interval > 1 and self.scheduler.current_step % interval != 0
+        if interval <= 1:
+            return False
+        current_step = getattr(self.scheduler, "current_step", None)
+        if (
+            not isinstance(current_step, int)
+            or isinstance(current_step, bool)
+            or current_step < 0
+        ):
+            raise RuntimeError(
+                "prefill_schedule_interval greater than one requires "
+                "scheduler.current_step to be a non-negative integer that "
+                "advances once per schedule() call"
+            )
+        return current_step % interval != 0
 
     def step(self) -> tuple[dict[int, EngineCoreOutputs], bool]:
         """Schedule, execute, and make output.


### PR DESCRIPTION
## Purpose

Make `--prefill-schedule-interval` effective for engines whose data-parallel
size is one. This includes tensor-parallel and decode-context-parallel serving
without data parallelism.

The scheduler already supports deferring new and in-progress prefill work on a
throttled step while continuing decode work. Before this change, only
`DPEngineCoreProc` generated the throttle signal. The base `EngineCore` always
passed `False`, so the documented option had no effect on TP/DCP deployments.

The base engine now derives the cadence signal from the scheduler's completed
step count. The data-parallel engine retains its synchronized DP counter. The
scheduler interface requires a non-negative step counter that advances once per
schedule call. An interval greater than one rejects schedulers that do not
provide this contract with a direct runtime error.

Pipeline-parallel asynchronous scheduling can temporarily make every decode
request ineligible. The scheduler admits prefill work in that state instead of
submitting an empty model-executor step. Prefill remains deferred whenever at
least one decode request is eligible.

Fixes #541.

## Compatibility

The default interval remains one, which never throttles and preserves existing
scheduling behavior. Configurations that explicitly select an interval greater
than one now defer prefill work on non-cadence steps only while decode work is
eligible to run. Custom schedulers used with a larger interval must implement
the declared step-counter contract. The existing capacity-bound guard still
overrides throttling when the prefill queue cannot drain, so prefills continue
to make progress.

## Validation

The GLM-5.3 qualification used TP4, DCP1, DFlash2 with seven draft tokens, a
4,096-token scheduler budget, and two concurrent requests:

- Decode request: 4,094 prompt tokens and 8,192 output tokens.
- Prefill request: 65,535 prompt tokens and one output token, submitted after
  the decode request emitted 2,048 tokens.
- Sampling: temperature zero, seed zero, and `ignore_eos=true`.

The position-aligned A/B run kept DFlash accepted length at 7.0 in both cases:

| Configuration | Decode target forwards during prefill | Decode tok/s during prefill | Prompt tok/s |
| --- | ---: | ---: | ---: |
| Interval 1 | 34 | 43.2 | 14,166 |
| Interval 8 | 156 | 197.3 | 10,426 |

Two additional interval-eight runs produced 150-170 target forwards,
196.1-206.8 decode tok/s, and 10,720-10,927 prompt tok/s. Both requests
completed with the requested token counts and no API error.

The publishable TP4/DCP1 container composition, including the scheduler-contract
and pipeline-eligibility checks, produced 154 target forwards, 199.5 decode
tok/s, and 10,752 prompt tok/s. The decode request returned all 8,192 requested
tokens, the prefill request accounted for all 65,535 prompt tokens, and neither
request returned an error.

A standalone 65,535-token prefill measured 14,577 prompt tok/s with interval
one and 14,691 prompt tok/s with interval eight. Throttling therefore adds no
standalone-prefill penalty because it requires concurrent decode work.

Repeated seeded control runs on the unmodified DFlash2 runtime did not produce
stable full-stream token hashes. Bitwise token hashes were therefore not used
as a correctness oracle. This change does not modify model weights, kernels, or
sampling logic; API completion, usage accounting, scheduler progress, and
request errors were checked instead.

Commands run:

```text
uvx pre-commit run --from-ref lil/dev/jovian-judgement --to-ref HEAD

# CPU-targeted unit coverage in the qualified runtime environment includes:
test_non_dp_prefill_schedule_interval_uses_scheduler_step
test_non_dp_prefill_schedule_interval_validates_scheduler_step
test_throttle_prefills_admits_work_when_decode_is_temporarily_ineligible
test_schedule_prefills_gating
test_throttle_defers_inflight_prefill_chunk
test_throttle_capacity_bound_guard_admits
test_throttle_prefills_excludes_fully_transferred_remote_kv
test_throttle_prefills_defers_remote_kv_resume_with_local_prefill
```

All pre-commit hooks and 16 selected unit-test cases passed. The two KV-transfer
cases were run with the serving image's `PYTORCH_CUDA_ALLOC_CONF` unset because
the test connector rejects the serving-only expandable-segments allocator.

## Duplicate check

No open pull request in `vllm-project/vllm` or `local-inference-lab/vllm`
mentions `prefill_schedule_interval`. Keyword searches for chunked-prefill
decode starvation found no implementation of this fix. Upstream issue #53277
describes cache-aware waiting admission and optional KV preemption; it does not
connect the existing cadence option to non-DP engines. Upstream issue #541 is
an unrelated historical Triton-support issue.

## AI assistance

OpenAI Codex assisted with diagnosis, implementation, tests, measurements, and
this pull-request description. A human maintainer must review the changed lines
and qualification evidence before merge.
