### PR TITLE
perf(spec-decode): reuse constrained rejection probabilities

### DIFF
--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -14,6 +14,8 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import (
     PLACEHOLDER_TOKEN_ID,
     RejectionSampler,
+    apply_sampling_constraints,
+    rejection_sample,
     sample_recovered_tokens,
 )
 from vllm.v1.sample.sampler import Sampler, SamplerOutput
@@ -127,6 +129,105 @@ def create_sampling_metadata(
         bad_words_token_ids={} if bad_words_token_ids is None else bad_words_token_ids,
         logitsprocs=LogitsProcessors(),
     )
+
+
+def test_apply_sampling_constraints_can_return_normalized_probabilities():
+    num_draft_tokens = 5
+    vocab_size = 257
+    generator = torch.Generator(device=DEVICE_TYPE).manual_seed(53)
+    logits = torch.randn(
+        num_draft_tokens,
+        vocab_size,
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+        generator=generator,
+    )
+    cu_num_draft_tokens = torch.tensor([3, 5], device=DEVICE_TYPE)
+    sampling_metadata = create_sampling_metadata(
+        all_greedy=False,
+        temperature=torch.tensor([0.7, 1.2], device=DEVICE_TYPE),
+        top_k=torch.tensor([19, 37], dtype=torch.int32, device=DEVICE_TYPE),
+        top_p=torch.tensor([0.6, 0.92], device=DEVICE_TYPE),
+    )
+
+    processed_logits = apply_sampling_constraints(
+        logits.clone(),
+        cu_num_draft_tokens,
+        sampling_metadata,
+    )
+    expected = processed_logits.softmax(dim=-1, dtype=torch.float32)
+    actual = apply_sampling_constraints(
+        logits.clone(),
+        cu_num_draft_tokens,
+        sampling_metadata,
+        return_probs=True,
+    )
+
+    assert torch.equal(actual != 0, expected != 0)
+    assert torch.allclose(actual, expected, atol=2e-7, rtol=2e-6)
+
+
+def test_rejection_sample_accepts_precomputed_target_probabilities():
+    batch_size = 2
+    max_spec_len = 3
+    vocab_size = 64
+    num_tokens = batch_size * max_spec_len
+    generator = torch.Generator(device=DEVICE_TYPE).manual_seed(59)
+    draft_logits = torch.randn(
+        num_tokens,
+        vocab_size,
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+        generator=generator,
+    )
+    target_logits = torch.randn(
+        num_tokens,
+        vocab_size,
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+        generator=generator,
+    )
+    draft_probs = draft_logits.softmax(dim=-1)
+    target_probs = target_logits.softmax(dim=-1)
+    draft_token_ids = draft_probs.argmax(dim=-1).to(torch.int32).contiguous()
+    bonus_token_ids = torch.tensor([[3], [7]], device=DEVICE_TYPE)
+    cu_num_draft_tokens = torch.tensor([3, 6], device=DEVICE_TYPE)
+
+    def make_metadata() -> SamplingMetadata:
+        return create_sampling_metadata(
+            all_greedy=False,
+            temperature=torch.ones(batch_size, device=DEVICE_TYPE),
+            generators={
+                request_id: torch.Generator(device=DEVICE_TYPE).manual_seed(
+                    67 + request_id
+                )
+                for request_id in range(batch_size)
+            },
+        )
+
+    from_logits = rejection_sample(
+        draft_token_ids,
+        [max_spec_len] * batch_size,
+        max_spec_len,
+        cu_num_draft_tokens,
+        draft_probs,
+        target_logits,
+        bonus_token_ids,
+        make_metadata(),
+    )
+    from_probs = rejection_sample(
+        draft_token_ids,
+        [max_spec_len] * batch_size,
+        max_spec_len,
+        cu_num_draft_tokens,
+        draft_probs,
+        target_probs,
+        bonus_token_ids,
+        make_metadata(),
+        target_is_probs=True,
+    )
+
+    assert torch.equal(from_probs, from_logits)
 
 
 ########################### Tests for Greedy Sampling ###################

--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -9,6 +9,8 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.sample.ops.topk_topp_sampler import (
+    apply_top_k_top_p,
+    apply_top_k_top_p_probs,
     apply_top_k_top_p_pytorch,
     random_sample,
 )
