### PR TITLE
[BugFix] Mamba sparse retention keeps a state below each boundary under EAGLE/MTP

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3492,7 +3492,10 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     assert [len(blocks) for blocks in computed_blocks.blocks] == [3, 12]
 
 
-def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
+@pytest.mark.parametrize("annotate_eagle_groups", [None, "full_only", "both"])
+def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop(
+    annotate_eagle_groups,
+):
     """Verify Mamba latest-only retention serves an MTP/EAGLE lookup.
 
     The full-attention EAGLE lookup drops one block below what it matched, so
@@ -3502,8 +3505,18 @@ def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
     boundary state leaves every retained state one block above every reachable
     candidate, and the reconciled hit is always zero (found live on
     GLM-5.3-Flash MTP: 0 hits across 16,897 queries).
+
+    Parametrized over how the groups are annotated, because the three cases
+    reach the manager's ``use_eagle`` bit by different routes and only one of
+    them is what production hits today: ``None`` is the coordinator's flag-all
+    fallback (no model annotator exists for glm5_next, so this is the live
+    path), ``full_only`` is a single annotated group (what a future annotator
+    would produce), and ``both`` is the hand-flagged case.
     """
     block_size = 32
+    num_spec = 3
+    full_is_eagle = annotate_eagle_groups in ("full_only", "both")
+    mamba_is_eagle = annotate_eagle_groups == "both"
     kv_cache_config = KVCacheConfig(
         num_blocks=100,
         kv_cache_tensors=[],
@@ -3516,7 +3529,7 @@ def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
                     head_size=1,
                     dtype=torch.float16,
                 ),
-                is_eagle_group=True,
+                is_eagle_group=full_is_eagle,
             ),
             KVCacheGroupSpec(
                 ["mamba_mtp"],
@@ -3525,8 +3538,9 @@ def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
                     shapes=((1, 1),),
                     dtypes=(torch.float32,),
                     mamba_cache_mode="align",
+                    num_speculative_blocks=num_spec,
                 ),
-                is_eagle_group=True,
+                is_eagle_group=mamba_is_eagle,
             ),
         ],
     )
@@ -3553,6 +3567,7 @@ def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
             chunk_end - req0.num_computed_tokens,
             num_computed_tokens,
             computed_blocks,
+            num_lookahead_tokens=num_spec,
         )
         assert blocks is not None
         req0.num_computed_tokens = chunk_end
@@ -3576,6 +3591,92 @@ def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
     computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
     assert num_computed_tokens == 2 * block_size
     assert [len(blocks) for blocks in computed_blocks.blocks] == [2, 2]
