### PR TITLE
fix(kv): allow engine-driven expandable segments

### DIFF
--- a/tests/v1/kv_connector/unit/test_config.py
+++ b/tests/v1/kv_connector/unit/test_config.py
@@ -101,6 +101,7 @@ def test_kv_connector(
 def _build_config(
     *,
     kv_connector: str | None,
+    kv_connector_extra_config: dict | None = None,
     enable_sleep_mode: bool = False,
     enable_cumem_allocator: bool = False,
 ) -> VllmConfig:
@@ -109,7 +110,11 @@ def _build_config(
     from types import SimpleNamespace
 
     kv_transfer_config = (
-        KVTransferConfig(kv_connector=kv_connector, kv_role="kv_both")
+        KVTransferConfig(
+            kv_connector=kv_connector,
+            kv_role="kv_both",
+            kv_connector_extra_config=kv_connector_extra_config or {},
+        )
         if kv_connector is not None
         else None
     )
@@ -135,6 +140,33 @@ def test_kv_connector_rejects_expandable_segments(monkeypatch, kv_connector):
     monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
     with pytest.raises(ValueError, match="expandable_segments"):
         _build_config(kv_connector=kv_connector)
+
+
+def test_lmcache_mp_engine_driven_allows_expandable_segments(monkeypatch):
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    _build_config(
+        kv_connector="LMCacheMPConnector",
+        kv_connector_extra_config={
+            "lmcache.mp.mp_transfer_mode": "engine_driven",
+        },
+    )
+
+
+@pytest.mark.parametrize("transfer_mode", [None, "auto", "lmcache_driven"])
+def test_lmcache_mp_non_engine_driven_rejects_expandable_segments(
+    monkeypatch, transfer_mode
+):
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    extra_config = (
+        {}
+        if transfer_mode is None
+        else {"lmcache.mp.mp_transfer_mode": transfer_mode}
+    )
+    with pytest.raises(ValueError, match="expandable_segments"):
+        _build_config(
+            kv_connector="LMCacheMPConnector",
+            kv_connector_extra_config=extra_config,
+        )
 
 
 def test_kv_connector_allows_expandable_segments_with_sleep_mode(monkeypatch):

--- a/tests/v1/kv_connector/unit/test_config.py
+++ b/tests/v1/kv_connector/unit/test_config.py
@@ -105,8 +105,20 @@ def _build_config(
     enable_sleep_mode: bool = False,
     enable_cumem_allocator: bool = False,
 ) -> VllmConfig:
-    """Build a VllmConfig that exercises _verify_kv_transfer_compat without
-    requiring a real model (avoids HF downloads in CI)."""
+    """Build a model-free config for KV-transfer compatibility checks.
+
+    Args:
+        kv_connector: KV connector name, or None to disable KV transfer.
+        kv_connector_extra_config: Optional connector-specific configuration.
+        enable_sleep_mode: Whether sleep mode is enabled.
+        enable_cumem_allocator: Whether the cuMem allocator is enabled.
+
+    Returns:
+        A VllmConfig suitable for exercising KV-transfer compatibility checks.
+
+    Raises:
+        ValueError: If the requested KV-transfer configuration is incompatible.
+    """
     from types import SimpleNamespace
 
     kv_transfer_config = (
@@ -158,9 +170,7 @@ def test_lmcache_mp_non_engine_driven_rejects_expandable_segments(
 ):
     monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
     extra_config = (
-        {}
-        if transfer_mode is None
-        else {"lmcache.mp.mp_transfer_mode": transfer_mode}
+        {} if transfer_mode is None else {"lmcache.mp.mp_transfer_mode": transfer_mode}
     )
     with pytest.raises(ValueError, match="expandable_segments"):
         _build_config(

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1071,6 +1071,17 @@ class VllmConfig:
         if self.model_config is not None and (self.model_config.enable_cumem_allocator):
             return
 
+        # Engine-driven LMCache MP transport does not pin or register KV
+        # addresses; GPU gather/scatter remains in the vLLM worker.
+        if (
+            self.kv_transfer_config.kv_connector == "LMCacheMPConnector"
+            and self.kv_transfer_config.kv_connector_extra_config.get(
+                "lmcache.mp.mp_transfer_mode"
+            )
+            == "engine_driven"
+        ):
+            return
+
         raise ValueError(
             f"KV connector {self.kv_transfer_config.kv_connector} is "
             "incompatible with PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True "


### PR DESCRIPTION
## Summary

Make the expandable-segments validator transfer-mode aware for LMCache MP.

- `lmcache_driven` still requires the shareable cuMem allocator
- `engine_driven` remains valid with PyTorch expandable segments because vLLM workers own gather/scatter
- forced/auto mode behavior remains fail-closed

## Tests

- focused validator regression coverage added
- Ruff/py_compile/diff checks passed in the qualified source lineage
- exercised in the final GLM-5.3 MTP3 TP4/DCP4 1M deployment

## Duplicate-work note

No open Jovian Judgement PR isolates this validator behavior. This is intentionally separate from the cuMem transport PR.

## AI assistance disclosure

AI assistance was used in preparing this contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enabled compatibility between `expandable_segments:True` and the LMCache KV connector when using engine-driven transfer mode.
  - Continued validation for unsupported or unspecified transfer modes, which still report configuration errors.
  - Added test coverage to verify accepted and rejected configuration combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
