### PR TITLE
fix(spec-decode): match probabilistic draft top-k and top-p

### DIFF
--- a/tests/v1/spec_decode/test_llm_base_proposer_sampling.py
+++ b/tests/v1/spec_decode/test_llm_base_proposer_sampling.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import dataclasses
 from types import SimpleNamespace
 
 import pytest
@@ -10,6 +11,7 @@ from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
 from vllm.v1.spec_decode.llm_base_proposer import (
     SpecDecodeBaseProposer,
     compute_probs_and_sample_next_token,
@@ -72,6 +74,78 @@ def test_compute_probs_and_sample_next_token_uses_fp64_exponential_race():
 
     assert torch.equal(actual_ids, expected_ids)
     assert torch.allclose(actual_probs, probs)
+
+
+def test_compute_probs_and_sample_next_token_returns_constrained_distribution():
+    batch_size = 3
+    vocab_size = 32
+    generator = torch.Generator(device=DEVICE_TYPE).manual_seed(29)
+    logits = torch.randn(
+        batch_size,
+        vocab_size,
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+        generator=generator,
+    )
+    metadata = dataclasses.replace(
+        _make_sampling_metadata(batch_size),
+        temperature=torch.tensor([0.7, 1.0, 1.3], device=DEVICE_TYPE),
+        top_k=torch.tensor([5, 9, 17], dtype=torch.int32, device=DEVICE_TYPE),
+        top_p=torch.tensor([0.6, 0.8, 0.95], device=DEVICE_TYPE),
+    )
+
+    expanded_logits = logits / metadata.temperature.unsqueeze(-1)
+    expected_probs = apply_top_k_top_p(
+        expanded_logits,
+        metadata.top_k,
+        metadata.top_p,
+    ).softmax(dim=-1, dtype=torch.float32)
+
+    token_ids, actual_probs = compute_probs_and_sample_next_token(
+        logits.clone(),
+        metadata,
+    )
+
+    assert torch.equal(actual_probs != 0, expected_probs != 0)
+    assert torch.allclose(actual_probs, expected_probs)
+    assert torch.all(actual_probs.gather(1, token_ids.unsqueeze(-1)) > 0)
+
+
+def test_parallel_draft_sampling_repeats_request_constraints_in_request_order():
+    batch_size = 2
+    positions_per_request = 3
+    vocab_size = 32
+    generator = torch.Generator(device=DEVICE_TYPE).manual_seed(31)
+    logits = torch.randn(
+        batch_size * positions_per_request,
+        vocab_size,
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+        generator=generator,
+    )
+    metadata = dataclasses.replace(
+        _make_sampling_metadata(batch_size),
+        temperature=torch.tensor([0.7, 1.3], device=DEVICE_TYPE),
+        top_k=torch.tensor([5, 11], dtype=torch.int32, device=DEVICE_TYPE),
+        top_p=torch.tensor([0.65, 0.9], device=DEVICE_TYPE),
+    )
+    proposer = object.__new__(SpecDecodeBaseProposer)
+    proposer._enable_probabilistic_draft_probs = True
+    proposer.use_fp64_gumbel = False
+
+    token_ids, actual_probs = proposer._sample_from_logits(logits.clone(), metadata)
+
+    temperature = metadata.temperature.repeat_interleave(positions_per_request)
+    top_k = metadata.top_k.repeat_interleave(positions_per_request)
+    top_p = metadata.top_p.repeat_interleave(positions_per_request)
+    expected_probs = apply_top_k_top_p(
+        logits / temperature.unsqueeze(-1),
+        top_k,
+        top_p,
+    ).softmax(dim=-1, dtype=torch.float32)
+    assert torch.equal(actual_probs != 0, expected_probs != 0)
+    assert torch.allclose(actual_probs, expected_probs)
+    assert torch.all(actual_probs.gather(1, token_ids.unsqueeze(-1)) > 0)
 
 
 @pytest.mark.parametrize(

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -45,6 +45,7 @@ from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
 from vllm.v1.kv_cache_interface import KVCacheConfig, UniformTypeKVCacheSpecs
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.topk_topp_sampler import (
+    apply_top_k_top_p,
     empty_exponential_noise_like,
     sample_with_exponential_noise,
 )
@@ -467,6 +468,16 @@ class SpecDecodeBaseProposer:
             sampling_metadata = dataclasses.replace(
                 sampling_metadata,
                 temperature=temperature.repeat_interleave(factor, dim=0),
+                top_p=(
+                    None
+                    if sampling_metadata.top_p is None
+                    else sampling_metadata.top_p.repeat_interleave(factor, dim=0)
+                ),
+                top_k=(
+                    None
+                    if sampling_metadata.top_k is None
+                    else sampling_metadata.top_k.repeat_interleave(factor, dim=0)
+                ),
             )
 
         return compute_probs_and_sample_next_token(
@@ -1882,12 +1893,16 @@ def compute_probs_and_sample_next_token(
         is_greedy = temperature < _SAMPLING_EPS
         temperature = torch.where(is_greedy, 1.0, temperature)
     logits.div_(temperature.view(-1, 1))
+    logits = apply_top_k_top_p(
+        logits,
+        sampling_metadata.top_k,
+        sampling_metadata.top_p,
+    )
     probs = logits.softmax(dim=-1, dtype=torch.float32)
 
-    # NOTE(woosuk): Currently, we ignore most of the sampling parameters in
-    # generating the draft tokens. We only use the temperature. While this
-    # could degrade the acceptance rate, it does not affect the distribution
-    # of the generated tokens after rejection sampling.
+    # Logits processors that depend on request history remain target-only.
+    # Temperature, top-k, and top-p are position-local, so the drafter can
+    # match those constraints exactly and keep q closer to the verifier's p.
 
     # TODO(woosuk): Consider seeds.
     q = empty_exponential_noise_like(probs, use_fp64_gumbel)


### PR DESCRIPTION
## Resulting behavior

Probabilistic speculative proposers apply request-local temperature, top-k,
and top-p constraints before sampling draft tokens and before publishing the
proposal distribution used by standard rejection sampling. Parallel DFlash
positions repeat each request's top-k and top-p values in request-major order.

Standard rejection sampling remains lossless because it still verifies every
proposal against the target distribution. Matching the position-local draft
constraints only moves the proposal distribution closer to the verifier
distribution and can increase acceptance. History-dependent processors such
as penalties, grammar masks, bad-word masks, and minimum-token state remain
target-only.

## Compatibility

Greedy sampling and requests without top-k or top-p retain their existing
behavior. The change does not alter model formats, serving arguments, or the
target sampling distribution.

This pull request targets `dev/jovian-judgement` revision
`9c4dd05487629eccb26d7166459867a3db9b099f`.

## Validation

Focused CUDA tests verify the constrained support and probability values, and
verify request-major expansion for parallel draft positions. The complete
three-pull-request DFlash sampling stack passes 17 focused tests on an NVIDIA
RTX PRO 6000 Blackwell Workstation GPU.

A matched five-seed GLM-5.3 DFlash K7 probe with temperature 1 and top-p 0.95
measured median accepted draft length 3.828 before constraint matching and
4.064 with constraint matching, a 6.2% increase. Median verifier throughput was
79.151 and 79.180 steps/s, respectively. Acceptance remains stochastic because
the draft sampler does not yet use per-request generators; verifier throughput
is reported separately from output-token throughput.

## Authorship

The implementation commit preserves MadeBy561 as author. Martin Vit rebased
and qualified the commit for `dev/jovian-judgement`.

AI assistance was used to inspect the sampling contract, run validation, and
prepare this pull request. The human submitter reviewed the changed lines and
evidence.
