### PR TITLE
perf(mamba): hoist the causal_conv1d_update token loads for decode

### DIFF
--- a/tests/kernels/mamba/test_causal_conv1d.py
+++ b/tests/kernels/mamba/test_causal_conv1d.py
@@ -392,3 +392,127 @@ def test_causal_conv1d_varlen(
     )
     unpadded_out = out[:, : out_ref_tensor.shape[-1]]
     assert torch.allclose(unpadded_out, out_ref_tensor, rtol=rtol, atol=atol)
+
+
+def _run_update_both_paths(monkeypatch, run):
+    """Run ``run`` with the hoisted decode path and with the generic loop."""
+    from vllm.model_executor.layers.mamba.ops import causal_conv1d as conv_module
+
+    monkeypatch.setattr(conv_module, "_UPDATE_HOIST_ENABLED", True)
+    hoisted = run()
+    monkeypatch.setattr(conv_module, "_UPDATE_HOIST_ENABLED", False)
+    generic = run()
+    return hoisted, generic
+
+
+@pytest.mark.parametrize("itype", [torch.bfloat16])
+@pytest.mark.parametrize("silu_activation", [False, True])
+@pytest.mark.parametrize("has_bias", [False, True])
+@pytest.mark.parametrize("seqlen", [1, 2, 5, 8])
+@pytest.mark.parametrize("batch", [1, 4, 8])
+@pytest.mark.parametrize("dim", [2048 + 16, 6144])
+def test_causal_conv1d_update_hoisted_path_is_bitwise(
+    monkeypatch, batch, dim, seqlen, has_bias, silu_activation, itype
+):
+    device = DEVICE
+    width = 4
+    set_random_seed(131 * seqlen + batch)
+    total_entries = 4 * batch + 1
+    x = torch.randn(batch, seqlen, dim, device=device, dtype=itype).transpose(1, 2)
+    conv_state = torch.randn(
+        total_entries, width - 1, dim, device=device, dtype=itype
+    ).transpose(1, 2)
+    weight = torch.randn(dim, width, device=device, dtype=itype)
+    bias = torch.randn(dim, device=device, dtype=itype) if has_bias else None
+    # +1 to skip the null block at index 0
+    conv_state_indices = (torch.randperm(total_entries - 1)[:batch] + 1).to(
+        dtype=torch.int32, device=device
+    )
+    activation = "silu" if silu_activation else None
+
+    def run():
+        state = conv_state.clone()
+        out = causal_conv1d_update(
+            x.clone(),
+            state,
+            weight,
+            bias,
+            activation=activation,
+            conv_state_indices=conv_state_indices,
+        )
+        return out, state
+
+    (out_h, state_h), (out_g, state_g) = _run_update_both_paths(monkeypatch, run)
+    assert torch.equal(out_h, out_g)
+    assert torch.equal(state_h, state_g)
+    out_ref = causal_conv1d_update_ref(
+        x.clone(),
+        conv_state[conv_state_indices].detach().clone(),
+        weight,
+        bias,
+        activation=activation,
+    )
+    assert torch.allclose(out_h, out_ref, rtol=1e-2, atol=5e-2)
+
+
+@pytest.mark.parametrize("itype", [torch.bfloat16])
+@pytest.mark.parametrize("silu_activation", [True])
+@pytest.mark.parametrize("has_bias", [True, False])
+@pytest.mark.parametrize("max_query_len", [1, 4, 8])
+@pytest.mark.parametrize("batch", [1, 4, 8])
+@pytest.mark.parametrize("dim", [2048 + 16, 6144])
+def test_causal_conv1d_update_hoisted_spec_decode_is_bitwise(
+    monkeypatch, batch, dim, max_query_len, has_bias, silu_activation, itype
+):
+    """Speculative-decode shape: varlen queries, accepted-token offsets and a
+    conv state that keeps the speculative window."""
+    device = DEVICE
+    width = 4
+    set_random_seed(977 * max_query_len + batch)
+    lengths = [1 + (i % max_query_len) for i in range(batch)]
+    lengths[0] = max_query_len
+    num_tokens = sum(lengths)
+    query_start_loc = torch.tensor(
+        [0] + list(torch.cumsum(torch.tensor(lengths), 0)),
+        dtype=torch.int32,
+        device=device,
+    )
+    num_accepted_tokens = torch.tensor(
+        [1 + (i % max_query_len) for i in range(batch)],
+        dtype=torch.int32,
+        device=device,
+    )
+    total_entries = 4 * batch + 1
+    state_len = width - 1 + max_query_len
+    x = torch.randn(num_tokens, dim, device=device, dtype=itype)
+    conv_state = torch.randn(
+        total_entries, state_len, dim, device=device, dtype=itype
+    ).transpose(1, 2)
+    weight = torch.randn(dim, width, device=device, dtype=itype)
+    bias = torch.randn(dim, device=device, dtype=itype) if has_bias else None
+    conv_state_indices = (torch.randperm(total_entries - 1)[:batch] + 1).to(
+        dtype=torch.int32, device=device
+    )
+    activation = "silu" if silu_activation else None
+
+    def run():
+        state = conv_state.clone()
+        out = torch.empty_like(x)
+        causal_conv1d_update(
+            x.clone(),
+            state,
+            weight,
+            bias,
+            activation=activation,
+            conv_state_indices=conv_state_indices,
+            num_accepted_tokens=num_accepted_tokens,
+            query_start_loc=query_start_loc,
+            max_query_len=max_query_len,
+            out=out,
+        )
+        return out, state
+
+    (out_h, state_h), (out_g, state_g) = _run_update_both_paths(monkeypatch, run)
+    assert torch.equal(out_h, out_g)
+    assert torch.equal(state_h, state_g)
+    assert torch.isfinite(out_h.float()).all()

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -5,12 +5,25 @@
 # Adapted from https://github.com/Dao-AILab/causal-conv1d/blob/main/causal_conv1d/causal_conv1d_interface.py
 
 
