### PR TITLE
[Quantization] Add EXL3 Trellis support on Jovian

### DIFF
--- a/tests/model_executor/test_eagle_quantization.py
+++ b/tests/model_executor/test_eagle_quantization.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -52,6 +53,49 @@ def test_get_draft_quant_config_without_draft_model():
     result = get_draft_quant_config(mock_vllm_config)
 
     assert result is None
+
+
+def test_dense_exl3_draft_skips_rank_sliced_hydration():
+    quant_config = Mock()
+    quant_config.get_name.return_value = "exl3"
+    draft_model_config = SimpleNamespace(
+        model="dense-exl3-draft",
+        hf_config=SimpleNamespace(),
+    )
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(draft_model_config=draft_model_config),
+        load_config=object(),
+        model_config=SimpleNamespace(hf_config=SimpleNamespace()),
+    )
+
+    with patch.object(VllmConfig, "get_quantization_config", return_value=quant_config):
+        result = get_draft_quant_config(vllm_config)
+
+    assert result is quant_config
+    quant_config.maybe_update_config.assert_not_called()
+
+
+def test_rank_sliced_exl3_draft_hydrates_from_target_metadata():
+    quant_config = Mock()
+    quant_config.get_name.return_value = "exl3"
+    target_hf = SimpleNamespace(hybrid_tr3_tail={"tp": 4})
+    draft_model_config = SimpleNamespace(
+        model="rank-sliced-draft",
+        hf_config=SimpleNamespace(),
+    )
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(draft_model_config=draft_model_config),
+        load_config=object(),
+        model_config=SimpleNamespace(hf_config=target_hf),
+    )
+
+    with patch.object(VllmConfig, "get_quantization_config", return_value=quant_config):
+        result = get_draft_quant_config(vllm_config)
+
+    assert result is quant_config
+    quant_config.maybe_update_config.assert_called_once_with(
+        "rank-sliced-draft", hf_config=target_hf
+    )
 
 
 @torch.inference_mode()

--- a/tests/models/deepseek_v32/test_weight_loading.py
+++ b/tests/models/deepseek_v32/test_weight_loading.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+from vllm.models.deepseek_v32.nvidia import model as deepseek_v32_model
+
+
+def test_rank_sliced_exl3_names_are_normalized_before_loading(monkeypatch):
+    model = object.__new__(deepseek_v32_model.DeepseekV32Model)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(n_routed_experts=0)
+    model.num_redundant_experts = 0
+    model.register_parameter(
+        "local_weight",
+        nn.Parameter(torch.zeros(1), requires_grad=False),
+    )
+
+    def normalize(name: str) -> str | None:
+        if ".rank1." in name:
+            return None
+        return name.replace(".rank0.mcg", "")
+
+    model.quant_config = SimpleNamespace(
+        normalize_rank_sliced_weight_name=normalize,
+    )
+    monkeypatch.setattr(
+        deepseek_v32_model,
+        "fused_moe_make_expert_params_mapping",
+        lambda *args, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        deepseek_v32_model,
+        "get_pp_missing_layer_names",
+        lambda *args, **kwargs: set(),
+    )
+    monkeypatch.setattr(
+        deepseek_v32_model,
+        "get_spec_layer_idx_from_weight_name",
+        lambda *args, **kwargs: None,
+    )
+
+    loaded = model.load_weights(
+        iter(
+            [
+                ("local_weight.rank1.mcg", torch.tensor([1.0])),
+                ("local_weight.rank0.mcg", torch.tensor([2.0])),
+            ]
+        )
+    )
+
+    assert loaded == {"local_weight"}
+    torch.testing.assert_close(model.local_weight, torch.tensor([2.0]))

--- a/tests/models/deepseek_v32/test_weight_loading.py
+++ b/tests/models/deepseek_v32/test_weight_loading.py
@@ -7,6 +7,7 @@ import torch
 from torch import nn
 
 from vllm.models.deepseek_v32.nvidia import model as deepseek_v32_model
+from vllm.models.deepseek_v32.nvidia import mtp as deepseek_v32_mtp
 
 
 def test_rank_sliced_exl3_names_are_normalized_before_loading(monkeypatch):
@@ -54,3 +55,43 @@ def test_rank_sliced_exl3_names_are_normalized_before_loading(monkeypatch):
 
     assert loaded == {"local_weight"}
     torch.testing.assert_close(model.local_weight, torch.tensor([2.0]))
+
+
+def test_rank_sliced_exl3_mtp_skips_peer_rank_payloads(monkeypatch):
+    model = object.__new__(deepseek_v32_mtp.DeepseekV32MTP)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(n_routed_experts=0)
+    model.model = SimpleNamespace(mtp_start_layer_idx=78, num_mtp_layers=1)
+    model.quant_config = SimpleNamespace(
+        normalize_rank_sliced_weight_name=lambda name: (
+            None if ".rank1." in name else name
+        ),
+    )
+    monkeypatch.setattr(
+        deepseek_v32_mtp,
+        "fused_moe_make_expert_params_mapping",
+        lambda *args, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        deepseek_v32_mtp,
+        "get_pp_missing_layer_names",
+        lambda *args, **kwargs: set(),
+    )
+    monkeypatch.setattr(
+        deepseek_v32_mtp,
+        "is_mtp_completeness_check_enabled",
+        lambda: False,
+    )
+
+    loaded = model.load_weights(
+        iter(
+            [
+                (
+                    "model.layers.78.mlp.experts.0.down_proj.rank1.mcg",
+                    torch.tensor([1.0]),
+                ),
+            ]
+        )
+    )
+
+    assert loaded == set()

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -405,7 +405,7 @@ def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
             self.plan_kwargs = kwargs
             return SimpleNamespace(source_format=kwargs["source_format"])
 
-        def prepare_weights(self, **kwargs):
+        def prepare_rank_sliced_trellis_weights(self, **kwargs):
             self.prepare_kwargs = kwargs
             return SimpleNamespace(plan=kwargs["plan"])
 
@@ -414,7 +414,6 @@ def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
     method = object.__new__(Exl3MoEMethod)
     method.quant_config = SimpleNamespace(bits=float(bits))
     method._rank_sliced_backing = lambda _layer, name: slabs[name]
-    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
     layer = SimpleNamespace(
         local_num_experts=experts,
         exl3_hidden_size=hidden,
@@ -423,14 +422,13 @@ def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
         exl3_layer_bitrates=(bits,) * experts,
         exl3_mixed_bitrate=False,
         activation=MoEActivation.SILU,
-        w13_mcg=SimpleNamespace(exl3_tensors={(0, "w1"): marker}),
     )
 
     method._prepare_rank_sliced_weights(layer)
 
     assert api.plan_kwargs == {
         "quant_modes": "w4a16",
-        "source_format": "exl3_trellis_mcg",
+        "source_format": "b12x_trellis",
         "activation": "silu",
         "params_dtype": torch.float16,
         "num_experts": experts,
@@ -439,12 +437,12 @@ def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
         "w13_layout": "w13",
         "trellis_bits": bits,
         "trellis_tile_config": (64, 128, 64, 128),
+        "trellis_codebook": "mcg",
+        "trellis_rate_granularity": "uniform",
     }
     assert api.prepare_kwargs["plan"] is layer.exl3_trellis_weights.plan
-    assert api.prepare_kwargs["params_dtype"] == torch.float16
-    assert api.prepare_kwargs["w1_fp4"] is slabs["w13_trellis"]
-    assert api.prepare_kwargs["w2_fp4"] is slabs["w2_trellis"]
-    assert api.prepare_kwargs["trellis_mcg"] is marker
+    assert api.prepare_kwargs["w13"] is slabs["w13_trellis"]
+    assert api.prepare_kwargs["w2"] is slabs["w2_trellis"]
 
 
 def test_rank_sliced_weights_pass_shared_h_rows_without_expansion(monkeypatch):
@@ -472,14 +470,13 @@ def test_rank_sliced_weights_pass_shared_h_rows_without_expansion(monkeypatch):
             return SimpleNamespace(source_format=kwargs["source_format"])
 
         @staticmethod
-        def prepare_weights(**kwargs):
+        def prepare_rank_sliced_trellis_weights(**kwargs):
             return SimpleNamespace(**kwargs)
 
     monkeypatch.setattr(exl3_module, "_load_b12x_fused_moe", lambda: FakeFusedMoe())
     method = object.__new__(Exl3MoEMethod)
     method.quant_config = SimpleNamespace(bits=float(bits))
     method._rank_sliced_backing = lambda _layer, name: slabs[name]
