### PR TITLE
perf(dflash2): fuse two-tap grouped convolution

### DIFF
--- a/tests/kernels/test_dflash2_grouped_conv.py
+++ b/tests/kernels/test_dflash2_grouped_conv.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.model_executor.models.qwen3_dflash2 import _grouped_conv
+
+pytestmark = pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="The fused grouped convolution requires CUDA",
+)
+
+
+def _reference_grouped_conv(
+    hidden_states: torch.Tensor,
+    delta: torch.Tensor,
+    base: torch.Tensor,
+    *,
+    block_size: int,
+    num_groups: int,
+    group_size: int,
+    taps: int,
+) -> torch.Tensor:
+    blocks = hidden_states.unflatten(-1, (num_groups, group_size))
+    coefficients = base.view(1, taps, num_groups, group_size) + delta.unsqueeze(-1)
+    output = coefficients[:, 0] * blocks
+    position = torch.arange(hidden_states.shape[0], device=hidden_states.device)
+    position = position & (block_size - 1)
+    for tap in range(1, taps):
+        shifted = F.pad(blocks[:-tap], (0, 0, 0, 0, tap, 0))
+        output += coefficients[:, tap] * shifted * (position >= tap).view(-1, 1, 1)
+    return output.flatten(-2)
+
+
+@pytest.mark.parametrize("rows", [1, 7, 8, 9, 16, 17, 64])
+def test_dflash2_grouped_conv_taps2_matches_bf16_reference(rows: int) -> None:
+    torch.manual_seed(20260901 + rows)
+    block_size = 8
+    num_groups = 256
+    group_size = 16
+    taps = 2
+    hidden_size = num_groups * group_size
+    hidden_states = torch.randn(
+        rows, hidden_size, device="cuda", dtype=torch.bfloat16
+    ).contiguous()
+    delta = torch.randn(
+        rows, taps, num_groups, device="cuda", dtype=torch.bfloat16
+    ).contiguous()
+    base = torch.randn(
+        taps, hidden_size, device="cuda", dtype=torch.bfloat16
+    ).contiguous()
+
+    actual = _grouped_conv(
+        hidden_states,
+        delta,
+        base,
+        block_size,
+        num_groups,
+        group_size,
+        taps,
+    )
+    expected = _reference_grouped_conv(
+        hidden_states,
+        delta,
+        base,
+        block_size=block_size,
+        num_groups=num_groups,
+        group_size=group_size,
+        taps=taps,
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_dflash2_grouped_conv_taps2_replays_under_cuda_graph() -> None:
+    torch.manual_seed(20260901)
+    rows = 8
+    block_size = 8
+    num_groups = 256
+    group_size = 16
+    taps = 2
+    hidden_size = num_groups * group_size
+    hidden_states = torch.randn(
+        rows, hidden_size, device="cuda", dtype=torch.bfloat16
+    ).contiguous()
+    delta = torch.randn(
+        rows, taps, num_groups, device="cuda", dtype=torch.bfloat16
+    ).contiguous()
+    base = torch.randn(
+        taps, hidden_size, device="cuda", dtype=torch.bfloat16
+    ).contiguous()
+
+    # Compile the Triton specialization before entering CUDA graph capture.
+    _grouped_conv(
+        hidden_states,
+        delta,
+        base,
+        block_size,
+        num_groups,
+        group_size,
+        taps,
+    )
+    torch.accelerator.synchronize()
+
+    device_module = torch.get_device_module(hidden_states.device)
+    graph = device_module.CUDAGraph()
+    with device_module.graph(graph):
+        captured = _grouped_conv(
+            hidden_states,
+            delta,
+            base,
+            block_size,
+            num_groups,
+            group_size,
+            taps,
+        )
+    graph.replay()
+    torch.accelerator.synchronize()
+
+    expected = _reference_grouped_conv(
+        hidden_states,
+        delta,
+        base,
+        block_size=block_size,
+        num_groups=num_groups,
+        group_size=group_size,
+        taps=taps,
+    )
+    torch.testing.assert_close(captured, expected, rtol=0, atol=0)

--- a/tests/kernels/test_dflash2_grouped_conv.py
+++ b/tests/kernels/test_dflash2_grouped_conv.py
@@ -5,10 +5,11 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+import vllm.model_executor.models.qwen3_dflash2 as dflash2_module
 from vllm.model_executor.models.qwen3_dflash2 import _grouped_conv
 
 pytestmark = pytest.mark.skipif(
-    not torch.accelerator.is_available(),
+    not torch.cuda.is_available(),
     reason="The fused grouped convolution requires CUDA",
 )
 
@@ -69,6 +70,60 @@ def test_dflash2_grouped_conv_taps2_matches_bf16_reference(rows: int) -> None:
         num_groups=num_groups,
         group_size=group_size,
         taps=taps,
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("broadcast_axis", ["row", "tap", "group"])
+def test_dflash2_grouped_conv_broadcast_delta_uses_generic_path(
+    broadcast_axis: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    torch.manual_seed(20260901)
+    rows = 8
+    block_size = 8
+    num_groups = 256
+    group_size = 16
+    taps = 2
+    hidden_size = num_groups * group_size
+    delta_shapes = {
+        "row": (1, taps, num_groups),
+        "tap": (rows, 1, num_groups),
+        "group": (rows, taps, 1),
+    }
+    hidden_states = torch.randn(
+        rows, hidden_size, device="cuda", dtype=torch.bfloat16
+    ).contiguous()
+    delta = torch.randn(
+        delta_shapes[broadcast_axis], device="cuda", dtype=torch.bfloat16
+    ).contiguous()
+    base = torch.randn(
+        taps, hidden_size, device="cuda", dtype=torch.bfloat16
+    ).contiguous()
+    expected = _reference_grouped_conv(
+        hidden_states,
+        delta,
+        base,
+        block_size=block_size,
+        num_groups=num_groups,
+        group_size=group_size,
+        taps=taps,
+    )
+
+    def reject_fused_path(*args: object, **kwargs: object) -> torch.Tensor:
+        pytest.fail("broadcast delta must use the generic grouped convolution")
+
+    monkeypatch.setattr(
+        dflash2_module, "_dflash2_grouped_conv_taps2", reject_fused_path
+    )
+    actual = _grouped_conv(
+        hidden_states,
+        delta,
+        base,
+        block_size,
+        num_groups,
+        group_size,
+        taps,
     )
 
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/vllm/model_executor/models/qwen3_dflash2.py
+++ b/vllm/model_executor/models/qwen3_dflash2.py
@@ -153,6 +153,7 @@ def _grouped_conv(
         and hidden_states.is_contiguous()
         and base.is_contiguous()
         and delta.ndim == 3
+        and delta.shape == (hidden_states.shape[0], taps, num_groups)
         and delta.stride(2) == 1
         and taps == 2
         and group_size == 16

--- a/vllm/model_executor/models/qwen3_dflash2.py
+++ b/vllm/model_executor/models/qwen3_dflash2.py
@@ -4,6 +4,7 @@
 import torch
 import torch.nn.functional as F
 from torch import nn
+from torch.library import wrap_triton
 
 from vllm.compilation.backends import set_model_tag
 from vllm.compilation.decorators import support_torch_compile
@@ -11,6 +12,7 @@ from vllm.config import CacheConfig, VllmConfig
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.triton_utils import tl, triton
 
 from .qwen3_dflash import (
     DFlashQwen3DecoderLayer,
@@ -18,6 +20,119 @@ from .qwen3_dflash import (
     DFlashQwen3Model,
 )
 from .utils import maybe_prefix
+
+
+@triton.jit
+def _round_to_bf16_rn(value):
+    """Materialize a BF16 RN boundary and prevent multiply-add contraction."""
+    return tl.inline_asm_elementwise(
+        "cvt.rn.bf16.f32 $0, $1;",
+        constraints="=h,f",
+        args=[value],
+        dtype=tl.bfloat16,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def _dflash2_grouped_conv_taps2_kernel(
+    hidden_ptr,
+    delta_ptr,
+    base_ptr,
+    output_ptr,
+    numel,
+    delta_stride_row,
+    delta_stride_tap,
+    delta_stride_group,
+    HIDDEN_SIZE: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    valid = offsets < numel
+    rows = offsets // HIDDEN_SIZE
+    features = offsets - rows * HIDDEN_SIZE
+    groups = features // GROUP_SIZE
+
+    hidden0 = tl.load(hidden_ptr + offsets, mask=valid, other=0.0)
+    delta0 = tl.load(
+        delta_ptr + rows * delta_stride_row + groups * delta_stride_group,
+        mask=valid,
+        other=0.0,
+    )
+    base0 = tl.load(base_ptr + features, mask=valid, other=0.0)
+    coefficient0 = _round_to_bf16_rn(base0.to(tl.float32) + delta0.to(tl.float32))
+    output0 = _round_to_bf16_rn(coefficient0.to(tl.float32) * hidden0.to(tl.float32))
+
+    has_predecessor = valid & ((rows % BLOCK_SIZE) != 0)
+    hidden1 = tl.load(
+        hidden_ptr + offsets - HIDDEN_SIZE,
+        mask=has_predecessor,
+        other=0.0,
+    )
+    delta1 = tl.load(
+        delta_ptr
+        + rows * delta_stride_row
+        + delta_stride_tap
+        + groups * delta_stride_group,
+        mask=valid,
+        other=0.0,
+    )
+    base1 = tl.load(
+        base_ptr + HIDDEN_SIZE + features,
+        mask=valid,
+        other=0.0,
+    )
+    coefficient1 = _round_to_bf16_rn(base1.to(tl.float32) + delta1.to(tl.float32))
+    output1 = _round_to_bf16_rn(coefficient1.to(tl.float32) * hidden1.to(tl.float32))
+    output = _round_to_bf16_rn(output0.to(tl.float32) + output1.to(tl.float32))
+    tl.store(output_ptr + offsets, output, mask=valid)
+
+
+@torch.library.custom_op("vllm::dflash2_grouped_conv_taps2", mutates_args=())
+def _dflash2_grouped_conv_taps2(
+    hidden_states: torch.Tensor,
+    delta: torch.Tensor,
+    base: torch.Tensor,
+    block_size: int,
+    num_groups: int,
+    group_size: int,
+) -> torch.Tensor:
+    output = torch.empty_like(hidden_states)
+    hidden_size = num_groups * group_size
+    block = 256
+    wrap_triton(_dflash2_grouped_conv_taps2_kernel)[
+        (triton.cdiv(hidden_states.numel(), block),)
+    ](
+        hidden_states,
+        delta,
+        base,
+        output,
+        hidden_states.numel(),
+        delta.stride(0),
+        delta.stride(1),
+        delta.stride(2),
+        HIDDEN_SIZE=hidden_size,
+        GROUP_SIZE=group_size,
+        BLOCK_SIZE=block_size,
+        BLOCK=block,
+    )
+    return output
+
+
+@_dflash2_grouped_conv_taps2.register_fake
+def _dflash2_grouped_conv_taps2_fake(
+    hidden_states: torch.Tensor,
+    delta: torch.Tensor,
+    base: torch.Tensor,
+    block_size: int,
+    num_groups: int,
+    group_size: int,
+) -> torch.Tensor:
+    del delta, base, block_size, num_groups, group_size
+    return torch.empty_like(hidden_states)
 
 
 def _grouped_conv(
@@ -29,6 +144,30 @@ def _grouped_conv(
     group_size: int,
     taps: int,
 ) -> torch.Tensor:
+    if (
+        hidden_states.is_cuda
+        and hidden_states.dtype == torch.bfloat16
+        and delta.dtype == torch.bfloat16
+        and base.dtype == torch.bfloat16
+        and hidden_states.ndim == 2
+        and hidden_states.is_contiguous()
+        and base.is_contiguous()
+        and delta.ndim == 3
+        and delta.stride(2) == 1
+        and taps == 2
+        and group_size == 16
+        and block_size == 8
+        and hidden_states.shape[1] == num_groups * group_size
+    ):
+        return _dflash2_grouped_conv_taps2(
+            hidden_states,
+            delta,
+            base,
+            block_size,
+            num_groups,
+            group_size,
+        )
+
     blocks = hidden_states.unflatten(-1, (num_groups, group_size))
     coefficients = base.view(1, taps, num_groups, group_size) + delta.unsqueeze(-1)
     output = coefficients[:, 0] * blocks


### PR DESCRIPTION
## Resulting behavior

GLM-5.3 DFlash2 executes each supported two-tap grouped convolution with one
Triton kernel instead of materializing coefficient, shift, mask, multiply, and
reduction intermediates as separate PyTorch launches.

The fused path requires CUDA BF16 tensors, contiguous hidden and base tensors,
two taps, groups of 16 channels, an eight-token recurrent block, and an exact
`(rows, taps, groups)` delta tensor. The GLM-5.3 checkpoint geometry is 4,096
hidden channels and 256 groups. Broadcastable row, tap, or group delta tensors
retain the generic implementation.

Explicit BF16 round-to-nearest boundaries preserve the generic operation order.
The optimized output is bit-identical to the BF16 reference, including recurrent
block boundaries where the predecessor tap must be zero.

The implementation commit retains MadeBy561 as its author. The tests and fused
dispatch safety guard are authored by Martin Vit.

## Compatibility

Checkpoint formats and serving arguments are unchanged. Unsupported dtypes,
layouts, shapes, and broadcastable delta inputs use the existing generic path.

## Validation

The CUDA suite ran in the source-locked GLM-5.3 runtime on one NVIDIA RTX PRO
6000 Blackwell Workstation GPU:

```text
CUDA_VISIBLE_DEVICES=0 /opt/venv/bin/python -m pytest \
  --confcutdir=/tmp /tmp/test_dflash2_grouped_conv.py -vv
11 passed
```

Exact equality covers 1, 7, 8, 9, 16, 17, and 64 rows; row, tap, and group
broadcasting; and CUDA graph capture/replay. A graph-amortized launch sweep over
blocks of 128, 256, 512, and 1,024 elements selected 256 for the production
8-, 32-, and 64-row shapes.

An isolated TP4/DCP1 comparison used the same GLM-5.3 NVFP4 target, seven-token
MXFP8 DFlash2 draft, independent 512-token target and recurrent cache pages, a
4,096-token scheduler budget, full decode CUDA graphs, and four RTX PRO 6000
Blackwell Workstation GPUs with a +6000 MHz memory-clock offset:

| Concurrency | Generic grouped convolution | Fused grouped convolution | Change |
| --- | ---: | ---: | ---: |
| 1 | 87.49 verifier steps/s | 90.07 verifier steps/s | +2.95% |
| 8 | 304.64 verifier steps/s | 306.54 verifier steps/s | +0.62% |

Searches of open `vllm-project/vllm` and `local-inference-lab/vllm` pull
requests found no other DFlash2 grouped-convolution implementation.

AI assistance was used to inspect the implementation, construct tests, analyze
review findings, and prepare this pull request. The human submitter reviewed the
changed lines and validation evidence.
