### PR TITLE
fix(executor): gracefully stop multiprocess workers

### DIFF
--- a/tests/v1/executor/test_multiproc_executor.py
+++ b/tests/v1/executor/test_multiproc_executor.py
@@ -4,10 +4,12 @@
 import weakref
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 
-from vllm.v1.executor.multiproc_executor import WorkerProc
+import vllm.envs as envs
+from vllm.v1.executor.multiproc_executor import MultiprocExecutor, WorkerProc
 
 
 class _ExitWorkerLoop(RuntimeError):
@@ -65,3 +67,99 @@ def test_execute_worker_rpc_returns_worker_exception():
     assert len(outputs) == 1
     assert isinstance(outputs[0], RuntimeError)
     assert str(outputs[0]) == "test error"
+
+
+def _make_executor_for_shutdown(
+    events: list[str], rpc_error: Exception | None = None
+) -> tuple[MultiprocExecutor, Mock]:
+    executor: Any = MultiprocExecutor.__new__(MultiprocExecutor)
+    executor.shutting_down = False
+    executor._workers_initialized = True
+
+    death_writer = SimpleNamespace(close=lambda: events.append("close_writer"))
+    worker = SimpleNamespace(
+        death_writer=death_writer,
+        proc=object(),
+        worker_response_mq=None,
+    )
+    executor.workers = [worker]
+    executor.rpc_broadcast_mq = SimpleNamespace(
+        shutdown=lambda: events.append("close_rpc_queue")
+    )
+    executor.response_mqs = [
+        SimpleNamespace(shutdown=lambda: events.append("close_response_queue"))
+    ]
+    executor.futures_queue = []
+
+    def collective_rpc(*args, **kwargs):
+        events.append("worker_shutdown")
+        if rpc_error is not None:
+            raise rpc_error
+
+    collective_rpc_mock = Mock(side_effect=collective_rpc)
+    executor.collective_rpc = collective_rpc_mock
+    executor._ensure_worker_termination = lambda procs: events.append(
+        "terminate_workers"
+    )
+    return executor, collective_rpc_mock
+
+
+def test_shutdown_stops_workers_before_closing_death_writers() -> None:
+    events: list[str] = []
+    executor, collective_rpc = _make_executor_for_shutdown(events)
+
+    executor.shutdown()
+
+    collective_rpc.assert_called_once_with(
+        "shutdown", timeout=envs.VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS
+    )
+    assert events[:3] == [
+        "worker_shutdown",
+        "close_writer",
+        "terminate_workers",
+    ]
+
+    executor.shutdown()
+    collective_rpc.assert_called_once()
+
+
+def test_shutdown_rpc_failure_still_forces_worker_cleanup(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    events: list[str] = []
+    executor, collective_rpc = _make_executor_for_shutdown(
+        events, rpc_error=TimeoutError("worker shutdown timed out")
+    )
+
+    executor.shutdown()
+
+    collective_rpc.assert_called_once()
+    assert events[:3] == [
+        "worker_shutdown",
+        "close_writer",
+        "terminate_workers",
+    ]
+    assert "failed to shut down workers gracefully" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("workers_initialized", "rpc_queue_available", "response_queues_available"),
+    [(False, True, True), (True, False, True), (True, True, False)],
+)
+def test_shutdown_skips_worker_rpc_until_queues_are_ready(
+    workers_initialized: bool,
+    rpc_queue_available: bool,
+    response_queues_available: bool,
+) -> None:
+    events: list[str] = []
+    executor, collective_rpc = _make_executor_for_shutdown(events)
+    executor._workers_initialized = workers_initialized
+    if not rpc_queue_available:
+        executor.rpc_broadcast_mq = None
+    if not response_queues_available:
+        executor.response_mqs = None
+
+    executor.shutdown()
+
+    collective_rpc.assert_not_called()
+    assert events[:2] == ["close_writer", "terminate_workers"]

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -118,6 +118,7 @@ class MultiprocExecutor(Executor):
     def _init_executor(self) -> None:
         # Call self.shutdown at exit to clean up
         # and ensure workers will be terminated.
+        self._workers_initialized = False
         self._finalizer = weakref.finalize(self, self.shutdown)
         self.is_failed = False
         self.failure_callback: FailureCallback | None = None
@@ -264,6 +265,7 @@ class MultiprocExecutor(Executor):
                 self._ensure_worker_termination([uw.proc for uw in unready_workers])
 
         self.output_rank = self._get_output_rank()
+        self._workers_initialized = True
 
     def get_response_mqs(self, unique_reply_rank: int = -1) -> list[MessageQueue]:
         assert unique_reply_rank >= -1 and unique_reply_rank < self.world_size, (
@@ -511,6 +513,23 @@ class MultiprocExecutor(Executor):
 
             # Make sure all the worker processes are terminated first.
             if workers := getattr(self, "workers", None):
+                if (
+                    getattr(self, "_workers_initialized", False)
+                    and getattr(self, "rpc_broadcast_mq", None) is not None
+                    and getattr(self, "response_mqs", None) is not None
+                    and getattr(self, "futures_queue", None) is not None
+                ):
+                    try:
+                        self.collective_rpc(
+                            "shutdown",
+                            timeout=envs.VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "[shutdown] Executor: failed to shut down workers "
+                            "gracefully"
+                        )
+
                 for w in workers:
                     # Close death_writer to signal child processes to exit
                     if w.death_writer is not None:


### PR DESCRIPTION
## Summary

Run each worker shutdown RPC before closing multiprocess death pipes and queues.

This lets KV connectors unregister imported cuMem mappings before worker teardown while preserving the existing forced cleanup fallback.

- guarded against partially initialized executors/queues
- idempotent shutdown
- timeout/failure logs and continues forced cleanup
- collective worker shutdown precedes death-writer closure

## Tests

- focused multiprocess shutdown regression suite: 12 passed in the qualified lineage
- automatic vLLM-only stop verified all four LMCache registrations, allocations, and 184 aliases return to zero while L1 remains intact
- requires a nonzero outer `--shutdown-timeout` and matching worker timeout budget in deployment

## Duplicate-work note

No open Jovian Judgement PR isolates this multiprocess shutdown ordering fix.

## AI assistance disclosure

AI assistance was used in preparing this contribution.