-    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
     layer = SimpleNamespace(
         local_num_experts=experts,
         exl3_hidden_size=hidden,
@@ -489,7 +486,6 @@ def test_rank_sliced_weights_pass_shared_h_rows_without_expansion(monkeypatch):
         exl3_mixed_bitrate=False,
         exl3_shared_h_rotations=True,
         activation=MoEActivation.SILU,
-        w13_mcg=SimpleNamespace(exl3_tensors={(0, "w1"): marker}),
     )
 
     method._prepare_rank_sliced_weights(layer)

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -1,0 +1,908 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.model_executor.layers.quantization.exl3 as exl3_module
+import vllm.model_executor.parameter as parameter_module
+from vllm.config import CompilationMode
+from vllm.model_executor.layers.fused_moe import MoEActivation, RoutedExperts
+from vllm.model_executor.layers.quantization import get_quantization_config
+from vllm.model_executor.layers.quantization.exl3 import (
+    Exl3Config,
+    Exl3MoEMethod,
+    Exl3MoEParameter,
+)
+from vllm.model_executor.models import glm4_moe
+
+
+def _rank_sliced_metadata(**overrides):
+    metadata = {
+        "format": "exl3-trellis",
+        "bits": 3.0,
+        "codebook": "mcg",
+        "experts_per_layer": 256,
+        "moe_layers": [3, 77],
+        "tensor_schema": (
+            "model.layers.{L}.mlp.experts.{E}.{proj}.rank{r}.{trellis|suh|svh|mcg}"
+        ),
+        "tp": 4,
+    }
+    metadata.update(overrides)
+    return metadata
+
+
+def test_rank_sliced_checkpoint_selects_exl3_override():
+    hf_config = SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
+
+    assert get_quantization_config("exl3") is Exl3Config
+    assert (
+        Exl3Config.override_quantization_method(
+            {"quant_method": "modelopt"}, None, hf_config
+        )
+        == "exl3"
+    )
+    assert (
+        Exl3Config.override_quantization_method(
+            {"quant_method": "modelopt"}, "fp8", hf_config
+        )
+        is None
+    )
+
+
+def test_glm_model_retains_quant_config_for_weight_loading(monkeypatch):
+    pp_group = SimpleNamespace(is_first_rank=False, is_last_rank=False)
+    monkeypatch.setattr(glm4_moe, "get_pp_group", lambda: pp_group)
+    monkeypatch.setattr(
+        glm4_moe,
+        "make_layers",
+        lambda *args, **kwargs: (0, 0, torch.nn.ModuleList()),
+    )
+    monkeypatch.setattr(
+        glm4_moe,
+        "make_empty_intermediate_tensors_factory",
+        lambda *args, **kwargs: object(),
+    )
+    quant_config = object()
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(
+                vocab_size=1,
+                hidden_size=8,
+                num_hidden_layers=0,
+            )
+        ),
+        cache_config=object(),
+        quant_config=quant_config,
+        parallel_config=SimpleNamespace(enable_eplb=False),
+        compilation_config=SimpleNamespace(mode=CompilationMode.NONE),
+    )
+
+    model = glm4_moe.Glm4MoeModel(vllm_config=vllm_config)
+
+    assert model.quant_config is quant_config
+
+
+def test_rank_three_per_expert_trellis_is_not_loaded_as_fused_weight():
+    experts = SimpleNamespace(
+        layer_name="model.layers.0.mlp.experts",
+        is_fused_checkpoint_transposed=False,
+    )
+    experts.get_expert_mapping = lambda **_: RoutedExperts.build_expert_params_mapping(
+        "gate_proj",
+        "down_proj",
+        "up_proj",
+        num_experts=1,
+        routed_experts_prefix="",
+        include_fused=True,
+    )
+    loaded_calls = []
+
+    def weight_loader(**kwargs):
+        loaded_calls.append(kwargs)
+        return True
+
+    experts.w13_trellis = SimpleNamespace(weight_loader=weight_loader)
+    trellis = torch.zeros((8, 16, 48), dtype=torch.int16)
+
+    loaded = list(
+        RoutedExperts.load_weights(
+            experts,
+            [("0.gate_proj.trellis", trellis)],
+        )
+    )
+
+    assert loaded == ["w13_trellis"]
+    assert len(loaded_calls) == 1
+    assert loaded_calls[0]["expert_id"] == 0
+    assert loaded_calls[0]["shard_id"] == "w1"
+    loaded_trellis = loaded_calls[0]["loaded_weight"]
+    assert loaded_trellis.shape == trellis.shape
+    assert loaded_trellis.data_ptr() == trellis.data_ptr()
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"codebook": "mul1"}, "MCG codebook"),
+        ({"moe_layers": [77, 3]}, "moe_layers"),
+        ({"tensor_schema": "unsupported"}, "tensor schema"),
+        ({"rotation_layout": "implicit_magic"}, "rotation_layout"),
+        ({"rotation_layout": "shared_h_v1"}, "shared_h_tensor_schema"),
+    ],
+)
+def test_rank_sliced_metadata_fails_closed(overrides, message):
+    config = Exl3Config()
+    hf_config = SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata(**overrides))
+
+    with pytest.raises(ValueError, match=message):
+        config.maybe_update_config("unused", hf_config)
+
+
+def test_rank_sliced_metadata_admits_only_declared_moe_layers():
+    config = Exl3Config()
+    config.maybe_update_config(
+        "unused",
+        SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata()),
+    )
+
+    assert config._moe_prefix_is_exl3("model.layers.3.mlp.experts")
+    assert config._moe_prefix_is_exl3("model.layers.77.mlp.experts")
+    assert not config._moe_prefix_is_exl3("model.layers.2.mlp.experts")
+    assert not config._moe_prefix_is_exl3("model.layers.78.mlp.experts")
+    assert (
+        config.codebook_for_prefix("model.layers.10.mlp.experts.0.gate_proj") == "mcg"
+    )
+
+
+def test_rank_sliced_shared_h_metadata_is_explicit_and_legacy_defaults_unchanged():
+    legacy = Exl3Config()
+    legacy.maybe_update_config(
+        "unused", SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
+    )
+    shared = Exl3Config()
+    shared.maybe_update_config(
+        "unused",
+        SimpleNamespace(
+            hybrid_tr3_tail=_rank_sliced_metadata(
+                rotation_layout="shared_h_v1",
+                shared_h_tensor_schema=(
+                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
+                ),
+            )
+        ),
+    )
+
+    assert legacy.rank_sliced_rotation_layout == "per_expert_v1"
+    assert shared.rank_sliced_rotation_layout == "shared_h_v1"
+
+
+def test_mixed_rank_sliced_metadata_hydrates_per_layer_bitrates(monkeypatch):
+    metadata = _rank_sliced_metadata(
+        bits="mixed",
+        bits_per_expert="tier_bitmap.json:k",
+        k_values=[3, 4],
+        experts_per_layer=4,
+        moe_layers=[77, 78],
+    )
+    payload = {
+        "77": {"k": [3, 4, 3, 4]},
+        # The checkpoint's MTP overlay records a uniform K3 tail this way.
+        "78": {"tail_tr3": [0, 1, 2, 3]},
+    }
+    monkeypatch.setattr(
+        exl3_module,
+        "get_hf_file_to_dict",
+        lambda filename, model_name, revision=None: payload,
+    )
+    config = Exl3Config()
+
+    config.maybe_update_config(
+        "unused",
+        SimpleNamespace(hybrid_tr3_tail=metadata, _commit_hash="revision"),
+    )
+
+    assert config.bits is None
+    assert config.rank_sliced_k_values == (3, 4)
+    assert config.rank_sliced_layer_bitrates("model.layers.77.mlp.experts") == (
+        3,
+        4,
+        3,
+        4,
+    )
+    assert config.rank_sliced_layer_bitrates("model.layers.78.mlp.experts") == (
+        3,
+        3,
+        3,
+        3,
+    )
+
+
+def test_rank_sliced_weight_name_keeps_only_local_tp_rank(monkeypatch):
+    config = Exl3Config()
+    config.maybe_update_config(
+        "unused",
+        SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata()),
+    )
+    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_rank", lambda: 2)
+    prefix = "model.layers.3.mlp.experts.17.gate_proj"
+
+    assert (
+        config.normalize_rank_sliced_weight_name(f"{prefix}.rank2.trellis")
+        == f"{prefix}.trellis"
+    )
+    assert config.normalize_rank_sliced_weight_name(f"{prefix}.rank1.trellis") is None
+    assert (
+        config.normalize_rank_sliced_weight_name("model.embed_tokens.weight")
+        == "model.embed_tokens.weight"
+    )
+
+
+def test_rank_sliced_shared_h_names_map_once_and_fail_closed(monkeypatch):
+    config = Exl3Config()
+    config.maybe_update_config(
+        "unused",
+        SimpleNamespace(
+            hybrid_tr3_tail=_rank_sliced_metadata(
+                rotation_layout="shared_h_v1",
+                shared_h_tensor_schema=(
+                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
+                ),
+            )
+        ),
+    )
+    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_rank", lambda: 2)
+    prefix = "model.layers.3.mlp.experts"
+
+    assert (
+        config.normalize_rank_sliced_weight_name(
+            f"{prefix}.shared_h.gate_proj.rank2.suh"
+        )
+        == f"{prefix}.0.gate_proj.suh"
+    )
+    assert (
+        config.normalize_rank_sliced_weight_name(
+            f"{prefix}.shared_h.down_proj.rank1.svh"
+        )
+        is None
+    )
+    with pytest.raises(ValueError, match="requires suh"):
+        config.normalize_rank_sliced_weight_name(
+            f"{prefix}.shared_h.gate_proj.rank2.svh"
+        )
+    with pytest.raises(ValueError, match="must store H-side rotations"):
+        config.normalize_rank_sliced_weight_name(f"{prefix}.7.down_proj.rank2.svh")
+
+    legacy = Exl3Config()
+    legacy.maybe_update_config(
+        "unused", SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
+    )
+    with pytest.raises(ValueError, match="does not declare"):
+        legacy.normalize_rank_sliced_weight_name(f"{prefix}.shared_h.up_proj.rank2.suh")
+
+
+def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    param = Exl3MoEParameter(
+        weight_loader=lambda *args, **kwargs: None,
+        num_experts=3,
+        shard_ids=("w1", "w3"),
+        preallocate=True,
+    )
+    w1 = torch.arange(8, dtype=torch.int16).reshape(2, 2, 2)
+    w3 = w1 + 20
+
+    param.load_exl3_weight(w1, expert_id=1, shard_id="w1")
+    param.load_exl3_weight(w3, expert_id=2, shard_id="w3")
+
+    assert param.exl3_backing is not None
+    assert tuple(param.exl3_backing.shape) == (2, 3, 2, 2, 2)
+    assert (
+        param.exl3_tensors[(1, "w1")].data_ptr() == param.exl3_backing[0, 1].data_ptr()
+    )
+    assert (
+        param.exl3_tensors[(2, "w3")].data_ptr() == param.exl3_backing[1, 2].data_ptr()
+    )
+    torch.testing.assert_close(param.exl3_tensors[(1, "w1")], w1)
+    torch.testing.assert_close(param.exl3_tensors[(2, "w3")], w3)
+
+
+def test_rank_sliced_broadcast_pointer_table_repeats_one_physical_row():
+    slab = torch.ones((1, 128), dtype=torch.float16)
+
+    table = Exl3MoEMethod._pointer_table(slab, num_experts=4)
+
+    assert table.tolist() == [slab.data_ptr()] * 4
+    with pytest.raises(RuntimeError, match="per-expert or broadcast"):
+        Exl3MoEMethod._pointer_table(
+            torch.ones((2, 128), dtype=torch.float16), num_experts=4
+        )
+
+
+def test_rank_sliced_shared_h_create_weights_allocates_one_physical_row(
+    monkeypatch,
+):
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 4
+    )
+    config = Exl3Config()
+    config.maybe_update_config(
+        "unused",
+        SimpleNamespace(
+            hybrid_tr3_tail=_rank_sliced_metadata(
+                rotation_layout="shared_h_v1",
+                shared_h_tensor_schema=(
+                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
+                ),
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        exl3_module,
+        "get_current_vllm_config_or_none",
+        lambda: SimpleNamespace(
+            scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
+            model_config=SimpleNamespace(runner_type="generate"),
+        ),
+    )
+    layer = torch.nn.Module()
+    layer.layer_name = "model.layers.3.mlp.experts"
+    moe = SimpleNamespace(
+        moe_parallel_config=SimpleNamespace(use_ep=False, tp_rank=0, tp_size=4),
+        has_bias=False,
+    )
+    method = Exl3MoEMethod(config, moe)
+
+    method.create_weights(
+        layer,
+        num_experts=256,
+        hidden_size=6144,
+        intermediate_size_per_partition=512,
+        params_dtype=torch.bfloat16,
+    )
+
+    assert layer.exl3_shared_h_rotations
+    assert layer.w13_suh.exl3_num_experts == 1
+    assert layer.w2_svh.exl3_num_experts == 1
+    assert layer.w13_svh.exl3_num_experts == 256
+    assert layer.w2_suh.exl3_num_experts == 256
+    assert layer.w13_trellis.exl3_num_experts == 256
+    assert layer.w2_trellis.exl3_num_experts == 256
+
+
+def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
+    experts = 2
+    hidden = intermediate = 128
+    bits = 3
+    slabs = {
+        "w13_trellis": torch.zeros(
+            (2, experts, hidden // 16, intermediate // 16, 16 * bits),
+            dtype=torch.int16,
+        ),
+        "w2_trellis": torch.zeros(
+            (experts, intermediate // 16, hidden // 16, 16 * bits),
+            dtype=torch.int16,
+        ),
+        "w13_suh": torch.ones((2, experts, hidden), dtype=torch.float16),
+        "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
+        "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
+        "w2_svh": torch.ones((experts, hidden), dtype=torch.float16),
+    }
+
+    class FakeFusedMoe:
+        def __init__(self):
+            self.plan_kwargs = None
+            self.prepare_kwargs = None
+
+        def plan_weights(self, **kwargs):
+            self.plan_kwargs = kwargs
+            return SimpleNamespace(source_format=kwargs["source_format"])
+
+        def prepare_weights(self, **kwargs):
+            self.prepare_kwargs = kwargs
+            return SimpleNamespace(plan=kwargs["plan"])
+
+    api = FakeFusedMoe()
+    monkeypatch.setattr(exl3_module, "_load_b12x_fused_moe", lambda: api)
+    method = object.__new__(Exl3MoEMethod)
+    method.quant_config = SimpleNamespace(bits=float(bits))
+    method._rank_sliced_backing = lambda _layer, name: slabs[name]
+    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
+    layer = SimpleNamespace(
+        local_num_experts=experts,
+        exl3_hidden_size=hidden,
+        exl3_intermediate_size_per_partition=intermediate,
+        exl3_params_dtype=torch.float16,
+        exl3_layer_bitrates=(bits,) * experts,
+        exl3_mixed_bitrate=False,
+        activation=MoEActivation.SILU,
+        w13_mcg=SimpleNamespace(exl3_tensors={(0, "w1"): marker}),
+    )
+
+    method._prepare_rank_sliced_weights(layer)
+
+    assert api.plan_kwargs == {
+        "quant_modes": "w4a16",
+        "source_format": "exl3_trellis_mcg",
+        "activation": "silu",
+        "params_dtype": torch.float16,
+        "num_experts": experts,
+        "hidden_size": hidden,
+        "intermediate_size": intermediate,
+        "w13_layout": "w13",
+        "trellis_bits": bits,
+        "trellis_tile_config": (64, 128, 64, 128),
+    }
+    assert api.prepare_kwargs["plan"] is layer.exl3_trellis_weights.plan
+    assert api.prepare_kwargs["params_dtype"] == torch.float16
+    assert api.prepare_kwargs["w1_fp4"] is slabs["w13_trellis"]
+    assert api.prepare_kwargs["w2_fp4"] is slabs["w2_trellis"]
+    assert api.prepare_kwargs["trellis_mcg"] is marker
+
+
+def test_rank_sliced_weights_pass_shared_h_rows_without_expansion(monkeypatch):
+    experts = 3
+    hidden = intermediate = 128
+    bits = 3
+    slabs = {
+        "w13_trellis": torch.zeros(
+            (2, experts, hidden // 16, intermediate // 16, 16 * bits),
+            dtype=torch.int16,
+        ),
+        "w2_trellis": torch.zeros(
+            (experts, intermediate // 16, hidden // 16, 16 * bits),
+            dtype=torch.int16,
+        ),
+        "w13_suh": torch.ones((2, 1, hidden), dtype=torch.float16),
+        "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
+        "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
+        "w2_svh": torch.ones((1, hidden), dtype=torch.float16),
+    }
+
+    class FakeFusedMoe:
+        @staticmethod
+        def plan_weights(**kwargs):
+            return SimpleNamespace(source_format=kwargs["source_format"])
+
+        @staticmethod
+        def prepare_weights(**kwargs):
+            return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(exl3_module, "_load_b12x_fused_moe", lambda: FakeFusedMoe())
+    method = object.__new__(Exl3MoEMethod)
+    method.quant_config = SimpleNamespace(bits=float(bits))
+    method._rank_sliced_backing = lambda _layer, name: slabs[name]
+    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
+    layer = SimpleNamespace(
+        local_num_experts=experts,
+        exl3_hidden_size=hidden,
+        exl3_intermediate_size_per_partition=intermediate,
+        exl3_params_dtype=torch.float16,
+        exl3_layer_bitrates=(bits,) * experts,
+        exl3_mixed_bitrate=False,
+        exl3_shared_h_rotations=True,
+        activation=MoEActivation.SILU,
+        w13_mcg=SimpleNamespace(exl3_tensors={(0, "w1"): marker}),
+    )
+
+    method._prepare_rank_sliced_weights(layer)
+
+    prepared = layer.exl3_trellis_weights
+    assert tuple(prepared.gate_suh.shape) == (1, hidden)
+    assert tuple(prepared.up_suh.shape) == (1, hidden)
+    assert tuple(prepared.down_svh.shape) == (1, hidden)
+    assert all(tuple(table.shape) == (experts,) for table in layer.exl3_pointer_tables)
+
+
+@pytest.mark.parametrize("shared_h", [False, True])
+def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
+    monkeypatch, shared_h
+):
+    experts = 4
+    hidden = intermediate = 128
+    bitrates = (3, 4, 3, 4)
+
+    def parameter(shard_ids=(), tensors=None, backing=None):
+        return SimpleNamespace(
+            exl3_shard_ids=list(shard_ids),
+            exl3_tensors=dict(tensors or {}),
+            exl3_backing=backing,
+        )
+
+    w13_tensors = {}
+    w2_tensors = {}
+    for expert, bits in enumerate(bitrates):
+        for shard in ("w1", "w3"):
+            w13_tensors[(expert, shard)] = torch.zeros(
+                (hidden // 16, intermediate // 16, 16 * bits),
+                dtype=torch.int16,
+            )
+        w2_tensors[(expert, "w2")] = torch.zeros(
+            (intermediate // 16, hidden // 16, 16 * bits),
+            dtype=torch.int16,
+        )
+
+    slabs = {
+        "w13_suh": torch.ones(
+            (2, 1 if shared_h else experts, hidden), dtype=torch.float16
+        ),
+        "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
+        "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
+        "w2_svh": torch.ones((1 if shared_h else experts, hidden), dtype=torch.float16),
+    }
+    layer = SimpleNamespace(
+        local_num_experts=experts,
+        exl3_hidden_size=hidden,
+        exl3_intermediate_size_per_partition=intermediate,
+        exl3_params_dtype=torch.float16,
+        exl3_layer_bitrates=bitrates,
+        activation=MoEActivation.SILU,
+        layer_name="model.layers.3.mlp.experts",
+        w13_trellis=parameter(("w1", "w3"), w13_tensors),
+        w2_trellis=parameter(("w2",), w2_tensors),
+    )
+    for prefix, shards in (("w13", ("w1", "w3")), ("w2", ("w2",))):
+        for suffix in ("suh", "svh", "mcg", "mul1"):
+            name = f"{prefix}_{suffix}"
+            backing = slabs.get(name)
+            setattr(layer, name, parameter(shards, backing=backing))
+
+    class FakeMixedApi:
+        def __init__(self):
+            self.prepared = []
+
+        def prepare_weights(self, **kwargs):
+            self.prepared.append(kwargs)
+            return SimpleNamespace(**kwargs)
+
+        @staticmethod
+        def build_tiered_maps(tier0, tier1, *, device):
+            assert tuple(tier0) == (0, 2)
+            assert tuple(tier1) == (1, 3)
+            return (
+                torch.tensor([0, 2, 1, 3], dtype=torch.int32, device=device),
+                torch.tensor([0, 1, 256, 257], dtype=torch.int32, device=device),
+            )
+
+        @staticmethod
+        def combine_trellis_rotations(tier0, tier1):
+            return tier0, tier1
+
+    api = FakeMixedApi()
+    monkeypatch.setattr(exl3_module, "_load_b12x_mixed_trellis", lambda: api)
+    method = object.__new__(Exl3MoEMethod)
+    method._rank_sliced_backing = lambda _layer, name: slabs[name]
+
+    method._prepare_mixed_rank_sliced_weights(layer)
+
+    assert [entry["trellis_bits"] for entry in api.prepared] == [3, 3, 4, 4]
+    assert [entry["num_experts"] for entry in api.prepared] == [2] * 4
+    for entry in api.prepared:
+        bits = entry["trellis_bits"]
+        assert tuple(entry["w13"].shape) == (
+            2,
+            2,
+            hidden // 16,
+            intermediate // 16,
+            16 * bits,
+        )
+        assert tuple(entry["w2"].shape) == (
+            2,
+            intermediate // 16,
+            hidden // 16,
+            16 * bits,
+        )
+    assert [entry["tile_config"] for entry in api.prepared] == [
+        (128, 128, 128, 128),
+        (128, 128, 128, 128),
+        (128, 128, 128, 128),
+        (128, 128, 128, 128),
+    ]
+    assert layer.exl3_mixed_trellis["tier_ids"] == ((0, 2), (1, 3))
+    assert layer.exl3_mixed_trellis["tier_bits"] == (3, 4)
+    assert len(layer.exl3_mixed_trellis["tiers"]) == 2
+    assert len(layer.exl3_mixed_trellis["prefill_tiers"]) == 2
+    rotations = layer.exl3_mixed_trellis["rotations"]
+    expected_h_rows = 1 if shared_h else experts
+    assert rotations.gate_suh.shape[0] == expected_h_rows
+    assert rotations.up_suh.shape[0] == expected_h_rows
+    assert rotations.down_svh.shape[0] == expected_h_rows
+    assert layer.exl3_mixed_trellis["broadcast_suh"] is shared_h
+    assert layer.exl3_mixed_trellis["broadcast_svh"] is shared_h
+    for entry in api.prepared:
+        expected_tier_rows = 1 if shared_h else 2
+        assert entry["gate_suh"].shape[0] == expected_tier_rows
+        assert entry["up_suh"].shape[0] == expected_tier_rows
+        assert entry["down_svh"].shape[0] == expected_tier_rows
+        assert (
+            entry["gate_suh"].untyped_storage().data_ptr()
+            == rotations.gate_suh.untyped_storage().data_ptr()
+        )
+    assert layer.w13_trellis.exl3_tensors == {}
+    assert layer.w2_trellis.exl3_tensors == {}
+    assert layer.w13_suh.exl3_backing is None
+    assert layer.w2_svh.exl3_backing is None
+
+
+def test_mixed_trellis_buffer_accounting_ignores_metadata() -> None:
+    shared = torch.empty(8, dtype=torch.uint8)
+    first = SimpleNamespace(tensor=shared, metadata=None, block_size=8)
+    second = SimpleNamespace(alias=shared.view(2, 4), label="prefill")
+
+    assert exl3_module._unique_tensor_storage_bytes(first, second) == 8
+
+
+def test_mixed_trellis_dispatches_decode_and_one_grid_prefill(monkeypatch):
+    class FakeMixedApi:
+        calls = []
+
+        def run_bound_mixed_trellis(self, x, weights, ids, binding, buffers):
+            del buffers
+            self.calls.append((int(x.shape[0]), binding.tiers, weights, ids))
+            return torch.full_like(x, binding.value)
+
+    mixed_api = FakeMixedApi()
+    decode_tiers = (object(), object())
+    prefill_tiers = (object(), object())
+    runtime = {
+        "mixed_api": mixed_api,
+        "decode": {
+            "launch": SimpleNamespace(value=1),
+            "binding": SimpleNamespace(value=1, tiers=decode_tiers),
+            "buffers": object(),
+        },
+        "prefill": {
+            "launch": SimpleNamespace(value=3),
+            "binding": SimpleNamespace(value=3, tiers=prefill_tiers),
+            "buffers": object(),
+        },
+        "max_decode_m": 8,
+        "max_batched_tokens": 16,
+        "prefill_capacity": 8,
+    }
+    layer = SimpleNamespace(
+        exl3_mixed_trellis={
+            "tiers": decode_tiers,
+            "prefill_tiers": prefill_tiers,
+            "global_to_combined": object(),
+            "descriptor_map": object(),
+            "rotations": object(),
+        }
+    )
+    method = object.__new__(Exl3MoEMethod)
+    monkeypatch.setattr(
+        method, "_mixed_rank_sliced_runtime", lambda layer, x, ids: runtime
+    )
+    weights = torch.ones((16, 2), dtype=torch.float32)
+    ids = torch.zeros((16, 2), dtype=torch.int64)
+
+    decode = method._apply_mixed_rank_sliced(
+        layer, torch.zeros((4, 4)), weights[:4], ids[:4]
+    )
+    prefill = method._apply_mixed_rank_sliced(layer, torch.zeros((16, 4)), weights, ids)
+
+    torch.testing.assert_close(decode, torch.ones_like(decode))
+    torch.testing.assert_close(prefill, torch.full_like(prefill, 3))
+    assert [call[0] for call in mixed_api.calls] == [4, 8, 8]
+    assert mixed_api.calls[0][1] == decode_tiers
+    assert all(call[1] == prefill_tiers for call in mixed_api.calls[1:])
+
+
+@pytest.mark.parametrize(
+    "tier_signature",
+    [
+        ((3, 192), (4, 64)),
+        ((3, 206), (4, 50)),
+        ((3, 148), (4, 108)),
+    ],
+)
+def test_mixed_trellis_prefill_block_policy_qualified_partitions(
+    tier_signature,
+) -> None:
+    common = {
+        "configured_block_m": 64,
+        "explicit_override": False,
+        "hidden_size": 6144,
+        "intermediate_size": 512,
+        "tier_signature": tier_signature,
+        "topk": 8,
+        "device_major": 12,
+        "prefill_tile_config": (128, 128, 32, 512),
+    }
+
+    assert exl3_module._resolve_mixed_trellis_prefill_block_m(**common) == 32
+    assert (
+        exl3_module._resolve_mixed_trellis_prefill_block_m(
+            **{**common, "explicit_override": True}
+        )
+        == 64
+    )
+
+
+def test_mixed_trellis_prefill_block_policy_rejects_unqualified_partition() -> None:
+    common = {
+        "configured_block_m": 64,
+        "explicit_override": False,
+        "hidden_size": 6144,
+        "intermediate_size": 512,
+        "tier_signature": ((3, 192), (4, 64)),
+        "topk": 8,
+        "device_major": 12,
+        "prefill_tile_config": (128, 128, 32, 512),
+    }
+    assert (
+        exl3_module._resolve_mixed_trellis_prefill_block_m(
+            **{**common, "tier_signature": ((3, 128), (4, 128))}
+        )
+        == 64
+    )
+    assert (
+        exl3_module._resolve_mixed_trellis_prefill_block_m(
+            **{**common, "tier_signature": ((4, 256),)}
+        )
+        == 64
+    )
+    assert (
+        exl3_module._resolve_mixed_trellis_prefill_block_m(
+            **{**common, "device_major": 11}
+        )
+        == 64
+    )
+
+
+@pytest.mark.parametrize(
+    ("hidden", "intermediate", "expected"),
+    [
+        (6144, 512, (128, 128, 32, 512)),
+        (256, 128, (128, 128, 64, 256)),
+        (128, 128, (128, 128, 128, 128)),
+    ],
+)
+def test_mixed_trellis_uses_large_m_safe_tile_geometry(hidden, intermediate, expected):
+    assert Exl3MoEMethod._mixed_trellis_tile_config(hidden, intermediate) == expected
+
+
+def test_rank_sliced_runtime_scope_is_per_owning_model():
+    """Target and rank-sliced MTP draft layers must not share a cached runtime.
+
+    The rank-sliced runtime cache stores mutable Trellis/prefill scratch and
+    parity staging buffers. A target MoE layer and an MTP draft layer of the same
+    model have identical shapes, topk and planner settings, so a shape-only key
+    would hand the draft the target's scratch and break the target/draft
+    isolation their independently captured CUDA graphs depend on.
+    """
+    target_config = SimpleNamespace()
+    draft_config = SimpleNamespace()
+
+    target_scope = exl3_module._runtime_scope_id(target_config)
+    draft_scope = exl3_module._runtime_scope_id(draft_config)
+
+    # Distinct owning configs must never collide...
+    assert target_scope != draft_scope
+    # ...and the scope must be stable, so every layer of one model keeps sharing
+    # a single runtime (the prefill arena is ~1 GiB; per-layer runtimes would not
+    # fit on a 75+ layer model).
+    assert exl3_module._runtime_scope_id(target_config) == target_scope
+    assert exl3_module._runtime_scope_id(draft_config) == draft_scope
+
+
+def test_rank_sliced_runtime_key_differs_across_models_with_same_shape():
+    """Two same-shape layers owned by different models get different cache keys."""
+
+    def _key(quant_config):
+        # Mirrors the scope-prefixed key built in Exl3MoEMethod._rank_sliced_runtime
+        # for two layers whose shape/planner components are byte-for-byte equal.
+        return (
+            exl3_module._runtime_scope_id(quant_config),
+            0,  # device index
+            torch.bfloat16,
+            5120,  # hidden size
+            768,  # intermediate size per partition
+            64,  # local experts
+            8,  # topk
+            3072,  # max batched tokens
+        )
+
+    target_config = SimpleNamespace()
+    draft_config = SimpleNamespace()
+
+    target_key = _key(target_config)
+    draft_key = _key(draft_config)
+
+    assert target_key != draft_key
+    # Everything except the leading scope is identical, proving the scope is the
+    # only thing preventing the collision.
+    assert target_key[1:] == draft_key[1:]
+    # Same owner -> same key, so target layers still share one runtime.
+    assert _key(target_config) == target_key
+
+
+def test_rank_sliced_window_defaults_to_min_capturable_m(monkeypatch) -> None:
+    """Every rank-sliced layer must cover small rows without an env workaround.
+
+    Regression test for the boot failure reported in vLLM #183: with the Trellis
+    window left at its historical default of 4, CUDA-graph capture of an EXL3
+    rank-sliced MTP draft reaches the eager parity path at m=1,2,3 and the engine
+    cannot start:
+
+        RuntimeError: EXL3 eager parity path entered during CUDA graph capture
+        (m=3); capture sizes must lie inside the Trellis window [4, 32]
+
+    It was invariant to num_speculative_tokens and to cudagraph_capture_sizes,
+    because m here is the draft's row count per step, not a target batch size.
+    Target profiling can also produce m=3, so role-dependent defaults merely
+    move the same failure from the draft to MTP0. The backend declares one
+    capability floor and uses it for both roles.
+    """
+    from types import SimpleNamespace
+
+    from vllm.model_executor.layers.quantization import exl3 as exl3_mod
+
+    monkeypatch.delenv("VLLM_EXL3_TRELLIS_MIN_M", raising=False)
+
+    # The GLM-5-family MTP head is named exactly like a target layer, so the role
+    # comes from the exl3_is_draft stamp applied by load_eagle_model -- name
+    # inspection alone cannot classify it.
+    draft = SimpleNamespace(
+        layer_name="model.layers.78.mlp.experts", exl3_is_draft=True
+    )
+    target = SimpleNamespace(layer_name="model.layers.30.mlp.experts")
+
+    assert exl3_mod._is_draft_layer(draft)
+    assert not exl3_mod._is_draft_layer(target)
+    # Unstamped draft with a distinctive prefix still classifies via fallback.
+    assert exl3_mod._is_draft_layer(
+        SimpleNamespace(layer_name="model.layers.0.mtp.mlp.experts")
+    )
+    # A stamp always wins over the name, in both directions.
+    assert not exl3_mod._is_draft_layer(
+        SimpleNamespace(layer_name="model.layers.0.mtp.experts", exl3_is_draft=False)
+    )
+
+    def resolved():
+        return exl3_mod._positive_env_int(
+            "VLLM_EXL3_TRELLIS_MIN_M", exl3_mod._DEFAULT_TRELLIS_MIN_M
+        )
+
+    assert resolved() == exl3_mod._DEFAULT_TRELLIS_MIN_M
+    assert resolved() == exl3_mod.MIN_CAPTURABLE_TRELLIS_M == 1
+
+    # An explicit value remains authoritative as a diagnostic kill switch.
+    monkeypatch.setenv("VLLM_EXL3_TRELLIS_MIN_M", "4")
+    assert resolved() == 4
+
+
+def test_draft_role_stamp_wins_over_name() -> None:
+    """The exl3_is_draft stamp set in create_weights is authoritative.
+
+    Forward/plan/capture time has no current vllm config, so the role cannot be
+    inferred there; create_weights stamps it from runner_type while the
+    construction context is live. Stamped values must win over any name
+    heuristic in both directions.
+    """
+    from types import SimpleNamespace
+
+    from vllm.model_executor.layers.quantization import exl3 as exl3_mod
+
+    # GLM-5-family MTP head: named like a target, stamped draft.
+    assert exl3_mod._is_draft_layer(
+        SimpleNamespace(layer_name="model.layers.78.mlp.experts", exl3_is_draft=True)
+    )
+    # Target stamped False keeps its role even with a suspicious name.
+    assert not exl3_mod._is_draft_layer(
+        SimpleNamespace(layer_name="model.layers.0.mtp.experts", exl3_is_draft=False)
+    )
+    # Unstamped layers fall back to the name heuristic.
+    assert exl3_mod._is_draft_layer(
+        SimpleNamespace(layer_name="model.layers.0.mtp.mlp.experts")
+    )
+    assert not exl3_mod._is_draft_layer(
+        SimpleNamespace(layer_name="model.layers.30.mlp.experts")
+    )

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -1,0 +1,464 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Dispatch-contract tests for the dual-plan rank-sliced EXL3 MoE runtime.
+
+The planned Trellis API and the ExLlamaV3 extension are mocked; these tests
+prove backend policy only:
+
+* decode window m in [min, max] binds the decode plan;
+* max < m <= scheduler capacity binds capacity-bounded prefill slices;
+* the opt-in prefill capacity defaults to the scheduler capacity;
+* m < min stays on the parity path with chunk-capped staging buffers;
+* VLLM_EXL3_PREFILL_TRELLIS=0 restores the single-plan parity behavior
+  with full-capacity staging;
+* m above planned capacity raises.
+
+CPU-only; no CUDA, B12X, or exllamav3_ext required.
+"""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.model_executor.layers.quantization.exl3 as exl3_module
+from vllm.model_executor.layers.quantization.exl3 import Exl3MoEMethod
+
+HIDDEN = 128
+INTERMEDIATE = 128
+EXPERTS = 8
+TOPK = 4
+MAX_BATCHED = 256
+
+
+class _FakePlan:
+    def __init__(self, caps):
+        self.caps = caps
+
+    def scratch_specs(self):
+        return (
+            SimpleNamespace(
+                shape=(64,),
+                dtype=torch.uint8,
+                device=self.caps["device"],
+            ),
+        )
+
+
+class _FakeFusedMoeApi:
+    def __init__(self):
+        self.planned = []
+        self.bound = []
+        self.routed = []
+
+    def Caps(self, **kwargs):
+        return kwargs
+
+    def plan(self, caps):
+        plan = _FakePlan(caps)
+        self.planned.append(caps)
+        return plan
+
+    def bind(
+        self,
+        plan,
+        *,
+        scratch,
+        a,
+        experts,
+        topk_weights,
+        topk_ids,
+        route_expert_map=None,
+        output_expert_map=None,
+        output=None,
+    ):
+        del scratch, experts
+        self.bound.append((plan, int(a.shape[0])))
+        self.routed.append((topk_weights.clone(), topk_ids.clone()))
+        return SimpleNamespace(
+            plan=plan,
+            a=a,
+            route_expert_map=route_expert_map,
+            output_expert_map=output_expert_map,
+            output=output,
+        )
+
+    def run(self, *, binding):
+        if binding.route_expert_map is not None:
+            tier_output = binding.a.to(torch.float32).mul(0.5)
+            if binding.output is not None:
+                binding.output.copy_(tier_output)
+                return binding.output
+            return tier_output
+        return binding.a.to(torch.float32)
+
+
+class _FakeMixedTrellisApi:
+    def __init__(self):
+        self.bound = []
+        self.compiled = []
+        self.routed = []
+
+    def max_packed_route_slots(self, routed_rows, block_size, experts):
+        del block_size, experts
+        return routed_rows
+
+    def compile_mixed_trellis(self, **kwargs):
+        launch = SimpleNamespace(**kwargs)
+        self.compiled.append(launch)
+        return launch
+
+    def make_mixed_trellis_buffers(self, launch, **kwargs):
+        del kwargs
+        return SimpleNamespace(scratch=torch.empty(launch.size_m, dtype=torch.uint8))
+
+    def bind_mixed_trellis(self, tier0, tier1, *args):
+        launch = args[-1]
+        binding = SimpleNamespace(tiers=(tier0, tier1), launch=launch)
+        self.bound.append(binding)
+        return binding
+
+    def run_bound_mixed_trellis(self, x, topk_weights, topk_ids, binding, buffers):
+        del buffers
+        self.routed.append((topk_weights.clone(), topk_ids.clone()))
+        return x.to(torch.float32)
+
+
+class _FakeExt:
+    """Parity extension without exl3_moe_fused: chunk loop only."""
+
+    def __init__(self):
+        self.moe_calls = []
+
+    def exl3_moe_max_concurrency(self, device):
+        del device
+        return 2
+
+    def exl3_moe(self, xh, out32, *args):
+        del args
+        self.moe_calls.append((int(xh.shape[0]), int(out32.shape[0])))
+
+
+def _make_layer():
+    return SimpleNamespace(
+        exl3_max_num_batched_tokens=MAX_BATCHED,
+        exl3_hidden_size=HIDDEN,
+        exl3_intermediate_size_per_partition=INTERMEDIATE,
+        local_num_experts=EXPERTS,
+        exl3_trellis_tile_config=(64, 128, 64, 128),
+        exl3_trellis_weights=SimpleNamespace(plan=object()),
+        exl3_pointer_tables=(),
+        exl3_expert_map=torch.arange(EXPERTS, dtype=torch.int64),
+    )
+
+
+def _make_mixed_layer():
+    layer = _make_layer()
+    layer.exl3_mixed_bitrate = True
+    layer.exl3_mixed_trellis = {
+        "tiers": (object(), object()),
+        "prefill_tiers": (object(), object()),
+        "tier_ids": ((0, 1, 2, 3), (4, 5, 6, 7)),
+        "tier_bits": (3, 4),
+        "global_to_combined": object(),
+        "descriptor_map": object(),
+        "rotations": object(),
+        "broadcast_suh": False,
+        "broadcast_svh": False,
+        "tile_config": (64, 128, 64, 128),
+        "prefill_tile_config": (128, 128, 128, 128),
+    }
+    return layer
+
+
+def _make_method():
+    method = object.__new__(Exl3MoEMethod)
+    method.quant_config = SimpleNamespace(
+        bits=3.0,
+        rank_sliced_metadata={"tp": 4},
+    )
+    return method
+
+
+class _Harness:
+    def __init__(self, env=None):
+        self._env = dict(env or {})
+        self._saved_env = {}
+        self._saved_capturing = None
+        self.api = _FakeFusedMoeApi()
+        self.ext = _FakeExt()
+        self.mixed_api = _FakeMixedTrellisApi()
+
+    def __enter__(self):
+        for name, value in self._env.items():
+            self._saved_env[name] = os.environ.get(name)
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        self._saved_loaders = (
+            exl3_module._load_b12x_fused_moe,
+            exl3_module._load_b12x_mixed_trellis,
+            exl3_module._load_exl3_ext,
+        )
+        exl3_module._load_b12x_fused_moe = lambda: self.api
+        exl3_module._load_b12x_mixed_trellis = lambda: self.mixed_api
+        exl3_module._load_exl3_ext = lambda: self.ext
+        self._saved_capturing = torch.cuda.is_current_stream_capturing
+        torch.cuda.is_current_stream_capturing = lambda: False
+        self._saved_current_device = torch.cuda.current_device
+        torch.cuda.current_device = lambda: 0
+        self._saved_device_properties = torch.cuda.get_device_properties
+        torch.cuda.get_device_properties = lambda device: SimpleNamespace(
+            multi_processor_count=1,
+            shared_memory_per_block_optin=1,
+        )
+        exl3_module._RANK_SLICED_RUNTIMES.clear()
+        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
+        return self
+
+    def __exit__(self, *exc):
+        (
+            exl3_module._load_b12x_fused_moe,
+            exl3_module._load_b12x_mixed_trellis,
+            exl3_module._load_exl3_ext,
+        ) = self._saved_loaders
+        torch.cuda.is_current_stream_capturing = self._saved_capturing
+        torch.cuda.current_device = self._saved_current_device
+        torch.cuda.get_device_properties = self._saved_device_properties
+        for name, value in self._saved_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        exl3_module._RANK_SLICED_RUNTIMES.clear()
+        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
+        return False
+
+    def planned_caps(self):
+        return self.api.planned
+
+
+def _apply(method, layer, m):
+    x = torch.zeros((m, HIDDEN), dtype=torch.bfloat16)
+    weights = torch.zeros((m, TOPK), dtype=torch.float32)
+    ids = torch.zeros((m, TOPK), dtype=torch.int64)
+    return method._apply_rank_sliced(layer, x, weights, ids)
+
+
+def test_opt_in_prefill_capacity_slices_dispatch():
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+        method = _make_method()
+        layer = _make_layer()
+
+        out = _apply(method, layer, 16)
+        assert out.dtype == torch.bfloat16 and out.shape == (16, HIDDEN)
+        # Two plans: decode (32, block 8), then bounded prefill (block 64).
+        assert [
+            (caps["max_tokens"], caps["w4a16_block_size_m"])
+            for caps in h.planned_caps()
+        ] == [(32, 8), (128, 64)]
+        assert all(caps["route_num_experts"] == 0 for caps in h.planned_caps())
+        assert h.api.bound[-1][0].caps["max_tokens"] == 32
+
+        _apply(method, layer, 200)
+        assert all(bound[0].caps["max_tokens"] == 128 for bound in h.api.bound[-2:])
+        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
+        assert not h.ext.moe_calls
+
+        _apply(method, layer, 2)
+        assert h.api.bound[-1][0].caps["max_tokens"] == 32
+        assert h.api.bound[-1][1] == 2
+        assert not h.ext.moe_calls
+
+        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
+        assert runtime["parity_rows"] == 128
+        assert runtime["xh"].shape[0] == 128
+        assert runtime["token_sorted"].numel() == 128 * TOPK
+        assert runtime["prefill_capacity"] == 128
+
+        # Batches above the scheduler contract must fail before allocating a
+        # replacement runtime or a larger Trellis arena during serving.
+        runtime_keys = tuple(exl3_module._RANK_SLICED_RUNTIMES)
+        runtime_count = len(exl3_module._RANK_SLICED_RUNTIMES)
+        plan_count = len(h.planned_caps())
+        with pytest.raises(
+            ValueError,
+            match=rf"m={MAX_BATCHED + 1}, capacity={MAX_BATCHED}",
+        ):
+            _apply(method, layer, MAX_BATCHED + 1)
+        assert tuple(exl3_module._RANK_SLICED_RUNTIMES) == runtime_keys
+        assert len(exl3_module._RANK_SLICED_RUNTIMES) == runtime_count
+        assert len(h.planned_caps()) == plan_count
+
+
+@pytest.mark.parametrize(
+    ("rows", "expected_slice_rows"),
+    ((127, [127]), (128, [128]), (129, [128, 1])),
+)
+def test_prefill_capacity_boundaries_preserve_rows_and_routing(
+    rows, expected_slice_rows
+):
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+        method = _make_method()
+        layer = _make_layer()
+        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
+        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
+        ids = ids.remainder(EXPERTS)
+
+        out = method._apply_rank_sliced(layer, x, weights, ids)
+
+        assert [bound[1] for bound in h.api.bound] == expected_slice_rows
+        assert torch.equal(out, x)
+        assert torch.equal(torch.cat([route[0] for route in h.api.routed]), weights)
+        assert torch.equal(torch.cat([route[1] for route in h.api.routed]), ids)
+        assert all(bound[0] is h.api.bound[0][0] for bound in h.api.bound)
+
+
+def test_default_prefill_capacity_keeps_single_dispatch():
+    with _Harness() as h:
+        out = _apply(_make_method(), _make_layer(), 200)
+
+        assert h.planned_caps()[-1]["max_tokens"] == MAX_BATCHED
+        assert [bound[1] for bound in h.api.bound] == [200]
+        assert out.shape == (200, HIDDEN)
+
+
+def test_mixed_prefill_capacity_slices_rows_and_routing():
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+        method = _make_method()
+        layer = _make_mixed_layer()
+        rows = 200
+        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
+        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
+        ids = ids.remainder(EXPERTS)
+
+        out = method._apply_rank_sliced(layer, x, weights, ids)
+
+        assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
+        assert [launch.moe_block_size for launch in h.mixed_api.compiled] == [8, 64]
+        assert h.mixed_api.compiled[1].force_tile_config == (128, 128, 128, 128)
+        assert [binding.tiers for binding in h.mixed_api.bound] == [
+            layer.exl3_mixed_trellis["tiers"],
+            layer.exl3_mixed_trellis["prefill_tiers"],
+        ]
+        assert not h.planned_caps()
+        assert not h.api.bound
+        assert torch.equal(out, x)
+        assert torch.equal(
+            torch.cat([route[0] for route in h.mixed_api.routed]), weights
+        )
+        assert torch.equal(torch.cat([route[1] for route in h.mixed_api.routed]), ids)
+
+
+def test_mixed_runtime_forwards_shared_h_broadcast_contract():
+    with _Harness() as h:
+        method = _make_method()
+        layer = _make_mixed_layer()
+        layer.exl3_mixed_trellis["broadcast_suh"] = True
+        layer.exl3_mixed_trellis["broadcast_svh"] = True
+        x = torch.zeros((16, HIDDEN), dtype=torch.bfloat16)
+        ids = torch.zeros((16, TOPK), dtype=torch.int64)
+
+        method._mixed_rank_sliced_runtime(layer, x, ids)
+
+        assert len(h.mixed_api.compiled) == 2
+        assert all(launch.broadcast_suh is True for launch in h.mixed_api.compiled)
+        assert all(launch.broadcast_svh is True for launch in h.mixed_api.compiled)
+
+
+def test_prefill_capacity_cannot_exceed_scheduler_bound():
+    env = {"VLLM_EXL3_PREFILL_CAPACITY": str(MAX_BATCHED + 1)}
+    with _Harness(env=env) as h:
+        with pytest.raises(ValueError, match="cannot exceed max_num_batched_tokens"):
+            _apply(_make_method(), _make_layer(), 16)
+        assert not h.planned_caps()
+
+
+def test_prefill_trellis_disabled_restores_parity():
+    with _Harness(env={"VLLM_EXL3_PREFILL_TRELLIS": "0"}) as h:
+        method = _make_method()
+        layer = _make_layer()
+
+        _apply(method, layer, 200)
+        # Single decode plan only; large m runs the parity chunk loop.
+        assert [
+            (caps["max_tokens"], caps["w4a16_block_size_m"])
+            for caps in h.planned_caps()
+        ] == [(32, 8)]
+        assert not h.api.bound
+        assert h.ext.moe_calls == [(128, 128), (72, 72)]
+
+        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
+        assert runtime["prefill_plan"] is None
+        assert runtime["parity_rows"] == MAX_BATCHED
+
+
+def test_prefill_block_m_env_override():
+    env = {
+        "VLLM_EXL3_PREFILL_BLOCK_M": "48",
+        "VLLM_EXL3_PREFILL_CAPACITY": "128",
+    }
+    with _Harness(env=env) as h:
+        method = _make_method()
+        layer = _make_layer()
+        _apply(method, layer, 40)
+        assert h.planned_caps()[-1]["w4a16_block_size_m"] == 48
+        assert h.api.bound[-1][0].caps["max_tokens"] == 128
+
+
+def test_parity_window_capacity_is_validated_before_planning():
+    env = {
+        "VLLM_EXL3_TRELLIS_MIN_M": "160",
+        "VLLM_EXL3_TRELLIS_MAX_M": "192",
+        "VLLM_EXL3_PREFILL_CHUNK": "128",
+    }
+    with _Harness(env=env) as h:
+        with pytest.raises(ValueError, match="cannot cover the EXL3 parity window"):
+            _apply(_make_method(), _make_layer(), 16)
+        assert not h.planned_caps()
+
+
+def test_disabled_prefill_plan_keeps_full_parity_capacity():
+    env = {
+        "VLLM_EXL3_TRELLIS_MIN_M": "160",
+        "VLLM_EXL3_TRELLIS_MAX_M": "192",
+        "VLLM_EXL3_PREFILL_CHUNK": "128",
+        "VLLM_EXL3_PREFILL_TRELLIS": "0",
+    }
+    with _Harness(env=env):
+        _apply(_make_method(), _make_layer(), 159)
+        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
+        assert runtime["parity_rows"] == MAX_BATCHED
+
+
+def test_explicit_parity_path_guarded_against_capture():
+    env = {
+        "VLLM_EXL3_TRELLIS_MIN_M": "4",
+        "VLLM_EXL3_PREFILL_CAPACITY": "128",
+    }
+    with _Harness(env=env) as h:
+        method = _make_method()
+        layer = _make_layer()
+        # Plan eagerly, then flip into "capturing" state.
+        _apply(method, layer, 16)
+        torch.cuda.is_current_stream_capturing = lambda: True
+        # Both trellis plans stay capture-safe.
+        _apply(method, layer, 16)
+        _apply(method, layer, 200)
+        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
+        # The eager parity path must refuse to be recorded.
+        with pytest.raises(RuntimeError, match="capture"):
+            _apply(method, layer, 2)
+
+
+if __name__ == "__main__":
+    test_opt_in_prefill_capacity_slices_dispatch()
+    test_prefill_trellis_disabled_restores_parity()
+    test_prefill_block_m_env_override()
+    test_explicit_parity_path_guarded_against_capture()
+    print("EXL3_PREFILL_PLAN_TESTS_OK")

--- a/tests/quantization/test_exl3_warmup.py
+++ b/tests/quantization/test_exl3_warmup.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.exl3 import (
+    Exl3MoEMethod,
+)
+
+
+def _layer_with_mixed_trellis(mixed: dict) -> SimpleNamespace:
+    return SimpleNamespace(
+        exl3_mixed_trellis=mixed,
+        exl3_mixed_bitrate=True,
+        layer_name="model.layers.3.mlp.experts",
+    )
+
+
+def test_mixed_trellis_warmup_unit_delegates_each_runtime_state() -> None:
+    warmup = Mock(side_effect=(6, 12))
+    api = SimpleNamespace(warmup_mixed_trellis_route_pack=warmup)
+    decode = {"launch": object(), "buffers": object()}
+    prefill = {"launch": object(), "buffers": object()}
+    expert_map = object()
+    layer = _layer_with_mixed_trellis(
+        {
+            "runtime": {
+                "mixed_api": api,
+                "decode": decode,
+                "prefill": prefill,
+            },
+            "global_to_combined": expert_map,
+        }
+    )
+    method = object.__new__(Exl3MoEMethod)
+
+    unit = method.get_b12x_warmup_unit(layer, (1, 32), torch.bfloat16)
+    unit.compile()
+
+    assert unit.name == "EXL3 mixed-Trellis route pack"
+    assert warmup.call_args_list == [
+        ((decode["launch"], decode["buffers"]), {"expert_map": expert_map}),
+        ((prefill["launch"], prefill["buffers"]), {"expert_map": expert_map}),
+    ]
+
+
+def test_mixed_trellis_warmup_unit_fails_closed_without_profiled_runtime() -> None:
+    layer = _layer_with_mixed_trellis({"global_to_combined": object()})
+    method = object.__new__(Exl3MoEMethod)
+
+    unit = method.get_b12x_warmup_unit(layer, (1,), torch.bfloat16)
+
+    with pytest.raises(RuntimeError, match="eager profile pass must plan"):
+        unit.compile()

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1264,6 +1264,10 @@ class ModelConfig:
                 "awq_marlin",
                 "inc",
                 "moe_wna16",
+                # Rank-sliced EXL3 checkpoints retain a ModelOpt dispatch tag
+                # for backward compatibility, so EXL3 must inspect metadata
+                # before the ModelOpt overrides claim them.
+                "exl3",
                 "modelopt",
                 "modelopt_fp4",
                 "modelopt_mxfp8",

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2206,6 +2206,21 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Each entry is VAR_NAME or VAR_NAME:<suffix> (suffix appended to
     # RDMA device name). Must be set together with VLLM_GPU_NIC_PCIE_MAPPING.
     "VLLM_NIC_SELECTION_VARS": lambda: os.getenv("VLLM_NIC_SELECTION_VARS", ""),
+    # --- EXL3 Trellis MoE runtime knobs (read directly by
+    # model_executor/layers/quantization/exl3.py; registered here so startup
+    # does not flag them as unknown). All are passthrough: consuming code
+    # applies its own defaults (the Trellis window minimum is 1 for both target
+    # and draft layers; an explicit value is a diagnostic override).
+    "VLLM_EXL3_TRELLIS_MIN_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MIN_M"),
+    "VLLM_EXL3_TRELLIS_MAX_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MAX_M"),
+    "VLLM_EXL3_TRELLIS_BLOCK_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_BLOCK_M"),
+    "VLLM_EXL3_PREFILL_CHUNK": lambda: os.getenv("VLLM_EXL3_PREFILL_CHUNK"),
+    "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv("VLLM_EXL3_PREFILL_CAPACITY"),
+    "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
+    "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
+    # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
+    "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
+    "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
 }
 
 

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import re
 from collections.abc import Callable, Iterable
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
@@ -32,6 +33,10 @@ if TYPE_CHECKING:
 
 
 logger = init_logger(__name__)
+
+# Per-expert checkpoint names carry an explicit expert index ("experts.{i}.");
+# fused pre-fused-checkpoint entries never do (see build_expert_params_mapping).
+_PER_EXPERT_IDX_RE = re.compile(r"experts\.\d+\.")
 
 
 class FusedMoeWeightScaleSupported(Enum):
@@ -881,14 +886,23 @@ class RoutedExperts(PluggableLayer):
         expert_mapping = self.get_expert_mapping(include_fused=True)
         for expert_name, loaded_weight in weights:
             qual_name = f"{self.layer_name}.{expert_name}"
-            # Fused expert weights can be identified by their 3D tensors
-            is_fused = loaded_weight.dim() == 3
+            # Fused expert weights are 3D tensors matched against a *fused*
+            # mapping entry. Rank alone is not decisive: per-expert tensors of
+            # some quantized formats (e.g. EXL3 trellis [K/16, N/16, 16*bpw])
+            # are also rank-3 and must not be routed down the fused
+            # transpose/chunk path. Fused entries are exactly those whose
+            # weight_name carries no per-expert index.
+            is_fused_rank = loaded_weight.dim() == 3
+            is_fused = False
             matched = False
             for param_name, weight_name, expert_id, shard_id in expert_mapping:
                 if weight_name not in qual_name:
                     if matched and is_fused:
                         break
                     continue
+                is_fused = (
+                    is_fused_rank and _PER_EXPERT_IDX_RE.search(weight_name) is None
+                )
                 matched = True
                 is_per_expert_fused_w13 = (
                     not is_fused

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -14,6 +14,7 @@ QuantizationMethods = Literal[
     "auto_awq",
     "fp8",
     "fbgemm_fp8",
+    "exl3",
     "fp_quant",
     "modelopt",
     "modelopt_fp4",
@@ -119,6 +120,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
     from .compressed_tensors.compressed_tensors import (
         CompressedTensorsConfig,
     )
+    from .exl3 import Exl3Config
     from .experts_int8 import ExpertsInt8Config
     from .fbgemm_fp8 import FBGEMMFp8Config
     from .fp8 import Fp8Config
@@ -142,6 +144,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
         "auto_awq": AutoAWQConfig,
         "fp8": Fp8Config,
         "fbgemm_fp8": FBGEMMFp8Config,
+        "exl3": Exl3Config,
         "fp_quant": FPQuantConfig,
         "modelopt": ModelOptFp8Config,
         "modelopt_fp4": ModelOptNvFp4Config,

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1,0 +1,2890 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""EXL3 (ExLlamaV3 trellis) quantization support.
+
+Rank-sliced routed-expert checkpoints use B12X's unified planned
+``fused_moe`` API for the Trellis decode/prefill windows and the ExLlamaV3
+extension for the small eager parity window. Generic dense and non-rank-sliced
+MoE checkpoints use the
+bit-faithful ``exllamav3_ext.exl3_gemm`` parity path. Every logical checkpoint
+matrix is dispatched independently: vLLM's packed QKV and gate/up modules are
+not treated as one EXL3 matrix because each source matrix owns its Hadamard
+vectors and codebook marker.
+
+Both dependencies are imported lazily. Importing this module, parsing
+checkpoint metadata, or compiling it with ``py_compile`` does not load either
+one or initialize CUDA.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import importlib
+import os
+import re
+import sys
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import torch
+from transformers import PretrainedConfig
+
+from vllm.config import get_current_vllm_config_or_none
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe import (
+    FusedMoEMethodBase,
+    FusedMoEQuantConfig,
+    MoEActivation,
+    RoutedExperts,
+)
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    LinearMethodBase,
+    QKVParallelLinear,
+    ReplicatedLinear,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+from vllm.model_executor.parameter import BasevLLMParameter
+from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
+        SharedExperts,
+    )
+    from vllm.model_executor.models.utils import WeightsMapper
+    from vllm.utils.b12x import B12xWarmupUnit
+
+logger = init_logger(__name__)
+
+_MCG_SENTINEL = 0xCBAC1FED
+_MUL1_SENTINEL = 0x83DCD12D
+_HADAMARD_BLOCK = 128
+_EXL3_EXT: Any | None = None
+_B12X_FUSED_MOE_API: Any | None = None
+_B12X_MIXED_TRELLIS_API: Any | None = None
+_RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
+_MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
+_NEXT_RUNTIME_SCOPE_ID = 0
+_MIXED_TRELLIS_ROUTE_BLOCK_SIZE = 8
+_GLM5_MIXED_TRELLIS_PREFILL_BLOCK_SIZE = 32
+_GLM5_MIXED_TRELLIS_BLOCK32_SIGNATURES = frozenset(
+    {
+        ((3, 192), (4, 64)),
+        ((3, 206), (4, 50)),
+        ((3, 148), (4, 108)),
+    }
+)
+
+
+def _resolve_mixed_trellis_prefill_block_m(
+    *,
+    configured_block_m: int,
+    explicit_override: bool,
+    hidden_size: int,
+    intermediate_size: int,
+    tier_signature: tuple[tuple[int, int], ...],
+    topk: int,
+    device_major: int,
+    prefill_tile_config: tuple[int, int, int, int],
+) -> int:
+    """Select the qualified GLM-5-family mixed-K prefill route block.
+
+    B12X's paired-M8 FC2 schedule makes block-32 numerically equivalent
+    to the established block-64 path while reducing scratch and improving the
+    dominant large-prefill kernel on SM12x. The allowlist contains only tier
+    partitions qualified end-to-end on GLM-5.2/5.3 checkpoints. Explicit operator
+    tuning and every other model geometry retain the configured value.
+    """
+
+    qualified = (
+        not explicit_override
+        and int(device_major) == 12
+        and int(hidden_size) == 6144
+        and int(intermediate_size) == 512
+        and tier_signature in _GLM5_MIXED_TRELLIS_BLOCK32_SIGNATURES
+        and int(topk) == 8
+        and tuple(int(value) for value in prefill_tile_config) == (128, 128, 32, 512)
+    )
+    if qualified:
+        return _GLM5_MIXED_TRELLIS_PREFILL_BLOCK_SIZE
+    return int(configured_block_m)
+
+
+# Smallest m the Trellis kernel path can service, and therefore the smallest
+# row count an EXL3 rank-sliced MoE layer can be CUDA-graph captured at. A
+# capture-size selector may read this to align its sizes with the backend
+# instead of failing at capture time.
+MIN_CAPTURABLE_TRELLIS_M = 1
+
+# Target execution also reaches m=1..3 during profiling and small-batch decode.
+# Keep every supported row count on the native path by default; operators may
+# still raise the threshold explicitly as a diagnostic kill switch.
+_DEFAULT_TRELLIS_MIN_M = MIN_CAPTURABLE_TRELLIS_M
+
+
+def _is_draft_layer(layer: Any) -> bool:
+    """True for a rank-sliced MTP/nextn/eagle draft MoE layer.
+
+    The role is stamped (``exl3_is_draft = True``) on every draft-owned module
+    by ``load_eagle_model`` at draft construction, which is the single funnel
+    every speculator draft passes through. It is NOT inferable here: a
+    GLM-5-family MTP head is an extra decoder layer named exactly like a
+    target layer (``model.layers.78.*`` with ``num_hidden_layers = 78``), and
+    this function runs at plan/capture/forward time, when
+    ``set_current_vllm_config`` has already exited and
+    ``get_current_vllm_config_or_none()`` returns None -- so both name and
+    layer-index inference silently fail. The substring fallback below covers
+    drafts built outside ``load_eagle_model``.
+    """
+    stamped = getattr(layer, "exl3_is_draft", None)
+    if stamped is not None:
+        return bool(stamped)
+    name = str(getattr(layer, "layer_name", "") or getattr(layer, "prefix", ""))
+    return any(
+        token in name
+        for token in (".mtp", "mtp.", "nextn", "eagle", "draft", "speculator")
+    )
+
+
+def _runtime_owner_token(quant_config: Any, layer: Any) -> tuple[int, bool]:
+    """Runtime-cache owner identity: (config scope, is_draft).
+
+    Adding the role makes target/draft isolation independent of whether the model
+    file happened to mint a separate quant config.
+    """
+    return (_runtime_scope_id(quant_config), _is_draft_layer(layer))
+
+
+def _runtime_scope_id(quant_config: Any) -> int:
+    """Stable identity for the model that owns a rank-sliced runtime.
+
+    A cached runtime owns mutable Trellis/prefill scratch plus parity staging and
+    sort buffers, so an entry must never be shared across models. A target MoE
+    layer and a rank-sliced MTP draft layer have identical shapes, topk and
+    planner settings -- both read ``max_num_batched_tokens`` from the same
+    scheduler config -- so a shape-only key makes the draft reuse the target's
+    scratch. That defeats the target/draft resource isolation their
+    independently captured CUDA graphs rely on.
+
+    Scoping by the owning quant config is deliberately coarser than per-layer:
+    the draft is built with its own ``Exl3Config`` while every layer of one model
+    shares a single config, so each model gets exactly one runtime. The prefill
+    arena alone is ~1 GiB, so per-layer runtimes would cost tens of GiB per rank
+    on a 75+ layer model and are not affordable.
+    """
+    global _NEXT_RUNTIME_SCOPE_ID
+    scope = getattr(quant_config, "_exl3_runtime_scope_id", None)
+    if scope is not None:
+        return scope
+    scope = _NEXT_RUNTIME_SCOPE_ID
+    _NEXT_RUNTIME_SCOPE_ID += 1
+    try:
+        quant_config._exl3_runtime_scope_id = scope  # noqa: SLF001
+    except AttributeError:
+        # Frozen/slotted config: fall back to object identity. Configs live for
+        # the process lifetime, so reuse-after-GC aliasing is not a concern here.
+        return id(quant_config)
+    return scope
+
+
+_RANK_SLICED_FORMAT = "exl3-trellis"
+_PER_EXPERT_ROTATION_LAYOUT = "per_expert_v1"
+_SHARED_H_ROTATION_LAYOUT = "shared_h_v1"
+_SHARED_H_TENSOR_SCHEMA = (
+    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
+)
+_RANK_SLICED_WEIGHT_RE = re.compile(
+    r"^(?P<prefix>.+)\.rank(?P<rank>\d+)\."
+    r"(?P<field>trellis|suh|svh|mcg|mul1)$"
+)
+_SHARED_H_WEIGHT_RE = re.compile(
+    r"^(?P<experts_prefix>.+\.experts)\.shared_h\."
+    r"(?P<projection>gate_proj|up_proj|down_proj)\.rank(?P<rank>\d+)\."
+    r"(?P<field>suh|svh)$"
+)
+_EXPERT_PROJECTION_RE = re.compile(
+    r"^.+\.experts\.\d+\.(?P<projection>gate_proj|up_proj|down_proj)$"
+)
+
+ShardId = str | int | tuple[int, ...] | None
+
+
+def _load_exl3_ext() -> Any:
+    """Load the existing ExLlamaV3 extension only from an actual CUDA call."""
+
+    global _EXL3_EXT
+    if _EXL3_EXT is not None:
+        return _EXL3_EXT
+
+    shim = os.environ.get("VLLM_EXL3_ABI_SHIM")
+    if shim:
+        ctypes.CDLL(shim, mode=ctypes.RTLD_GLOBAL)
+
+    ext_path = os.environ.get("VLLM_EXL3_EXT_PATH")
+    if ext_path:
+        search_dir = ext_path if os.path.isdir(ext_path) else os.path.dirname(ext_path)
+        if search_dir and search_dir not in sys.path:
+            sys.path.insert(0, search_dir)
+
+    try:
+        ext = importlib.import_module("exllamav3_ext")
+    except Exception as exc:
+        hint = (
+            "Set VLLM_EXL3_EXT_PATH to the directory containing "
+            "exllamav3_ext*.so (and VLLM_EXL3_ABI_SHIM when the local "
+            "PyTorch ABI shim is required)."
+        )
+        raise RuntimeError(f"Unable to import exllamav3_ext. {hint}") from exc
+
+    if not hasattr(ext, "exl3_gemm"):
+        raise RuntimeError(
+            "The imported exllamav3_ext does not export exl3_gemm; rebuild the "
+            "track_a_retile extension used by this overlay."
+        )
+    _EXL3_EXT = ext
+    return ext
+
+
+def _load_b12x_fused_moe() -> Any:
+    """Resolve the public unified MoE API lazily."""
+
+    global _B12X_FUSED_MOE_API
+    if _B12X_FUSED_MOE_API is not None:
+        return _B12X_FUSED_MOE_API
+    try:
+        from b12x.moe import fused_moe
+    except Exception as exc:
+        raise RuntimeError(
+            "Rank-sliced EXL3 requires the exl3_trellis_mcg source in "
+            "b12x.moe.fused_moe. Install a matching B12X build."
+        ) from exc
+    _B12X_FUSED_MOE_API = fused_moe
+    return fused_moe
+
+
+def _load_b12x_mixed_trellis() -> Any:
+    """Resolve the one-grid mixed-bitrate Trellis API lazily."""
+
+    global _B12X_MIXED_TRELLIS_API
+    if _B12X_MIXED_TRELLIS_API is not None:
+        return _B12X_MIXED_TRELLIS_API
+    try:
+        module = importlib.import_module("b12x.moe._shared.kernels.w4a16.mixed_trellis")
+        prepare = importlib.import_module("b12x.moe._shared.kernels.w4a16.prepare")
+        host = importlib.import_module("b12x.moe._shared.kernels.w4a16.host")
+    except Exception as exc:
+        raise RuntimeError(
+            "Mixed-bitrate rank-sliced EXL3 requires the matching B12X "
+            "mixed_trellis implementation."
+        ) from exc
+    api = SimpleNamespace(
+        build_tiered_maps=module.build_tiered_maps,
+        bind_mixed_trellis=module.bind_mixed_trellis,
+        combine_trellis_rotations=module.combine_trellis_rotations,
+        compile_mixed_trellis=module.compile_mixed_trellis,
+        make_mixed_trellis_buffers=module.make_mixed_trellis_buffers,
+        max_packed_route_slots=host.max_packed_route_slots,
+        prepare_weights=prepare.prepare_trellis256_moe_weights,
+        run_bound_mixed_trellis=module.run_bound_mixed_trellis,
+        warmup_mixed_trellis_route_pack=module.warmup_mixed_trellis_route_pack,
+    )
+    _B12X_MIXED_TRELLIS_API = api
+    return api
+
+
+def _unique_tensor_storage_bytes(*buffers: Any) -> int:
+    """Count unique tensor storage while ignoring buffer metadata fields."""
+
+    total = 0
+    seen: set[tuple[int, int]] = set()
+    for buffers_ in buffers:
+        for value in vars(buffers_).values():
+            if not isinstance(value, torch.Tensor):
+                continue
+            storage = value.untyped_storage()
+            storage_key = (storage.data_ptr(), storage.nbytes())
+            if storage_key not in seen:
+                seen.add(storage_key)
+                total += storage.nbytes()
+    return total
+
+
+def _scratch_view(backing: torch.Tensor, spec: Any) -> torch.Tensor:
+    """Return a typed plan-scratch view over a shared byte arena."""
+
+    nbytes = int(spec.dtype.itemsize)
+    for dim in spec.shape:
+        nbytes *= int(dim)
+    return backing.narrow(0, 0, nbytes).view(spec.dtype).view(tuple(spec.shape))
+
+
+def _positive_env_int(name: str, default: int) -> int:
+    # An env var that is present but blank means "unset". Compose and Kubernetes
+    # both render an unset variable as the empty string, so int("") would abort
+    # engine startup with a bare
+    #   ValueError: invalid literal for int() with base 10: ''
+    # that names neither the variable nor the fix.
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        raise ValueError(
+            f"{name} must be a positive integer or unset, got {raw!r}"
+        ) from None
+    if value <= 0:
+        raise ValueError(f"{name} must be positive, got {value}")
+    return value
+
+
+def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
+    """Resolve the optional EXL3 arena bound within the scheduler contract."""
+
+    prefill_capacity = _positive_env_int(
+        "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
+    )
+    if prefill_capacity > max_batched_tokens:
+        raise ValueError(
+            "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
+            "max_num_batched_tokens: "
+            f"capacity={prefill_capacity}, max={max_batched_tokens}"
+        )
+    return prefill_capacity
+
+
+@torch.library.custom_op(
+    "vllm::exl3_gemm",
+    mutates_args=(),
+    device_types="cuda",
+)
+def _exl3_gemm(
+    x: torch.Tensor,
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    mcg: bool,
+    mul1: bool,
+) -> torch.Tensor:
+    """Opaque torch op around the bit-faithful ExLlamaV3 dense call."""
+
+    ext = _load_exl3_ext()
+    output = torch.empty(
+        (x.shape[0], trellis.shape[1] * 16),
+        dtype=torch.float16,
+        device=x.device,
+    )
+    x_had = torch.empty_like(x)
+    ext.exl3_gemm(
+        x,
+        trellis,
+        output,
+        suh,
+        x_had,
+        svh,
+        -1,
+        mcg,
+        mul1,
+        0,
+    )
+    return output
+
+
+@_exl3_gemm.register_fake
+def _exl3_gemm_fake(
+    x: torch.Tensor,
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    mcg: bool,
+    mul1: bool,
+) -> torch.Tensor:
+    del suh, svh, mcg, mul1
+    return torch.empty(
+        (x.shape[0], trellis.shape[1] * 16),
+        dtype=torch.float16,
+        device=x.device,
+    )
+
+
+class Exl3Config(QuantizationConfig):
+    """Configuration for modern and legacy EXL3 trellis checkpoints."""
+
+    def __init__(
+        self,
+        bits: float | None = None,
+        head_bits: float | None = None,
+        codebook: str | None = None,
+        version: str | None = None,
+        tensor_storage: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__()
+        self.bits = bits
+        self.head_bits = head_bits
+        self.codebook = codebook
+        self.version = version
+        self.tensor_storage = tensor_storage or {}
+        self._eager_checked = False
+        self.rank_sliced_metadata: dict[str, Any] | None = None
+        self.rank_sliced_rotation_layout = _PER_EXPERT_ROTATION_LAYOUT
+        self.rank_sliced_k_values: tuple[int, ...] | None = None
+        self.rank_sliced_bits_by_layer: dict[int, tuple[int, ...]] = {}
+
+    def get_name(self) -> str:
+        return "exl3"
+
+    def get_supported_act_dtypes(self) -> list[torch.dtype]:
+        # The kernel boundary is always fp16.  BF16 model activations are cast
+        # in apply() and converted back after the fp16 bias addition.
+        return [torch.float16, torch.bfloat16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 80
+
+    @staticmethod
+    def get_config_filenames() -> list[str]:
+        return ["quantization_config.json"]
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> Exl3Config:
+        return cls(
+            bits=config.get("bits"),
+            head_bits=config.get("head_bits"),
+            codebook=config.get("codebook"),
+            version=config.get("version"),
+            tensor_storage=config.get("tensor_storage"),
+        )
+
+    @classmethod
+    def override_quantization_method(
+        cls,
+        hf_quant_cfg: dict[str, Any],
+        user_quant: str | None,
+        hf_config: PretrainedConfig | None = None,
+    ) -> str | None:
+        del hf_quant_cfg
+        if user_quant is not None and user_quant != "exl3":
+            return None
+        metadata = getattr(hf_config, "hybrid_tr3_tail", None)
+        if isinstance(metadata, dict) and metadata.get("format") == _RANK_SLICED_FORMAT:
+            return "exl3"
+        return None
+
+    def maybe_update_config(
+        self,
+        model_name: str,
+        hf_config: PretrainedConfig | None = None,
+        revision: str | None = None,
+    ) -> None:
+        rank_sliced = getattr(hf_config, "hybrid_tr3_tail", None)
+        if (
+            isinstance(rank_sliced, dict)
+            and rank_sliced.get("format") == _RANK_SLICED_FORMAT
+        ):
+            self._configure_rank_sliced(rank_sliced)
+            if self.rank_sliced_k_values is not None:
+                resolved_revision = revision
+                if resolved_revision is None and hf_config is not None:
+                    resolved_revision = getattr(hf_config, "_commit_hash", None)
+                self._load_rank_sliced_bitrates(
+                    model_name,
+                    revision=resolved_revision,
+                )
+            return
+
+        # vLLM returns the summary embedded in config.json without consulting
+        # get_config_filenames().  Hydrate the per-module records explicitly.
+        if not self.tensor_storage:
+            resolved_revision = revision
+            if resolved_revision is None and hf_config is not None:
+                resolved_revision = getattr(hf_config, "_commit_hash", None)
+            config = get_hf_file_to_dict(
+                "quantization_config.json",
+                model_name,
+                revision=resolved_revision,
+            )
+            if not config or not config.get("tensor_storage"):
+                raise ValueError(
+                    "EXL3 requires quantization_config.json with a non-empty "
+                    "tensor_storage map. For branch-indexed Hugging Face repos, "
+                    "download/serve an actual bpw revision rather than main."
+                )
+            self.bits = config.get("bits", self.bits)
+            self.head_bits = config.get("head_bits", self.head_bits)
+            self.codebook = config.get("codebook", self.codebook)
+            self.version = config.get("version", self.version)
+            self.tensor_storage = config["tensor_storage"]
+
+        self._validate_storage_metadata()
+        self._force_independent_lm_head(hf_config)
+
+    def _configure_rank_sliced(self, metadata: dict[str, Any]) -> None:
+        required = {
+            "bits",
+            "codebook",
+            "experts_per_layer",
+            "moe_layers",
+            "tensor_schema",
+            "tp",
+        }
+        missing = sorted(required.difference(metadata))
+        if missing:
+            raise ValueError(
+                "rank-sliced EXL3 metadata is missing: " + ", ".join(missing)
+            )
+        if metadata["codebook"] != "mcg":
+            raise ValueError(
+                "rank-sliced EXL3 currently requires the MCG codebook, got "
+                f"{metadata['codebook']!r}"
+            )
+        layers = metadata["moe_layers"]
+        if (
+            not isinstance(layers, list)
+            or len(layers) != 2
+            or int(layers[0]) < 0
+            or int(layers[1]) < int(layers[0])
+        ):
+            raise ValueError("rank-sliced EXL3 moe_layers must be [first, last]")
+        expected_schema = (
+            "model.layers.{L}.mlp.experts.{E}.{proj}.rank{r}.{trellis|suh|svh|mcg}"
+        )
+        if metadata["tensor_schema"] != expected_schema:
+            raise ValueError(
+                "unsupported rank-sliced EXL3 tensor schema: "
+                f"{metadata['tensor_schema']!r}"
+            )
+        rotation_layout = str(
+            metadata.get("rotation_layout", _PER_EXPERT_ROTATION_LAYOUT)
+        )
+        if rotation_layout not in {
+            _PER_EXPERT_ROTATION_LAYOUT,
+            _SHARED_H_ROTATION_LAYOUT,
+        }:
+            raise ValueError(
+                f"unsupported rank-sliced EXL3 rotation_layout: {rotation_layout!r}"
+            )
+        shared_schema = metadata.get("shared_h_tensor_schema")
+        if rotation_layout == _SHARED_H_ROTATION_LAYOUT:
+            if shared_schema != _SHARED_H_TENSOR_SCHEMA:
+                raise ValueError(
+                    "shared_h_v1 rank-sliced EXL3 requires "
+                    f"shared_h_tensor_schema={_SHARED_H_TENSOR_SCHEMA!r}"
+                )
+        elif shared_schema is not None:
+            raise ValueError(
+                "shared_h_tensor_schema is only valid with "
+                "rotation_layout='shared_h_v1'"
+            )
+        self.rank_sliced_metadata = dict(metadata)
+        self.rank_sliced_rotation_layout = rotation_layout
+        bits_field = metadata["bits"]
+        if isinstance(bits_field, str) and bits_field.strip().lower() == "mixed":
+            k_values = tuple(
+                sorted({int(value) for value in metadata.get("k_values", ())})
+            )
+            if not k_values or any(value not in (3, 4, 5, 6) for value in k_values):
+                raise ValueError(
+                    "mixed rank-sliced EXL3 requires k_values within 3..6, got "
+                    f"{metadata.get('k_values')!r}"
+                )
+            if not isinstance(metadata.get("bits_per_expert"), str):
+                raise ValueError(
+                    "mixed rank-sliced EXL3 requires a bits_per_expert JSON reference"
+                )
+            self.bits = None
+            self.rank_sliced_k_values = k_values
+        else:
+            self.bits = float(bits_field)
+            self.rank_sliced_k_values = None
+        self.codebook = str(metadata["codebook"])
+        self.version = str(metadata.get("exllamav3_version", "rank-sliced"))
+
+    def _load_rank_sliced_bitrates(
+        self,
+        model_name: str,
+        *,
+        revision: str | None,
+    ) -> None:
+        assert self.rank_sliced_metadata is not None
+        reference = str(self.rank_sliced_metadata["bits_per_expert"])
+        try:
+            filename, field = reference.rsplit(":", 1)
+        except ValueError as exc:
+            raise ValueError(
+                "rank-sliced EXL3 bits_per_expert must use 'file.json:field' syntax, "
+                f"got {reference!r}"
+            ) from exc
+        payload = get_hf_file_to_dict(filename, model_name, revision=revision)
+        if not isinstance(payload, dict):
+            raise ValueError(f"rank-sliced EXL3 could not load {filename!r}")
+
+        experts = int(self.rank_sliced_metadata["experts_per_layer"])
+        first, last = (int(value) for value in self.rank_sliced_metadata["moe_layers"])
+        allowed = set(self.rank_sliced_k_values or ())
+        by_layer: dict[int, tuple[int, ...]] = {}
+        for layer_index in range(first, last + 1):
+            entry = payload.get(str(layer_index))
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    f"rank-sliced EXL3 bitrate map is missing layer {layer_index}"
+                )
+            raw = entry.get(field)
+            # The GLM-5-family MTP overlay records routed experts under tail_tr3
+            # instead of repeating a 256-entry K3 vector.
+            if raw is None and len(entry.get("tail_tr3", ())) == experts:
+                raw = [3] * experts
+            if not isinstance(raw, list) or len(raw) != experts:
+                raise ValueError(
+                    "rank-sliced EXL3 bitrate map must contain one entry per expert: "
+                    f"layer={layer_index}, field={field!r}, expected={experts}"
+                )
+            bitrates = tuple(int(value) for value in raw)
+            unexpected = sorted(set(bitrates).difference(allowed))
+            if unexpected:
+                raise ValueError(
+                    f"rank-sliced EXL3 layer {layer_index} uses undeclared bitrates "
+                    f"{unexpected}; declared={sorted(allowed)}"
+                )
+            by_layer[layer_index] = bitrates
+        self.rank_sliced_bits_by_layer = by_layer
+
+    def rank_sliced_layer_bitrates(self, layer_name: str) -> tuple[int, ...]:
+        match = re.search(r"(?:^|\.)layers\.(\d+)(?:\.|$)", layer_name)
+        if match is None:
+            raise ValueError(
+                f"cannot resolve rank-sliced EXL3 layer index from {layer_name!r}"
+            )
+        layer_index = int(match.group(1))
+        if self.rank_sliced_k_values is None:
+            if self.bits is None or float(self.bits) != int(self.bits):
+                raise ValueError(f"invalid uniform EXL3 bitrate {self.bits!r}")
+            experts = int(self.rank_sliced_metadata["experts_per_layer"])
+            return (int(self.bits),) * experts
+        try:
+            return self.rank_sliced_bits_by_layer[layer_index]
+        except KeyError as exc:
+            raise ValueError(
+                f"rank-sliced EXL3 bitrate map has no layer {layer_index}"
+            ) from exc
+
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper) -> None:
+        # Keep both spellings: loader prefixes use vLLM names, while packed
+        # source-matrix discovery intentionally refers to the unstacked HF name.
+        mapped = hf_to_vllm_mapper.apply_dict(self.tensor_storage)
+        self.tensor_storage = {**self.tensor_storage, **mapped}
+
+    def _validate_storage_metadata(self) -> None:
+        bad: list[str] = []
+        exl3_count = 0
+        for prefix, entry in self.tensor_storage.items():
+            if entry.get("quant_format") != "exl3":
+                continue
+            exl3_count += 1
+            stored = entry.get("stored_tensors", {})
+            suffixes = {name.rsplit(".", 1)[-1] for name in stored}
+            required = {"trellis"}
+            if not ({"suh", "su"} & suffixes):
+                required.add("suh|su")
+            if not ({"svh", "sv"} & suffixes):
+                required.add("svh|sv")
+            missing = [name for name in required if name not in suffixes]
+            if missing:
+                bad.append(f"{prefix}: missing {','.join(sorted(missing))}")
+            if {"mcg", "mul1"} <= suffixes:
+                bad.append(f"{prefix}: both mcg and mul1 are present")
+        if not exl3_count:
+            raise ValueError("quantization_config.json has no EXL3 tensor records")
+        if bad:
+            raise ValueError("Invalid EXL3 tensor metadata: " + "; ".join(bad[:16]))
+
+    def _force_independent_lm_head(self, hf_config: PretrainedConfig | None) -> None:
+        if hf_config is None or not self.has_quantized_lm_head():
+            return
+        configs: list[Any] = [hf_config]
+        try:
+            text_config = hf_config.get_text_config()
+        except (AttributeError, TypeError):
+            text_config = None
+        if text_config is not None and text_config is not hf_config:
+            configs.append(text_config)
+        changed = False
+        for config in configs:
+            if getattr(config, "tie_word_embeddings", False):
+                config.tie_word_embeddings = False
+                changed = True
+        if changed:
+            logger.warning_once(
+                "EXL3 metadata contains an independently quantized lm_head; "
+                "overriding tie_word_embeddings so vLLM instantiates it."
+            )
+
+    def _require_enforce_eager(self) -> None:
+        if self.rank_sliced_metadata is not None:
+            # The routed-expert fast path is eagerly planned before graph
+            # capture. Only its large-M parity fallback remains eager.
+            return
+        # exllamav3_ext's exl3_gemm autotunes with timing launches on the first
+        # call per (m-bucket, k, n, K) shape hash; under CUDA-graph capture
+        # those launches fault, and m-bucketing means a warmup pass cannot
+        # reliably cover every bucket. Fail fast at build time instead of
+        # faulting mid-capture.
+        if self._eager_checked:
+            return
+        self._eager_checked = True
+        vllm_config = get_current_vllm_config_or_none()
+        if vllm_config is None:
+            return
+        if not vllm_config.model_config.enforce_eager:
+            raise ValueError(
+                "The EXL3 quantization backend requires eager execution: "
+                "pass --enforce-eager (enforce_eager=True). exl3_gemm "
+                "autotunes with timing launches on first use per shape "
+                "bucket, which is incompatible with CUDA-graph capture."
+            )
+
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> QuantizeMethodBase | None:
+        self._require_enforce_eager()
+        is_lm_head = layer.__class__.__name__ == "ParallelLMHead"
+        if is_lm_head and not prefix:
+            prefix = "lm_head"
+        if isinstance(layer, LinearBase) or is_lm_head:
+            if not self._linear_prefix_is_exl3(prefix):
+                return UnquantizedLinearMethod()
+            return Exl3LinearMethod(self)
+        if isinstance(layer, RoutedExperts):
+            if not self._moe_prefix_is_exl3(prefix, layer):
+                return None
+            return Exl3MoEMethod(self, layer.moe_config)
+        return None
+
+    def _storage_entry(self, prefix: str) -> dict[str, Any] | None:
+        candidates = [prefix]
+        if prefix.startswith("model."):
+            candidates.append(prefix.removeprefix("model."))
+        else:
+            candidates.append(f"model.{prefix}")
+
+        # Multimodal wrappers often add an extra `model` or `language_model`
+        # segment relative to vLLM's text-only module — interior
+        # (`model.language_model.layers...`) or leading
+        # (`language_model.lm_head`), so leading segments collapse too.
+        parts = prefix.split(".")
+        for removable in ("model", "language_model"):
+            for idx in range(0, len(parts) - 1):
+                if parts[idx] != removable:
+                    continue
+                collapsed = ".".join(parts[:idx] + parts[idx + 1 :])
+                candidates.extend((collapsed, f"model.{collapsed}"))
+                if collapsed.startswith("model."):
+                    candidates.append(collapsed.removeprefix("model."))
+
+        for candidate in dict.fromkeys(candidates):
+            entry = self.tensor_storage.get(candidate)
+            if entry is not None:
+                return entry
+        return None
+
+    def _is_exl3_prefix(self, prefix: str) -> bool:
+        entry = self._storage_entry(prefix)
+        return entry is not None and entry.get("quant_format") == "exl3"
+
+    def _linear_prefix_is_exl3(self, prefix: str) -> bool:
+        if self._is_exl3_prefix(prefix):
+            return True
+        leaf = prefix.rsplit(".", 1)[-1]
+        source_leaves = self.packed_modules_mapping.get(leaf)
+        if not source_leaves:
+            return False
+        base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
+        return all(
+            self._is_exl3_prefix(f"{base}.{source}" if base else source)
+            for source in source_leaves
+        )
+
+    def _moe_prefix_is_exl3(
+        self, prefix: str, layer: torch.nn.Module | None = None
+    ) -> bool:
+        if self.rank_sliced_metadata is not None:
+            match = re.search(r"layers\.(\d+)\b", prefix)
+            if match is None:
+                return False
+            first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
+            return first <= int(match.group(1)) <= last
+        # Use the layer's checkpoint projection names (the same fields
+        # _validate_codebooks keys off) so remapped-projection MoE
+        # checkpoints are still detected; fall back to the defaults when the
+        # layer variant does not carry them.
+        projections = tuple(
+            getattr(layer, attr, default)
+            for attr, default in (
+                ("ckpt_gate_proj_name", "gate_proj"),
+                ("ckpt_up_proj_name", "up_proj"),
+                ("ckpt_down_proj_name", "down_proj"),
+            )
+        )
+        expert_prefixes = (f"{prefix}.0", f"{prefix}.experts.0")
+        return any(
+            all(
+                self._is_exl3_prefix(f"{expert}.{projection}")
+                for projection in projections
+            )
+            for expert in expert_prefixes
+        )
+
+    def codebook_for_prefix(self, prefix: str) -> str | None:
+        if self.rank_sliced_metadata is not None:
+            match = re.search(r"layers\.(\d+)\b", prefix)
+            if match is None:
+                return None
+            first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
+            return "mcg" if first <= int(match.group(1)) <= last else None
+        entry = self._storage_entry(prefix)
+        if entry is None:
+            return None
+        suffixes = {name.rsplit(".", 1)[-1] for name in entry.get("stored_tensors", {})}
+        if "mcg" in suffixes:
+            return "mcg"
+        if "mul1" in suffixes:
+            return "mul1"
+        return None
+
+    def has_quantized_lm_head(self) -> bool:
+        return self._is_exl3_prefix("lm_head")
+
+    def normalize_rank_sliced_weight_name(self, name: str) -> str | None:
+        """Drop non-local TP payloads and remove the serialized rank segment."""
+        if self.rank_sliced_metadata is None:
+            return name
+        shared_match = _SHARED_H_WEIGHT_RE.match(name)
+        if shared_match is not None:
+            if self.rank_sliced_rotation_layout != _SHARED_H_ROTATION_LAYOUT:
+                raise ValueError(
+                    "rank-sliced EXL3 contains shared-H tensors but metadata "
+                    "does not declare rotation_layout='shared_h_v1'"
+                )
+            projection = shared_match.group("projection")
+            field = shared_match.group("field")
+            expected_field = "svh" if projection == "down_proj" else "suh"
+            if field != expected_field:
+                raise ValueError(
+                    "invalid shared-H EXL3 tensor: "
+                    f"projection={projection!r} requires {expected_field}, got {field}"
+                )
+            if int(shared_match.group("rank")) != get_tensor_model_parallel_rank():
+                return None
+            return f"{shared_match.group('experts_prefix')}.0.{projection}.{field}"
+        match = _RANK_SLICED_WEIGHT_RE.match(name)
+        if match is None:
+            return name
+        if self.rank_sliced_rotation_layout == _SHARED_H_ROTATION_LAYOUT:
+            projection_match = _EXPERT_PROJECTION_RE.match(match.group("prefix"))
+            if projection_match is not None:
+                projection = projection_match.group("projection")
+                field = match.group("field")
+                is_h_side = (
+                    projection in {"gate_proj", "up_proj"} and field == "suh"
+                ) or (projection == "down_proj" and field == "svh")
+                if is_h_side:
+                    raise ValueError(
+                        "shared_h_v1 must store H-side rotations under "
+                        "experts.shared_h, not under an expert id"
+                    )
+        if int(match.group("rank")) != get_tensor_model_parallel_rank():
+            return None
+        return f"{match.group('prefix')}.{match.group('field')}"
+
+
+class Exl3Parameter(BasevLLMParameter):
+    """Zero-sized parameter holding independently shaped EXL3 components."""
+
+    def __new__(cls, *, weight_loader):
+        data = torch.empty(0, dtype=torch.uint8)
+        return super().__new__(cls, data=data, weight_loader=weight_loader)
+
+    def __init__(self, *, weight_loader):
+        self.exl3_tensors: dict[ShardId, torch.Tensor] = {}
+        super().__init__(data=self.data, weight_loader=weight_loader)
+
+    def load_exl3_weight(
+        self,
+        loaded_weight: torch.Tensor,
+        shard_id: ShardId = None,
+    ) -> None:
+        self.exl3_tensors[shard_id] = loaded_weight.contiguous()
+
+
+def _exl3_weight_loader(
+    param: Exl3Parameter,
+    loaded_weight: torch.Tensor,
+    loaded_shard_id: ShardId = None,
+) -> None:
+    param.load_exl3_weight(loaded_weight, loaded_shard_id)
+
+
+class Exl3LinearMethod(LinearMethodBase):
+    def __init__(self, quant_config: Exl3Config) -> None:
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        del params_dtype, extra_weight_attrs
+        if layer.__class__.__name__ == "ParallelLMHead":
+            org = getattr(layer, "org_vocab_size", None)
+            total = getattr(layer, "num_embeddings", None)
+            if org is not None and total is not None and org != total:
+                raise NotImplementedError(
+                    "EXL3 lm_head with added vocabulary is unsupported: the "
+                    f"trellis tensor covers the original {org} rows but the "
+                    f"layer allocates {total}; TP slicing would silently "
+                    "misalign. Strip --lora-extra-vocab-size / added tokens "
+                    "or leave lm_head unquantized."
+                )
+        # Respect the layer's effective topology. disable_tp linears set their
+        # own tp_size=1, while ReplicatedLinear carries full weights even when
+        # the process-wide tensor group is larger than one.
+        if isinstance(layer, ReplicatedLinear):
+            layer.exl3_tp_rank = 0
+            layer.exl3_tp_size = 1
+        else:
+            layer.exl3_tp_rank = getattr(
+                layer, "tp_rank", get_tensor_model_parallel_rank()
+            )
+            layer.exl3_tp_size = getattr(
+                layer, "tp_size", get_tensor_model_parallel_world_size()
+            )
+        layer.exl3_input_size = input_size
+        layer.exl3_input_size_per_partition = input_size_per_partition
+        layer.exl3_output_size = output_size
+        layer.exl3_output_partition_sizes = output_partition_sizes
+        layer.exl3_shard_ids = self._shard_ids_for_layer(layer, output_partition_sizes)
+        layer.exl3_parallel_mode = (
+            "row" if input_size_per_partition != input_size else "column"
+        )
+        source_prefixes = self._source_prefixes_for_layer(layer, layer.exl3_shard_ids)
+        layer.exl3_expected_codebooks = {
+            shard_id: self.quant_config.codebook_for_prefix(source_prefix)
+            for shard_id, source_prefix in zip(
+                layer.exl3_shard_ids, source_prefixes, strict=True
+            )
+        }
+
+        # su/sv are legacy packed sign bitfields.  Modern checkpoints load
+        # suh/svh directly.
+        for name in ("suh", "svh", "su", "sv", "trellis", "mcg", "mul1"):
+            layer.register_parameter(
+                name,
+                Exl3Parameter(weight_loader=_exl3_weight_loader),
+            )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        self._materialize_legacy_hadamard(layer)
+        missing: list[str] = []
+        for attr in ("suh", "svh", "trellis"):
+            param = getattr(layer, attr)
+            for shard_id in layer.exl3_shard_ids:
+                if shard_id not in param.exl3_tensors:
+                    missing.append(f"{attr}[{shard_id!r}]")
+        for shard_id in layer.exl3_shard_ids:
+            expected = layer.exl3_expected_codebooks[shard_id]
+            has_mcg = shard_id in layer.mcg.exl3_tensors
+            has_mul1 = shard_id in layer.mul1.exl3_tensors
+            if has_mcg and has_mul1:
+                missing.append(f"codebook[{shard_id!r}]=both mcg and mul1")
+            elif expected == "mcg" and not has_mcg:
+                missing.append(f"mcg[{shard_id!r}]")
+            elif expected == "mul1" and not has_mul1:
+                missing.append(f"mul1[{shard_id!r}]")
+            elif expected is None and (has_mcg or has_mul1):
+                missing.append(f"unexpected codebook[{shard_id!r}]")
+        if missing:
+            prefix = getattr(layer, "prefix", layer.__class__.__name__)
+            raise ValueError(
+                f"Missing or inconsistent EXL3 tensors for {prefix}: "
+                + ", ".join(missing)
+            )
+
+        self._validate_loaded_tensors(layer)
+        self._shard_tensors_for_tensor_parallel(layer)
+        self._validate_loaded_tensors(layer)
+
+        # device_loading_context has moved the zero-sized registered parameter
+        # to the model target device.  Its device is the safest destination for
+        # the tensors kept in the side dictionaries.
+        device = layer.trellis.device
+        for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
+            param = getattr(layer, attr)
+            for shard_id, tensor in list(param.exl3_tensors.items()):
+                param.exl3_tensors[shard_id] = tensor.to(
+                    device=device, non_blocking=True
+                ).contiguous()
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        original_shape = x.shape[:-1]
+        original_dtype = x.dtype
+        x_2d = x.reshape(-1, x.shape[-1]).to(torch.float16).contiguous()
+        outputs = [
+            self._apply_one(layer, x_2d, shard_id) for shard_id in layer.exl3_shard_ids
+        ]
+        output = outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=-1)
+        if bias is not None:
+            output = output + bias.to(dtype=output.dtype)
+        output = output.reshape(*original_shape, output.shape[-1])
+        return output if output.dtype == original_dtype else output.to(original_dtype)
+
+    @staticmethod
+    def _unpack_signs(bitfield: torch.Tensor) -> torch.Tensor:
+        words = bitfield.contiguous().view(torch.uint16).to(torch.int32)
+        masks = 1 << torch.arange(16, device=words.device, dtype=torch.int32)
+        negative = (words.unsqueeze(-1) & masks) != 0
+        return (
+            torch.where(
+                negative,
+                torch.tensor(-1.0, device=words.device, dtype=torch.float16),
+                torch.tensor(1.0, device=words.device, dtype=torch.float16),
+            )
+            .flatten()
+            .contiguous()
+        )
+
+    @classmethod
+    def _materialize_legacy_hadamard(cls, layer: torch.nn.Module) -> None:
+        for packed_name, half_name in (("su", "suh"), ("sv", "svh")):
+            packed = getattr(layer, packed_name).exl3_tensors
+            half = getattr(layer, half_name).exl3_tensors
+            for shard_id in layer.exl3_shard_ids:
+                if shard_id not in half and shard_id in packed:
+                    half[shard_id] = cls._unpack_signs(packed[shard_id])
+
+    @staticmethod
+    def _validate_marker(tensor: torch.Tensor, expected: int, name: str) -> None:
+        if tensor.dtype != torch.int32 or tensor.numel() != 1:
+            raise ValueError(f"EXL3 {name} must be a scalar int32 sentinel")
+        value = int(tensor.reshape(()).item()) & 0xFFFFFFFF
+        if value != expected:
+            raise ValueError(
+                f"Invalid EXL3 {name} sentinel 0x{value:08x}; expected 0x{expected:08x}"
+            )
+
+    @classmethod
+    def _validate_loaded_tensors(cls, layer: torch.nn.Module) -> None:
+        for shard_id in layer.exl3_shard_ids:
+            trellis = layer.trellis.exl3_tensors[shard_id]
+            suh = layer.suh.exl3_tensors[shard_id]
+            svh = layer.svh.exl3_tensors[shard_id]
+            if trellis.dtype != torch.int16 or trellis.ndim != 3:
+                raise ValueError("EXL3 trellis must be rank-3 int16")
+            if trellis.shape[2] % 16 or not 1 <= trellis.shape[2] // 16 <= 8:
+                raise ValueError(
+                    f"Invalid EXL3 trellis bit width {trellis.shape[2]} / 16"
+                )
+            if suh.dtype != torch.float16 or suh.ndim != 1:
+                raise ValueError("EXL3 suh must be rank-1 float16")
+            if svh.dtype != torch.float16 or svh.ndim != 1:
+                raise ValueError("EXL3 svh must be rank-1 float16")
+            k = trellis.shape[0] * 16
+            n = trellis.shape[1] * 16
+            if suh.numel() != k or svh.numel() != n:
+                raise ValueError(
+                    "EXL3 dimensions disagree: "
+                    f"trellis={tuple(trellis.shape)}, suh={suh.numel()}, "
+                    f"svh={svh.numel()}"
+                )
+            if k % _HADAMARD_BLOCK or n % _HADAMARD_BLOCK:
+                raise ValueError(
+                    f"EXL3 kernel dimensions must be {_HADAMARD_BLOCK}-aligned, "
+                    f"got K={k}, N={n}"
+                )
+            if shard_id in layer.mcg.exl3_tensors:
+                cls._validate_marker(
+                    layer.mcg.exl3_tensors[shard_id], _MCG_SENTINEL, "mcg"
+                )
+            if shard_id in layer.mul1.exl3_tensors:
+                cls._validate_marker(
+                    layer.mul1.exl3_tensors[shard_id], _MUL1_SENTINEL, "mul1"
+                )
+
+    @staticmethod
+    def _slice_exl3_tensor(
+        tensor: torch.Tensor,
+        *,
+        dim: int,
+        start: int,
+        size: int,
+    ) -> torch.Tensor:
+        if start % _HADAMARD_BLOCK or size % _HADAMARD_BLOCK:
+            axis = "output" if dim == 1 else "input"
+            raise ValueError(
+                f"EXL3 TP {axis} slice must be {_HADAMARD_BLOCK}-aligned, "
+                f"got start={start}, size={size}"
+            )
+        return tensor.narrow(dim, start // 16, size // 16).contiguous()
+
+    @staticmethod
+    def _output_shard_size(layer: torch.nn.Module, shard_id: ShardId) -> int:
+        if shard_id is None:
+            return layer.exl3_output_partition_sizes[0]
+        if isinstance(shard_id, str) and shard_id in ("q", "k", "v"):
+            return layer.exl3_output_partition_sizes[{"q": 0, "k": 1, "v": 2}[shard_id]]
+        if isinstance(shard_id, tuple):
+            return sum(layer.exl3_output_partition_sizes[idx] for idx in shard_id)
+        if isinstance(shard_id, int):
+            return layer.exl3_output_partition_sizes[shard_id]
+        return layer.exl3_output_partition_sizes[layer.exl3_shard_ids.index(shard_id)]
+
+    @staticmethod
+    def _qkv_output_start(
+        layer: torch.nn.Module, shard_id: ShardId, shard_size: int
+    ) -> int:
+        if shard_id in ("k", "v"):
+            shard_rank = layer.exl3_tp_rank // layer.num_kv_head_replicas
+        else:
+            shard_rank = layer.exl3_tp_rank
+        return shard_rank * shard_size
+
+    @classmethod
+    def _shard_tensors_for_tensor_parallel(cls, layer: torch.nn.Module) -> None:
+        if layer.exl3_tp_size == 1:
+            return
+        if layer.exl3_parallel_mode == "row":
+            start = layer.exl3_tp_rank * layer.exl3_input_size_per_partition
+            size = layer.exl3_input_size_per_partition
+            for shard_id in layer.exl3_shard_ids:
+                layer.suh.exl3_tensors[shard_id] = (
+                    layer.suh.exl3_tensors[shard_id].narrow(0, start, size).contiguous()
+                )
+                layer.trellis.exl3_tensors[shard_id] = cls._slice_exl3_tensor(
+                    layer.trellis.exl3_tensors[shard_id],
+                    dim=0,
+                    start=start,
+                    size=size,
+                )
+            return
+
+        already_sharded = cls._expand_tuple_output_shards(layer)
+        for shard_id in layer.exl3_shard_ids:
+            if shard_id in already_sharded:
+                continue
+            size = cls._output_shard_size(layer, shard_id)
+            start = cls._qkv_output_start(layer, shard_id, size)
+            layer.svh.exl3_tensors[shard_id] = (
+                layer.svh.exl3_tensors[shard_id].narrow(0, start, size).contiguous()
+            )
+            layer.trellis.exl3_tensors[shard_id] = cls._slice_exl3_tensor(
+                layer.trellis.exl3_tensors[shard_id],
+                dim=1,
+                start=start,
+                size=size,
+            )
+
+    @classmethod
+    def _expand_tuple_output_shards(cls, layer: torch.nn.Module) -> set[int]:
+        tuples = [sid for sid in layer.exl3_shard_ids if isinstance(sid, tuple)]
+        if not tuples:
+            return set()
+
+        expanded_ids: list[ShardId] = []
+        component_ids: set[int] = set()
+        for shard_id in layer.exl3_shard_ids:
+            if isinstance(shard_id, tuple):
+                expanded_ids.extend(shard_id)
+                component_ids.update(shard_id)
+            else:
+                expanded_ids.append(shard_id)
+
+        for tuple_id in tuples:
+            full_offsets: dict[int, int] = {}
+            offset = 0
+            for idx in tuple_id:
+                full_offsets[idx] = offset
+                offset += layer.exl3_output_partition_sizes[idx] * layer.exl3_tp_size
+            for idx in tuple_id:
+                size = layer.exl3_output_partition_sizes[idx]
+                start = full_offsets[idx] + layer.exl3_tp_rank * size
+                layer.suh.exl3_tensors[idx] = layer.suh.exl3_tensors[tuple_id]
+                layer.svh.exl3_tensors[idx] = (
+                    layer.svh.exl3_tensors[tuple_id].narrow(0, start, size).contiguous()
+                )
+                layer.trellis.exl3_tensors[idx] = cls._slice_exl3_tensor(
+                    layer.trellis.exl3_tensors[tuple_id],
+                    dim=1,
+                    start=start,
+                    size=size,
+                )
+                layer.exl3_expected_codebooks[idx] = layer.exl3_expected_codebooks[
+                    tuple_id
+                ]
+                for marker in ("mcg", "mul1"):
+                    tensors = getattr(layer, marker).exl3_tensors
+                    if tuple_id in tensors:
+                        tensors[idx] = tensors[tuple_id]
+            for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
+                getattr(layer, attr).exl3_tensors.pop(tuple_id, None)
+            layer.exl3_expected_codebooks.pop(tuple_id, None)
+
+        layer.exl3_shard_ids = expanded_ids
+        return component_ids
+
+    @staticmethod
+    def _shard_ids_for_layer(
+        layer: torch.nn.Module,
+        output_partition_sizes: list[int],
+    ) -> list[ShardId]:
+        if len(output_partition_sizes) == 1:
+            return [None]
+        prefix = getattr(layer, "prefix", "")
+        if isinstance(layer, QKVParallelLinear) and len(output_partition_sizes) == 3:
+            return ["q", "k", "v"]
+        if prefix.endswith("in_proj_qkvz"):
+            return [(0, 1, 2), 3]
+        return list(range(len(output_partition_sizes)))
+
+    def _source_prefixes_for_layer(
+        self, layer: torch.nn.Module, shard_ids: list[ShardId]
+    ) -> list[str]:
+        prefix = getattr(layer, "prefix", "")
+        if len(shard_ids) == 1:
+            return [prefix or "lm_head"]
+        leaf = prefix.rsplit(".", 1)[-1]
+        base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
+        sources = self.quant_config.packed_modules_mapping.get(leaf)
+        if sources and len(sources) == len(shard_ids):
+            return [f"{base}.{source}" if base else source for source in sources]
+        raise ValueError(
+            f"EXL3 does not know the source matrices for packed layer {prefix}; "
+            "add it to the model's packed_modules_mapping."
+        )
+
+    @staticmethod
+    def _apply_one(
+        layer: torch.nn.Module, x: torch.Tensor, shard_id: ShardId
+    ) -> torch.Tensor:
+        trellis = layer.trellis.exl3_tensors[shard_id]
+        packed_k = trellis.shape[0] * 16
+        if x.shape[-1] > packed_k:
+            raise ValueError(
+                f"EXL3 input width {x.shape[-1]} exceeds packed K={packed_k}"
+            )
+        if x.shape[-1] < packed_k:
+            x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
+        output = _exl3_gemm(
+            x,
+            trellis,
+            layer.suh.exl3_tensors[shard_id],
+            layer.svh.exl3_tensors[shard_id],
+            shard_id in layer.mcg.exl3_tensors,
+            shard_id in layer.mul1.exl3_tensors,
+        )
+        logical_n = Exl3LinearMethod._output_shard_size(layer, shard_id)
+        if output.shape[-1] < logical_n:
+            raise ValueError(
+                f"EXL3 packed N={output.shape[-1]} is below logical N={logical_n}"
+            )
+        return output[..., :logical_n]
+
+
+class Exl3MoEParameter(BasevLLMParameter):
+    """EXL3 tensors keyed by expert/projection, optionally in one GPU slab."""
+
+    def __new__(
+        cls,
+        *,
+        weight_loader,
+        num_experts: int = 0,
+        shard_ids: tuple[str, ...] = (),
+        preallocate: bool = False,
+    ):
+        del num_experts, shard_ids, preallocate
+        data = torch.empty(0, dtype=torch.uint8)
+        return super().__new__(cls, data=data, weight_loader=weight_loader)
+
+    def __init__(
+        self,
+        *,
+        weight_loader,
+        num_experts: int = 0,
+        shard_ids: tuple[str, ...] = (),
+        preallocate: bool = False,
+    ):
+        self.exl3_tensors: dict[tuple[int, str], torch.Tensor] = {}
+        self.exl3_backing: torch.Tensor | None = None
+        self.exl3_num_experts = int(num_experts)
+        self.exl3_shard_ids = tuple(shard_ids)
+        self.exl3_preallocate = bool(preallocate)
+        super().__init__(data=self.data, weight_loader=weight_loader)
+
+    def load_exl3_weight(
+        self,
+        loaded_weight: torch.Tensor,
+        *,
+        expert_id: int,
+        shard_id: str,
+    ) -> None:
+        key = (int(expert_id), str(shard_id))
+        if not self.exl3_preallocate:
+            self.exl3_tensors[key] = loaded_weight.contiguous()
+            return
+        if self.exl3_num_experts <= 0 or shard_id not in self.exl3_shard_ids:
+            raise ValueError(
+                f"invalid EXL3 slab key expert={expert_id}, shard={shard_id!r}"
+            )
+        if not 0 <= int(expert_id) < self.exl3_num_experts:
+            raise ValueError(
+                f"EXL3 expert {expert_id} is outside [0, {self.exl3_num_experts})"
+            )
+        if self.device.type == "meta":
+            raise RuntimeError("rank-sliced EXL3 slabs cannot be allocated on meta")
+        if self.exl3_backing is None:
+            prefix = (
+                (len(self.exl3_shard_ids), self.exl3_num_experts)
+                if len(self.exl3_shard_ids) > 1
+                else (self.exl3_num_experts,)
+            )
+            self.exl3_backing = torch.empty(
+                prefix + tuple(loaded_weight.shape),
+                dtype=loaded_weight.dtype,
+                device=self.device,
+            )
+        shard_index = self.exl3_shard_ids.index(shard_id)
+        target = (
+            self.exl3_backing[shard_index, expert_id]
+            if len(self.exl3_shard_ids) > 1
+            else self.exl3_backing[expert_id]
+        )
+        if tuple(target.shape) != tuple(loaded_weight.shape):
+            raise ValueError(
+                "rank-sliced EXL3 tensor shape changed within one slab: "
+                f"expected={tuple(target.shape)}, got={tuple(loaded_weight.shape)}"
+            )
+        target.copy_(loaded_weight, non_blocking=True)
+        self.exl3_tensors[key] = target
+
+
+def _exl3_moe_weight_loader(
+    param: Exl3MoEParameter,
+    loaded_weight: torch.Tensor,
+    weight_name: str,
+    shard_id: str,
+    expert_id: int,
+    return_success: bool = False,
+) -> bool | None:
+    del weight_name
+    param.load_exl3_weight(
+        loaded_weight,
+        expert_id=expert_id,
+        shard_id=shard_id,
+    )
+    return True if return_success else None
+
+
+# Model loaders (e.g. llama4-style paths) check this attribute before routing
+# expert tensors through a param's weight_loader with MoE kwargs.
+_exl3_moe_weight_loader.supports_moe_loading = True  # type: ignore[attr-defined]
+
+
+class Exl3MoEMethod(FusedMoEMethodBase):
+    """Correctness MoE path: route, then use three dense EXL3 GEMMs/expert."""
+
+    def __init__(self, quant_config: Exl3Config, moe) -> None:
+        super().__init__(moe)
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: RoutedExperts,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        del extra_weight_attrs
+        if params_dtype not in (torch.bfloat16, torch.float16):
+            raise ValueError(
+                f"EXL3 MoE requires BF16 or FP16 activations, got {params_dtype}"
+            )
+        if self.moe.moe_parallel_config.use_ep:
+            raise NotImplementedError(
+                "EXL3 correctness MoE currently supports TP but not expert parallelism"
+            )
+        if self.moe.has_bias:
+            raise NotImplementedError(
+                "EXL3 correctness MoE does not yet support expert biases"
+            )
+        layer.exl3_tp_rank = self.moe.moe_parallel_config.tp_rank
+        layer.exl3_tp_size = self.moe.moe_parallel_config.tp_size
+        layer.exl3_hidden_size = hidden_size
+        layer.exl3_intermediate_size_per_partition = intermediate_size_per_partition
+        layer.exl3_params_dtype = params_dtype
+        rank_sliced = self.quant_config.rank_sliced_metadata is not None
+        shared_h = (
+            rank_sliced
+            and self.quant_config.rank_sliced_rotation_layout
+            == _SHARED_H_ROTATION_LAYOUT
+        )
+        layer.exl3_shared_h_rotations = shared_h
+        if rank_sliced:
+            checkpoint_tp = int(self.quant_config.rank_sliced_metadata["tp"])
+            if checkpoint_tp != layer.exl3_tp_size:
+                raise ValueError(
+                    "rank-sliced EXL3 checkpoint TP does not match runtime: "
+                    f"checkpoint={checkpoint_tp}, runtime={layer.exl3_tp_size}"
+                )
+            expected_experts = int(
+                self.quant_config.rank_sliced_metadata["experts_per_layer"]
+            )
+            if expected_experts != num_experts:
+                raise ValueError(
+                    "rank-sliced EXL3 expert count does not match the model: "
+                    f"checkpoint={expected_experts}, model={num_experts}"
+                )
+            vllm_config = get_current_vllm_config_or_none()
+            scheduler_config = (
+                vllm_config.scheduler_config if vllm_config is not None else None
+            )
+            # No silent fallback: a wrong capacity here puts the target and the
+            # rank-sliced MTP draft on different plans with no error, which is
+            # exactly the class of mismatch that corrupts only at scale.
+            if (
+                scheduler_config is None
+                or getattr(scheduler_config, "max_num_batched_tokens", None) is None
+            ):
+                raise ValueError(
+                    "EXL3 rank-sliced MoE requires scheduler_config."
+                    "max_num_batched_tokens to plan its Trellis arena; refusing to "
+                    "guess a capacity."
+                )
+            layer.exl3_max_num_batched_tokens = int(
+                scheduler_config.max_num_batched_tokens
+            )
+            # Stamp the layer role while the model-construction config context
+            # is still active. Forward time (the profile pass and CUDA graph
+            # capture) runs with no current vllm config, so neither name- nor
+            # index-based detection can resolve the role there -- a GLM-5-family
+            # style MTP head is named exactly like a target layer
+            # (model.layers.<num_hidden_layers>.*). runner_type is minted as
+            # "draft" for every model-backed speculator draft
+            # (SpeculativeConfig.__post_init__ -> ModelConfig(runner="draft")),
+            # which also covers speculators that bypass load_eagle_model.
+            layer.exl3_is_draft = (
+                getattr(vllm_config.model_config, "runner_type", None) == "draft"
+            )
+            layer.exl3_layer_bitrates = self.quant_config.rank_sliced_layer_bitrates(
+                str(layer.layer_name)
+            )
+            layer.exl3_mixed_bitrate = len(set(layer.exl3_layer_bitrates)) > 1
+        for prefix, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
+            for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
+                shared_parameter = shared_h and (
+                    (prefix == "w13" and suffix == "suh")
+                    or (prefix == "w2" and suffix == "svh")
+                )
+                layer.register_parameter(
+                    f"{prefix}_{suffix}",
+                    Exl3MoEParameter(
+                        weight_loader=_exl3_moe_weight_loader,
+                        num_experts=1 if shared_parameter else num_experts,
+                        shard_ids=shard_ids,
+                        preallocate=rank_sliced
+                        and suffix
+                        in (
+                            {"suh", "svh"}
+                            if getattr(layer, "exl3_mixed_bitrate", False)
+                            else {"suh", "svh", "trellis"}
+                        ),
+                    ),
+                )
+
+    def process_weights_after_loading(self, layer: RoutedExperts) -> None:
+        required = {"w13": ("w1", "w3"), "w2": ("w2",)}
+        missing: list[str] = []
+        for prefix, shard_ids in required.items():
+            for attr in ("suh", "svh", "trellis"):
+                tensors = getattr(layer, f"{prefix}_{attr}").exl3_tensors
+                shared_parameter = getattr(
+                    layer, "exl3_shared_h_rotations", False
+                ) and (
+                    (prefix == "w13" and attr == "suh")
+                    or (prefix == "w2" and attr == "svh")
+                )
+                expert_ids = (
+                    (0,) if shared_parameter else range(layer.local_num_experts)
+                )
+                for expert_id in expert_ids:
+                    for shard_id in shard_ids:
+                        if (expert_id, shard_id) not in tensors:
+                            missing.append(f"{prefix}_{attr}[{expert_id},{shard_id}]")
+        if missing:
+            raise ValueError(
+                f"Missing EXL3 MoE tensors for {layer.layer_name}: "
+                + ", ".join(missing[:32])
+                + (" ..." if len(missing) > 32 else "")
+            )
+        self._validate_codebooks(layer)
+        if self.quant_config.rank_sliced_metadata is None:
+            self._shard_tensors_for_tensor_parallel(layer)
+        device = layer.w13_trellis.device
+        for prefix in ("w13", "w2"):
+            for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
+                param = getattr(layer, f"{prefix}_{attr}")
+                for key, tensor in list(param.exl3_tensors.items()):
+                    param.exl3_tensors[key] = tensor.to(
+                        device=device, non_blocking=True
+                    ).contiguous()
+        self._validate_moe_shapes(layer)
+
+        if self.quant_config.rank_sliced_metadata is not None:
+            self._prepare_rank_sliced_weights(layer)
+            return
+
+    def _validate_codebooks(self, layer: RoutedExperts) -> None:
+        projections = {
+            "w1": layer.ckpt_gate_proj_name,
+            "w2": layer.ckpt_down_proj_name,
+            "w3": layer.ckpt_up_proj_name,
+        }
+        for expert_id in range(layer.local_num_experts):
+            for shard_id, projection in projections.items():
+                prefix = f"{layer.layer_name}.{expert_id}.{projection}"
+                expected = self.quant_config.codebook_for_prefix(prefix)
+                group = "w2" if shard_id == "w2" else "w13"
+                key = (expert_id, shard_id)
+                has_mcg = key in getattr(layer, f"{group}_mcg").exl3_tensors
+                has_mul1 = key in getattr(layer, f"{group}_mul1").exl3_tensors
+                if has_mcg and has_mul1:
+                    raise ValueError(f"EXL3 MoE {prefix} has both codebooks")
+                if expected == "mcg" and not has_mcg:
+                    raise ValueError(f"EXL3 MoE {prefix} is missing mcg")
+                if expected == "mul1" and not has_mul1:
+                    raise ValueError(f"EXL3 MoE {prefix} is missing mul1")
+                if expected is None and (has_mcg or has_mul1):
+                    raise ValueError(
+                        f"EXL3 MoE {prefix} has an unexpected codebook marker"
+                    )
+                if has_mcg:
+                    Exl3LinearMethod._validate_marker(
+                        getattr(layer, f"{group}_mcg").exl3_tensors[key],
+                        _MCG_SENTINEL,
+                        "mcg",
+                    )
+                if has_mul1:
+                    Exl3LinearMethod._validate_marker(
+                        getattr(layer, f"{group}_mul1").exl3_tensors[key],
+                        _MUL1_SENTINEL,
+                        "mul1",
+                    )
+
+    @classmethod
+    def _shard_tensors_for_tensor_parallel(cls, layer: RoutedExperts) -> None:
+        if layer.exl3_tp_size == 1:
+            return
+        start = layer.exl3_tp_rank * layer.exl3_intermediate_size_per_partition
+        size = layer.exl3_intermediate_size_per_partition
+        for expert_id in range(layer.local_num_experts):
+            for shard_id in ("w1", "w3"):
+                key = (expert_id, shard_id)
+                layer.w13_svh.exl3_tensors[key] = (
+                    layer.w13_svh.exl3_tensors[key].narrow(0, start, size).contiguous()
+                )
+                layer.w13_trellis.exl3_tensors[key] = (
+                    Exl3LinearMethod._slice_exl3_tensor(
+                        layer.w13_trellis.exl3_tensors[key],
+                        dim=1,
+                        start=start,
+                        size=size,
+                    )
+                )
+            key = (expert_id, "w2")
+            layer.w2_suh.exl3_tensors[key] = (
+                layer.w2_suh.exl3_tensors[key].narrow(0, start, size).contiguous()
+            )
+            layer.w2_trellis.exl3_tensors[key] = Exl3LinearMethod._slice_exl3_tensor(
+                layer.w2_trellis.exl3_tensors[key],
+                dim=0,
+                start=start,
+                size=size,
+            )
+
+    @staticmethod
+    def _validate_moe_shapes(layer: RoutedExperts) -> None:
+        for expert_id in range(layer.local_num_experts):
+            for group, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
+                for shard_id in shard_ids:
+                    key = (expert_id, shard_id)
+                    trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
+                    suh_key = (
+                        (0, shard_id)
+                        if getattr(layer, "exl3_shared_h_rotations", False)
+                        and group == "w13"
+                        else key
+                    )
+                    svh_key = (
+                        (0, shard_id)
+                        if getattr(layer, "exl3_shared_h_rotations", False)
+                        and group == "w2"
+                        else key
+                    )
+                    suh = getattr(layer, f"{group}_suh").exl3_tensors[suh_key]
+                    svh = getattr(layer, f"{group}_svh").exl3_tensors[svh_key]
+                    if (
+                        trellis.dtype != torch.int16
+                        or trellis.ndim != 3
+                        or trellis.shape[2] % 16
+                        or not 1 <= trellis.shape[2] // 16 <= 8
+                        or suh.dtype != torch.float16
+                        or suh.ndim != 1
+                        or svh.dtype != torch.float16
+                        or svh.ndim != 1
+                        or suh.numel() != trellis.shape[0] * 16
+                        or svh.numel() != trellis.shape[1] * 16
+                        or (trellis.shape[0] * 16) % _HADAMARD_BLOCK
+                        or (trellis.shape[1] * 16) % _HADAMARD_BLOCK
+                    ):
+                        raise ValueError(
+                            f"Invalid EXL3 MoE tensors for expert={expert_id}, "
+                            f"projection={shard_id}"
+                        )
+
+    @staticmethod
+    def _rank_sliced_backing(
+        layer: RoutedExperts,
+        param_name: str,
+    ) -> torch.Tensor:
+        param = getattr(layer, param_name)
+        backing = param.exl3_backing
+        if backing is None or not backing.is_contiguous():
+            raise RuntimeError(
+                f"rank-sliced EXL3 parameter {param_name} has no contiguous slab"
+            )
+        for (expert_id, shard_id), tensor in param.exl3_tensors.items():
+            shard_index = param.exl3_shard_ids.index(shard_id)
+            expected = (
+                backing[shard_index, expert_id]
+                if len(param.exl3_shard_ids) > 1
+                else backing[expert_id]
+            )
+            if tensor.data_ptr() != expected.data_ptr():
+                raise RuntimeError(
+                    "rank-sliced EXL3 expert payload lost its slab alias: "
+                    f"{param_name}[{expert_id},{shard_id}]"
+                )
+        return backing
+
+    @staticmethod
+    def _pointer_table(
+        slab: torch.Tensor,
+        *,
+        num_experts: int | None = None,
+    ) -> torch.Tensor:
+        if slab.ndim < 2 or not slab[0].is_contiguous():
+            raise RuntimeError("EXL3 pointer-table rows must be contiguous")
+        rows = int(slab.shape[0])
+        entries = rows if num_experts is None else int(num_experts)
+        if rows not in {1, entries}:
+            raise RuntimeError(
+                "EXL3 pointer-table rows must be per-expert or broadcast: "
+                f"rows={rows}, experts={entries}"
+            )
+        step = slab.stride(0) * slab.element_size()
+        base = slab.data_ptr()
+        return torch.tensor(
+            [
+                base + (0 if rows == 1 else expert_id) * step
+                for expert_id in range(entries)
+            ],
+            dtype=torch.int64,
+            device=slab.device,
+        )
+
+    @staticmethod
+    def _select_rotation_rows(
+        rotations: torch.Tensor,
+        expert_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        if int(rotations.shape[0]) == 1:
+            return rotations
+        return rotations.index_select(0, expert_ids).contiguous()
+
+    @staticmethod
+    def _trellis_tile_config(hidden_size: int, intermediate_size: int):
+        if hidden_size % 128 or intermediate_size % 128:
+            raise ValueError(
+                "rank-sliced EXL3 full rotations require hidden and "
+                "intermediate dimensions divisible by 128"
+            )
+        if hidden_size % 256 == 0 and intermediate_size % 256 == 0:
+            return (64, 256, 64, 256)
+        return (64, 128, 64, 128)
+
+    @staticmethod
+    def _mixed_trellis_tile_config(hidden_size: int, intermediate_size: int):
+        if hidden_size % 128 or intermediate_size % 128:
+            raise ValueError(
+                "mixed rank-sliced EXL3 requires hidden and intermediate "
+                "dimensions divisible by 128"
+            )
+        # The mixed K3/K4 megakernel needs a 128-wide FC1 K tile. The older
+        # 64x256 FC1 geometry loses partial reductions at large prefill M. A
+        # 512-wide FC2 tile removes the second persistent wave on GLM-5 models.
+        if hidden_size % 512 == 0:
+            return (128, 128, 32, 512)
+        if hidden_size % 256 == 0:
+            return (128, 128, 64, 256)
+        return (128, 128, 128, 128)
+
+    @staticmethod
+    def _mixed_trellis_prefill_tile_config(hidden_size: int, intermediate_size: int):
+        # Route packing stays block-64, while B12X's mixed-kernel ABI v2
+        # executes FC2 as arithmetic-equivalent 8-row subtiles.  Reuse the
+        # checkpoint's original one-grid tile geometry so prefill has the same
+        # reduction order as the stock-r16 quality reference.
+        return Exl3MoEMethod._mixed_trellis_tile_config(hidden_size, intermediate_size)
+
+    def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
+        mixed_api = _load_b12x_mixed_trellis()
+        num_experts = int(layer.local_num_experts)
+        hidden_size = int(layer.exl3_hidden_size)
+        intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+        bitrates = tuple(int(value) for value in layer.exl3_layer_bitrates)
+        if len(bitrates) != num_experts:
+            raise ValueError(
+                "mixed rank-sliced EXL3 bitrate count does not match experts: "
+                f"bitrates={len(bitrates)}, experts={num_experts}"
+            )
+        tiers = {
+            bits: tuple(
+                expert_id
+                for expert_id, expert_bits in enumerate(bitrates)
+                if expert_bits == bits
+            )
+            for bits in sorted(set(bitrates))
+        }
+        if len(tiers) != 2:
+            raise ValueError(
+                "the one-grid mixed Trellis path currently requires exactly two "
+                f"bitrates, got {tuple(tiers)}"
+            )
+
+        w13_param = layer.w13_trellis
+        w2_param = layer.w2_trellis
+        w13_shards = tuple(w13_param.exl3_shard_ids)
+        w2_shards = tuple(w2_param.exl3_shard_ids)
+        if w13_shards != ("w1", "w3") or w2_shards != ("w2",):
+            raise ValueError(
+                "mixed rank-sliced EXL3 requires w13=(w1,w3) and w2=(w2), got "
+                f"{w13_shards}/{w2_shards}"
+            )
+
+        gate_suh, up_suh = self._rank_sliced_backing(layer, "w13_suh")
+        gate_svh, up_svh = self._rank_sliced_backing(layer, "w13_svh")
+        down_suh = self._rank_sliced_backing(layer, "w2_suh")
+        down_svh = self._rank_sliced_backing(layer, "w2_svh")
+        device = gate_suh.device
+        mixed_tile_config = self._mixed_trellis_tile_config(
+            hidden_size, intermediate_size
+        )
+        prefill_tile_config = self._mixed_trellis_prefill_tile_config(
+            hidden_size, intermediate_size
+        )
+        tier_order = tuple(
+            expert_id for expert_ids in tiers.values() for expert_id in expert_ids
+        )
+        tier_index = torch.tensor(tier_order, dtype=torch.long, device=device)
+        combined_gate_suh = self._select_rotation_rows(gate_suh, tier_index)
+        combined_up_suh = self._select_rotation_rows(up_suh, tier_index)
+        broadcast_suh = int(combined_gate_suh.shape[0]) == 1
+        if broadcast_suh != (int(combined_up_suh.shape[0]) == 1):
+            raise ValueError(
+                "mixed EXL3 gate/up SUH rotations must both be per-expert "
+                "or both broadcast"
+            )
+        combined_intermediate_rotations = torch.cat(
+            (
+                gate_svh.index_select(0, tier_index),
+                up_svh.index_select(0, tier_index),
+                down_suh.index_select(0, tier_index),
+            ),
+            dim=1,
+        ).contiguous()
+        combined_down_svh = self._select_rotation_rows(down_svh, tier_index)
+        broadcast_svh = int(combined_down_svh.shape[0]) == 1
+        combined_rotations = SimpleNamespace(
+            intermediate=combined_intermediate_rotations,
+            gate_suh=combined_gate_suh,
+            up_suh=combined_up_suh,
+            down_svh=combined_down_svh,
+        )
+        prepared_tiers = []
+        prefill_tiers = []
+        tier_ids = []
+        tier_offset = 0
+        for bits, expert_ids in tiers.items():
+            expected_last = 16 * bits
+            w13 = torch.stack(
+                tuple(
+                    torch.stack(
+                        tuple(
+                            w13_param.exl3_tensors[(expert_id, shard_id)]
+                            for expert_id in expert_ids
+                        )
+                    )
+                    for shard_id in w13_shards
+                )
+            ).contiguous()
+            w2 = torch.stack(
+                tuple(
+                    w2_param.exl3_tensors[(expert_id, "w2")] for expert_id in expert_ids
+                )
+            ).contiguous()
+            expected_w13 = (
+                2,
+                len(expert_ids),
+                hidden_size // 16,
+                intermediate_size // 16,
+                expected_last,
+            )
+            expected_w2 = (
+                len(expert_ids),
+                intermediate_size // 16,
+                hidden_size // 16,
+                expected_last,
+            )
+            if tuple(w13.shape) != expected_w13 or tuple(w2.shape) != expected_w2:
+                raise ValueError(
+                    f"mixed EXL3 K{bits} slab geometry mismatch: "
+                    f"w13={tuple(w13.shape)}, w2={tuple(w2.shape)}, "
+                    f"expected={expected_w13}/{expected_w2}"
+                )
+
+            tier_slice = slice(tier_offset, tier_offset + len(expert_ids))
+            tier_gate_suh = (
+                combined_gate_suh
+                if int(combined_gate_suh.shape[0]) == 1
+                else combined_gate_suh[tier_slice]
+            )
+            tier_up_suh = (
+                combined_up_suh
+                if int(combined_up_suh.shape[0]) == 1
+                else combined_up_suh[tier_slice]
+            )
+            intermediate_rotations = combined_intermediate_rotations[tier_slice]
+            tier_down_svh = (
+                combined_down_svh
+                if int(combined_down_svh.shape[0]) == 1
+                else combined_down_svh[tier_slice]
+            )
+
+            def prepare_tier(
+                tile_config: tuple[int, int, int, int],
+                *,
+                w13: torch.Tensor = w13,
+                w2: torch.Tensor = w2,
+                expert_count: int = len(expert_ids),
+                bits: int = bits,
+                tier_gate_suh: torch.Tensor = tier_gate_suh,
+                tier_up_suh: torch.Tensor = tier_up_suh,
+                intermediate_rotations: torch.Tensor = intermediate_rotations,
+                tier_down_svh: torch.Tensor = tier_down_svh,
+            ):
+                return mixed_api.prepare_weights(
+                    w13=w13,
+                    w2=w2,
+                    hidden_size=hidden_size,
+                    intermediate_size=intermediate_size,
+                    num_experts=expert_count,
+                    activation=layer.activation.value,
+                    fc1_tile_n=tile_config[1],
+                    fc2_tile_n=tile_config[3],
+                    params_dtype=torch.float16,
+                    w13_layout="trellis3_t256_proj",
+                    trellis_bits=bits,
+                    codebook="mcg",
+                    gate_suh=tier_gate_suh,
+                    up_suh=tier_up_suh,
+                    intermediate_rotations=intermediate_rotations,
+                    down_svh=tier_down_svh,
+                    tile_config=tile_config,
+                    workspace=w13.view(torch.int32).reshape(-1)[:1],
+                )
+
+            prepared_tiers.append(prepare_tier(mixed_tile_config))
+            prefill_tiers.append(prepare_tier(prefill_tile_config))
+            tier_ids.append(expert_ids)
+            tier_offset += len(expert_ids)
+
+        global_to_combined, descriptor_map = mixed_api.build_tiered_maps(
+            tier_ids[0], tier_ids[1], device=device
+        )
+        layer.exl3_mixed_trellis = {
+            "tiers": tuple(prepared_tiers),
+            "prefill_tiers": tuple(prefill_tiers),
+            "tier_ids": tuple(tier_ids),
+            "tier_bits": tuple(tiers),
+            "global_to_combined": global_to_combined,
+            "descriptor_map": descriptor_map,
+            "rotations": combined_rotations,
+            "broadcast_suh": broadcast_suh,
+            "broadcast_svh": broadcast_svh,
+            "tile_config": mixed_tile_config,
+            "prefill_tile_config": prefill_tile_config,
+        }
+        layer.exl3_trellis_tile_config = mixed_tile_config
+
+        # The prepared tier objects own compact, tier-ordered copies. Release
+        # per-expert source tensors and the original rotation slabs now rather
+        # than retaining both representations for every layer.
+        for prefix in ("w13", "w2"):
+            for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
+                param = getattr(layer, f"{prefix}_{suffix}")
+                param.exl3_tensors.clear()
+                param.exl3_backing = None
+        logger.info(
+            "EXL3 mixed Trellis %s: tiers=%s",
+            layer.layer_name,
+            tuple((bits, len(ids)) for bits, ids in zip(tiers, tier_ids, strict=True)),
+        )
+        layer.b12x_warmup_provider = self
+
+    def _prepare_rank_sliced_weights(self, layer: RoutedExperts) -> None:
+        if getattr(layer, "exl3_mixed_bitrate", False):
+            self._prepare_mixed_rank_sliced_weights(layer)
+            return
+        api = _load_b12x_fused_moe()
+        num_experts = int(layer.local_num_experts)
+        hidden_size = int(layer.exl3_hidden_size)
+        intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+        layer_bitrates = tuple(getattr(layer, "exl3_layer_bitrates", ()))
+        if len(set(layer_bitrates)) != 1:
+            raise ValueError(
+                "uniform rank-sliced EXL3 layer has invalid bitrates "
+                f"{layer_bitrates!r}"
+            )
+        bits = int(layer_bitrates[0])
+        if bits not in (3, 4, 5, 6):
+            raise ValueError(
+                f"rank-sliced EXL3 requires an integral 3/4/5/6 bitrate, got {bits!r}"
+            )
+
+        w13 = self._rank_sliced_backing(layer, "w13_trellis")
+        w2 = self._rank_sliced_backing(layer, "w2_trellis")
+        gate_suh, up_suh = self._rank_sliced_backing(layer, "w13_suh")
+        gate_svh, up_svh = self._rank_sliced_backing(layer, "w13_svh")
+        down_suh = self._rank_sliced_backing(layer, "w2_suh")
+        down_svh = self._rank_sliced_backing(layer, "w2_svh")
+        expected_w13 = (
+            2,
+            num_experts,
+            hidden_size // 16,
+            intermediate_size // 16,
+            16 * bits,
+        )
+        expected_w2 = (
+            num_experts,
+            intermediate_size // 16,
+            hidden_size // 16,
+            16 * bits,
+        )
+        if tuple(w13.shape) != expected_w13 or tuple(w2.shape) != expected_w2:
+            raise ValueError(
+                "rank-sliced EXL3 slab geometry mismatch: "
+                f"w13={tuple(w13.shape)}, w2={tuple(w2.shape)}, "
+                f"expected={expected_w13}/{expected_w2}"
+            )
+
+        intermediate_rotations = torch.empty(
+            (num_experts, 3 * intermediate_size),
+            dtype=torch.float16,
+            device=w13.device,
+        )
+        intermediate_rotations[:, :intermediate_size].copy_(gate_svh)
+        intermediate_rotations[:, intermediate_size : 2 * intermediate_size].copy_(
+            up_svh
+        )
+        intermediate_rotations[:, 2 * intermediate_size :].copy_(down_suh)
+        tile_config = self._trellis_tile_config(hidden_size, intermediate_size)
+        marker = layer.w13_mcg.exl3_tensors[(0, "w1")]
+        weight_plan = api.plan_weights(
+            quant_modes="w4a16",
+            source_format="exl3_trellis_mcg",
+            activation=layer.activation.value,
+            params_dtype=layer.exl3_params_dtype,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            w13_layout="w13",
+            trellis_bits=bits,
+            trellis_tile_config=tile_config,
+        )
+        layer.exl3_trellis_weights = api.prepare_weights(
+            plan=weight_plan,
+            params_dtype=layer.exl3_params_dtype,
+            w1_fp4=w13,
+            w2_fp4=w2,
+            gate_suh=gate_suh,
+            up_suh=up_suh,
+            intermediate_rotations=intermediate_rotations,
+            down_svh=down_svh,
+            trellis_mcg=marker,
+        )
+
+        slabs = (
+            w13[0],
+            gate_suh,
+            gate_svh,
+            w13[1],
+            up_suh,
+            up_svh,
+            w2,
+            down_suh,
+            down_svh,
+        )
+        layer.exl3_pointer_tables = tuple(
+            self._pointer_table(slab, num_experts=num_experts) for slab in slabs
+        )
+        layer.exl3_expert_map = torch.arange(
+            num_experts,
+            dtype=torch.int64,
+            device=w13.device,
+        )
+        layer.exl3_trellis_tile_config = tile_config
+        if getattr(layer, "exl3_shared_h_rotations", False):
+            saved_bytes = (num_experts - 1) * 3 * hidden_size * 2
+            logger.info_once(
+                "EXL3 shared-H rotation layout active; saving %.2f MiB per "
+                "routed-expert layer and TP rank",
+                saved_bytes / (1024 * 1024),
+            )
+
+    def get_fused_moe_quant_config(
+        self, layer: RoutedExperts
+    ) -> FusedMoEQuantConfig | None:
+        del layer
+        return None
+
+    @property
+    def topk_indices_dtype(self) -> torch.dtype | None:
+        return torch.long
+
+    def get_b12x_warmup_unit(
+        self,
+        layer: RoutedExperts,
+        token_counts: tuple[int, ...],
+        output_dtype: torch.dtype,
+    ) -> B12xWarmupUnit:
+        from vllm.utils.b12x import B12xWarmupUnit
+
+        del token_counts, output_dtype
+        if not getattr(layer, "exl3_mixed_bitrate", False):
+            raise RuntimeError("B12X route-pack warmup requires mixed-bitrate EXL3")
+
+        def compile() -> None:
+            _warmup_exl3_mixed_trellis_route_pack(layer)
+
+        return B12xWarmupUnit(
+            name="EXL3 mixed-Trellis route pack",
+            key=(type(self), id(layer)),
+            compile=compile,
+        )
+
+    def _mixed_rank_sliced_runtime(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> dict[str, Any]:
+        mixed = layer.exl3_mixed_trellis
+        max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
+        max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
+        prefill_block_raw = os.environ.get("VLLM_EXL3_PREFILL_BLOCK_M")
+        prefill_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
+        if max_decode_m > max_batched_tokens:
+            max_decode_m = max_batched_tokens
+        topk = int(topk_ids.shape[1])
+        tier_signature = tuple(
+            (int(bits), len(ids))
+            for bits, ids in zip(mixed["tier_bits"], mixed["tier_ids"], strict=True)
+        )
+        props = torch.cuda.get_device_properties(x.device)
+        prefill_block_m = _resolve_mixed_trellis_prefill_block_m(
+            configured_block_m=prefill_block_m,
+            explicit_override=bool(
+                prefill_block_raw is not None and prefill_block_raw.strip()
+            ),
+            hidden_size=int(layer.exl3_hidden_size),
+            intermediate_size=int(layer.exl3_intermediate_size_per_partition),
+            tier_signature=tier_signature,
+            topk=topk,
+            device_major=int(getattr(props, "major", 0)),
+            prefill_tile_config=mixed["prefill_tile_config"],
+        )
+        logger.info_once(
+            "EXL3 mixed Trellis prefill block policy: selected=%d "
+            "configured=%d explicit=%s shape=%dx%d tiers=%s topk=%d "
+            "sm=%d tile=%s",
+            prefill_block_m,
+            _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64),
+            bool(prefill_block_raw is not None and prefill_block_raw.strip()),
+            int(layer.exl3_hidden_size),
+            int(layer.exl3_intermediate_size_per_partition),
+            tier_signature,
+            topk,
+            int(getattr(props, "major", 0)),
+            mixed["prefill_tile_config"],
+        )
+        broadcast_suh = bool(mixed["broadcast_suh"])
+        broadcast_svh = bool(mixed["broadcast_svh"])
+        key = (
+            _runtime_owner_token(self.quant_config, layer),
+            x.device.index,
+            x.dtype,
+            topk_ids.dtype,
+            int(layer.exl3_hidden_size),
+            int(layer.exl3_intermediate_size_per_partition),
+            tier_signature,
+            topk,
+            max_decode_m,
+            max_batched_tokens,
+            prefill_capacity,
+            mixed["tile_config"],
+            mixed["prefill_tile_config"],
+            prefill_block_m,
+            broadcast_suh,
+            broadcast_svh,
+        )
+        runtime = _MIXED_TRELLIS_RUNTIMES.get(key)
+        if runtime is not None:
+            mixed["runtime"] = runtime
+            return runtime
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "Mixed-bitrate EXL3 runtime must be compiled during the eager "
+                "profile pass before CUDA graph capture"
+            )
+        if topk_ids.dtype not in (torch.int32, torch.int64):
+            raise TypeError(
+                "mixed-bitrate EXL3 requires int32/int64 route IDs, got "
+                f"{topk_ids.dtype}"
+            )
+
+        mixed_api = _load_b12x_mixed_trellis()
+        device = x.device
+        total_experts = sum(experts for _, experts in tier_signature)
+
+        def make_state(
+            capacity: int,
+            block_size_m: int,
+            tile_config: tuple[int, int, int, int],
+            tiers: tuple[Any, Any],
+        ) -> dict[str, Any]:
+            route_slots = mixed_api.max_packed_route_slots(
+                capacity * topk,
+                block_size_m,
+                total_experts,
+            )
+            launch = mixed_api.compile_mixed_trellis(
+                size_m=capacity,
+                hidden_size=int(layer.exl3_hidden_size),
+                intermediate_size=int(layer.exl3_intermediate_size_per_partition),
+                tier0_num_experts=tier_signature[0][1],
+                tier1_num_experts=tier_signature[1][1],
+                tier0_bits=tier_signature[0][0],
+                tier1_bits=tier_signature[1][0],
+                top_k=topk,
+                max_m_blocks=(route_slots + block_size_m - 1) // block_size_m,
+                moe_block_size=block_size_m,
+                sms=int(props.multi_processor_count),
+                max_shared_mem=int(props.shared_memory_per_block_optin),
+                force_tile_config=tile_config,
+                rotation_input_dtype=("bf16" if x.dtype == torch.bfloat16 else "fp16"),
+                route_ids_dtype=topk_ids.dtype,
+                broadcast_suh=broadcast_suh,
+                broadcast_svh=broadcast_svh,
+            )
+            return {
+                "capacity": capacity,
+                "launch": launch,
+                "binding": mixed_api.bind_mixed_trellis(
+                    tiers[0],
+                    tiers[1],
+                    mixed["global_to_combined"],
+                    mixed["descriptor_map"],
+                    mixed["rotations"],
+                    launch,
+                ),
+                "buffers": mixed_api.make_mixed_trellis_buffers(
+                    launch,
+                    device=device,
+                    sms=int(props.multi_processor_count),
+                ),
+            }
+
+        decode = make_state(
+            max_decode_m,
+            _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+            mixed["tile_config"],
+            mixed["tiers"],
+        )
+        prefill = None
+        if max_batched_tokens > max_decode_m:
+            if os.environ.get("VLLM_EXL3_PREFILL_TRELLIS", "1") != "1":
+                raise ValueError("mixed-K EXL3 requires VLLM_EXL3_PREFILL_TRELLIS=1")
+            prefill = make_state(
+                prefill_capacity,
+                prefill_block_m,
+                mixed["prefill_tile_config"],
+                mixed["prefill_tiers"],
+            )
+        runtime = {
+            "mixed_api": mixed_api,
+            "decode": decode,
+            "prefill": prefill,
+            "max_decode_m": max_decode_m,
+            "max_batched_tokens": max_batched_tokens,
+            "prefill_capacity": prefill_capacity,
+        }
+        _MIXED_TRELLIS_RUNTIMES[key] = runtime
+        mixed["runtime"] = runtime
+        decode_bytes = _unique_tensor_storage_bytes(decode["buffers"])
+        prefill_bytes = (
+            0 if prefill is None else _unique_tensor_storage_bytes(prefill["buffers"])
+        )
+        logger.info_once(
+            "EXL3 mixed Trellis runtime planned: tiers=%s one-grid decode=%d "
+            "one-grid prefill=%d/%d block_m=%d buffers=%.1f+%.1f MiB",
+            tier_signature,
+            max_decode_m,
+            prefill_capacity,
+            max_batched_tokens,
+            prefill_block_m,
+            decode_bytes / (1 << 20),
+            prefill_bytes / (1 << 20),
+        )
+        return runtime
+
+    def _apply_mixed_rank_sliced(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        runtime = self._mixed_rank_sliced_runtime(layer, x, topk_ids)
+        m = int(x.shape[0])
+        if m > runtime["max_batched_tokens"]:
+            raise ValueError(
+                "mixed-bitrate EXL3 batch exceeds planned capacity: "
+                f"m={m}, capacity={runtime['max_batched_tokens']}"
+            )
+
+        def run_state(
+            slice_x: torch.Tensor,
+            slice_weights: torch.Tensor,
+            slice_ids: torch.Tensor,
+            state: dict[str, Any],
+        ) -> torch.Tensor:
+            return (
+                runtime["mixed_api"]
+                .run_bound_mixed_trellis(
+                    slice_x,
+                    slice_weights,
+                    slice_ids,
+                    state["binding"],
+                    state["buffers"],
+                )
+                .to(slice_x.dtype)
+            )
+
+        if m <= runtime["max_decode_m"]:
+            return run_state(
+                x,
+                topk_weights,
+                topk_ids,
+                runtime["decode"],
+            )
+
+        if runtime["prefill"] is None:
+            raise RuntimeError("mixed-K EXL3 one-grid prefill plan is unavailable")
+        prefill_capacity = int(runtime["prefill_capacity"])
+        if m <= prefill_capacity:
+            return run_state(
+                x,
+                topk_weights,
+                topk_ids,
+                runtime["prefill"],
+            )
+
+        output = torch.empty_like(x)
+        for start in range(0, m, prefill_capacity):
+            stop = min(start + prefill_capacity, m)
+            slice_output = run_state(
+                x[start:stop],
+                topk_weights[start:stop],
+                topk_ids[start:stop],
+                runtime["prefill"],
+            )
+            output[start:stop].copy_(slice_output)
+        return output
+
+    def _rank_sliced_runtime(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> dict[str, Any]:
+        # Rank-sliced target and draft layers both reach small row counts
+        # (typically m=1..3) during profiling, decode, or CUDA-graph capture. If
+        # m falls outside the Trellis window the eager parity path is reached;
+        # under capture that is illegal and during eager execution it adds an
+        # avoidable external-extension ABI dependency:
+        #
+        #   RuntimeError: EXL3 eager parity path entered during CUDA graph
+        #   capture (m=3); capture sizes must lie inside the Trellis window
+        #   [4, 32]
+        #
+        # The backend therefore owns one capability-based default for both
+        # roles. An explicit env value remains authoritative for diagnostics.
+        min_trellis_m = _positive_env_int(
+            "VLLM_EXL3_TRELLIS_MIN_M", _DEFAULT_TRELLIS_MIN_M
+        )
+        max_trellis_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
+        block_m = _positive_env_int("VLLM_EXL3_TRELLIS_BLOCK_M", 8)
+        chunk = _positive_env_int("VLLM_EXL3_PREFILL_CHUNK", 128)
+        prefill_trellis = os.environ.get("VLLM_EXL3_PREFILL_TRELLIS", "1") == "1"
+        prefill_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
+        if min_trellis_m > max_trellis_m:
+            raise ValueError(
+                "VLLM_EXL3_TRELLIS_MIN_M cannot exceed VLLM_EXL3_TRELLIS_MAX_M"
+            )
+        # Both capacities are batch-invariant runtime properties. The scheduler
+        # bound remains fail-closed while a smaller opt-in Trellis capacity is
+        # handled by slicing at dispatch.
+        max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
+        prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
+        parity_rows = (
+            min(chunk, max_batched_tokens)
+            if prefill_plan_enabled
+            else max_batched_tokens
+        )
+        max_parity_batch = min(max_batched_tokens, min_trellis_m - 1)
+        if max_parity_batch > parity_rows:
+            raise ValueError(
+                "VLLM_EXL3_PREFILL_CHUNK cannot cover the EXL3 parity window: "
+                f"chunk={chunk}, required_rows={max_parity_batch}. Increase "
+                "VLLM_EXL3_PREFILL_CHUNK or lower VLLM_EXL3_TRELLIS_MIN_M."
+            )
+        topk = int(topk_ids.shape[1])
+        device_index = x.device.index
+        key = (
+            # Owning model scope first: the cached runtime holds mutable scratch,
+            # so a target layer and a same-shape rank-sliced MTP draft layer must
+            # not share an entry (see _runtime_scope_id).
+            _runtime_owner_token(self.quant_config, layer),
+            device_index,
+            x.dtype,
+            int(layer.exl3_hidden_size),
+            int(layer.exl3_intermediate_size_per_partition),
+            int(layer.local_num_experts),
+            topk,
+            max_batched_tokens,
+            min_trellis_m,
+            max_trellis_m,
+            block_m,
+            chunk,
+            prefill_trellis,
+            prefill_block_m,
+            layer.exl3_trellis_tile_config,
+            prefill_capacity,
+        )
+        runtime = _RANK_SLICED_RUNTIMES.get(key)
+        if runtime is not None:
+            return runtime
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "Rank-sliced EXL3 runtime must be planned during the eager "
+                "profile pass before CUDA graph capture"
+            )
+
+        api = _load_b12x_fused_moe()
+
+        def _plan_with_scratch(plan_max_tokens: int, plan_block_m: int):
+            caps = api.Caps(
+                max_tokens=plan_max_tokens,
+                num_topk=topk,
+                # vLLM supplies final top-k IDs/weights to bind(); the fused-MoE
+                # router workspace is unused. A zero route-workspace request
+                # still lets the W4A16 core derive route_E from weight_E.
+                route_num_experts=0,
+                device=x.device,
+                weight_plan=layer.exl3_trellis_weights.plan,
+                quant_mode="w4a16",
+                w4a16_block_size_m=plan_block_m,
+            )
+            plan = api.plan(caps)
+            scratch_spec = plan.scratch_specs()[0]
+            scratch = torch.empty(
+                scratch_spec.shape,
+                dtype=scratch_spec.dtype,
+                device=scratch_spec.device,
+            )
+            return plan, scratch
+
+        trellis_plan, trellis_scratch = _plan_with_scratch(max_trellis_m, block_m)
+        # Prefill batches (m > max_trellis_m) run through a second planned
+        # Trellis capacity instead of the eager ExLlamaV3 parity path. The
+        # large block keeps expert tiles streamed once per block of routed
+        # rows rather than once per 8-row block.
+        prefill_plan = None
+        prefill_scratch = None
+        if prefill_plan_enabled:
+            prefill_plan, prefill_scratch = _plan_with_scratch(
+                prefill_capacity, prefill_block_m
+            )
+
+        ext = _load_exl3_ext()
+        required_ext = {
+            "exl3_moe",
+            "exl3_moe_max_concurrency",
+        }
+        missing_ext = sorted(name for name in required_ext if not hasattr(ext, name))
+        if missing_ext:
+            raise RuntimeError(
+                "The EXL3 extension lacks routed-expert entry points: "
+                + ", ".join(missing_ext)
+            )
+        concurrency = int(ext.exl3_moe_max_concurrency(torch.cuda.current_device()))
+        hidden_size = int(layer.exl3_hidden_size)
+        intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+        num_experts = int(layer.local_num_experts)
+        device = x.device
+        # With the prefill plan live, the parity path only ever serves
+        # m < min_trellis_m, so its persistent staging shrinks to one chunk.
+        runtime = {
+            "api": api,
+            "trellis_plan": trellis_plan,
+            "trellis_scratch": trellis_scratch,
+            "prefill_plan": prefill_plan,
+            "prefill_scratch": prefill_scratch,
+            "ext": ext,
+            "min_trellis_m": min_trellis_m,
+            "max_trellis_m": max_trellis_m,
+            "max_batched_tokens": max_batched_tokens,
+            "prefill_capacity": prefill_capacity,
+            "parity_rows": parity_rows,
+            "topk": topk,
+            "chunk": chunk,
+            "xh": torch.empty(
+                (parity_rows, hidden_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "out32": torch.empty(
+                (parity_rows, hidden_size),
+                dtype=torch.float32,
+                device=device,
+            ),
+            "tg": torch.empty(
+                (concurrency, chunk, hidden_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "tu": torch.empty(
+                (concurrency, chunk, hidden_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "ig": torch.empty(
+                (concurrency, chunk, intermediate_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "iu": torch.empty(
+                (concurrency, chunk, intermediate_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "expert_count": torch.empty(
+                num_experts + 1,
+                dtype=torch.int64,
+                device=device,
+            ),
+            "expert_offsets": torch.empty(
+                num_experts + 1,
+                dtype=torch.int64,
+                device=device,
+            ),
+            "token_sorted": torch.empty(
+                parity_rows * topk,
+                dtype=torch.int64,
+                device=device,
+            ),
+            "weight_sorted": torch.empty(
+                parity_rows * topk,
+                dtype=torch.float16,
+                device=device,
+            ),
+            "flat_token": torch.arange(
+                chunk,
+                dtype=torch.int64,
+                device=device,
+            ).repeat_interleave(topk),
+            "ones": torch.ones(
+                chunk * topk,
+                dtype=torch.int64,
+                device=device,
+            ),
+        }
+        _RANK_SLICED_RUNTIMES[key] = runtime
+        prefill_arena_mib = (
+            0.0
+            if prefill_scratch is None
+            else prefill_scratch.numel() * prefill_scratch.element_size() / (1 << 20)
+        )
+        logger.info_once(
+            "EXL3 rank-sliced runtime planned: Trellis m=%d..%d block_m=%d, "
+            "prefill %s scheduler_capacity=%d chunk=%d topk=%d",
+            min_trellis_m,
+            max_trellis_m,
+            block_m,
+            (
+                f"trellis block_m={prefill_block_m} "
+                f"capacity={prefill_capacity} arena={prefill_arena_mib:.1f}MiB"
+                if prefill_plan is not None
+                else "parity"
+            ),
+            max_batched_tokens,
+            chunk,
+            topk,
+        )
+        return runtime
+
+    def _apply_rank_sliced(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        if getattr(layer, "exl3_mixed_bitrate", False):
+            return self._apply_mixed_rank_sliced(
+                layer,
+                x,
+                topk_weights,
+                topk_ids,
+            )
+        runtime = self._rank_sliced_runtime(layer, x, topk_ids)
+        m = int(x.shape[0])
+        if runtime["min_trellis_m"] <= m <= runtime["max_trellis_m"]:
+            binding = runtime["api"].bind(
+                runtime["trellis_plan"],
+                scratch=runtime["trellis_scratch"],
+                a=x,
+                experts=layer.exl3_trellis_weights,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+            )
+            output = runtime["api"].run(binding=binding)
+            return output.to(x.dtype)
+
+        if runtime["prefill_plan"] is not None and m > runtime["max_trellis_m"]:
+            if m > runtime["max_batched_tokens"]:
+                raise ValueError(
+                    "EXL3 batch exceeds its planned capacity: "
+                    f"m={m}, capacity={runtime['max_batched_tokens']}"
+                )
+            prefill_capacity = int(runtime["prefill_capacity"])
+            if m <= prefill_capacity:
+                binding = runtime["api"].bind(
+                    runtime["prefill_plan"],
+                    scratch=runtime["prefill_scratch"],
+                    a=x,
+                    experts=layer.exl3_trellis_weights,
+                    topk_weights=topk_weights,
+                    topk_ids=topk_ids,
+                )
+                output = runtime["api"].run(binding=binding)
+                return output.to(x.dtype)
+
+            output = torch.empty_like(x)
+            for start in range(0, m, prefill_capacity):
+                stop = min(start + prefill_capacity, m)
+                binding = runtime["api"].bind(
+                    runtime["prefill_plan"],
+                    scratch=runtime["prefill_scratch"],
+                    a=x[start:stop],
+                    experts=layer.exl3_trellis_weights,
+                    topk_weights=topk_weights[start:stop],
+                    topk_ids=topk_ids[start:stop],
+                )
+                slice_output = runtime["api"].run(binding=binding)
+                output[start:stop].copy_(slice_output)
+            return output
+
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "EXL3 eager parity path entered during CUDA graph capture "
+                f"(m={m}); capture sizes must lie inside the Trellis window "
+                f"[{runtime['min_trellis_m']}, {runtime['max_trellis_m']}]. "
+                f"Layer {getattr(layer, 'layer_name', '<unknown>')!r} was "
+                f"classified as {'draft' if _is_draft_layer(layer) else 'target'}. "
+                "A rank-sliced draft layer should have had its window widened to "
+                f"MIN_CAPTURABLE_TRELLIS_M={MIN_CAPTURABLE_TRELLIS_M} "
+                "automatically; if VLLM_EXL3_TRELLIS_MIN_M is set explicitly, "
+                f"lower it to {MIN_CAPTURABLE_TRELLIS_M} or unset it."
+            )
+        if m > runtime["parity_rows"]:
+            raise ValueError(
+                "EXL3 batch exceeds its planned parity capacity: "
+                f"m={m}, capacity={runtime['parity_rows']}"
+            )
+        ext = runtime["ext"]
+        xh = runtime["xh"][:m]
+        xh.copy_(x)
+        out32 = runtime["out32"][:m]
+        out32.zero_()
+        chunk = int(runtime["chunk"])
+        pointer_args = layer.exl3_pointer_tables
+        if m > chunk and hasattr(ext, "exl3_moe_fused"):
+            ext.exl3_moe_fused(
+                xh,
+                out32,
+                topk_ids,
+                topk_weights,
+                layer.exl3_expert_map,
+                runtime["expert_count"],
+                runtime["expert_offsets"],
+                runtime["token_sorted"],
+                runtime["weight_sorted"],
+                runtime["tg"],
+                runtime["tu"],
+                runtime["ig"],
+                runtime["iu"],
+                0,
+                3,
+                3,
+                3,
+                *pointer_args,
+                True,
+                False,
+                True,
+                False,
+                True,
+                False,
+                0.0,
+                0,
+            )
+            return out32.to(x.dtype)
+
+        local_ids = layer.exl3_expert_map[topk_ids.long()]
+        half_weights = topk_weights.to(torch.float16)
+        topk = int(runtime["topk"])
+        for start in range(0, m, chunk):
+            current_m = min(chunk, m - start)
+            flat = local_ids[start : start + current_m].reshape(-1)
+            order = torch.argsort(flat)
+            route_count = current_m * topk
+            token_ids = runtime["flat_token"][:route_count].index_select(0, order)
+            route_weights = (
+                half_weights[start : start + current_m]
+                .reshape(-1)
+                .index_select(0, order)
+            )
+            counts = runtime["expert_count"]
+            counts.zero_()
+            counts.scatter_add_(0, flat, runtime["ones"][:route_count])
+            ext.exl3_moe(
+                xh[start : start + current_m],
+                out32[start : start + current_m],
+                counts,
+                token_ids,
+                route_weights,
+                runtime["tg"],
+                runtime["tu"],
+                runtime["ig"],
+                runtime["iu"],
+                0,
+                3,
+                3,
+                3,
+                *pointer_args,
+                True,
+                False,
+                True,
+                False,
+                True,
+                False,
+                0.0,
+            )
+        return out32.to(x.dtype)
+
+    def apply(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: SharedExperts | None,
+        shared_experts_input: torch.Tensor | None,
+    ) -> torch.Tensor:
+        del shared_experts, shared_experts_input
+        if layer.activation != MoEActivation.SILU:
+            raise NotImplementedError(
+                f"EXL3 correctness MoE supports SiLU only, got {layer.activation}"
+            )
+        if layer.expert_map is not None:
+            raise NotImplementedError("EXL3 MoE expert maps/EPLB are not supported")
+        if layer.apply_router_weight_on_input:
+            raise NotImplementedError(
+                "EXL3 MoE does not support router weights applied on input"
+            )
+
+        original_shape = x.shape[:-1]
+        original_dtype = x.dtype
+        x_2d = x.reshape(-1, x.shape[-1]).contiguous()
+        ids = topk_ids.reshape(x_2d.shape[0], -1).contiguous()
+        weights = topk_weights.reshape_as(ids).to(torch.float32).contiguous()
+        if self.quant_config.rank_sliced_metadata is not None:
+            output = self._apply_rank_sliced(layer, x_2d, weights, ids)
+            return output.reshape(*original_shape, output.shape[-1])
+
+        x_2d = x_2d.to(torch.float16)
+        ids = ids.to(torch.long)
+        weights = weights.to(torch.float16)
+        output = torch.zeros(
+            (x_2d.shape[0], layer.hidden_size),
+            dtype=torch.float32,
+            device=x.device,
+        )
+        for expert_id in range(layer.local_num_experts):
+            positions = (ids == expert_id).nonzero(as_tuple=False)
+            if positions.shape[0] == 0:
+                continue
+            token_ids = positions[:, 0]
+            route_ids = positions[:, 1]
+            expert_input = x_2d.index_select(0, token_ids)
+            gate = self._apply_expert(layer, "w13", expert_input, expert_id, "w1")
+            up = self._apply_expert(layer, "w13", expert_input, expert_id, "w3")
+            hidden = torch.nn.functional.silu(gate) * up
+            expert_output = self._apply_expert(layer, "w2", hidden, expert_id, "w2")
+            route_weight = weights[token_ids, route_ids].unsqueeze(-1)
+            output.index_add_(
+                0,
+                token_ids,
+                (expert_output * route_weight).to(torch.float32),
+            )
+        output = output.reshape(*original_shape, output.shape[-1])
+        return output if output.dtype == original_dtype else output.to(original_dtype)
+
+    def apply_monolithic(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        router_logits: torch.Tensor,
+        input_ids: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del layer, x, router_logits, input_ids
+        raise NotImplementedError("EXL3 MoE uses vLLM's external router")
+
+    @staticmethod
+    def _apply_expert(
+        layer: RoutedExperts,
+        group: str,
+        x: torch.Tensor,
+        expert_id: int,
+        shard_id: str,
+    ) -> torch.Tensor:
+        key = (expert_id, shard_id)
+        trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
+        packed_k = trellis.shape[0] * 16
+        if x.shape[-1] > packed_k:
+            raise ValueError(
+                f"EXL3 MoE input width {x.shape[-1]} exceeds packed K={packed_k}"
+            )
+        if x.shape[-1] < packed_k:
+            x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
+        output = _exl3_gemm(
+            x,
+            trellis,
+            getattr(layer, f"{group}_suh").exl3_tensors[key],
+            getattr(layer, f"{group}_svh").exl3_tensors[key],
+            key in getattr(layer, f"{group}_mcg").exl3_tensors,
+            key in getattr(layer, f"{group}_mul1").exl3_tensors,
+        )
+        logical_n = (
+            layer.hidden_size
+            if shard_id == "w2"
+            else layer.exl3_intermediate_size_per_partition
+        )
+        if output.shape[-1] < logical_n:
+            raise ValueError(
+                f"EXL3 MoE packed N={output.shape[-1]} is below logical N={logical_n}"
+            )
+        return output[..., :logical_n]
+
+
+def _warmup_exl3_mixed_trellis_route_pack(layer: RoutedExperts) -> int:
+    """Materialize one mixed-Trellis layer's route-pack modules before KV sizing.
+
+    The first profile pass creates every layer's immutable mixed-Trellis
+    runtime. Route packing itself has power-of-two capacity specializations,
+    however, so profiling only the maximum batch leaves smaller decode,
+    speculative, and final-prefill-chunk modules lazy. Delegate enumeration to
+    B12X while those persistent CUDA allocations can still be measured by the
+    worker's second profile pass.
+    """
+    mixed = layer.exl3_mixed_trellis
+    runtime = mixed.get("runtime")
+    if runtime is None:
+        raise RuntimeError(
+            "mixed-bitrate EXL3 route-pack warmup found no runtime for "
+            f"{layer.layer_name}; the eager profile pass must plan the runtime "
+            "before kernel warmup"
+        )
+    api = runtime["mixed_api"]
+    warmup = getattr(api, "warmup_mixed_trellis_route_pack", None)
+    if not callable(warmup):
+        raise RuntimeError(
+            "mixed-bitrate EXL3 route-pack warmup requires a matching B12X build"
+        )
+
+    warmed = 0
+    for state_name in ("decode", "prefill"):
+        state = runtime.get(state_name)
+        if state is None:
+            continue
+        warmed += int(
+            warmup(
+                state["launch"],
+                state["buffers"],
+                expert_map=mixed["global_to_combined"],
+            )
+        )
+    return warmed
+
+
+__all__ = ["Exl3Config", "Exl3LinearMethod", "Exl3MoEMethod"]

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -264,8 +264,8 @@ def _load_b12x_fused_moe() -> Any:
         from b12x.moe import fused_moe
     except Exception as exc:
         raise RuntimeError(
-            "Rank-sliced EXL3 requires the exl3_trellis_mcg source in "
-            "b12x.moe.fused_moe. Install a matching B12X build."
+            "Rank-sliced EXL3 requires the native Trellis preparation "
+            "contract in b12x.moe.fused_moe. Install a matching B12X build."
         ) from exc
     _B12X_FUSED_MOE_API = fused_moe
     return fused_moe
@@ -2026,10 +2026,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
         intermediate_rotations[:, 2 * intermediate_size :].copy_(down_suh)
         tile_config = self._trellis_tile_config(hidden_size, intermediate_size)
-        marker = layer.w13_mcg.exl3_tensors[(0, "w1")]
         weight_plan = api.plan_weights(
             quant_modes="w4a16",
-            source_format="exl3_trellis_mcg",
+            source_format="b12x_trellis",
             activation=layer.activation.value,
             params_dtype=layer.exl3_params_dtype,
             num_experts=num_experts,
@@ -2038,17 +2037,17 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             w13_layout="w13",
             trellis_bits=bits,
             trellis_tile_config=tile_config,
+            trellis_codebook="mcg",
+            trellis_rate_granularity="uniform",
         )
-        layer.exl3_trellis_weights = api.prepare_weights(
+        layer.exl3_trellis_weights = api.prepare_rank_sliced_trellis_weights(
             plan=weight_plan,
-            params_dtype=layer.exl3_params_dtype,
-            w1_fp4=w13,
-            w2_fp4=w2,
+            w13=w13,
+            w2=w2,
             gate_suh=gate_suh,
             up_suh=up_suh,
             intermediate_rotations=intermediate_rotations,
             down_svh=down_svh,
-            trellis_mcg=marker,
         )
 
         slabs = (

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -323,7 +323,22 @@ class DeepSeekMTP(nn.Module, DeepseekV2MixtureOfExperts):
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         _pending_wk_fp8: dict = {}  # FP8 indexer wk dequant buffer
+        # Rank-sliced EXL3 checkpoints ship one tensor per TP rank
+        # (`....rank{r}.{trellis|suh|svh|mcg}`), while Exl3MoEMethod registers a
+        # single fused param per projection group (`w13_mcg`, `w2_trellis`, ...).
+        # Strip the `.rank{r}` segment before expert mapping, exactly as the
+        # target model (deepseek_v2.load_weights) does; otherwise the MTP loader
+        # looks up `...routed_experts.w2_rank0.mcg` and KeyErrors.
+        rank_sliced_name = getattr(
+            self.quant_config,
+            "normalize_rank_sliced_weight_name",
+            None,
+        )
         for name, loaded_weight in weights:
+            if rank_sliced_name is not None:
+                name = rank_sliced_name(name)
+                if name is None:
+                    continue
             if "rotary_emb.inv_freq" in name:
                 continue
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1407,6 +1407,7 @@ class DeepseekV2Model(nn.Module):
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
         self.config = config
+        self.quant_config = quant_config
         self.device = current_platform.device_type
         self.hidden_size = config.hidden_size
         self.vocab_size = config.vocab_size
@@ -1606,12 +1607,21 @@ class DeepseekV2Model(nn.Module):
         pp_missing_layer_names = get_pp_missing_layer_names(self)
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
+        rank_sliced_name = getattr(
+            self.quant_config,
+            "normalize_rank_sliced_weight_name",
+            None,
+        )
         # With index_topk_freq>1 only some layers build an indexer, yet the
         # checkpoint ships indexer weights for all of them; track the built ones.
         indexer_present_prefixes = {
             n.rsplit(".indexer.", 1)[0] for n in params_dict if ".indexer." in n
         }
         for name, loaded_weight in weights:
+            if rank_sliced_name is not None:
+                name = rank_sliced_name(name)
+                if name is None:
+                    continue
             if "rotary_emb.inv_freq" in name:
                 continue
 

--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -422,6 +422,7 @@ class Glm4MoeModel(nn.Module):
         quant_config = vllm_config.quant_config
         enable_eplb = vllm_config.parallel_config.enable_eplb
         self.config = config
+        self.quant_config = quant_config
 
         self.vocab_size = config.vocab_size
 
@@ -497,6 +498,21 @@ class Glm4MoeModel(nn.Module):
             n_shared_experts=self.config.n_shared_experts or 1,
             enabled=self.is_fused_shared_expert_enabled,
         )
+        rank_sliced_name = getattr(
+            self.quant_config,
+            "normalize_rank_sliced_weight_name",
+            None,
+        )
+        if rank_sliced_name is not None:
+            source_weights = weights
+
+            def normalized_weights():
+                for name, weight in source_weights:
+                    normalized_name = rank_sliced_name(name)
+                    if normalized_name is not None:
+                        yield normalized_name, weight
+
+            weights = normalized_weights()
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -941,11 +941,38 @@ def get_draft_quant_config(vllm_config: VllmConfig) -> "QuantizationConfig | Non
     draft_model_config = vllm_config.speculative_config.draft_model_config
     draft_load_config = vllm_config.load_config
 
-    return (
-        VllmConfig.get_quantization_config(draft_model_config, draft_load_config)
-        if draft_model_config
-        else None
+    if not draft_model_config:
+        return None
+
+    quant_config = VllmConfig.get_quantization_config(
+        draft_model_config, draft_load_config
     )
+
+    # EXL3 rank-sliced (hybrid_tr3_tail) metadata is hydrated by VllmConfig via
+    # Exl3Config.maybe_update_config() for the *target* model only. The draft/MTP
+    # quant config is built separately here, so without this call its
+    # rank_sliced_metadata stays None and a rank-sliced MTP MoE layer silently
+    # falls back to the stock (non-tr3) expert path, KeyError-ing on
+    # `...experts.routed_experts.wN_rankR.mcg`. Mirror the target-model call so
+    # the MTP layer's experts load through the tr3 path.
+    if (
+        quant_config is not None
+        and getattr(quant_config, "get_name", lambda: None)() == "exl3"
+    ):
+        draft_hf = getattr(draft_model_config, "hf_config", None)
+        target_hf = getattr(
+            getattr(vllm_config, "model_config", None), "hf_config", None
+        )
+        hf_config = draft_hf
+        if getattr(draft_hf, "hybrid_tr3_tail", None) is None:
+            hf_config = target_hf
+        if getattr(hf_config, "hybrid_tr3_tail", None) is not None:
+            quant_config.maybe_update_config(
+                draft_model_config.model,
+                hf_config=hf_config,
+            )
+
+    return quant_config
 
 
 def extract_layer_index(layer_name: str, num_attn_module: int = 1) -> int:

--- a/vllm/models/deepseek_v32/nvidia/model.py
+++ b/vllm/models/deepseek_v32/nvidia/model.py
@@ -169,6 +169,7 @@ class DeepseekV32Model(torch.nn.Module):
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
         self.config = config
+        self.quant_config = quant_config
         from vllm.platforms import current_platform
 
         self.device = current_platform.device_type
@@ -335,7 +336,16 @@ class DeepseekV32Model(torch.nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         _pending_wk_fp8: dict = {}
+        rank_sliced_name = getattr(
+            self.quant_config,
+            "normalize_rank_sliced_weight_name",
+            None,
+        )
         for name, loaded_weight in weights:
+            if rank_sliced_name is not None:
+                name = rank_sliced_name(name)
+                if name is None:
+                    continue
             if "rotary_emb.inv_freq" in name:
                 continue
             # MTP / nextn layers are loaded by the MTP model, not here.

--- a/vllm/models/deepseek_v32/nvidia/mtp.py
+++ b/vllm/models/deepseek_v32/nvidia/mtp.py
@@ -360,7 +360,16 @@ class DeepseekV32MTP(nn.Module, DeepseekV2MixtureOfExperts):
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         _pending_wk_fp8: dict = {}
+        rank_sliced_name = getattr(
+            self.quant_config,
+            "normalize_rank_sliced_weight_name",
+            None,
+        )
         for name, loaded_weight in weights:
+            if rank_sliced_name is not None:
+                name = rank_sliced_name(name)
+                if name is None:
+                    continue
             if "rotary_emb.inv_freq" in name:
                 continue
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)


### PR DESCRIPTION
## Summary

Add a fail-closed EXL3 checkpoint backend for dense linear layers, routed
experts, rank-sliced Trellis experts, and GLM-family MTP draft layers on Jovian
Judgement. It supports uniform and mixed-bitrate checkpoints, shared-H
rotations, bounded one-grid prefill, and route-pack warmup through Jovian's
central B12X warmup-provider interface.

The implementation targets the APIs exported by pinned `b12x==1.3.0`:
immutable mixed-tier metadata is bound once with `bind_mixed_trellis`, then
executed through the graph-safe `run_bound_mixed_trellis` path.

Selection remains fail-closed: EXL3 takes priority only when checkpoint
metadata claims it, and schemas, codebooks, layouts, TP geometry, and runtime
capacities are validated before execution. GLM-5.2 and GLM-5.3 share the same
qualified GLM-5 architecture policy. Draft and target runtime caches remain
isolated.

## Duplicate-work check

No open Jovian PR matched this work. PR #190 added the original EXL3 support
to Gilded Gnosis, and #228 extends that older branch with mixed Trellis and
optional online overlays. This port targets current Jovian loaders and B12X
contracts and deliberately excludes the superseded SparkInfer/mixed-runtime
APIs and online BF16-to-EXL3 encoding.

## Validation

- Focused and existing regressions: `115 passed, 1 skipped` across EXL3
  loading/planning/warmup, Eagle quantization, padded MoE loading, B12X warmup,
  and GPU-worker warmup ordering.
- cn3 additionally passed target/MTP rank-sliced loader regressions and native
  B12X Trellis preparation tests. Full 295 GB target and MTP checkpoint
  traversals completed, and native Trellis preparation completed on all four
  TP ranks.
- `uvx ruff check` passed for all changed Python files after rebasing onto
  `dev/jovian-judgement` at `9c4dd0548`; `git diff --check` also passed.
- The qualified r21 uniform-EXL3 deployment returned the expected answer
  (`42`), sustained `61.044849 tok/s`, and completed a 3,074-token cold prefill
  in `2.133 s` (`1,441 tok/s`).

## Non-goals

- online BF16-to-EXL3 encoding and persistent encoding cache;
- NVFP4 KV-cache compression, which is handled separately in #549;
- the native SM120 `next_n > 2` gate, which regressed median decode throughput
  in qualification and remains disabled.

## AI assistance

OpenAI Codex assisted with the Jovian port, test construction, and review. The
submitter reviewed the resulting diff and qualification evidence; all commits
include `Assisted-by` and DCO sign-off trailers, and original human
contributors are retained with co-author trailers where applicable.