@@ -18,6 +20,46 @@ DEVICE_TYPE = current_platform.device_type
 
 BATCH_SIZE = 1024
 VOCAB_SIZE = 128 * 1024
+
+
+@pytest.mark.parametrize("batch_size", [1, 3, 7])
+@pytest.mark.parametrize("use_top_k", [False, True])
+def test_apply_top_k_top_p_probs_matches_processed_logits(
+    batch_size: int,
+    use_top_k: bool,
+):
+    vocab_size = 257
+    generator = torch.Generator(device=DEVICE_TYPE).manual_seed(41 + batch_size)
+    logits = torch.randn(
+        batch_size,
+        vocab_size,
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+        generator=generator,
+    )
+    top_k = (
+        torch.arange(17, 17 + batch_size, dtype=torch.int32, device=DEVICE_TYPE)
+        if use_top_k
+        else None
+    )
+    top_p = torch.linspace(0.55, 0.95, batch_size, device=DEVICE_TYPE)
+
+    expected = apply_top_k_top_p(logits.clone(), top_k, top_p).softmax(
+        dim=-1,
+        dtype=torch.float32,
+    )
+    input_buffer = logits.clone()
+    actual = apply_top_k_top_p_probs(input_buffer, top_k, top_p)
+
+    assert actual.data_ptr() == input_buffer.data_ptr()
+    assert torch.equal(actual != 0, expected != 0)
+    assert torch.allclose(actual, expected, atol=2e-7, rtol=2e-6)
+    assert torch.allclose(
+        actual.sum(dim=-1),
+        torch.ones(batch_size, device=DEVICE_TYPE),
+        atol=2e-7,
+        rtol=0,
+    )
 
 
 def _flashinfer_topk_topp_supported() -> bool:

--- a/tests/v1/spec_decode/test_llm_base_proposer_sampling.py
+++ b/tests/v1/spec_decode/test_llm_base_proposer_sampling.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import dataclasses
 from types import SimpleNamespace
 
 import pytest