+import os
+
 import numpy as np
 import torch
 
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import NULL_BLOCK_ID, PAD_SLOT_ID
+
+# ``causal_conv1d_update`` decode path.  For width-4 kernels with at most
+# ``_UPDATE_HOIST_MAX_SEQLEN`` tokens per sequence (single-token and
+# speculative decode) every token row is loaded before the token loop instead
+# of one dependent global load per token, and the channel tile shrinks so the
+# short launch fills more SMs.  The per-token arithmetic sequence is the
+# generic loop's, so outputs and the conv state are bitwise identical.
+# ``VLLM_CAUSAL_CONV1D_UPDATE_HOIST=0`` keeps the generic loop.
+_UPDATE_HOIST_ENABLED = os.getenv("VLLM_CAUSAL_CONV1D_UPDATE_HOIST", "1") != "0"
+_UPDATE_HOIST_MAX_SEQLEN = 8
+_UPDATE_HOIST_BLOCK_N = 64
 
 
 @triton.jit(do_not_specialize_on_alignment=["num_cache_lines"])
@@ -804,6 +817,8 @@ def _causal_conv1d_update_kernel(
     HAS_NULL_BLOCK: tl.constexpr,
     BLOCK_N: tl.constexpr,
     launch_pdl: tl.constexpr,
+    HOIST_X: tl.constexpr,
+    SEQLEN_MAX: tl.constexpr,
 ):
     if launch_pdl:
         tl.extra.cuda.gdc_wait()
