### PR TITLE
fix(b12x): keep DSA cache layer-compact

### DIFF
--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -109,6 +109,16 @@ def test_b12x_sparse_mla_accepts_glm_dsa_contract(monkeypatch) -> None:
     )
 
 
+def test_b12x_dsa_requires_layer_compact_cache_layout() -> None:
+    assert B12xMLASparseBackend.supported_kv_cache_layouts() == (KVCacheLayout.LBNHC,)
+
+
+def test_b12x_glm5_next_requires_block_outermost_cache_layout() -> None:
+    assert B12xGLM5NextMLASparseBackend.supported_kv_cache_layouts() == (
+        KVCacheLayout.BLHNC,
+    )
+
+
 def _glm5_next_config(
     *,
     dcp_size: int = 1,

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -453,11 +453,8 @@ class B12xMLASparseBackend(AttentionBackend):
 
     @classmethod
     def supported_kv_cache_layouts(cls) -> tuple[KVCacheLayout, ...]:
-        # Sparse index caches share manager blocks with their MLA layer. Keep
-        # the layer dimension inside the manager's block so block copies and
-        # swaps carry both cache regions together. DeepSeek-V4's index backend
-        # already imposes the same constraint, so this preserves its layout.
-        return (KVCacheLayout.BLHNC,)
+        # The DSA kernels consume one layer-compact, token-major cache view.
+        return (KVCacheLayout.LBNHC,)
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
@@ -520,6 +517,13 @@ class B12xMLASparseBackend(AttentionBackend):
 
 
 class B12xGLM5NextMLASparseBackend(B12xMLASparseBackend):
+    @classmethod
+    def supported_kv_cache_layouts(cls) -> tuple[KVCacheLayout, ...]:
+        # GLM-Next's pooled index tail shares manager blocks with its MLA
+        # latent page. Keep the layer dimension inside the manager block so
+        # copies and swaps carry both cache regions together.
+        return (KVCacheLayout.BLHNC,)
+
     @staticmethod
     def get_builder_cls() -> type["B12xGLM5NextMLASparseMetadataBuilder"]:
         return B12xGLM5NextMLASparseMetadataBuilder


### PR DESCRIPTION
## Summary

Keep the generic B12X DSA sparse-MLA cache in the layer-compact `LBNHC`
layout consumed by its kernels. Override that contract only for GLM5Next,
whose pooled-index tail shares the manager page and therefore requires
`BLHNC`.

This prevents the shared backend from selecting a valid-looking but incorrect
layout for GLM-5.2/5.3 non-Flash DSA models. Both layout contracts have focused
regression coverage.

## Duplicate-work check

No open PR matched the DSA layer-compact or GLM5Next block-outermost layout
split. This is separate from #549: that PR adds the packed NVFP4 cache ABI,
while this fix defines the underlying generic DSA versus GLM5Next layout
contract for every supported packed cache dtype.

## Validation

- `uvx ruff check tests/v1/attention/test_b12x_sparse_mla_api.py vllm/v1/attention/backends/mla/b12x_mla_sparse.py`: passed after rebasing onto `dev/jovian-judgement` at `9c4dd0548`.
- `git diff --check upstream/dev/jovian-judgement...HEAD`: passed.
- Focused B12X sparse-MLA API tests passed in the qualified r21 container.
- The cn3 integration run reproduced zero attention output with the inherited
  GLM5Next layout and produced correct output (`42`) with the layer-compact
  DSA layout. The qualified service sustained `61.044849 tok/s` for the
  single-request decode cell.

## AI assistance

OpenAI Codex assisted with porting, regression construction, and review. The
submitter reviewed the resulting diff and qualification evidence; the commit
includes `Assisted-by` and DCO sign-off trailers.
