### PR TITLE
perf(router): enable ll_bf16 on SM120 with FP32 guard

### DIFF
--- a/tests/kernels/test_gate_linear_rocm_dispatch.py
+++ b/tests/kernels/test_gate_linear_rocm_dispatch.py
@@ -26,6 +26,7 @@ def _make_gate(
     bias: bool = False,
     params_dtype: torch.dtype = torch.bfloat16,
     out_dtype: torch.dtype | None = torch.float32,
+    force_fp32_compute: bool = False,
 ) -> GateLinear:
     """Build a GateLinear with platform predicates mocked, no GPU needed."""
     for target in (
@@ -62,6 +63,7 @@ def _make_gate(
         bias=bias,
         out_dtype=out_dtype,
         params_dtype=params_dtype,
+        force_fp32_compute=force_fp32_compute,
     )
 
 
@@ -129,6 +131,19 @@ def test_sm120_ll_bf16_respects_bias(monkeypatch):
         bias=True,
     )
 
+    assert not gate.allow_ll_bf16_gemm
+
+
+def test_sm120_force_fp32_compute_preserves_fp32_weight_contract(monkeypatch):
+    gate = _make_gate(
+        monkeypatch,
+        is_rocm=False,
+        is_cuda=True,
+        device_capability=(12, 0),
+        force_fp32_compute=True,
+    )
+
+    assert gate.weight.dtype == torch.float32
     assert not gate.allow_ll_bf16_gemm
 
 

--- a/tests/kernels/test_gate_linear_rocm_dispatch.py
+++ b/tests/kernels/test_gate_linear_rocm_dispatch.py
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Platform-agnostic eligibility tests for GateLinear's fused router GEMM.
+"""Platform-agnostic eligibility tests for GateLinear router GEMMs.
 
 These assert the ``allow_cublas_router_gemm`` dispatch flag directly, so they
 run device-free by mocking the platform predicates. The flag decides whether
 the bf16xbf16->fp32 router GEMM uses ``torch.mm``'s fused out_dtype epilogue
 (one kernel) or falls back to a bf16 matmul plus a standalone bf16->fp32 copy.
 
-The ROCm branch is guarded on ``not bias`` because ``torch.mm`` has no bias
-term; a biased gate must fall back so the bias is not silently dropped.
+ROCm's fused ``torch.mm`` branch and SM120's CuTe branch are both guarded on
+``not bias`` so a biased gate cannot silently drop its bias term.
 """
 
 import torch