@@ -10,6 +11,7 @@ from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
 from vllm.v1.spec_decode.llm_base_proposer import (
     SpecDecodeBaseProposer,
     compute_probs_and_sample_next_token,
@@ -72,6 +74,78 @@ def test_compute_probs_and_sample_next_token_uses_fp64_exponential_race():
 
     assert torch.equal(actual_ids, expected_ids)
     assert torch.allclose(actual_probs, probs)
+
+
+def test_compute_probs_and_sample_next_token_returns_constrained_distribution():
+    batch_size = 3
+    vocab_size = 32
+    generator = torch.Generator(device=DEVICE_TYPE).manual_seed(29)
+    logits = torch.randn(
+        batch_size,
+        vocab_size,
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+        generator=generator,
+    )
+    metadata = dataclasses.replace(
+        _make_sampling_metadata(batch_size),
+        temperature=torch.tensor([0.7, 1.0, 1.3], device=DEVICE_TYPE),
+        top_k=torch.tensor([5, 9, 17], dtype=torch.int32, device=DEVICE_TYPE),
+        top_p=torch.tensor([0.6, 0.8, 0.95], device=DEVICE_TYPE),
+    )
+
+    expanded_logits = logits / metadata.temperature.unsqueeze(-1)
+    expected_probs = apply_top_k_top_p(
+        expanded_logits,
+        metadata.top_k,
+        metadata.top_p,
+    ).softmax(dim=-1, dtype=torch.float32)
+
+    token_ids, actual_probs = compute_probs_and_sample_next_token(
+        logits.clone(),
+        metadata,
+    )
+
+    assert torch.equal(actual_probs != 0, expected_probs != 0)
+    assert torch.allclose(actual_probs, expected_probs)
+    assert torch.all(actual_probs.gather(1, token_ids.unsqueeze(-1)) > 0)
+
+
+def test_parallel_draft_sampling_repeats_request_constraints_in_request_order():
+    batch_size = 2
+    positions_per_request = 3
+    vocab_size = 32
+    generator = torch.Generator(device=DEVICE_TYPE).manual_seed(31)
+    logits = torch.randn(
+        batch_size * positions_per_request,
+        vocab_size,
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+        generator=generator,
+    )
+    metadata = dataclasses.replace(
+        _make_sampling_metadata(batch_size),
+        temperature=torch.tensor([0.7, 1.3], device=DEVICE_TYPE),
+        top_k=torch.tensor([5, 11], dtype=torch.int32, device=DEVICE_TYPE),
+        top_p=torch.tensor([0.65, 0.9], device=DEVICE_TYPE),
+    )
+    proposer = object.__new__(SpecDecodeBaseProposer)
+    proposer._enable_probabilistic_draft_probs = True
+    proposer.use_fp64_gumbel = False
+
+    token_ids, actual_probs = proposer._sample_from_logits(logits.clone(), metadata)
+
+    temperature = metadata.temperature.repeat_interleave(positions_per_request)
+    top_k = metadata.top_k.repeat_interleave(positions_per_request)
+    top_p = metadata.top_p.repeat_interleave(positions_per_request)
+    expected_probs = apply_top_k_top_p(
+        logits / temperature.unsqueeze(-1),
+        top_k,
+        top_p,
+    ).softmax(dim=-1, dtype=torch.float32)
+    assert torch.equal(actual_probs != 0, expected_probs != 0)
+    assert torch.allclose(actual_probs, expected_probs)
+    assert torch.all(actual_probs.gather(1, token_ids.unsqueeze(-1)) > 0)
 
 
 @pytest.mark.parametrize(

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -374,6 +374,14 @@ def apply_top_k_top_p_probs(
     full-vocabulary softmax in callers that need probabilities rather than
     processed logits. ``logits`` may be reused as the output buffer when it is
     float32.
+
+    Args:
+        logits: Unnormalized token scores with shape ``[batch_size, vocab_size]``.
+        k: Per-row top-k limits, or ``None`` when top-k is disabled.
+        p: Per-row top-p thresholds, or ``None`` when top-p is disabled.
+
+    Returns:
+        Normalized constrained probabilities with the same shape as ``logits``.
     """
     if p is None:
         return apply_top_k_top_p(logits, k, p).softmax(dim=-1, dtype=torch.float32)

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -364,6 +364,44 @@ def apply_top_k_top_p(
     return apply_top_k_top_p_pytorch(logits, k, p)
 
 
+def apply_top_k_top_p_probs(
+    logits: torch.Tensor, k: torch.Tensor | None, p: torch.Tensor | None
+) -> torch.Tensor:
+    """Apply top-k/top-p and return normalized probabilities.
+
+    The small-batch PyTorch top-p path already computes probabilities to find
+    the nucleus cutoff. Returning those probabilities directly avoids a second
+    full-vocabulary softmax in callers that need probabilities rather than
+    processed logits. ``logits`` may be reused as the output buffer when it is
+    float32.
+    """
+    if p is None:
+        return apply_top_k_top_p(logits, k, p).softmax(dim=-1, dtype=torch.float32)
+
+    if current_platform.is_cpu() or (HAS_TRITON and logits.shape[0] >= 8):
+        return apply_top_k_top_p(logits, k, p).softmax(dim=-1, dtype=torch.float32)
+
+    logits_sort, logits_idx = logits.sort(dim=-1, descending=False)
+
+    if k is not None:
+        top_k_mask = logits_sort.size(1) - k.to(torch.long)
+        top_k_mask = logits_sort.gather(1, top_k_mask.unsqueeze(dim=1))
+        logits_sort.masked_fill_(logits_sort < top_k_mask, -float("inf"))
+
+    probs_sort = logits_sort.softmax(dim=-1, dtype=torch.float32)
+    probs_cumsum = probs_sort.cumsum(dim=-1)
+    top_p_mask = probs_cumsum <= 1 - p.unsqueeze(dim=1)
+    top_p_mask[:, -1] = False
+    probs_sort.masked_fill_(top_p_mask, 0.0)
+    probs_sort.div_(probs_sort.sum(dim=-1, keepdim=True))
+
+    if logits.dtype == torch.float32:
+        probs = logits.zero_()
+    else:
+        probs = torch.zeros_like(logits, dtype=torch.float32)
+    return probs.scatter_(dim=-1, index=logits_idx, src=probs_sort)
+
+
 def apply_top_k_top_p_pytorch(
     logits: torch.Tensor,
     k: torch.Tensor | None,

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -536,6 +536,7 @@ def apply_sampling_constraints(
         cu_num_draft_tokens: Cumulative number of draft tokens.
         sampling_metadata: Metadata containing sampling parameters such as
             temperature and whether greedy sampling is used.
+        return_probs: Return normalized probabilities instead of processed logits.
 
     Returns:
         torch.Tensor: Processed logits, or normalized probabilities when

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -18,7 +18,10 @@ from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
 from vllm.v1.sample.ops.penalties import apply_all_penalties
-from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
+from vllm.v1.sample.ops.topk_topp_sampler import (
+    apply_top_k_top_p,
+    apply_top_k_top_p_probs,
+)
 from vllm.v1.sample.sampler import Sampler
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.spec_decode.utils import unconditional_to_conditional_rates
@@ -164,10 +167,12 @@ class RejectionSampler(nn.Module):
         # [num_tokens, vocab_size]
         # NOTE(woosuk): `target_logits` can be updated in place inside the
         # `apply_sampling_constraints` function.
+        target_is_probs = sampling_metadata.max_num_logprobs is None
         target_logits = apply_sampling_constraints(
             target_logits,
             metadata.cu_num_draft_tokens,
             sampling_metadata,
+            return_probs=target_is_probs,
         )
 
         output_token_ids = rejection_sample(
@@ -179,6 +184,7 @@ class RejectionSampler(nn.Module):
             target_logits,
             bonus_token_ids,
             sampling_metadata,
+            target_is_probs=target_is_probs,
             synthetic_mode=self.synthetic_mode,
             synthetic_conditional_rates=self.synthetic_conditional_rates,
             use_fp64_gumbel=self.use_fp64_gumbel,
@@ -406,6 +412,7 @@ def rejection_sample(
     # [batch_size, 1]
     bonus_token_ids: torch.Tensor,
     sampling_metadata: SamplingMetadata,
+    target_is_probs: bool = False,
     synthetic_mode: bool = False,
     synthetic_conditional_rates: torch.Tensor | None = None,
     use_fp64_gumbel: bool = False,
@@ -468,8 +475,13 @@ def rejection_sample(
         if sampling_metadata.all_greedy:
             return output_token_ids
 
-    # Compute probability distribution from target logits.
-    target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)
+    # The small-batch top-p fast path can pass normalized probabilities
+    # directly and avoid repeating a full-vocabulary softmax here.
+    target_probs = (
+        target_logits
+        if target_is_probs
+        else target_logits.softmax(dim=-1, dtype=torch.float32)
+    )
     assert target_probs.is_contiguous()
 
     # Sample recovered tokens for each position.
@@ -511,6 +523,7 @@ def apply_sampling_constraints(
     logits: torch.Tensor,  # [num_tokens, vocab_size]
     cu_num_draft_tokens: torch.Tensor,  # [batch_size]
     sampling_metadata: SamplingMetadata,
+    return_probs: bool = False,
 ) -> torch.Tensor:
     """Process logits based on sampling metadata.
 
@@ -525,8 +538,8 @@ def apply_sampling_constraints(
             temperature and whether greedy sampling is used.
 
     Returns:
-        torch.Tensor: Processed logits if non-greedy sampling is used,
-        otherwise returns the original logits.
+        torch.Tensor: Processed logits, or normalized probabilities when
+        ``return_probs`` is true. Greedy sampling returns the original logits.
     """
     assert logits.ndim == 2
     assert cu_num_draft_tokens.ndim == 1
@@ -562,6 +575,8 @@ def apply_sampling_constraints(
 
     # NOTE(woosuk): `apply_top_k_top_p` uses sorting to calculate the mask,
     # which is slow for large vocab sizes. This may cause performance issues.
+    if return_probs:
+        return apply_top_k_top_p_probs(logits, top_k, top_p)
     return apply_top_k_top_p(logits, top_k, top_p)
 
 

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -45,6 +45,7 @@ from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
 from vllm.v1.kv_cache_interface import KVCacheConfig, UniformTypeKVCacheSpecs
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.topk_topp_sampler import (
+    apply_top_k_top_p,
     empty_exponential_noise_like,
     sample_with_exponential_noise,
 )
@@ -467,6 +468,16 @@ class SpecDecodeBaseProposer:
             sampling_metadata = dataclasses.replace(
                 sampling_metadata,
                 temperature=temperature.repeat_interleave(factor, dim=0),
+                top_p=(
+                    None
+                    if sampling_metadata.top_p is None
+                    else sampling_metadata.top_p.repeat_interleave(factor, dim=0)
+                ),
+                top_k=(
+                    None
+                    if sampling_metadata.top_k is None
+                    else sampling_metadata.top_k.repeat_interleave(factor, dim=0)
+                ),
             )
 
         return compute_probs_and_sample_next_token(
@@ -1882,12 +1893,16 @@ def compute_probs_and_sample_next_token(
         is_greedy = temperature < _SAMPLING_EPS
         temperature = torch.where(is_greedy, 1.0, temperature)
     logits.div_(temperature.view(-1, 1))
+    logits = apply_top_k_top_p(
+        logits,
+        sampling_metadata.top_k,
+        sampling_metadata.top_p,
+    )
     probs = logits.softmax(dim=-1, dtype=torch.float32)
 
-    # NOTE(woosuk): Currently, we ignore most of the sampling parameters in
-    # generating the draft tokens. We only use the temperature. While this
-    # could degrade the acceptance rate, it does not affect the distribution
-    # of the generated tokens after rejection sampling.
+    # Logits processors that depend on request history remain target-only.
+    # Temperature, top-k, and top-p are position-local, so the drafter can
+    # match those constraints exactly and keep q closer to the verifier's p.
 
     # TODO(woosuk): Consider seeds.
     q = empty_exponential_noise_like(probs, use_fp64_gumbel)

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -45,7 +45,7 @@ from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
 from vllm.v1.kv_cache_interface import KVCacheConfig, UniformTypeKVCacheSpecs
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.topk_topp_sampler import (
-    apply_top_k_top_p,
+    apply_top_k_top_p_probs,
     empty_exponential_noise_like,
     sample_with_exponential_noise,
 )
@@ -1893,12 +1893,11 @@ def compute_probs_and_sample_next_token(
         is_greedy = temperature < _SAMPLING_EPS
         temperature = torch.where(is_greedy, 1.0, temperature)
     logits.div_(temperature.view(-1, 1))
-    logits = apply_top_k_top_p(
+    probs = apply_top_k_top_p_probs(
         logits,
         sampling_metadata.top_k,
         sampling_metadata.top_p,
     )
-    probs = logits.softmax(dim=-1, dtype=torch.float32)
 
     # Logits processors that depend on request history remain target-only.
     # Temperature, top-k, and top-p are position-local, so the drafter can


### PR DESCRIPTION
## Resulting behavior

Standard speculative rejection sampling can consume normalized target
probabilities produced while applying top-k and top-p constraints. The
small-batch probability helper preserves the constrained support, normalizes
each row, and reuses a disposable FP32 logits buffer when possible. This avoids
recomputing a full-vocabulary softmax after the same probabilities were already
needed to determine the nucleus cutoff.

Requests that return processed log probabilities keep the processed-logit
path. Greedy requests and constraints that do not use the probability helper
retain their existing path.

## Compatibility

The rejection sampler accepts either processed logits or explicitly marked
normalized probabilities. Its default call contract remains processed logits.
Checkpoint formats, serving arguments, and target distributions are unchanged.

This pull request depends on #573, which implements probabilistic draft
constraint matching on branch `perf/dflash-constraint-match-jj-20260901`, and targets
`dev/jovian-judgement` revision
`9c4dd05487629eccb26d7166459867a3db9b099f`.

## Validation

Focused CUDA tests prove that the probability helper preserves constrained
support and values within FP32 tolerance, and that seeded rejection sampling
returns identical token IDs when supplied logits or precomputed probabilities.
Processed-logprob requests retain the processed-logit fallback. The complete
three-pull-request DFlash sampling stack passes 17 focused tests on an NVIDIA
RTX PRO 6000 Blackwell Workstation GPU.

The change removes one redundant vocabulary-wide softmax from affected
verifier steps. A matched C1 probe measured verifier throughput within
run-to-run variation; this pull request claims eliminated GPU work, not an
independent end-to-end throughput increase.

## Authorship

The implementation commit preserves MadeBy561 as author. Martin Vit rebased
and qualified the commit for `dev/jovian-judgement`.

AI assistance was used to inspect the sampling contract, run validation, and
prepare this pull request. The human submitter reviewed the changed lines and
evidence.
