### PR TITLE
feat(glm): support B12X NVFP4 KV cache

### DIFF
--- a/tests/models/test_glm5next_pooled_indexer.py
+++ b/tests/models/test_glm5next_pooled_indexer.py
@@ -185,17 +185,44 @@ def test_glm53_packed_c4_metadata_uses_parent_stride() -> None:
 
 
 def _packed_main_cache(
-    *, device: torch.device, blocks: int, layers: int, block_size: int, layer: int
+    *,
+    device: torch.device,
+    blocks: int,
+    layers: int,
+    block_size: int,
+    layer: int,
+    record_bytes: int = 528,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    page_bytes = block_size * (528 + 33)
+    semantic_page_bytes = block_size * record_bytes
+    content_page_bytes = ((semantic_page_bytes + 8447) // 8448) * 8448
+    page_bytes = content_page_bytes + block_size * 33
     raw = torch.zeros(blocks * layers * page_bytes, dtype=torch.uint8, device=device)
     main = torch.as_strided(
         raw,
-        size=(blocks, block_size, 528),
-        stride=(layers * page_bytes, 528, 1),
+        size=(blocks, block_size, record_bytes),
+        stride=(layers * page_bytes, record_bytes, 1),
         storage_offset=layer * page_bytes,
     )
     return raw, main
+
+
+def test_glm53_packed_tail_accepts_nvfp4_main_record() -> None:
+    _, main = _packed_main_cache(
+        device=torch.device("cpu"),
+        blocks=2,
+        layers=3,
+        block_size=3328,
+        layer=1,
+        record_bytes=304,
+    )
+
+    index_cache, subpages, parent_stride_pages = (
+        Glm5NextPooledIndexer._index_cache_view(main)
+    )
+
+    assert subpages == 13
+    assert parent_stride_pages == 399
+    assert index_cache.stride() == (8448, 132, 1)
 
 
 def test_glm53_decode_table_capacity_uses_batched_token_limit() -> None:

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -835,6 +835,7 @@ def test_b12x_glm5_next_cache_geometry_is_finalized_before_bind(monkeypatch) -> 
 
     impl = object.__new__(B12xMLASparseImpl)
     impl._is_glm_next = True
+    impl._uses_nvfp4_cache = False
     impl._cache_record_bytes = 528
     impl._module = FakeModule
     impl._kernel_page_size = 64

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -111,6 +111,16 @@ def test_b12x_sparse_mla_accepts_glm_dsa_contract(monkeypatch) -> None:
     )
 
 
+def test_b12x_dsa_requires_layer_compact_cache_layout() -> None:
+    assert B12xMLASparseBackend.supported_kv_cache_layouts() == (KVCacheLayout.LBNHC,)
+
+
+def test_b12x_glm5_next_requires_block_outermost_cache_layout() -> None:
+    assert B12xGLM5NextMLASparseBackend.supported_kv_cache_layouts() == (
+        KVCacheLayout.BLHNC,
+    )
+
+
 def _glm5_next_config(
     *,
     dcp_size: int = 1,

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -33,6 +33,7 @@ from vllm.v1.attention.backends.mla.b12x_indexer import B12xIndexerBackend
 from vllm.v1.attention.backends.mla.b12x_mla_sparse import (
     B12xGLM5NextMLASparseBackend,
     B12xGLM5NextMLASparseMetadataBuilder,
+    B12xGLMDSAMLASparseBackend,
     B12xMLASparseBackend,
     B12xMLASparseImpl,
     B12xMLASparseMetadata,
@@ -73,6 +74,15 @@ def test_b12x_selector_routes_supported_attention_families() -> None:
     assert indexer_cls is B12xDeepseekV32Indexer
     assert backend_cls is B12xMLASparseBackend
 
+    config.model_config = SimpleNamespace(
+        hf_text_config=SimpleNamespace(model_type="glm_moe_dsa")
+    )
+    indexer_cls, backend_cls = _select_sparse_components(
+        config, None, DeepseekV32Indexer
+    )
+    assert indexer_cls is B12xDeepseekV32Indexer
+    assert backend_cls is B12xGLMDSAMLASparseBackend
+
 
 def test_b12x_sparse_mla_accepts_glm_dsa_contract(monkeypatch) -> None:
     monkeypatch.setattr(b12x_mla_sparse, "get_b12x_sparse_mla", lambda: object())
@@ -109,6 +119,83 @@ def test_b12x_sparse_mla_accepts_glm_dsa_contract(monkeypatch) -> None:
         _canonicalize_sparse_mla_kv_cache_dtype(B12xMLASparseBackend, "auto")
         == "fp8_ds_mla"
     )
+
+    with set_current_vllm_config(config):
+        invalid_reasons = B12xMLASparseBackend.validate_configuration(
+            head_size=576,
+            dtype=torch.bfloat16,
+            kv_cache_dtype="nvfp4_ds_mla",
+            block_size=64,
+            use_mla=True,
+            has_sink=False,
+            use_sparse=True,
+            use_mm_prefix=False,
+            use_per_head_quant_scales=False,
+            device_capability=DeviceCapability(12, 0),
+            attn_type="decoder",
+        )
+
+    assert invalid_reasons == []
+
+
+def test_b12x_glm_dsa_nvfp4_cache_spec(monkeypatch) -> None:
+    monkeypatch.setattr(b12x_mla_sparse, "get_b12x_sparse_mla", lambda: object())
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(model_type="glm_moe_dsa")
+        )
+    )
+    probe = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.uint8,
+        cache_dtype_str="nvfp4_ds_mla",
+    )
+
+    with set_current_vllm_config(config):
+        packed = B12xMLASparseBackend.customize_spec(probe)
+
+    assert packed.state_content_bytes == 368
+    assert packed.page_size_bytes == 64 * 368
+    assert packed.model_version == "glm_moe_dsa"
+    assert B12xMLASparseBackend.customize_spec(packed) == packed
+
+    packed_without_config = B12xGLMDSAMLASparseBackend.customize_spec(probe)
+    assert packed_without_config == packed
+
+
+def test_b12x_nvfp4_rejects_non_glm_dsa_architecture(monkeypatch) -> None:
+    monkeypatch.setattr(b12x_mla_sparse, "get_b12x_sparse_mla", lambda: object())
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(
+                model_type="deepseek_v32",
+                index_topk=2048,
+                kv_lora_rank=512,
+                qk_rope_head_dim=64,
+            )
+        )
+    )
+
+    with set_current_vllm_config(config):
+        invalid_reasons = B12xMLASparseBackend.validate_configuration(
+            head_size=576,
+            dtype=torch.bfloat16,
+            kv_cache_dtype="nvfp4_ds_mla",
+            block_size=64,
+            use_mla=True,
+            has_sink=False,
+            use_sparse=True,
+            use_mm_prefix=False,
+            use_per_head_quant_scales=False,
+            device_capability=DeviceCapability(12, 0),
+            attn_type="decoder",
+        )
+
+    assert invalid_reasons == [
+        ("B12X nvfp4_ds_mla requires GLM5Next or the GLM-5.2/5.3 DSA architecture")
+    ]
 
 
 def test_b12x_dsa_requires_layer_compact_cache_layout() -> None:
@@ -180,7 +267,7 @@ def test_b12x_glm5_next_cache_spec_and_layout(monkeypatch) -> None:
             attn_type="decoder",
         )
         packed = B12xMLASparseBackend.customize_spec(probe)
-        layouts = B12xMLASparseBackend.supported_kv_cache_layouts()
+        layouts = B12xGLM5NextMLASparseBackend.supported_kv_cache_layouts()
     packed_without_config_context = B12xMLASparseBackend.customize_spec(packed)
 
     assert invalid_reasons == []
@@ -231,6 +318,29 @@ def test_b12x_glm5_next_binds_nvfp4_record_width(monkeypatch) -> None:
     assert planned == [64]
     with pytest.raises(ValueError, match="page_size, 304"):
         impl.bind_kv_cache(torch.empty((2, 64, 528), dtype=torch.uint8))
+
+
+def test_b12x_glm_dsa_binds_nvfp4_fp8_rope_record() -> None:
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._is_glm_next = False
+    impl._uses_glm_dsa_nvfp4_cache = True
+
+    impl.bind_kv_cache(torch.empty((2, 64, 368), dtype=torch.uint8))
+
+    with pytest.raises(ValueError, match="page_size, 368"):
+        impl.bind_kv_cache(torch.empty((2, 64, 432), dtype=torch.uint8))
+
+
+def test_b12x_nvfp4_run_options_match_each_glm_record_abi() -> None:
+    assert b12x_mla_sparse._nvfp4_run_options(is_glm_next=False) == {
+        "scale_format": 2,
+        "fp8_rope": True,
+    }
+    assert b12x_mla_sparse._nvfp4_run_options(is_glm_next=True) == {
+        "scale_format": 2,
+        "fp8_rope": False,
+        "latent_scale_per_token": True,
+    }
 
 
 def test_packed_nvfp4_mla_dtype_bypasses_generic_layout_guard() -> None:
@@ -657,6 +767,36 @@ def test_b12x_glm5_next_cache_writer_ignores_empty_rope() -> None:
     )
 
     assert calls == [(kv_c, kv_cache, slots)]
