### PR TITLE
fix(dcp): handle empty ranks and gather sparse MLA queries

### DIFF
--- a/tests/kernels/test_fused_deepseek_v32_norm_rope.py
+++ b/tests/kernels/test_fused_deepseek_v32_norm_rope.py
@@ -234,6 +234,57 @@ def test_fused_norm_rope(num_tokens: int, index_interleave: bool, mla_dtype: str
     assert (topk == -1).all(), "topk buffer not cleared on indexer layer"
 
 
+def test_fused_norm_rope_computes_q_for_unmapped_dcp_tokens():
+    """DCP cache ownership must not turn replicated query rows into padding."""
+    torch.manual_seed(11)
+    dev = "cuda"
+    num_tokens = 4
+    pos = torch.arange(num_tokens, device=dev, dtype=torch.int64)
+    q_c = torch.randn(num_tokens, Q_LORA, device=dev, dtype=torch.bfloat16)
+    kv_c = torch.randn(num_tokens, KV_LORA, device=dev, dtype=torch.bfloat16)
+    k_pe = torch.randn(num_tokens, ROPE_DIM, device=dev, dtype=torch.bfloat16)
+    qw = torch.randn(Q_LORA, device=dev, dtype=torch.bfloat16)
+    kvw = torch.randn(KV_LORA, device=dev, dtype=torch.bfloat16)
+    cos_sin = make_cos_sin(16, ROPE_DIM, dev)
+    mla_cache = torch.zeros(
+        1,
+        num_tokens,
+        KV_LORA + ROPE_DIM,
+        device=dev,
+        dtype=torch.bfloat16,
+    )
+    slot_mapping = torch.tensor([0, -1, 1, -1], device=dev, dtype=torch.int64)
+    topk = torch.empty((num_tokens, 2048), device=dev, dtype=torch.int32)
+
+    q_out = K.fused_norm_rope(
+        pos,
+        q_c,
+        qw,
+        EPS,
+        kv_c,
+        kvw,
+        EPS,
+        k_pe,
+        cos_sin,
+        None,
+        None,
+        None,
+        EPS,
+        None,
+        topk,
+        slot_mapping=slot_mapping,
+        mla_kv_cache=mla_cache,
+        has_indexer=False,
+    )
+
+    assert_bf16(q_out, rms_norm(q_c, qw), "DCP q_c rmsnorm")
+    kv_ref = rms_norm(kv_c, kvw)
+    kpe_ref = rope(k_pe.float(), pos, cos_sin, interleave=True)
+    expected_cache = torch.cat([kv_ref[[0, 2]], kpe_ref[[0, 2]]], dim=-1)
+    assert_bf16(mla_cache[0, :2], expected_cache, "DCP-owned MLA cache rows")
+    assert torch.count_nonzero(mla_cache[0, 2:]) == 0
+
+
 def test_fused_norm_rope_writes_strided_indexer_cache_pages():
     """BLHNC indexer pages must retain their physical block stride."""
     torch.manual_seed(7)

--- a/tests/models/deepseek_v32/test_attention.py
+++ b/tests/models/deepseek_v32/test_attention.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.models.deepseek_v32 import attention as deepseek_v32_attention
+
+
+@pytest.mark.parametrize("full_ckv_dcp", [False, True])
+def test_sparse_dcp_collectives_match_cache_mode(monkeypatch, full_ckv_dcp):
+    attention = object.__new__(deepseek_v32_attention.DeepseekV32Attention)
+    nn.Module.__init__(attention)
+    attention.indexer = None
+    attention.skip_topk = True
+    attention.use_pcp = False
+    attention.layer_name = "model.layers.0.self_attn.attn"
+    attention._fp8_kv_needs_view = False
+    attention._fp8_query = False
+    attention.num_local_heads = 1
+    attention.kv_lora_rank = 2
+    attention.v_head_dim = 2
+    attention.W_UV = torch.eye(2).unsqueeze(0)
+
+    seq_lens = torch.tensor([1, 2], dtype=torch.int32)
+    query_start_loc = torch.tensor([0, 1, 3], dtype=torch.int32)
+    metadata = SimpleNamespace(
+        num_actual_tokens=3,
+        num_decodes=1,
+        seq_lens=seq_lens,
+        query_start_loc=query_start_loc,
+        decode=SimpleNamespace(seq_lens=seq_lens[:1]),
+    )
+    attn_out = torch.arange(6, dtype=torch.float32).view(3, 1, 2)
+    gathered_query = torch.empty((3, 2, 2))
+    query_gather = Mock(return_value=gathered_query)
+    combine = Mock(return_value=attn_out)
+    attention.dcp_manager = SimpleNamespace(
+        query_gather=query_gather,
+        combine=combine,
+    )
+    attention.impl = SimpleNamespace(
+        dcp_world_size=2,
+        pcp_world_size=1,
+        uses_full_ckv_dcp=Mock(return_value=full_ckv_dcp),
+        forward_mqa=Mock(return_value=(attn_out, torch.zeros(3, 1))),
+    )
+    monkeypatch.setattr(
+        deepseek_v32_attention,
+        "get_attention_context",
+        lambda layer_name: (metadata, None, torch.empty(0), torch.empty(0)),
+    )
+
+    output = torch.empty((3, 2))
+    attention._sparse_indexer_and_attn(
+        q_c=torch.empty((3, 2)),
+        index_q_fp8=None,
+        index_k=None,
+        index_weights_out=None,
+        kv_c=None,
+        k_pe=None,
+        ql_nope=torch.empty((3, 1, 1)),
+        mqa_q=torch.empty((3, 1, 1)),
+        output=output,
+    )
+
+    if full_ckv_dcp:
+        query_gather.assert_not_called()
+        combine.assert_not_called()
+    else:
+        query_gather.assert_called_once()
+        assert attention.impl.forward_mqa.call_args.args[0] is gathered_query
+        assert combine.call_args.kwargs["seq_lens"] is seq_lens
+        assert combine.call_args.kwargs["query_start_loc"] is query_start_loc
+    torch.testing.assert_close(output, attn_out.flatten(1))

--- a/tests/v1/attention/test_dcp_ops.py
+++ b/tests/v1/attention/test_dcp_ops.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.v1.attention.ops.dcp import mask_dcp_empty_shards_
+
+
+def test_mask_dcp_empty_shards_with_no_local_sequences() -> None:
+    lse = torch.zeros((4, 1), dtype=torch.float32)
+    seq_lens = torch.empty((0,), dtype=torch.int32)
+    query_start_loc = torch.zeros((1,), dtype=torch.int32)
+
+    mask_dcp_empty_shards_(lse, seq_lens, query_start_loc)
+
+    assert torch.isneginf(lse).all()

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -567,33 +567,44 @@ class DeepseekV32Attention(MLAAttention):
         else:
             mqa_q_arg = (ql_nope[:num_actual], mqa_q[:num_actual])
 
-        if self.use_pcp and self.impl.dcp_world_size > self.impl.pcp_world_size:
-            if isinstance(mqa_q_arg, tuple):
-                mqa_q_arg = torch.cat(mqa_q_arg, dim=-1)
-            mqa_q_arg = get_tp_group().all_gather(mqa_q_arg, dim=1)
+        full_ckv_dcp = self.impl.uses_full_ckv_dcp(  # type: ignore[attr-defined]
+            attn_metadata, num_actual
+        )
+        if self.impl.dcp_world_size > 1:
+            assert self.dcp_manager is not None
+            if self.use_pcp:
+                if self.impl.dcp_world_size > self.impl.pcp_world_size:
+                    if isinstance(mqa_q_arg, tuple):
+                        mqa_q_arg = torch.cat(mqa_q_arg, dim=-1)
+                    mqa_q_arg = get_tp_group().all_gather(mqa_q_arg, dim=1)
+            else:
+                if isinstance(mqa_q_arg, tuple):
+                    mqa_q_arg = torch.cat(mqa_q_arg, dim=-1)
+                if not full_ckv_dcp:
+                    assert self.dcp_manager.query_gather is not None
+                    mqa_q_arg = self.dcp_manager.query_gather(mqa_q_arg)
         attn_out, lse = self.impl.forward_mqa(  # type: ignore[attr-defined]
             mqa_q_arg, kv_cache, attn_metadata, self
         )
 
-        if self.use_pcp and self.impl.dcp_world_size > 1:
+        if self.impl.dcp_world_size > 1 and not full_ckv_dcp:
             assert lse is not None and self.dcp_manager is not None
-            seq_lens = (
-                attn_metadata.decode.seq_lens
-                if attn_metadata.decode is not None
-                else cast(torch.Tensor, attn_metadata.seq_lens)[  # type: ignore[attr-defined]
-                    : attn_metadata.num_decodes
-                ]
+            # This implementation always uses sparse MQA for both prefill and
+            # decode.  The DCP combine therefore covers every sequence in the
+            # batch, not only the leading decode sequences.
+            seq_lens = cast(
+                torch.Tensor,
+                attn_metadata.seq_lens,  # type: ignore[attr-defined]
             )
-            query_start_loc = attn_metadata.query_start_loc[
-                : attn_metadata.num_decodes + 1
-            ]
+            query_start_loc = attn_metadata.query_start_loc
             attn_out = self.dcp_manager.combine(
                 attn_out,
                 lse,
                 seq_lens=seq_lens,
                 query_start_loc=query_start_loc,
             )
-            attn_out = finalize_mla_pcp_decode(attn_out, self.num_heads)
+            if self.use_pcp:
+                attn_out = finalize_mla_pcp_decode(attn_out, self.num_heads)
 
         # NOTE(woosuk): While the below does not need to be in the eager region,
         # we put it here to avoid copying the attention output. Move this back to the

--- a/vllm/models/deepseek_v32/common/kernels.py
+++ b/vllm/models/deepseek_v32/common/kernels.py
@@ -184,8 +184,9 @@ def _fused_norm_rope_kernel(
     if slot_mapping_ptr is None:
         if kv_out_ptr is None and kpe_out_ptr is None and index_k_out_ptr is None:
             return
-    elif tl.load(slot_mapping_ptr + tok_idx) < 0:
-        # Padding
+    elif pid != 2 and tl.load(slot_mapping_ptr + tok_idx) < 0:
+        # A negative DCP slot suppresses rank-local cache writes. Q remains
+        # replicated and must still be computed on every rank.
         return
 
     if pid == 2:

--- a/vllm/v1/attention/ops/dcp.py
+++ b/vllm/v1/attention/ops/dcp.py
@@ -49,6 +49,11 @@ def mask_dcp_empty_shards_(
         or query_start_loc.shape[0] != seq_lens.shape[0] + 1
     ):
         raise ValueError("query_start_loc must contain one boundary per sequence")
+    if seq_lens.numel() == 0:
+        # A DCP rank can receive no local sequences during draft prefill. Its
+        # contribution must be ignored by the cross-rank LSE reduction.
+        lse.fill_(float("-inf"))
+        return
 
     row_indices = torch.arange(
         lse.shape[0], device=lse.device, dtype=query_start_loc.dtype


### PR DESCRIPTION
## Summary

Fix sparse-MLA correctness under decode-context parallelism:

- empty DCP ranks contribute an ignored LSE value instead of indexing an empty
  rank-local sequence-length tensor;
- the fused DeepSeek V3.2 query/cache kernel computes replicated query rows even
  when a negative slot suppresses that rank's KV and index-cache writes;
- ordinary non-PCP DCP gathers query heads and combines rank-local output/LSE
  using the full sparse batch metadata;
- full-CKV DCP prefill keeps its existing local-query path and does not perform
  the ordinary query/output collectives.

PCP behavior and its final head-layout transform remain unchanged.

## Root cause

The fused NVIDIA norm/RoPE/cache kernel treated a negative DCP slot as padding
for every fused branch. DCP shards KV ownership with negative slots on non-owner
ranks, but queries remain replicated; skipping Q normalization left query rows
uninitialized before the cross-rank gather. The attention wrapper also applied
decode-only combine metadata to an implementation that always uses sparse MQA.

## Validation

- cn3, 4x RTX PRO 6000 Blackwell, exact r15 base
  `voipmonitor/vllm@sha256:d9ca4c299fdb8e6176d70f36c8f98a687474eef807b7a71fe6fee9f154208fe0`
- GLM-5.3-EXL3-TR3-3.0bpw, TP4/DCP4, B12X sparse MLA, FP8 KV,
  `max_num_seqs=8`: deterministic `6 * 7` request returns `42`.
- Negative controls: the unpatched specialized DCP4 path produced corrupt text;
  DCP1 and the generic sparse-MLA DCP4 path both returned `42`.
- Focused GPU regressions: 3 passed, covering negative DCP slots and ordinary
  versus full-CKV collective selection.
- `ruff check`, `ruff format --check`, and `git diff --check`: passed.

## AI assistance

OpenAI Codex assisted with diagnosis, regression construction, implementation,
and review. The submitter reviewed the resulting diff; both commits include
`Assisted-by` and DCO sign-off trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DeepSeek attention behavior across distributed cache and full-CKV modes.
  * Ensured query normalization and RoPE processing continue for tokens without local cache ownership.
  * Correctly ignores empty distributed attention shards during result reduction.

* **Tests**
  * Added regression coverage for distributed attention collectives, unmapped tokens, and empty-shard handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->