+
+
+def test_hybrid_mamba_retention_eagle_backoff_is_one_alignment_unit():
+    """The EAGLE back-off is one ALIGNMENT unit, which is not one Mamba block.
+
+    When the groups' block sizes differ, the scheduler alignment is their LCM,
+    and the full-attention finder subtracts ``min(alignment, its block_size)``
+    and re-floors -- landing one alignment unit below the boundary regardless.
+    Backing off one Mamba block instead retains a state at the wrong offset:
+    Mamba's own finder then rejects it (its hit must be alignment-aligned) and
+    the reconciled hit stays 0, so the extra block is dead weight.
+
+    Here alignment is 64 and the Mamba block is 32, so the reachable position
+    is two Mamba blocks below the boundary, not one.
+    """
+    mamba_block = 32
+    full_block = 64  # scheduler alignment = lcm(64, 32) = 64 = 2 mamba blocks
+    kv_cache_config = KVCacheConfig(
+        num_blocks=200,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=full_block,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                ),
+                is_eagle_group=True,
+            ),
+            KVCacheGroupSpec(
+                ["mamba_mtp"],
+                MambaSpec(
+                    block_size=mamba_block,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+                is_eagle_group=True,
+            ),
+        ],
+    )
+    # hash_block_size must divide every group's block size, so it is the
+    # smaller (Mamba) block; the scheduler alignment is still the LCM, 64.
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=mamba_block,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    # 255 tokens: replay boundary floor(254 / 64) * 64 = 192. In Mamba blocks
+    # that is index 5; the EAGLE-reachable position 192 - 64 = 128 is index 3.
+    token_ids = [i for i in range(7) for _ in range(mamba_block)] + [7] * 31
+    req0 = make_request("0", token_ids, mamba_block, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    for chunk_end in (64, 128, 192, 255):
+        blocks = manager.allocate_slots(
+            req0,
+            chunk_end - req0.num_computed_tokens,
+            num_computed_tokens,
+            computed_blocks,
+        )
+        assert blocks is not None
+        req0.num_computed_tokens = chunk_end
+
+    pool = manager.block_pool
+    cached_mamba = {
+        i
+        for i in range(len(req0.block_hashes))
+        if pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
+        is not None
+    }
+    # Index 3 is the one a post-drop lookup can ask for; index 4 (one block
+    # below the boundary) is what a block-sized back-off would have kept.
+    assert 3 in cached_mamba, f"reachable state missing; cached={sorted(cached_mamba)}"
+    assert 4 not in cached_mamba, "one-block back-off retained an unreachable state"
+
+    manager.free(req0)
+    req1 = make_request("1", token_ids, mamba_block, sha256)
+    _, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    assert num_computed_tokens == 128
 
 
 def test_block_lookup_cache_single_block_per_key():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3492,6 +3492,92 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     assert [len(blocks) for blocks in computed_blocks.blocks] == [3, 12]
 
 
+def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
+    """Verify Mamba latest-only retention serves an MTP/EAGLE lookup.
+
+    The full-attention EAGLE lookup drops one block below what it matched, so
+    until a request decodes past the block boundary after its prompt, the only
+    candidate the coordinator can offer the Mamba group is one block below the
+    replay boundary. Mamba retention must keep that state too; keeping only the
+    boundary state leaves every retained state one block above every reachable
+    candidate, and the reconciled hit is always zero (found live on
+    GLM-5.3-Flash MTP: 0 hits across 16,897 queries).
+    """
+    block_size = 32
+    kv_cache_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                ),
+                is_eagle_group=True,
+            ),
+            KVCacheGroupSpec(
+                ["mamba_mtp"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+                is_eagle_group=True,
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    # 127 tokens: replay boundary floor(126 / 32) * 32 = 96, i.e. block 2's end.
+    # Prefill in block-aligned chunks the way the align-mode scheduler does:
+    # the state one block below the boundary only materializes as a chunk's
+    # running-state block, so a single-shot prefill could not retain it.
+    token_ids = [i for i in range(3) for _ in range(block_size)] + [3] * 31
+    req0 = make_request("0", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    for chunk_end in (32, 64, 96, 127):
+        blocks = manager.allocate_slots(
+            req0,
+            chunk_end - req0.num_computed_tokens,
+            num_computed_tokens,
+            computed_blocks,
+        )
+        assert blocks is not None
+        req0.num_computed_tokens = chunk_end
+
+    # Mamba keeps the boundary state (block 2) plus the state one block below
+    # (block 1) -- the only position an EAGLE-dropped lookup can reach while
+    # the request has not decoded past the next block boundary.
+    pool = manager.block_pool
+    expected_mamba_cached = {1, 2}
+    for i in range(3):
+        cached = pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
+        if i in expected_mamba_cached:
+            assert cached is not None, f"mamba hash {i} should be cached"
+        else:
+            assert cached is None, f"mamba hash {i} should not be cached"
+    manager.free(req0)
+
+    # Identical resend: full attention matches blocks 0-2 (96 tokens) and the
+    # EAGLE drop caps the candidate at 64; the retained state at 64 serves it.
+    req1 = make_request("1", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    assert num_computed_tokens == 2 * block_size
+    assert [len(blocks) for blocks in computed_blocks.blocks] == [2, 2]
+
+
 def test_block_lookup_cache_single_block_per_key():
     cache = BlockHashToBlockMap()
     key0 = BlockHashWithGroupId(b"hash0")

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -149,6 +149,14 @@ class KVCacheCoordinator(ABC):
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
 
+        # Sparse retention must key off "some group's lookup applies the EAGLE
+        # drop", not "this group holds draft layers": the coordinator reconciles
+        # every group to ONE hit length, so a drop anywhere shortens the
+        # candidate offered to all of them. A group that kept only its own
+        # boundary state would then sit above every reachable candidate.
+        for manager in self.single_type_managers:
+            manager.lookup_drops_eagle_block = bool(self.eagle_group_ids)
+
         # A positive retention interval must be a multiple of the base hit granularity
         # (``scheduler_block_size``) to land on real cache-hit boundaries.
         # 0 = keep only the latest replay boundary; None = dense;

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -33,6 +33,32 @@ from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
 
 
+def reachable_hit_positions(
+    boundary_tokens: int,
+    alignment_tokens: int,
+    use_eagle: bool,
+) -> tuple[int, ...]:
+    """Token positions a cache hit can land on for one reachable boundary.
+
+    A lookup floors the boundary to ``alignment_tokens``. Under EAGLE the
+    full-attention finder additionally subtracts ``min(alignment_tokens,
+    its own block_size)`` and re-floors to the alignment, which lands on
+    exactly one alignment unit below the boundary either way. That lower
+    position is the ONLY one this group can be asked for until the request
+    decodes past the next boundary, so sparse-retention masks must treat both
+    as reachable: retaining only the boundary leaves every kept state above
+    every candidate a lookup can produce, and the reconciled hit is always 0.
+
+    Expressing the back-off in tokens rather than blocks is what makes this
+    correct when a group's block size differs from the alignment: one block is
+    the right step only when they are equal.
+    """
+    aligned = boundary_tokens // alignment_tokens * alignment_tokens
+    if not use_eagle:
+        return (aligned,)
+    return (aligned, max(aligned - alignment_tokens, 0))
+
+
 class SingleTypeKVCacheManager(ABC):
     """
     An abstract base class for a manager that handle the kv cache management
@@ -102,11 +128,16 @@ class SingleTypeKVCacheManager(ABC):
         self.kv_cache_group_id = kv_cache_group_id
         self._null_block = block_pool.null_block
 
-        # Whether this group's prefix-cache hits drop the EAGLE/MTP lookahead
-        # block. Only consulted by managers whose hit logic is sparse within an
-        # aligned segment (SWA). Initialized lazily by the coordinator after
+        # Whether THIS group's own prefix-cache lookup drops the EAGLE/MTP
+        # lookahead block. Initialized lazily by the coordinator after
         # determining the attention groups.
         self.use_eagle = False
+
+        # Whether ANY group's lookup applies that drop, which is what sparse
+        # retention must key off: the coordinator reconciles every group to one
+        # hit length, so a drop anywhere shortens the candidate offered here.
+        # See ``reachable_hit_positions``. Set by the coordinator.
+        self.lookup_drops_eagle_block = False
 
         # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
         # managers (full attention, mamba "align"); harmlessly empty elsewhere.
@@ -457,7 +488,8 @@ class SingleTypeKVCacheManager(ABC):
             end_block=num_full_blocks,
             alignment_tokens=self.scheduler_block_size,
             kv_cache_spec=self.kv_cache_spec,
-            use_eagle=self.use_eagle,
+            # Retention, unlike lookup, cares whether the drop happens anywhere.
+            use_eagle=self.use_eagle or self.lookup_drops_eagle_block,
             retention_interval=retention_interval,
             reachable_boundaries=reachable_boundaries,
         )
@@ -1428,25 +1460,15 @@ class MambaManager(SingleTypeKVCacheManager):
         # (2) Reachable-boundary states: the replay boundary (``num_prompt - 1``,
         # capped by ``get_computed_blocks``) and any shared-prefix junction, both
         # of which segments would otherwise skip under sparse retention. A Mamba
-        # hit needs exactly the single state block ending on the boundary.
-        #
-        # Under EAGLE/MTP the full-attention lookup drops one block below what
-        # it matched, so until the request decodes past the block boundary
-        # after ``boundary_tokens`` the only candidate the coordinator can
-        # offer this group is one block below the boundary. Keep that state
-        # too; keeping only the boundary state leaves every retained state one
-        # block above every reachable candidate, and the reconciled hit is
-        # always zero.
+        # hit needs exactly the single state block ending on the reachable
+        # position, so retain one block per position rather than a run.
         for boundary_tokens in reachable_boundaries:
-            aligned = boundary_tokens // alignment_tokens * alignment_tokens
-            boundary_block = aligned // block_size - 1
-            for kept in (
-                (boundary_block, boundary_block - 1)
-                if use_eagle
-                else (boundary_block,)
+            for position in reachable_hit_positions(
+                boundary_tokens, alignment_tokens, use_eagle
             ):
-                if start_block <= kept < end_block:
-                    mask[kept - start_block] = True
+                boundary_block = position // block_size - 1
+                if start_block <= boundary_block < end_block:
+                    mask[boundary_block - start_block] = True
 
         return mask
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1408,9 +1408,11 @@ class MambaManager(SingleTypeKVCacheManager):
         mask = [False] * (end_block - start_block)
 
         # (1) Segment-boundary states. A Mamba hit needs exactly the single
-        # state block ending on the boundary (no window, and draft models have
-        # no mamba layers, so no eagle shift). Block ``i`` ends at token
-        # ``(i + 1) * block_size``.
+        # state block ending on the boundary (no window). Segment tails get no
+        # EAGLE shift: under the EAGLE drop the fixed point settles on the next
+        # lower tail, costing at most one segment of hit length, unlike the
+        # reachable boundaries below where the unshifted state is the only one.
+        # Block ``i`` ends at token ``(i + 1) * block_size``.
         segment_tokens = None if retention_interval == 0 else retention_interval
         if segment_tokens is not None:
             per_segment = segment_tokens // block_size
@@ -1427,11 +1429,24 @@ class MambaManager(SingleTypeKVCacheManager):
         # capped by ``get_computed_blocks``) and any shared-prefix junction, both
         # of which segments would otherwise skip under sparse retention. A Mamba
         # hit needs exactly the single state block ending on the boundary.
+        #
+        # Under EAGLE/MTP the full-attention lookup drops one block below what
+        # it matched, so until the request decodes past the block boundary
+        # after ``boundary_tokens`` the only candidate the coordinator can
+        # offer this group is one block below the boundary. Keep that state
+        # too; keeping only the boundary state leaves every retained state one
+        # block above every reachable candidate, and the reconciled hit is
+        # always zero.
         for boundary_tokens in reachable_boundaries:
             aligned = boundary_tokens // alignment_tokens * alignment_tokens
             boundary_block = aligned // block_size - 1
-            if start_block <= boundary_block < end_block:
-                mask[boundary_block - start_block] = True
+            for kept in (
+                (boundary_block, boundary_block - 1)
+                if use_eagle
+                else (boundary_block,)
+            ):
+                if start_block <= kept < end_block:
+                    mask[kept - start_block] = True
 
         return mask
 


### PR DESCRIPTION
Prefix caching never hits on hybrid models running MTP/EAGLE spec decode. Measured on GLM-5.3-Flash in production: 0 hit tokens against 16,897 queried, silently.

The full-attention EAGLE lookup drops one block below what it matched, but latest-only Mamba retention (`prefix_cache_retention_interval=0`, the default) keeps only the state at the boundary itself, one block above anything a lookup can ever request. The reconciled hit is always 0.

Fix: when the group runs under EAGLE, also retain the state one block below each reachable boundary. Costs at most one extra state page per request; non-speculative behavior unchanged.

Verified live on a 4x DGX Spark GLM-5.3-Flash deployment (MTP k=3, TP=4): an identical 8,901-token resend now hits 4,608 tokens, warm TTFT 2.66 s vs 5.88 s cold, warm output byte-identical at temperature 0. Regression test included (fails without the fix); `tests/v1/core/test_prefix_caching.py` passes 92/92.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved prompt caching for hybrid attention and Mamba models using EAGLE/MTP.
  - Preserves an additional boundary state so requests that fall one block below a match can still reuse cached data.
  - Enables expected two-block cache hits for eligible repeated prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->