@@ -22,6 +22,7 @@ def _make_gate(
     *,
     is_rocm: bool,
     is_cuda: bool = False,
+    device_capability: tuple[int, int] | None = None,
     bias: bool = False,
     params_dtype: torch.dtype = torch.bfloat16,
     out_dtype: torch.dtype | None = torch.float32,
@@ -43,10 +44,17 @@ def _make_gate(
     platform = gate_linear_mod.current_platform
     monkeypatch.setattr(platform, "is_cuda", lambda: is_cuda)
     monkeypatch.setattr(platform, "is_rocm", lambda: is_rocm)
-    # Force the CUDA specialized-kernel gate off so ROCm eligibility is the
-    # only thing under test (these are the SM90/SM100 capability checks).
-    monkeypatch.setattr(platform, "is_device_capability", lambda *a, **k: False)
+    monkeypatch.setattr(
+        platform,
+        "is_device_capability",
+        lambda capability: capability == device_capability,
+    )
     monkeypatch.setattr(platform, "is_device_capability_family", lambda *a, **k: False)
+    if is_cuda and device_capability == (12, 0):
+        monkeypatch.setattr(
+            "vllm.model_executor.kernels.linear.cute_dsl.ll_bf16.is_available",
+            lambda: True,
+        )
 
     return GateLinear(
         input_size=2048,
@@ -96,3 +104,43 @@ def test_rocm_set_out_dtype_respects_bias_guard(monkeypatch):
     gate = _make_gate(monkeypatch, is_rocm=True, bias=True, out_dtype=None)
     gate.set_out_dtype(torch.float32)
     assert not gate.allow_cublas_router_gemm
+
+
+def test_sm120_enables_only_ll_bf16_router(monkeypatch):
+    gate = _make_gate(
+        monkeypatch,
+        is_rocm=False,
+        is_cuda=True,
+        device_capability=(12, 0),
+    )
+
+    assert gate.allow_ll_bf16_gemm
+    assert not gate.allow_specialized_router_gemm
+    assert not gate.allow_dsv3_router_gemm
+    assert not gate.allow_cublas_router_gemm
+
+
+def test_sm120_ll_bf16_respects_bias(monkeypatch):
+    gate = _make_gate(
+        monkeypatch,
+        is_rocm=False,
+        is_cuda=True,
+        device_capability=(12, 0),
+        bias=True,
+    )
+
+    assert not gate.allow_ll_bf16_gemm
+
+
+def test_sm120_set_out_dtype_enables_ll_bf16(monkeypatch):
+    gate = _make_gate(
+        monkeypatch,
+        is_rocm=False,
+        is_cuda=True,
+        device_capability=(12, 0),
+        out_dtype=None,
+    )
+
+    assert not gate.allow_ll_bf16_gemm
+    gate.set_out_dtype(torch.float32)
+    assert gate.allow_ll_bf16_gemm

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -58,8 +58,14 @@ class GateLinear(ReplicatedLinear):
     ):
         is_hopper = current_platform.is_device_capability((9, 0))
         is_blackwell = current_platform.is_device_capability_family(100)
+        is_blackwell_rtx = current_platform.is_device_capability((12, 0))
         can_use_specialized_kernels = (
             current_platform.is_cuda() and (is_hopper or is_blackwell) and not bias
+        )
+        self._can_use_ll_bf16 = (
+            current_platform.is_cuda()
+            and (is_hopper or is_blackwell or is_blackwell_rtx)
+            and not bias
         )
 
         # If fp32 compute is required and no specialized kernel is available,
@@ -133,7 +139,7 @@ class GateLinear(ReplicatedLinear):
         # 1. PDL support. Both dot-product and split-K kernels.
         # 2. Thread Block Clusters. Split-K kernel for cross-CTA reduction.
         self.allow_ll_bf16_gemm = False
-        if can_use_specialized_kernels:
+        if self._can_use_ll_bf16:
             from vllm.model_executor.kernels.linear.cute_dsl.ll_bf16 import (
                 is_available,
             )
@@ -165,7 +171,7 @@ class GateLinear(ReplicatedLinear):
             self.allow_cublas_router_gemm = self.weight.dtype == torch.bfloat16
 
         # out_dtype may start as None -> recompute eligibility here
-        if self.allow_specialized_router_gemm:
+        if self._can_use_ll_bf16:
             from vllm.model_executor.kernels.linear.cute_dsl.ll_bf16 import (
                 is_available,
             )


### PR DESCRIPTION
## Purpose

Use the existing low-latency BF16 router GEMM for its supported SM120 shape
without weakening callers that require FP32 computation.

## Behavior

- Permit `ll_bf16` on exact SM120 devices for bias-free BF16 router inputs with
  at most 16 rows.
- Keep the DSV3, FP32, BF16x3, and cuBLAS architecture gates unchanged.
- Preserve FP32 weights and the existing route when
  `force_fp32_compute=True`.
- Cover both initial and deferred output-dtype selection.

## Replacement scope and attribution

This pull request replaces #543. It ports MadeBy561's implementation commit
directly onto `dev/jovian-judgement` and adds the missing regression test for
the forced-FP32 contract.

MadeBy561 remains the author of the implementation commit, including the
original OpenAI Codex co-author trailer. Martin Vít authored only the additional
contract test.

The duplicate-work search found #543 as the only local pull request implementing
this exact SM120 router dispatch. This pull request replaces that branch with
the qualified implementation plus its required compatibility test.

## Validation

Status: **qualified as part of the GLM-5.3 TP4 runtime stack**.

- Device-free dispatch tests cover SM120 eligibility, bias rejection, deferred
  output selection, and forced-FP32 exclusion.
- An independent-merge simulation with the other GLM-5.3 runtime pull requests
  completes without conflicts and matches the qualified container's vLLM
  runtime source.
- The combined device-free vLLM suite reports 75 passed and 35 skipped.
- Ruff and `git diff --check` pass for the complete vLLM pull-request stack.
- The qualified container passed no-speculation, three-token multi-token
  prediction, and seven-token DFlash2 serving at tensor parallelism four and
  decode context parallelism one without a decode or 32k-prefill regression.

## AI assistance

OpenAI Codex assisted with port construction, compatibility analysis, and
validation. Martin Vít directed the port, reviewed its intended behavior and
evidence, and remains responsible for the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fused gate linear operations on Blackwell RTX hardware.
  * Added support for eligible BF16 matrix multiplication paths on CUDA capability 12.0 devices.
  * Preserved safeguards for bias usage and FP32 computation requirements.
  * Expanded validation coverage for output dtype configuration and hardware-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->