+
+
+def test_b12x_glm_dsa_nvfp4_cache_writer_keeps_rope() -> None:
+    calls: list[tuple[torch.Tensor, ...]] = []
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._is_glm_next = False
+    impl._uses_glm_dsa_nvfp4_cache = True
+    impl._concat_and_cache_nvfp4_mla_fp8_rope = lambda *args: calls.append(args)
+    kv_c = torch.empty((3, 512), dtype=torch.bfloat16)
+    k_pe = torch.empty((3, 1, 64), dtype=torch.bfloat16)
+    kv_cache = torch.empty((2, 64, 368), dtype=torch.uint8)
+    slots = torch.tensor([0, 64, -1], dtype=torch.int64)
+    scale = torch.ones((), dtype=torch.float32)
+
+    impl.do_kv_cache_update(
+        kv_c,
+        k_pe,
+        kv_cache,
+        slots,
+        "nvfp4_ds_mla",
+        scale,
+    )
+
+    assert len(calls) == 1
+    actual_kv_c, actual_k_pe, actual_cache, actual_slots, actual_scale = calls[0]
+    assert actual_kv_c is kv_c
+    assert torch.equal(actual_k_pe, k_pe.squeeze(1))
+    assert actual_cache is kv_cache
+    assert torch.equal(actual_slots, slots)
+    assert actual_scale is scale
 
 
 def test_b12x_glm5_next_cache_geometry_is_finalized_before_bind(monkeypatch) -> None:

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -8,10 +8,11 @@ from typing import Any
 import pytest
 import torch
 
-from vllm.config import AttentionConfig, set_current_vllm_config
+from vllm.config import AttentionConfig, VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.attention.mla_attention import (
     MLAAttention,
     _canonicalize_sparse_mla_kv_cache_dtype,
+    _maybe_view_mla_cache_as_fp8,
 )
 from vllm.model_executor.layers.attention.sparse_mla_attention import (
     SparseMLACommonMetadataBuilder,
@@ -23,7 +24,7 @@ from vllm.models.deepseek_v32.attention import (
     _select_sparse_components,
 )
 from vllm.models.deepseek_v32.b12x import B12xDeepseekV32Indexer
-from vllm.platforms.interface import DeviceCapability
+from vllm.platforms.interface import DeviceCapability, Platform
 from vllm.v1.attention.backends.b12x import B12xPagedAttentionBackend
 from vllm.v1.attention.backends.mla import b12x_indexer as generic_b12x_indexer
 from vllm.v1.attention.backends.mla import b12x_mla_sparse
@@ -148,7 +149,6 @@ def test_b12x_glm5_next_cache_spec_and_layout(monkeypatch) -> None:
         cache_dtype_str="fp8_ds_mla",
         state_content_bytes=656,
     )
-
     unidentified = B12xMLASparseBackend.customize_spec(probe)
     packed_by_glm_backend = B12xGLM5NextMLASparseBackend.customize_spec(probe)
     with set_current_vllm_config(config):
@@ -172,13 +172,84 @@ def test_b12x_glm5_next_cache_spec_and_layout(monkeypatch) -> None:
     assert invalid_reasons == []
     assert unidentified == probe
     assert packed_by_glm_backend.state_content_bytes == 528
-    assert packed_by_glm_backend.page_size_padded == 64 * 528 + 16 * 128 * 2
+    assert packed_by_glm_backend.page_size_bytes == 64 * (528 + 33)
     assert packed_by_glm_backend.model_version == "glm5_next"
     assert packed.state_content_bytes == 528
-    assert packed.page_size_padded == 64 * 528 + 16 * 128 * 2
+    assert packed.page_size_bytes == 64 * (528 + 33)
     assert packed.model_version == "glm5_next"
     assert packed_without_config_context == packed
     assert layouts == (KVCacheLayout.BLHNC,)
+    assert "nvfp4_ds_mla" in B12xMLASparseBackend.supported_kv_cache_dtypes
+
+
+def test_b12x_glm5_next_nvfp4_cache_spec() -> None:
+    probe = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=512,
+        dtype=torch.uint8,
+        cache_dtype_str="nvfp4_ds_mla",
+        state_content_bytes=656,
+    )
+
+    with set_current_vllm_config(_glm5_next_config()):
+        packed = B12xMLASparseBackend.customize_spec(probe)
+
+    assert packed.state_content_bytes == 304
+    assert packed.page_tail_bytes_per_token == 33
+    assert packed.page_size_padded == 3 * 64 * 132
+    assert packed.page_size_bytes == 3 * 64 * 132 + 64 * 33
+    assert packed.model_version == "glm5_next"
+
+
+def test_b12x_glm5_next_binds_nvfp4_record_width(monkeypatch) -> None:
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._is_glm_next = True
+    impl._cache_record_bytes = 304
+    planned: list[int] = []
+    monkeypatch.setattr(impl, "_set_kernel_page_size", planned.append)
+
+    impl.bind_kv_cache(torch.empty((2, 64, 304), dtype=torch.uint8))
+
+    assert planned == [64]
+    with pytest.raises(ValueError, match="page_size, 304"):
+        impl.bind_kv_cache(torch.empty((2, 64, 528), dtype=torch.uint8))
+
+
+def test_packed_nvfp4_mla_dtype_bypasses_generic_layout_guard() -> None:
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(use_mla=True),
+        cache_config=SimpleNamespace(cache_dtype="nvfp4_ds_mla"),
+    )
+
+    assert VllmConfig.validate_nvfp4_kv_cache_with_mla(config) is config
+
+    config.cache_config.cache_dtype = "nvfp4"
+    with pytest.raises(ValueError, match="not supported with MLA"):
+        VllmConfig.validate_nvfp4_kv_cache_with_mla(config)
+
+
+@pytest.mark.parametrize("cache_dtype", ["fp8_ds_mla", "nvfp4_ds_mla"])
+def test_packed_mla_cache_keeps_uint8_forward_view(cache_dtype: str) -> None:
+    cache = torch.empty((2, 64, 304), dtype=torch.uint8)
+
+    forwarded = _maybe_view_mla_cache_as_fp8(cache, cache_dtype)
+
+    assert forwarded is cache
+    assert forwarded.dtype == torch.uint8
+
+
+def test_plain_fp8_mla_cache_uses_native_fp8_forward_view(monkeypatch) -> None:
+    cache = torch.empty((2, 64, 512), dtype=torch.uint8)
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.attention.mla_attention.current_platform.fp8_dtype",
+        lambda: torch.float8_e4m3fn,
+    )
+
+    forwarded = _maybe_view_mla_cache_as_fp8(cache, "fp8")
+
+    assert forwarded.data_ptr() == cache.data_ptr()
+    assert forwarded.dtype == torch.float8_e4m3fn
 
 
 def test_b12x_glm5_next_keeps_hybrid_manager_page_unsplit() -> None:
@@ -190,6 +261,40 @@ def test_b12x_glm5_next_keeps_hybrid_manager_page_unsplit() -> None:
     assert B12xGLM5NextMLASparseBackend.supported_kv_cache_layouts() == (
         KVCacheLayout.BLHNC,
     )
+
+
+def test_b12x_glm5_next_nvfp4_aligns_hybrid_page_to_packed_record(
+    monkeypatch,
+) -> None:
+    mamba_page_size = 1_085_440
+    config = _glm5_next_config(dcp_size=4, cp_interleave=4)
+    config.model_config.is_hybrid = True
+    config.model_config.use_mla = True
+    config.model_config.architecture = "Glm5NextForConditionalGeneration"
+    config.model_config.dtype = torch.bfloat16
+    config.model_config.get_num_kv_heads = lambda parallel_config: 1
+    config.model_config.get_head_size = lambda: 512
+    config.cache_config.cache_dtype = "nvfp4_ds_mla"
+    config.cache_config.block_size = 256
+    config.cache_config.mamba_block_size = None
+    config.cache_config.user_specified_mamba_block_size = False
+    config.cache_config.mamba_cache_mode = "align"
+    config.cache_config.mamba_page_size_padded = None
+
+    model_cls = SimpleNamespace(
+        get_mamba_state_shape_from_config=lambda vllm_config: ((mamba_page_size,),),
+        get_mamba_state_dtype_from_config=lambda vllm_config: (torch.uint8,),
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.models.ModelRegistry.resolve_model_cls",
+        lambda *args, **kwargs: (model_cls, None),
+    )
+
+    Platform._align_hybrid_block_size(config, B12xGLM5NextMLASparseBackend)
+
+    assert config.cache_config.block_size == 3328
+    assert config.cache_config.mamba_block_size == 3328
+    assert config.cache_config.mamba_page_size_padded == 3328 * (304 + 33)
 
 
 def test_b12x_glm5_next_rejects_unaligned_dcp(monkeypatch) -> None:
@@ -392,6 +497,7 @@ def test_b12x_glm5_next_cache_bind_replans_aligned_manager_page(monkeypatch) -> 
 
     impl = object.__new__(B12xMLASparseImpl)
     impl._is_glm_next = True
+    impl._cache_record_bytes = 528
     impl._module = FakeModule
     impl._kernel_page_size = 64
     impl._input_num_heads = 64