@@ -995,6 +1010,65 @@ def _causal_conv1d_update_kernel(
     # STEP 5: compute each token
     if launch_pdl:
         tl.extra.cuda.gdc_launch_dependents()
+
+    if HOIST_X and KERNEL_WIDTH == 4:
+        # Hoisted decode path: load every token row up front (one round trip
+        # instead of ``seqlen`` dependent ones), then run the unrolled token
+        # loop with exactly the generic loop's per-token arithmetic
+        # (bias -> col0*w0 -> col1*w1 -> col2*w2 -> x*w3 -> silu).
+        for t in tl.static_range(SEQLEN_MAX):
+            v = tl.load(
+                x_base_1d + t * stride_x_token,
+                mask=mask_x_1d & (t < seqlen),
+                other=0.0,
+            )
+            if t == 0:
+                xr0 = v
+            elif t == 1:
+                xr1 = v
+            elif t == 2:
+                xr2 = v
+            elif t == 3:
+                xr3 = v
+            elif t == 4:
+                xr4 = v
+            elif t == 5:
+                xr5 = v
+            elif t == 6:
+                xr6 = v
+            elif t == 7:
+                xr7 = v
+        for t in tl.static_range(SEQLEN_MAX):
+            if t == 0:
+                xr = xr0
+            elif t == 1:
+                xr = xr1
+            elif t == 2:
+                xr = xr2
+            elif t == 3:
+                xr = xr3
+            elif t == 4:
+                xr = xr4
+            elif t == 5:
+                xr = xr5
+            elif t == 6:
+                xr = xr6
+            else:
+                xr = xr7
+            if t < seqlen:
+                acc = acc_preload
+                acc += col0 * w_col0
+                acc += col1 * w_col1
+                acc += col2 * w_col2
+                acc += xr * w_col3
+                col0 = col1
+                col1 = col2
+                col2 = xr
+                if SILU_ACTIVATION:
+                    acc = acc / (1 + tl.exp(-acc))
+                o_ptrs = o_ptr + o_offset + t * stride_o_token + (idx_feats * stride_o_dim)
+                tl.store(o_ptrs, acc, mask=mask_x_1d)
+        return
 
     for idx_token in tl.range(seqlen):
         acc = acc_preload
@@ -1229,6 +1303,9 @@ def causal_conv1d_update(
             triton.cdiv(dim, META["BLOCK_N"]),
         )
 
+    hoist_x = bool(
+        _UPDATE_HOIST_ENABLED and width == 4 and 1 <= seqlen <= _UPDATE_HOIST_MAX_SEQLEN
+    )
     _causal_conv1d_update_kernel[grid](
         # Pointers to matrices
         x,
@@ -1271,8 +1348,10 @@ def causal_conv1d_update(
         IS_SPEC_DECODING=num_accepted_tokens is not None,
         NP2_STATELEN=np2_statelen,
         HAS_NULL_BLOCK=null_block_id is not None,
-        BLOCK_N=256,
+        BLOCK_N=_UPDATE_HOIST_BLOCK_N if hoist_x else 256,
         launch_pdl=current_platform.is_arch_support_pdl(),
+        HOIST_X=hoist_x,
+        SEQLEN_MAX=int(seqlen),
     )
     if unsqueeze:
         out = out.squeeze(-1)


### PR DESCRIPTION
## Purpose

Speed up `causal_conv1d_update` for decode and speculative-decode batches. Its token loop issued one dependent global load per token; for width-4 kernels with at most eight tokens per sequence the hoisted path loads every token row before the loop and uses a 64-channel tile so the short launch fills more SMs.

## Behavior

- Applies to width-4 convolutions with `1 <= seqlen <= 8` (single-token decode, MTP and DFlash speculative decode). Other widths and longer updates keep the generic loop unchanged.
- The per-token arithmetic sequence is the generic loop's (bias, col0*w0, col1*w1, col2*w2, x*w3, SiLU), so the output and the conv state are bitwise identical.
- `VLLM_CAUSAL_CONV1D_UPDATE_HOIST=0` keeps the generic loop.

## Compatibility

No interface, checkpoint or numerics change. The kernel is already specialized on the constexpr `seqlen`, so the added `SEQLEN_MAX` constexpr creates no additional compilations.

## Validation

Tests, run inside the GLM-5.3 serving image on one RTX PRO 6000 Blackwell:

```text
python -m pytest tests/kernels/mamba/test_causal_conv1d.py -k update
272 passed
```

New cases: `test_causal_conv1d_update_hoisted_path_is_bitwise` (seqlen 1, 2, 5, 8; batch 1, 4, 8; dim 2064 and 6144; with and without bias and SiLU) compares the hoisted and generic paths with `torch.equal` on the output and the conv state and checks the output against the reference; `test_causal_conv1d_update_hoisted_spec_decode_is_bitwise` does the same for varlen queries with accepted-token offsets and the speculative conv-state window.

Kernel time (GLM-5.3-Flash TP4 decode shape, torch profiler, per call): 5.94 us (generic, 256-channel tile) to 2.68 us (hoisted, 64-channel tile) at one request with eight tokens; 9.13 to 4.96 us at eight requests. The generic loop with the 64-channel tile alone measures 3.96 us, so both parts contribute.

Serving: 31 KDA layers per step save about 0.1 ms per verifier step at concurrency 1 (about 1%). Fresh-boot four-cell C1 sequences with the change were at or above the control in every cell (90.76/89.27/88.86/88.71 vs 90.44/89.25/88.84/87.45 verifier steps/s), within the run-to-run band as expected for a change of this size.

Precision: bitwise-identical output and conv state by construction and by test; no serving numerics change.

Generated with Claude Code; the submitter reviewed the change and ran the validation on the listed hardware.