@@ -631,7 +737,7 @@ def test_glm_selector_metadata_builder_stages_padded_rows_and_capture(
     monkeypatch.setattr(
         SparseMLACommonMetadataBuilder,
         "build",
-        lambda *args, **kwargs: SimpleNamespace(),
+        lambda *args, **kwargs: SimpleNamespace(num_prefills=0),
     )
     builder = _bare_glm_selector_metadata_builder()
     common = SimpleNamespace(
@@ -707,7 +813,7 @@ def test_glm_selector_metadata_builder_requires_complete_runtime_state(
     monkeypatch.setattr(
         SparseMLACommonMetadataBuilder,
         "build",
-        lambda *args, **kwargs: SimpleNamespace(),
+        lambda *args, **kwargs: SimpleNamespace(num_prefills=0),
     )
     builder = _bare_glm_selector_metadata_builder()
     common = SimpleNamespace(

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -292,9 +292,23 @@ def test_b12x_glm5_next_nvfp4_aligns_hybrid_page_to_packed_record(
 
     Platform._align_hybrid_block_size(config, B12xGLM5NextMLASparseBackend)
 
+    materialized_probe = MLAAttentionSpec(
+        block_size=config.cache_config.block_size,
+        num_kv_heads=1,
+        head_size=512,
+        dtype=torch.uint8,
+        cache_dtype_str="nvfp4_ds_mla",
+        state_content_bytes=656,
+    )
+    with set_current_vllm_config(config):
+        materialized = B12xGLM5NextMLASparseBackend.customize_spec(
+            materialized_probe
+        )
+
     assert config.cache_config.block_size == 3328
     assert config.cache_config.mamba_block_size == 3328
-    assert config.cache_config.mamba_page_size_padded == 3328 * (304 + 33)
+    assert materialized.page_size_bytes == 1_123_584
+    assert config.cache_config.mamba_page_size_padded == materialized.page_size_bytes
 
 
 def test_b12x_glm5_next_rejects_unaligned_dcp(monkeypatch) -> None:

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -307,9 +307,7 @@ def test_b12x_glm5_next_nvfp4_aligns_hybrid_page_to_packed_record(
         state_content_bytes=656,
     )
     with set_current_vllm_config(config):
-        materialized = B12xGLM5NextMLASparseBackend.customize_spec(
-            materialized_probe
-        )
+        materialized = B12xGLM5NextMLASparseBackend.customize_spec(materialized_probe)
 
     assert config.cache_config.block_size == 3328
     assert config.cache_config.mamba_block_size == 3328
@@ -512,8 +510,98 @@ def test_b12x_glm5_next_selected_indices_use_physical_slots() -> None:
         )
         == 64
     )
-    assert _is_glm_next_ckv_source_layout(cache, page_size=64)
-    assert not _is_glm_next_ckv_source_layout(cache[:, :, ::2], page_size=64)
+    assert _is_glm_next_ckv_source_layout(cache, page_size=64, record_bytes=528)
+    assert not _is_glm_next_ckv_source_layout(
+        cache[:, :, ::2], page_size=64, record_bytes=528
+    )
+
+
+@pytest.mark.parametrize("record_bytes", [528, 304])
+def test_b12x_glm5_next_full_ckv_workspaces_follow_cache_format(
+    record_bytes: int,
+) -> None:
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._max_tokens = 32
+    impl._q_head_dim = 512
+    impl._ckv_local_capacity = 128
+    impl.dcp_world_size = 4
+    impl._cache_record_bytes = record_bytes
+    plan = SimpleNamespace(shapes_and_dtypes=lambda: (((16,), torch.uint8),))
+
+    specs = impl._workspace_specs(plan, input_num_heads=8, include_ckv=True)
+
+    assert specs[-2:] == (
+        ((128, record_bytes), torch.uint8),
+        ((512, record_bytes), torch.uint8),
+    )
+
+
+@pytest.mark.parametrize("record_bytes", [528, 304])
+def test_b12x_glm5_next_full_ckv_gather_preserves_native_records(
+    monkeypatch: pytest.MonkeyPatch,
+    record_bytes: int,
+) -> None:
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._kernel_page_size = 2
+    impl._ckv_local_capacity = 4
+    impl._cache_record_bytes = record_bytes
+    impl.dcp_world_size = 2
+    impl.uses_full_ckv_dcp = lambda *_: True
+
+    kv_cache = (
+        torch.arange(4 * record_bytes, dtype=torch.int64)
+        .to(torch.uint8)
+        .view(2, 2, record_bytes)
+    )
+    local_buffer = torch.full((4, record_bytes), 255, dtype=torch.uint8)
+    gathered_buffer = torch.empty((8, record_bytes), dtype=torch.uint8)
+    metadata = SimpleNamespace(
+        num_actual_tokens=3,
+        dcp_local_total_tokens=3,
+        dcp_padded_total_tokens=4,
+        dcp_local_cu_seq_lens=torch.tensor([0, 3], dtype=torch.int32),
+        block_table=torch.tensor([[0, 1]], dtype=torch.int32),
+        num_reqs=1,
+    )
+
+    def fake_cp_gather_cache(**kwargs: Any) -> None:
+        kwargs["dst"].copy_(kwargs["src_cache"].view(-1, record_bytes)[:3])
+
+    def fake_all_gather(_group: Any, src: torch.Tensor, dst: torch.Tensor) -> None:
+        dst.copy_(src.repeat(2))
+
+    monkeypatch.setattr(b12x_mla_sparse.ops, "cp_gather_cache", fake_cp_gather_cache)
+    monkeypatch.setattr(
+        b12x_mla_sparse, "_dcp_all_gather_current_stream", fake_all_gather
+    )
+    monkeypatch.setattr(b12x_mla_sparse, "get_dcp_group", lambda: object())
+
+    gathered = impl._gather_full_ckv(kv_cache, metadata, local_buffer, gathered_buffer)
+
+    expected_rank = torch.cat(
+        (kv_cache.view(-1, record_bytes)[:3], torch.zeros((1, record_bytes))),
+        dim=0,
+    )
+    assert gathered.shape == (4, 2, record_bytes)
+    assert torch.equal(gathered.view(-1, record_bytes), expected_rank.repeat(2, 1))
+
+
+def test_b12x_glm5_next_full_ckv_gather_rejects_wrong_record_width() -> None:
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._kernel_page_size = 2
+    impl._ckv_local_capacity = 4
+    impl._cache_record_bytes = 304
+    impl.dcp_world_size = 2
+    impl.uses_full_ckv_dcp = lambda *_: True
+    metadata = SimpleNamespace(num_actual_tokens=1)
+
+    with pytest.raises(ValueError, match="requires native 304-byte records"):
+        impl._gather_full_ckv(
+            torch.empty((2, 2, 528), dtype=torch.uint8),
+            metadata,
+            torch.empty((4, 304), dtype=torch.uint8),
+            torch.empty((8, 304), dtype=torch.uint8),
+        )
 
 
 def test_sparse_index_remap_tiling_covers_glm5_next_width() -> None:

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -211,6 +211,7 @@ def test_b12x_glm5_next_binds_nvfp4_record_width(monkeypatch) -> None:
     impl = object.__new__(B12xMLASparseImpl)
     impl._is_glm_next = True
     impl._cache_record_bytes = 304
+    impl._ckv_gather_enabled = False
     planned: list[int] = []
     monkeypatch.setattr(impl, "_set_kernel_page_size", planned.append)
 
@@ -639,6 +640,7 @@ def test_b12x_glm5_next_cache_geometry_is_finalized_before_bind(monkeypatch) -> 
 def test_b12x_glm5_next_full_ckv_bind_requires_geometry_finalization() -> None:
     impl = object.__new__(B12xMLASparseImpl)
     impl._is_glm_next = True
+    impl._cache_record_bytes = 528
     impl._ckv_gather_enabled = True
     impl._kernel_page_size_finalized = False
 

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers.attention.mla_attention import (
     MLAAttention,
     _canonicalize_sparse_mla_kv_cache_dtype,
     _maybe_view_mla_cache_as_fp8,
+    _uses_packed_sparse_mla_workspace,
 )
 from vllm.model_executor.layers.attention.sparse_mla_attention import (
     SparseMLACommonMetadataBuilder,
@@ -256,6 +257,24 @@ def test_plain_fp8_mla_cache_uses_native_fp8_forward_view(monkeypatch) -> None:
 
     assert forwarded.data_ptr() == cache.data_ptr()
     assert forwarded.dtype == torch.float8_e4m3fn
+
+
+@pytest.mark.parametrize(
+    ("resolved_cache_dtype", "expected"),
+    [
+        ("fp8_ds_mla", True),
+        ("nvfp4_ds_mla", True),
+        ("auto", False),
+        (None, False),
+    ],
+)
+def test_packed_workspace_uses_resolved_layer_cache_spec(
+    resolved_cache_dtype: str | None,
+    expected: bool,
+) -> None:
+    spec = SimpleNamespace(cache_dtype_str=resolved_cache_dtype)
+
+    assert _uses_packed_sparse_mla_workspace(spec) is expected
 
 
 def test_b12x_glm5_next_keeps_hybrid_manager_page_unsplit() -> None:

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -45,6 +45,7 @@ CacheDType = Literal[
     "fp8_e5m2",
     "fp8_inc",
     "fp8_ds_mla",
+    "nvfp4_ds_mla",
     "turboquant_k8v4",
     "turboquant_4bit_nc",
     "turboquant_k3v4_nc",
@@ -125,6 +126,7 @@ class CacheConfig:
     to fp8.
     "nvfp4_4over6" uses the NVFP4 layout and selects between max/6 and max/4
     scales per 16 values by minimizing squared reconstruction error.
+    "nvfp4_ds_mla" uses the model-specific packed sparse-MLA record.
     """
     is_attention_free: bool = False
     """Whether the model is attention-free. This is primarily set in

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2678,6 +2678,7 @@ class VllmConfig:
             return self
         if (
             self.cache_config.cache_dtype.startswith("nvfp4")
+            and self.cache_config.cache_dtype != "nvfp4_ds_mla"
             and self.model_config.use_mla
         ):
             raise ValueError(

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -368,6 +368,26 @@ def _canonicalize_sparse_mla_kv_cache_dtype(
     return kv_cache_dtype
 
 
+_PACKED_SPARSE_MLA_CACHE_DTYPES = frozenset({"fp8_ds_mla", "nvfp4_ds_mla"})
+
+
+def _is_packed_sparse_mla_cache_dtype(kv_cache_dtype: CacheDType) -> bool:
+    """Return whether an MLA cache uses an opaque packed-byte record."""
+    return kv_cache_dtype in _PACKED_SPARSE_MLA_CACHE_DTYPES
+
+
+def _maybe_view_mla_cache_as_fp8(
+    kv_cache: torch.Tensor,
+    kv_cache_dtype: CacheDType,
+) -> torch.Tensor:
+    """View ordinary FP8 caches as FP8 while preserving packed byte records."""
+    if is_quantized_kv_cache(kv_cache_dtype) and not (
+        _is_packed_sparse_mla_cache_dtype(kv_cache_dtype)
+    ):
+        return kv_cache.view(current_platform.fp8_dtype())
+    return kv_cache
+
+
 def _get_kv_b_proj_input_dtype(
     kv_b_proj: ColumnParallelLinear, use_fp8_prefill: bool
 ) -> torch.dtype | None:
@@ -615,7 +635,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             query_dtype = (
                 current_platform.fp8_dtype()
                 if is_quantized_kv_cache(self.kv_cache_dtype)
-                and self.kv_cache_dtype != "fp8_ds_mla"
+                and not _is_packed_sparse_mla_cache_dtype(self.kv_cache_dtype)
                 and self.impl.supports_quant_query_input
                 else dtype
             )
@@ -832,8 +852,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         k_c_normed = k_c_normed[:num_actual_toks, ...]
         k_pe = k_pe[:num_actual_toks, ...]
 
-        if fp8_attention and self.kv_cache_dtype != "fp8_ds_mla":
-            kv_cache = kv_cache.view(current_platform.fp8_dtype())
+        kv_cache = _maybe_view_mla_cache_as_fp8(kv_cache, self.kv_cache_dtype)
 
         assert (
             attn_metadata.num_decodes is not None
@@ -2211,7 +2230,9 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
             self.determine_chunked_prefill_workspace_size(vllm_config)
         )
 
-        use_packed_fp8_cache = vllm_config.cache_config.cache_dtype == "fp8_ds_mla"
+        use_packed_sparse_mla_cache = _is_packed_sparse_mla_cache_dtype(
+            vllm_config.cache_config.cache_dtype
+        )
         self.dcp_manager: MLADCPManager | None = None
         if self.dcp_world_size > 1:
             # Note(hc): The local kvcache is incomplete when DCP is triggered,
@@ -2225,9 +2246,11 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                     + self.chunked_prefill_workspace_size // self.dcp_world_size,
                     self.mla_dims.kv_lora_rank + self.mla_dims.qk_rope_head_dim,
                 ),
-                dtype=torch.bfloat16
-                if use_packed_fp8_cache
-                else self.model_config.dtype,
+                dtype=(
+                    torch.bfloat16
+                    if use_packed_sparse_mla_cache
+                    else self.model_config.dtype
+                ),
                 device=device,
             )
             self.dcp_manager = getattr(attention_layer, "dcp_manager", None)
@@ -2242,7 +2265,9 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                     self.chunked_prefill_workspace_size,
                     self.mla_dims.kv_lora_rank + self.mla_dims.qk_rope_head_dim,
                 ),
-                dtype=torch.bfloat16 if use_packed_fp8_cache else self.q_data_type,
+                dtype=(
+                    torch.bfloat16 if use_packed_sparse_mla_cache else self.q_data_type
+                ),
                 device=device,
             )
 

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -353,7 +353,17 @@ def _select_mqa_query(
     num_mqa_tokens: int,
     full_ckv_dcp: bool,
 ) -> tuple[torch.Tensor, bool]:
-    """Select local or replicated query geometry for MLA decode/prefill."""
+    """Select local or replicated query geometry for MLA decode/prefill.
+
+    Args:
+        q: Query tensor in the local DCP geometry.
+        q_dcp_replicated: Optional query tensor replicated across DCP ranks.
+        num_mqa_tokens: Number of active query tokens.
+        full_ckv_dcp: Whether the backend gathers the complete CKV cache.
+
+    Returns:
+        The selected query rows and whether replicated geometry was selected.
+    """
     if q_dcp_replicated is not None and not full_ckv_dcp:
         return q_dcp_replicated[:num_mqa_tokens], True
     return q[:num_mqa_tokens], False
@@ -385,15 +395,44 @@ _PACKED_SPARSE_MLA_CACHE_DTYPES = frozenset({"fp8_ds_mla", "nvfp4_ds_mla"})
 
 
 def _is_packed_sparse_mla_cache_dtype(kv_cache_dtype: CacheDType) -> bool:
-    """Return whether an MLA cache uses an opaque packed-byte record."""
+    """Return whether an MLA cache uses an opaque packed-byte record.
+
+    Args:
+        kv_cache_dtype: Resolved cache dtype name.
+
+    Returns:
+        Whether the dtype represents a packed sparse MLA record.
+    """
     return kv_cache_dtype in _PACKED_SPARSE_MLA_CACHE_DTYPES
+
+
+def _uses_packed_sparse_mla_workspace(kv_cache_spec: AttentionSpec) -> bool:
+    """Determine workspace layout from the resolved layer cache spec.
+
+    Args:
+        kv_cache_spec: Cache specification for the builder's layer group.
+
+    Returns:
+        Whether the layer group uses packed sparse MLA records.
+    """
+    cache_dtype = getattr(kv_cache_spec, "cache_dtype_str", None)
+    return cache_dtype is not None and _is_packed_sparse_mla_cache_dtype(cache_dtype)
 
 
 def _maybe_view_mla_cache_as_fp8(
     kv_cache: torch.Tensor,
     kv_cache_dtype: CacheDType,
 ) -> torch.Tensor:
-    """View ordinary FP8 caches as FP8 while preserving packed byte records."""
+    """View ordinary FP8 caches as FP8 while preserving packed byte records.
+
+    Args:
+        kv_cache: Cache tensor supplied by the allocator.
+        kv_cache_dtype: Resolved cache dtype name for the layer.
+
+    Returns:
+        An FP8 view for ordinary quantized caches, or the original tensor for
+        packed sparse MLA and unquantized caches.
+    """
     if is_quantized_kv_cache(kv_cache_dtype) and not (
         _is_packed_sparse_mla_cache_dtype(kv_cache_dtype)
     ):
@@ -2250,8 +2289,8 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
             self.determine_chunked_prefill_workspace_size(vllm_config)
         )
 
-        use_packed_sparse_mla_cache = _is_packed_sparse_mla_cache_dtype(
-            vllm_config.cache_config.cache_dtype
+        use_packed_sparse_mla_cache = _uses_packed_sparse_mla_workspace(
+            self.kv_cache_spec
         )
         self.dcp_manager: MLADCPManager | None = None
         if self.dcp_world_size > 1:

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -312,7 +312,11 @@ class DeepseekV32Attention(MLAAttention):
 
         fp8_attention = is_quantized_kv_cache(self.kv_cache_dtype)
         self._fp8_query = fp8_attention and self.impl.supports_quant_query_input
-        self._fp8_kv_needs_view = fp8_attention and self.kv_cache_dtype != "fp8_ds_mla"
+        self._native_packed_kv_update = self.kv_cache_dtype == "nvfp4_ds_mla"
+        self._fp8_kv_needs_view = fp8_attention and self.kv_cache_dtype not in (
+            "fp8_ds_mla",
+            "nvfp4_ds_mla",
+        )
 
         self._index_rope_interleave = getattr(config, "indexer_rope_interleave", False)
 
@@ -421,12 +425,18 @@ class DeepseekV32Attention(MLAAttention):
             mla_k_scale = None
             indexer_k_cache = None
             mla_slot = None
+        elif self._native_packed_kv_update:
+            # Keep the fused indexer-cache write, but let the sparse backend
+            # own the model-specific packed MLA record update below.
+            mla_kv_cache = None
+            mla_k_scale = None
         else:
             mla_kv_cache = self.kv_cache
             mla_k_scale = self._k_scale
 
-        kv_c_out = torch.empty_like(kv_c) if self.use_pcp else None
-        k_pe_out = torch.empty_like(k_pe) if self.use_pcp else None
+        separate_kv_update = self.use_pcp or self._native_packed_kv_update
+        kv_c_out = torch.empty_like(kv_c) if separate_kv_update else None
+        k_pe_out = torch.empty_like(k_pe) if separate_kv_update else None
         q_c = fused_norm_rope(
             positions,
             q_c,
@@ -540,17 +550,23 @@ class DeepseekV32Attention(MLAAttention):
             return
         attn_metadata = cast("MLACommonMetadata", attn_metadata)
 
-        if self.use_pcp:
+        if self.use_pcp or self._native_packed_kv_update:
             assert kv_c is not None and k_pe is not None
-            kv_for_cache, kpe_for_cache, cache_slot_mapping = (
-                maybe_gather_mla_latent_cache_inputs(
-                    kv_c,
-                    k_pe.unsqueeze(1),
-                    layer_slot_mapping,
-                    attn_metadata.num_decode_tokens,
-                    True,
+            if self.use_pcp:
+                kv_for_cache, kpe_for_cache, cache_slot_mapping = (
+                    maybe_gather_mla_latent_cache_inputs(
+                        kv_c,
+                        k_pe.unsqueeze(1),
+                        layer_slot_mapping,
+                        attn_metadata.num_decode_tokens,
+                        True,
+                    )
                 )
-            )
+            else:
+                kv_for_cache = kv_c
+                kpe_for_cache = k_pe.unsqueeze(1)
+                cache_slot_mapping = layer_slot_mapping
+            assert cache_slot_mapping is not None
             self.impl.do_kv_cache_update(  # type: ignore[attr-defined]
                 kv_for_cache,
                 kpe_for_cache,

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -175,10 +175,18 @@ def _select_sparse_components(
     ):
         from vllm.models.deepseek_v32.b12x import B12xDeepseekV32Indexer
         from vllm.v1.attention.backends.mla.b12x_mla_sparse import (
+            B12xGLMDSAMLASparseBackend,
             B12xMLASparseBackend,
         )
 
-        return B12xDeepseekV32Indexer, B12xMLASparseBackend
+        model_config = getattr(vllm_config, "model_config", None)
+        hf_config = getattr(model_config, "hf_text_config", None)
+        backend_cls = (
+            B12xGLMDSAMLASparseBackend
+            if getattr(hf_config, "model_type", None) == "glm_moe_dsa"
+            else B12xMLASparseBackend
+        )
+        return B12xDeepseekV32Indexer, backend_cls
     return indexer_cls, attn_backend
 
 

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -46,7 +46,6 @@ _SELECTION_WIDTH = 2051
 _INDEX_CACHE_WIDTH = 132
 _INDEX_PAGE_SIZE = 64
 _INDEX_PAGE_BYTES = _INDEX_PAGE_SIZE * _INDEX_CACHE_WIDTH
-_MLA_RECORD_BYTES = 528
 
 
 class Glm5NextPooledIndexer(nn.Module):
@@ -267,22 +266,25 @@ class Glm5NextPooledIndexer(nn.Module):
         if (
             main_cache.ndim != 3
             or main_cache.dtype != torch.uint8
-            or int(main_cache.shape[-1]) != _MLA_RECORD_BYTES
+            or int(main_cache.shape[-1]) <= 0
         ):
-            raise ValueError("GLM MLA cache must be uint8 [pages, block, 528]")
-        pages, block_size, _ = map(int, main_cache.shape)
+            raise ValueError("GLM MLA cache must be uint8 [pages, block, record_bytes]")
+        pages, block_size, record_bytes = map(int, main_cache.shape)
         if pages <= 0 or block_size % (_POOL_SIZE * _INDEX_PAGE_SIZE):
             raise ValueError(
                 "GLM MLA pages must contain a whole number of 64-pool C4 pages"
             )
-        if tuple(map(int, main_cache.stride()[1:])) != (_MLA_RECORD_BYTES, 1):
+        if tuple(map(int, main_cache.stride()[1:])) != (record_bytes, 1):
             raise ValueError("GLM MLA cache records must be contiguous within a page")
 
         subpages_per_parent = block_size // (_POOL_SIZE * _INDEX_PAGE_SIZE)
         parent_stride_bytes = int(main_cache.stride(0))
-        semantic_page_bytes = block_size * _MLA_RECORD_BYTES
+        semantic_page_bytes = block_size * record_bytes
+        index_tail_offset_bytes = (
+            (semantic_page_bytes + _INDEX_PAGE_BYTES - 1) // _INDEX_PAGE_BYTES
+        ) * _INDEX_PAGE_BYTES
         index_tail_bytes = subpages_per_parent * _INDEX_PAGE_BYTES
-        if parent_stride_bytes < semantic_page_bytes + index_tail_bytes:
+        if parent_stride_bytes < index_tail_offset_bytes + index_tail_bytes:
             raise ValueError("GLM MLA cache page does not contain its FP8 index tail")
         if parent_stride_bytes % _INDEX_PAGE_BYTES:
             raise ValueError(
@@ -295,7 +297,7 @@ class Glm5NextPooledIndexer(nn.Module):
                 "GLM virtual C4 page IDs exceed the int32 page-table range"
             )
 
-        tail_offset = int(main_cache.storage_offset()) + semantic_page_bytes
+        tail_offset = int(main_cache.storage_offset()) + index_tail_offset_bytes
         tail_end = (
             tail_offset + max_virtual_page * _INDEX_PAGE_BYTES + _INDEX_PAGE_BYTES
         )

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -383,7 +383,17 @@ class Glm5NextPooledIndexer(nn.Module):
         num_prefills: int,
         num_decode_tokens: int,
     ) -> tuple[torch.Tensor, torch.Tensor] | None:
-        """Return the direct physical selection produced for pure decode."""
+        """Return the direct physical selection produced for pure decode.
+
+        Args:
+            num_tokens: Number of active token rows.
+            num_prefills: Number of prefill requests.
+            num_decode_tokens: Number of decode token rows.
+
+        Returns:
+            Physical selected slots and active counts, or ``None`` when direct
+            selection is unavailable for the current batch geometry.
+        """
         if (
             not self._emit_physical_selection
             or self.dcp_world_size != 1

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -261,7 +261,14 @@ class Glm5NextPooledIndexer(nn.Module):
 
     @staticmethod
     def _active_index_page_count(seq_len: int) -> int:
-        """Return FP8 C4 pages that can contain completed visible pools."""
+        """Return FP8 C4 pages that can contain completed visible pools.
+
+        Args:
+            seq_len: Visible sequence length in tokens.
+
+        Returns:
+            Number of index pages that may contain completed pools.
+        """
         completed_pools = seq_len // _POOL_SIZE
         return max(1, math.ceil(completed_pools / _INDEX_PAGE_SIZE))
 

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -6,6 +6,7 @@ import functools
 import os
 import platform
 import sys
+from dataclasses import replace
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -934,7 +935,16 @@ class Platform:
             cache_config.mamba_block_size = cache_config.block_size
 
         # Pad mamba page size to exactly match attention page size
-        attn_page_size = cache_config.block_size * attn_page_size_1_token
+        if model_config.use_mla and cache_config.cache_dtype == "nvfp4_ds_mla":
+            materialized_mla_spec = replace(
+                mla_spec, block_size=cache_config.block_size
+            )
+            with set_current_vllm_config(vllm_config):
+                attn_page_size = backend_cls.customize_spec(
+                    materialized_mla_spec
+                ).page_size_bytes
+        else:
+            attn_page_size = cache_config.block_size * attn_page_size_1_token
         assert attn_page_size >= mamba_page_size
 
         if attn_page_size == mamba_page_size:

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -800,13 +800,29 @@ class Platform:
 
         # Compute attention page size for 1 token
         if model_config.use_mla:
-            attn_page_size_1_token = MLAAttentionSpec(
+            mla_spec = MLAAttentionSpec(
                 block_size=1,
                 num_kv_heads=model_config.get_num_kv_heads(parallel_config),
                 head_size=model_config.get_head_size(),
                 dtype=kv_cache_dtype,
+                cache_dtype_str=cache_config.cache_dtype,
                 kv_quant_mode=kv_quant_mode,
-            ).page_size_bytes
+            )
+            # Most MLA cache formats are at least as large as the dense
+            # latent proxy above, so the materialized specs can safely pad
+            # Mamba up later. GLM5Next's packed NVFP4 record is smaller. Use
+            # the backend-published record width here so the manager chooses
+            # a large enough attention block before it fixes the Mamba page.
+            if cache_config.cache_dtype == "nvfp4_ds_mla":
+                with set_current_vllm_config(vllm_config):
+                    customized_mla_spec = backend_cls.customize_spec(mla_spec)
+                assert isinstance(customized_mla_spec, MLAAttentionSpec)
+                mla_spec = customized_mla_spec
+            # Hybrid sizing needs the unaligned per-token row. Page alignment
+            # is applied after the manager block size is known.
+            attn_page_size_1_token = (
+                mla_spec.state_content_size_bytes + mla_spec.page_tail_bytes_per_token
+            )
         elif cache_config.cache_dtype.startswith("turboquant_"):
             # TQ has a packed K|V layout; the standard FullAttentionSpec
             # formula over-sizes it and trips unify_kv_cache_spec_page_size

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -45,6 +45,7 @@ STR_DTYPE_TO_TORCH_DTYPE = {
     "fp8_per_token_head": torch.uint8,
     "fp8_inc": torch.float8_e4m3fn,
     "fp8_ds_mla": torch.uint8,
+    "nvfp4_ds_mla": torch.uint8,
     "turboquant_k8v4": torch.uint8,
     "turboquant_4bit_nc": torch.uint8,
     "turboquant_k3v4_nc": torch.uint8,

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -1154,6 +1154,12 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         if not module.is_supported():
             raise RuntimeError("B12X sparse MLA is not supported on this device.")
         required_symbols = ["Caps", "plan", "run_decode", "run_extend"]
+        if self._is_glm_next:
+            required_symbols.append(
+                "concat_and_cache_glm_next_mla_nvfp4"
+                if uses_nvfp4_cache
+                else "concat_and_cache_glm_next_mla_fp8"
+            )
         if self._uses_glm_dsa_nvfp4_cache:
             required_symbols.append("concat_and_cache_nvfp4_mla_fp8_rope")
         for name in required_symbols:
@@ -1165,7 +1171,11 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         self._concat_and_cache_glm_next_mla = None
         if self._is_glm_next:
             self._model_type = int(module.ModelType.GLM_NEXT)
-            self._concat_and_cache_glm_next_mla = module.concat_and_cache_glm_next_mla
+            self._concat_and_cache_glm_next_mla = (
+                module.concat_and_cache_glm_next_mla_nvfp4
+                if self._uses_nvfp4_cache
+                else module.concat_and_cache_glm_next_mla_fp8
+            )
         elif self._uses_glm_dsa_nvfp4_cache:
             self._model_type = int(module.ModelType.GLM_NSA)
             self._concat_and_cache_nvfp4_mla_fp8_rope = (
@@ -1245,6 +1255,11 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
             )
             if self._model_type is not None:
                 caps_kwargs["model_type"] = self._model_type
+            if self._uses_nvfp4_cache:
+                caps_kwargs.update(
+                    _nvfp4_run_options(is_glm_next=self._is_glm_next)
+                )
+            caps_kwargs["cache_record_bytes"] = self._cache_record_bytes
             return self._module.plan(self._module.Caps(**caps_kwargs))
 
         decode_plan = make_plan("decode")
@@ -1702,20 +1717,16 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
             selected_indices=selected_indices,
             cache_seqlens_int32=cache_seq_lens,
             nsa_cache_seqlens_int32=active_counts,
+            kv_cache=kv_cache_for_run,
         )
         run = self._run_decode if plan is self._decode_plan else self._run_extend
         run_kwargs = dict(
             binding=binding,
-            kv_cache=kv_cache_for_run,
             sm_scale=self.scale,
             v_head_dim=self.kv_lora_rank,
             return_lse=self.need_to_return_lse_for_decode,
             lse_scale="natural",
         )
-        if self._model_type is not None:
-            run_kwargs["model_type"] = self._model_type
-        if self._uses_nvfp4_cache:
-            run_kwargs.update(_nvfp4_run_options(is_glm_next=self._is_glm_next))
         result = run(**run_kwargs)
         if self.need_to_return_lse_for_decode:
             output, lse = result

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -262,7 +262,17 @@ def _global_causal_lens_for_ckv_gather(
     req_id_per_token: torch.Tensor,
     num_actual_tokens: int,
 ) -> torch.Tensor:
-    """Return each query token's causal length in the gathered global cache."""
+    """Compute each query token's causal length in the gathered global cache.
+
+    Args:
+        global_seq_lens: Global cache sequence length for each request.
+        query_start_loc: Start offset of each request's query chunk.
+        req_id_per_token: Request identifier for each query token.
+        num_actual_tokens: Number of active query tokens.
+
+    Returns:
+        Causal cache length for each active query token.
+    """
     num_reqs = global_seq_lens.shape[0]
     qsl = query_start_loc[: num_reqs + 1].to(torch.int32)
     req_ids = req_id_per_token[:num_actual_tokens].to(torch.int64)

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -151,12 +151,13 @@ def _is_glm_next_ckv_source_layout(
     kv_cache: torch.Tensor,
     *,
     page_size: int,
+    record_bytes: int,
 ) -> bool:
     return (
         kv_cache.dtype == torch.uint8
         and kv_cache.ndim == 3
-        and tuple(kv_cache.shape[1:]) == (page_size, _GLM_NEXT_CACHE_RECORD_BYTES)
-        and kv_cache.stride(1) == _GLM_NEXT_CACHE_RECORD_BYTES
+        and tuple(kv_cache.shape[1:]) == (page_size, record_bytes)
+        and kv_cache.stride(1) == record_bytes
         and kv_cache.stride(2) == 1
     )
 
@@ -1217,13 +1218,13 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         )
         ckv_specs = (
             (
-                (self._ckv_local_capacity, _GLM_NEXT_CACHE_RECORD_BYTES),
+                (self._ckv_local_capacity, self._cache_record_bytes),
                 torch.uint8,
             ),
             (
                 (
                     self.dcp_world_size * self._ckv_local_capacity,
-                    _GLM_NEXT_CACHE_RECORD_BYTES,
+                    self._cache_record_bytes,
                 ),
                 torch.uint8,
             ),
@@ -1378,19 +1379,22 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         if not self.uses_full_ckv_dcp(attn_metadata, attn_metadata.num_actual_tokens):
             raise RuntimeError("full CKV gather called for an ineligible batch")
         if not _is_glm_next_ckv_source_layout(
-            kv_cache, page_size=self._kernel_page_size
+            kv_cache,
+            page_size=self._kernel_page_size,
+            record_bytes=self._cache_record_bytes,
         ):
             raise ValueError(
-                "GLM5Next CKV gather requires native 528-byte records; "
+                "GLM5Next CKV gather requires native "
+                f"{self._cache_record_bytes}-byte records; "
                 f"got shape={tuple(kv_cache.shape)}, stride={kv_cache.stride()}"
             )
         expected_local_shape = (
             self._ckv_local_capacity,
-            _GLM_NEXT_CACHE_RECORD_BYTES,
+            self._cache_record_bytes,
         )
         expected_gathered_shape = (
             self.dcp_world_size * self._ckv_local_capacity,
-            _GLM_NEXT_CACHE_RECORD_BYTES,
+            self._cache_record_bytes,
         )
         if tuple(local_buffer.shape) != expected_local_shape:
             raise RuntimeError("CKV local workspace has an invalid shape")
@@ -1416,7 +1420,7 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
             gathered_buffer[: self.dcp_world_size * padded_tokens].view(-1),
         )
         return gathered_buffer.view(
-            -1, self._kernel_page_size, _GLM_NEXT_CACHE_RECORD_BYTES
+            -1, self._kernel_page_size, self._cache_record_bytes
         )
 
     def forward_mqa(

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -461,11 +461,8 @@ class B12xMLASparseBackend(AttentionBackend):
 
     @classmethod
     def supported_kv_cache_layouts(cls) -> tuple[KVCacheLayout, ...]:
-        # Sparse index caches share manager blocks with their MLA layer. Keep
-        # the layer dimension inside the manager's block so block copies and
-        # swaps carry both cache regions together. DeepSeek-V4's index backend
-        # already imposes the same constraint, so this preserves its layout.
-        return (KVCacheLayout.BLHNC,)
+        # The DSA kernels consume one layer-compact, token-major cache view.
+        return (KVCacheLayout.LBNHC,)
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
@@ -530,6 +527,13 @@ class B12xMLASparseBackend(AttentionBackend):
 
 
 class B12xGLM5NextMLASparseBackend(B12xMLASparseBackend):
+    @classmethod
+    def supported_kv_cache_layouts(cls) -> tuple[KVCacheLayout, ...]:
+        # GLM-Next's pooled index tail shares manager blocks with its MLA
+        # latent page. Keep the layer dimension inside the manager block so
+        # copies and swaps carry both cache regions together.
+        return (KVCacheLayout.BLHNC,)
+
     @staticmethod
     def get_builder_cls() -> type["B12xGLM5NextMLASparseMetadataBuilder"]:
         return B12xGLM5NextMLASparseMetadataBuilder

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -48,7 +48,9 @@ if TYPE_CHECKING:
 
 _GLM_NEXT_MODEL_TYPES = frozenset(("glm5_next", "glm5_next_text"))
 _GLM_NEXT_CACHE_RECORD_BYTES = 528
+_GLM_NEXT_NVFP4_CACHE_RECORD_BYTES = 304
 _GLM_NEXT_INDEX_TAIL_BYTES_PER_TOKEN = 132 // 4
+_GLM_NEXT_INDEX_PAGE_BYTES = 64 * 132
 
 
 def _is_glm_next_config(hf_config: object | None) -> bool:
@@ -146,6 +148,7 @@ class B12xMLASparseBackend(AttentionBackend):
         "fp8",
         "fp8_e4m3",
         "fp8_ds_mla",
+        "nvfp4_ds_mla",
     ]
 
     @staticmethod
@@ -178,9 +181,15 @@ class B12xMLASparseBackend(AttentionBackend):
                 "B12X GLM5Next sparse MLA requires head_size=512, got "
                 f"{spec.head_size}."
             )
+        record_bytes = (
+            _GLM_NEXT_NVFP4_CACHE_RECORD_BYTES
+            if spec.cache_dtype_str == "nvfp4_ds_mla"
+            else _GLM_NEXT_CACHE_RECORD_BYTES
+        )
         return replace(
             spec,
-            state_content_bytes=_GLM_NEXT_CACHE_RECORD_BYTES,
+            state_content_bytes=record_bytes,
+            alignment=_GLM_NEXT_INDEX_PAGE_BYTES,
             page_tail_bytes_per_token=_GLM_NEXT_INDEX_TAIL_BYTES_PER_TOKEN,
             model_version="glm5_next",
         )
@@ -244,6 +253,8 @@ class B12xMLASparseBackend(AttentionBackend):
                 if dcp_error := _glm_next_dcp_error(vllm_config):
                     return dcp_error
                 return None
+            if kv_cache_dtype == "nvfp4_ds_mla":
+                return "B12X nvfp4_ds_mla is supported only for GLM5Next"
             if head_size != 576:
                 return "B12X sparse MLA requires head_size=576"
             if int(getattr(hf_config, "kv_lora_rank", 0)) != 512:
@@ -657,11 +668,21 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
                 raise ValueError("B12X sparse MLA requires head_size=576.")
         if self.topk_indices_buffer is None:
             raise ValueError("B12X sparse MLA requires a top-k index buffer.")
-        if kv_cache_dtype != "fp8_ds_mla":
+        uses_nvfp4_cache = kv_cache_dtype == "nvfp4_ds_mla"
+        if kv_cache_dtype != "fp8_ds_mla" and not (
+            self._is_glm_next and uses_nvfp4_cache
+        ):
             raise ValueError(
-                "B12X sparse MLA requires the packed fp8_ds_mla KV cache; "
+                "B12X sparse MLA requires a packed fp8_ds_mla or "
+                "nvfp4_ds_mla KV cache; "
                 f"got kv_cache_dtype={kv_cache_dtype!r}."
             )
+        self._uses_nvfp4_cache = uses_nvfp4_cache
+        self._cache_record_bytes = (
+            _GLM_NEXT_NVFP4_CACHE_RECORD_BYTES
+            if self._uses_nvfp4_cache
+            else _GLM_NEXT_CACHE_RECORD_BYTES
+        )
 
         module = get_b12x_sparse_mla()
         if module is None:
@@ -789,10 +810,13 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
 
     def bind_kv_cache(self, kv_cache: torch.Tensor) -> None:
         if self._is_glm_next:
-            if kv_cache.ndim != 3 or int(kv_cache.shape[-1]) != 528:
+            if (
+                kv_cache.ndim != 3
+                or int(kv_cache.shape[-1]) != self._cache_record_bytes
+            ):
                 raise ValueError(
                     "B12X GLM5Next cache must have shape "
-                    "[pages, page_size, 528], got "
+                    f"[pages, page_size, {self._cache_record_bytes}], got "
                     f"shape={tuple(kv_cache.shape)}, stride={kv_cache.stride()}, "
                     f"dtype={kv_cache.dtype}"
                 )
@@ -931,6 +955,12 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         )
         if self._model_type is not None:
             run_kwargs["model_type"] = self._model_type
+        if self._uses_nvfp4_cache:
+            run_kwargs.update(
+                scale_format=2,
+                fp8_rope=False,
+                latent_scale_per_token=True,
+            )
         result = run(**run_kwargs)
         if self.need_to_return_lse_for_decode:
             output, lse = result

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -51,16 +51,22 @@ if TYPE_CHECKING:
 
 
 _GLM_NEXT_MODEL_TYPES = frozenset(("glm5_next", "glm5_next_text"))
+_GLM_DSA_MODEL_TYPES = frozenset(("glm_moe_dsa",))
 _GLM_NEXT_CACHE_RECORD_BYTES = 528
 _GLM_NEXT_NVFP4_CACHE_RECORD_BYTES = 304
 _GLM_NEXT_INDEX_TAIL_BYTES_PER_TOKEN = 132 // 4
 _GLM_NEXT_INDEX_PAGE_BYTES = 64 * 132
+_GLM_DSA_NVFP4_CACHE_RECORD_BYTES = 368
 
 logger = init_logger(__name__)
 
 
 def _is_glm_next_config(hf_config: object | None) -> bool:
     return getattr(hf_config, "model_type", None) in _GLM_NEXT_MODEL_TYPES
+
+
+def _is_glm_dsa_config(hf_config: object | None) -> bool:
+    return getattr(hf_config, "model_type", None) in _GLM_DSA_MODEL_TYPES
 
 
 def _current_hf_text_config() -> object | None:
@@ -75,6 +81,25 @@ def _is_glm_next_spec(spec: AttentionSpec) -> bool:
         return True
     hf_config = _current_hf_text_config()
     return hf_config is not None and _is_glm_next_config(hf_config)
+
+
+def _is_glm_dsa_spec(spec: AttentionSpec) -> bool:
+    if isinstance(spec, MLAAttentionSpec) and spec.model_version == "glm_moe_dsa":
+        return True
+    hf_config = _current_hf_text_config()
+    return hf_config is not None and _is_glm_dsa_config(hf_config)
+
+
+def _nvfp4_run_options(*, is_glm_next: bool) -> dict[str, bool | int]:
+    if is_glm_next:
+        # GLM5Next has no RoPE payload and stores one latent scale per token.
+        return {
+            "scale_format": 2,
+            "fp8_rope": False,
+            "latent_scale_per_token": True,
+        }
+    # GLM-5.2/5.3 DSA stores its 64-dimensional RoPE tail as E4M3.
+    return {"scale_format": 2, "fp8_rope": True}
 
 
 def _glm_next_recipe_error(hf_config: object) -> str | None:
@@ -434,12 +459,27 @@ class B12xMLASparseBackend(AttentionBackend):
 
     @classmethod
     def customize_spec(cls, spec: AttentionSpec) -> AttentionSpec:
-        if not _is_glm_next_spec(spec):
+        is_glm_next = _is_glm_next_spec(spec)
+        is_glm_dsa_nvfp4 = isinstance(spec, MLAAttentionSpec) and (
+            spec.cache_dtype_str == "nvfp4_ds_mla" and _is_glm_dsa_spec(spec)
+        )
+        if not is_glm_next and not is_glm_dsa_nvfp4:
             return spec
         if not isinstance(spec, MLAAttentionSpec):
             raise TypeError(
-                "B12X GLM5Next sparse MLA requires an MLAAttentionSpec, got "
+                "B12X GLM sparse MLA requires an MLAAttentionSpec, got "
                 f"{type(spec).__name__}."
+            )
+        if is_glm_dsa_nvfp4:
+            if spec.head_size != 576:
+                raise ValueError(
+                    "B12X GLM DSA NVFP4 sparse MLA requires head_size=576, got "
+                    f"{spec.head_size}."
+                )
+            return replace(
+                spec,
+                state_content_bytes=_GLM_DSA_NVFP4_CACHE_RECORD_BYTES,
+                model_version="glm_moe_dsa",
             )
         if spec.head_size != 512:
             raise ValueError(
@@ -515,8 +555,11 @@ class B12xMLASparseBackend(AttentionBackend):
                 if dcp_error := _glm_next_dcp_error(vllm_config):
                     return dcp_error
                 return None
-            if kv_cache_dtype == "nvfp4_ds_mla":
-                return "B12X nvfp4_ds_mla is supported only for GLM5Next"
+            if kv_cache_dtype == "nvfp4_ds_mla" and not _is_glm_dsa_config(hf_config):
+                return (
+                    "B12X nvfp4_ds_mla requires GLM5Next or the "
+                    "GLM-5.2/5.3 DSA architecture"
+                )
             if head_size != 576:
                 return "B12X sparse MLA requires head_size=576"
             if int(getattr(hf_config, "kv_lora_rank", 0)) != 512:
@@ -524,6 +567,17 @@ class B12xMLASparseBackend(AttentionBackend):
             if int(getattr(hf_config, "qk_rope_head_dim", 0)) != 64:
                 return "B12X sparse MLA requires qk_rope_head_dim=64"
         return None
+
+
+class B12xGLMDSAMLASparseBackend(B12xMLASparseBackend):
+    @classmethod
+    def customize_spec(cls, spec: AttentionSpec) -> AttentionSpec:
+        if not isinstance(spec, MLAAttentionSpec):
+            raise TypeError(
+                "B12X GLM DSA sparse MLA requires an MLAAttentionSpec, got "
+                f"{type(spec).__name__}."
+            )
+        return super().customize_spec(replace(spec, model_version="glm_moe_dsa"))
 
 
 class B12xGLM5NextMLASparseBackend(B12xMLASparseBackend):
@@ -1038,6 +1092,7 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         vllm_config = get_current_vllm_config()
         hf_config = vllm_config.model_config.hf_text_config
         self._is_glm_next = _is_glm_next_config(hf_config)
+        self._is_glm_dsa = _is_glm_dsa_config(hf_config)
         self.supports_mtp_with_cp_non_trivial_interleave_size = self._is_glm_next
         if self._is_glm_next:
             if recipe_error := _glm_next_recipe_error(hf_config):
@@ -1056,35 +1111,51 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         if self.topk_indices_buffer is None:
             raise ValueError("B12X sparse MLA requires a top-k index buffer.")
         uses_nvfp4_cache = kv_cache_dtype == "nvfp4_ds_mla"
-        if kv_cache_dtype != "fp8_ds_mla" and not (
-            self._is_glm_next and uses_nvfp4_cache
+        self._uses_glm_dsa_nvfp4_cache = self._is_glm_dsa and uses_nvfp4_cache
+        if uses_nvfp4_cache and not (
+            self._is_glm_next or self._uses_glm_dsa_nvfp4_cache
         ):
+            raise ValueError(
+                "B12X nvfp4_ds_mla requires GLM5Next or the "
+                "GLM-5.2/5.3 DSA architecture."
+            )
+        if kv_cache_dtype not in ("fp8_ds_mla", "nvfp4_ds_mla"):
             raise ValueError(
                 "B12X sparse MLA requires a packed fp8_ds_mla or "
                 "nvfp4_ds_mla KV cache; "
                 f"got kv_cache_dtype={kv_cache_dtype!r}."
             )
         self._uses_nvfp4_cache = uses_nvfp4_cache
-        self._cache_record_bytes = (
-            _GLM_NEXT_NVFP4_CACHE_RECORD_BYTES
-            if self._uses_nvfp4_cache
-            else _GLM_NEXT_CACHE_RECORD_BYTES
-        )
+        if self._is_glm_next and self._uses_nvfp4_cache:
+            self._cache_record_bytes = _GLM_NEXT_NVFP4_CACHE_RECORD_BYTES
+        elif self._uses_glm_dsa_nvfp4_cache:
+            self._cache_record_bytes = _GLM_DSA_NVFP4_CACHE_RECORD_BYTES
+        else:
+            self._cache_record_bytes = _GLM_NEXT_CACHE_RECORD_BYTES
 
         module = get_b12x_sparse_mla()
         if module is None:
             raise RuntimeError("B12X sparse MLA requires `pip install vllm[b12x]`.")
         if not module.is_supported():
             raise RuntimeError("B12X sparse MLA is not supported on this device.")
-        for name in ("Caps", "plan", "run_decode", "run_extend"):
+        required_symbols = ["Caps", "plan", "run_decode", "run_extend"]
+        if self._uses_glm_dsa_nvfp4_cache:
+            required_symbols.append("concat_and_cache_nvfp4_mla_fp8_rope")
+        for name in required_symbols:
             getattr(module, name)
         self._run_decode = module.run_decode
         self._run_extend = module.run_extend
         self._model_type: int | None = None
+        self._concat_and_cache_nvfp4_mla_fp8_rope = None
         self._concat_and_cache_glm_next_mla = None
         if self._is_glm_next:
             self._model_type = int(module.ModelType.GLM_NEXT)
             self._concat_and_cache_glm_next_mla = module.concat_and_cache_glm_next_mla
+        elif self._uses_glm_dsa_nvfp4_cache:
+            self._model_type = int(module.ModelType.GLM_NSA)
+            self._concat_and_cache_nvfp4_mla_fp8_rope = (
+                module.concat_and_cache_nvfp4_mla_fp8_rope
+            )
 
         scheduler_config = vllm_config.scheduler_config
         max_tokens = int(scheduler_config.max_num_batched_tokens)
@@ -1295,6 +1366,17 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         self._kernel_page_size_finalized = True
 
     def bind_kv_cache(self, kv_cache: torch.Tensor) -> None:
+        if getattr(self, "_uses_glm_dsa_nvfp4_cache", False) and (
+            kv_cache.ndim != 3
+            or int(kv_cache.shape[-1]) != _GLM_DSA_NVFP4_CACHE_RECORD_BYTES
+            or kv_cache.dtype != torch.uint8
+        ):
+            raise ValueError(
+                "B12X GLM DSA NVFP4 cache must have shape "
+                f"[pages, page_size, {_GLM_DSA_NVFP4_CACHE_RECORD_BYTES}] "
+                "uint8, got "
+                f"shape={tuple(kv_cache.shape)}, dtype={kv_cache.dtype}."
+            )
         if self._is_glm_next:
             if (
                 kv_cache.ndim != 3
@@ -1330,6 +1412,18 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         kv_cache_dtype: str,
         k_scale: torch.Tensor,
     ) -> None:
+        if getattr(self, "_uses_glm_dsa_nvfp4_cache", False):
+            if kv_cache.numel() == 0:
+                return
+            assert self._concat_and_cache_nvfp4_mla_fp8_rope is not None
+            self._concat_and_cache_nvfp4_mla_fp8_rope(
+                kv_c_normed,
+                k_pe.squeeze(1),
+                kv_cache,
+                slot_mapping.flatten(),
+                k_scale,
+            )
+            return
         if not self._is_glm_next:
             return super().do_kv_cache_update(
                 kv_c_normed,
@@ -1592,11 +1686,7 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         if self._model_type is not None:
             run_kwargs["model_type"] = self._model_type
         if self._uses_nvfp4_cache:
-            run_kwargs.update(
-                scale_format=2,
-                fp8_rope=False,
-                latent_scale_per_token=True,
-            )
+            run_kwargs.update(_nvfp4_run_options(is_glm_next=self._is_glm_next))
         result = run(**run_kwargs)
         if self.need_to_return_lse_for_decode:
             output, lse = result


### PR DESCRIPTION
## Summary

Enable B12X `nvfp4_ds_mla` KV-cache storage for both GLM sparse-attention
families:

- GLM5Next / GLM-5.3-Flash uses its 304-byte latent record, no RoPE payload,
  per-token latent scales, and a 33-byte/token pooled-index tail;
- the shared GLM-5.2/GLM-5.3 non-Flash DSA architecture uses a 368-byte record
  containing a 512-element NVFP4 latent with E4M3 scales and a 64-byte E4M3
  RoPE payload.

The non-Flash adapter is selected explicitly from `model_type=glm_moe_dsa`.
It uses B12X `ModelType.GLM_NSA`, scale format 2, `fp8_rope=True`, and the
public `concat_and_cache_nvfp4_mla_fp8_rope` writer. GLM5Next retains its
independent ABI and pooled-index behavior. Unrelated 576-wide sparse-MLA models
remain rejected; dimensions alone do not opt a model into either ABI.

Packed records stay `uint8` through forward, cache update, hybrid-page sizing,
and DCP workspace/gather paths. Ordinary FP8 still receives its native FP8
view. Cache ABI is determined by model family and cache dtype, not an
environment variable.

## Duplicate-work check

No other open Jovian PR adds the non-Flash GLM DSA record. PR #301 contains
older Infernal Invocation GLM-5.2 prior art but is not based on Jovian and does
not provide this B12X 1.3 architecture-scoped adapter. This PR remains the
existing GLM5Next NVFP4 work and is expanded here because the core packed-cache
plumbing is shared.

## Dependency

- B12X PR #266 provides the required runtime API.
- #559 provides the generic DSA versus GLM5Next cache-layout split. The
  equivalent commit is included in this qualified branch so the stacked
  configuration is testable. Once #559 lands, its visible diff drops from this
  PR.

## Component validation

- GLM5Next sparse B12X MLA API and pooled-indexer suites: 51 passed, 11
  expected skips for the original Flash scope.
- Focused packed/NVFP4 cache-contract regressions for the combined scope: 16
  passed; GLM5Next model regression module: 49 passed.
- All three non-Flash adapter files pass Ruff after merging
  `dev/jovian-judgement` at `9c4dd0548`; `git diff --check` passes.
- The merge conflict with the new upstream physical-selection provider was
  resolved by retaining both that provider and the GLM DSA/NVFP4 state. No
  force-push is required.

## Full-system validation

Original GLM5Next qualification on four RTX PRO 6000 Blackwell GPUs completed
FULL CUDA graph capture, correctness, text/vision, prefix caching, throughput,
and KLD sampling. NVFP4 exposed 9,455,057 usable KV tokens versus 7,533,909 for
matched FP8 (+25.5%) at the same physical allocation.

The exact non-Flash stack was booted on cn3 with TP4/DCP4, EXL3, B12X,
`nvfp4_ds_mla`, and `KV_FP8_ROPE=0`. Both 295 GB target and MTP traversals and
native Trellis preparation completed, and execution reached the packed
NVFP4/DCP4 CUDA-graph path. Qualification exposed and fixed packed-cache FP8
reinterpretation and missing non-PCP DCP query gather. The latter is submitted
separately as #560.

The qualified r21 non-Flash service returned the expected answer (`42`) and
sustained `61.044849 tok/s`. A further full 295 GB reload was not repeated
after the final narrow DCP correction; focused regressions cover that path.

## Image integration note

Image launchers should expose one `KV_CACHE_DTYPE` value and emit one CLI
argument. This source PR does not change a published image entrypoint.

## AI assistance

OpenAI Codex assisted with implementation, porting, test construction, and
review. The submitter reviewed the resulting diff and qualification evidence;
commits include DCO sign-off and assistance/co-author trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `nvfp4_ds_mla` packed-cache support for GLM5Next and GLM DSA sparse MLA models.
  * Enabled model-specific cache layouts, record sizes, runtime updates, and distributed execution.
  * Added configuration and runtime support for selecting the new cache dtype.

* **Bug Fixes**
  * Improved hybrid attention cache sizing, page alignment, and packed-cache handling.
  * Enabled supported NVFP4 cache and MLA combinations.

* **Tests**
  * Expanded coverage for cache sizing, binding, alignment, metadata, workspace handling, distributed execution, and runtime validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->