### PR TITLE
perf(distributed): route mid-size TP all-reduces to the bf16 PCIe two-shot

### DIFF
--- a/tests/distributed/test_b12x_pcie_all_reduce.py
+++ b/tests/distributed/test_b12x_pcie_all_reduce.py
@@ -17,6 +17,7 @@ from vllm.distributed.device_communicators.b12x_pcie_all_reduce import (
     _dma_min_bytes,
     _oneshot_limits,
     _parse_byte_size,
+    _twoshot_max_bytes,
     get_b12x_pcie_allreduce,
 )
 from vllm.distributed.parallel_state import (
@@ -48,7 +49,19 @@ def _make_communicator(
     communicator._capture_stream = None
     communicator.allreduce_max_bytes = allreduce_max_bytes
     communicator.fused_max_bytes = fused_max_bytes
+    communicator._twoshot = None
+    communicator.twoshot_max_bytes = 0
     return communicator, runtime
+
+
+def _attach_twoshot(
+    communicator: B12xPcieAllReduce, *, max_bytes: int, accepts: bool = True
+) -> MagicMock:
+    twoshot = MagicMock()
+    twoshot.accepts.return_value = accepts
+    communicator._twoshot = twoshot
+    communicator.twoshot_max_bytes = max_bytes
+    return twoshot
 
 
 @pytest.mark.parametrize(
@@ -320,3 +333,81 @@ def test_b12x_fused_allreduce_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
         nprocs=2,
         join=True,
     )
+
+
+def test_twoshot_limit_defaults_to_768kb(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VLLM_PCIE_TWOSHOT_ALLREDUCE_MAX_SIZE", raising=False)
+    assert _twoshot_max_bytes() == 768 << 10
+    monkeypatch.setenv("VLLM_PCIE_TWOSHOT_ALLREDUCE_MAX_SIZE", "2MB")
+    assert _twoshot_max_bytes() == 2 << 20
+    for disabled in ("0", "off", " NONE ", "", "disabled"):
+        monkeypatch.setenv("VLLM_PCIE_TWOSHOT_ALLREDUCE_MAX_SIZE", disabled)
+        assert _twoshot_max_bytes() == 0
+
+
+def test_midsize_allreduce_dispatches_twoshot() -> None:
+    communicator, runtime = _make_communicator(allreduce_max_bytes=16)
+    twoshot = _attach_twoshot(communicator, max_bytes=1 << 20)
+    expected = torch.empty(64)
+    twoshot.all_reduce.return_value = expected
+    inp = torch.randn(64)  # 256 bytes: above the one-shot ceiling
+
+    assert communicator.should_custom_ar(inp)
+    assert communicator.custom_all_reduce(inp) is expected
+    twoshot.all_reduce.assert_called_once_with(inp)
+    runtime.all_reduce.assert_not_called()
+
+
+def test_oneshot_keeps_priority_below_its_ceiling() -> None:
+    communicator, runtime = _make_communicator(allreduce_max_bytes=1024)
+    twoshot = _attach_twoshot(communicator, max_bytes=1 << 20)
+    expected = torch.empty(64)
+    runtime.all_reduce.return_value = expected
+    inp = torch.randn(64)
+
+    assert communicator.custom_all_reduce(inp) is expected
+    runtime.all_reduce.assert_called_once_with(inp, stream=None)
+    twoshot.all_reduce.assert_not_called()
+
+
+def test_twoshot_window_ends_at_its_limit() -> None:
+    communicator, runtime = _make_communicator(allreduce_max_bytes=16)
+    twoshot = _attach_twoshot(communicator, max_bytes=128)
+    dma = MagicMock()
+    dma.should_allreduce.return_value = True
+    expected = torch.empty(64)
+    dma.all_reduce.return_value = expected
+    communicator._dma = dma
+    inp = torch.randn(64)  # 256 bytes: above the two-shot window
+
+    assert communicator.custom_all_reduce(inp) is expected
+    twoshot.all_reduce.assert_not_called()
+    dma.all_reduce.assert_called_once_with(inp)
+
+
+def test_twoshot_respects_runtime_acceptance() -> None:
+    communicator, _ = _make_communicator(allreduce_max_bytes=16)
+    twoshot = _attach_twoshot(communicator, max_bytes=1 << 20, accepts=False)
+    inp = torch.randn(64)
+
+    assert not communicator.should_custom_ar(inp)
+    assert communicator.custom_all_reduce(inp) is None
+    twoshot.all_reduce.assert_not_called()
+
+
+def test_graph_warmup_returns_placeholder_for_twoshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    communicator, runtime = _make_communicator(allreduce_max_bytes=16)
+    twoshot = _attach_twoshot(communicator, max_bytes=1 << 20)
+    communicator._is_capturing = True
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(
+        b12x_pcie_all_reduce, "_is_piecewise_cudagraph_runtime", lambda: False
+    )
+    inp = torch.randn(64)
+
+    out = communicator.custom_all_reduce(inp)
+    assert out is not None and out.shape == inp.shape and out is not inp
+    twoshot.all_reduce.assert_not_called()
+    runtime.all_reduce.assert_not_called()

--- a/vllm/distributed/device_communicators/b12x_pcie_all_reduce.py
+++ b/vllm/distributed/device_communicators/b12x_pcie_all_reduce.py
@@ -47,6 +47,29 @@ def _parse_byte_size(value: str) -> int:
         raise ValueError(f"invalid byte-size suffix: {suffix!r}") from exc
 
 
+def _twoshot_max_bytes() -> int:
+    """Largest all-reduce routed to the lossless bf16 two-shot (0 disables).
+
+    Measured on four RTX PRO 6000 Blackwell (PCIe, TP4): the pull two-shot
+    beats the NCCL ring from the one-shot ceiling up to 768 KB (128 KB 15.0
+    vs 16.7 us, 512 KB 32.8 vs 41.7, 768 KB 44.5 vs 54.5) and matches it at
+    1 MB and above, so the default stops at 768 KB.
+    """
+    raw = os.getenv("VLLM_PCIE_TWOSHOT_ALLREDUCE_MAX_SIZE", "768KB").strip().lower()
+    if raw in ("", "0", "off", "none", "disabled"):
+        return 0
+    return _parse_byte_size(raw)
+
+
+@lru_cache(maxsize=1)
+def _load_b12x_twoshot_bf16() -> Any | None:
+    try:
+        from b12x.comm.pcie.pcie_twoshot_bf16 import PCIeTwoShotBF16
+    except Exception:  # pragma: no cover - optional
+        return None
+    return PCIeTwoShotBF16
+
+
 @lru_cache(maxsize=1)
 def _load_b12x_pcie() -> tuple[Any, Any, Any] | None:
     try:
@@ -212,15 +235,19 @@ class B12xPcieAllReduce:
         assert runtime is not None
         self._runtime = runtime
         self._initialize_dma(dma_cls)
+        self._twoshot: Any | None = None
+        self.twoshot_max_bytes = 0
+        self._initialize_twoshot()
         self.disabled = False
 
         if self.rank == 0:
             logger.info(
                 "Using B12X PCIe all-reduce (algorithm=%s, one-shot max=%d, "
-                "fused max=%d, DMA min=%s).",
+                "fused max=%d, two-shot bf16 max=%s, DMA min=%s).",
                 getattr(runtime, "algorithm", "oneshot"),
                 self.allreduce_max_bytes,
                 self.fused_max_bytes,
+                self.twoshot_max_bytes if self._twoshot is not None else "off",
                 getattr(self._dma, "min_bytes", "off"),
             )
 
@@ -272,6 +299,57 @@ class B12xPcieAllReduce:
         dma.min_bytes = min_bytes
         self._dma = dma
 
+    def _initialize_twoshot(self) -> None:
+        """Lossless bf16 two-shot for payloads above the one-shot ceiling."""
+        max_bytes = _twoshot_max_bytes()
+        if max_bytes <= 0 or self.world_size not in (2, 4, 8):
+            return
+        twoshot_cls = _load_b12x_twoshot_bf16()
+        if twoshot_cls is None:
+            logger.warning("B12X PCIe two-shot bf16 requested but unavailable.")
+            return
+        row_elems = int(os.getenv("VLLM_PCIE_TWOSHOT_ROW_ELEMS", "4096"))
+        # Rows are counted in row_elems-wide bf16 rows; keep a multiple of the
+        # world size and enough capacity for the configured byte ceiling.
+        max_rows = max_bytes // (row_elems * 2)
+        max_rows -= max_rows % self.world_size
+        if max_rows < self.world_size:
+            return
+        twoshot: Any | None = None
+        init_error: Exception | None = None
+        try:
+            twoshot = twoshot_cls.from_exchange_group(
+                exchange_group=self.device_group,
+                device=self.device,
+                max_rows=max_rows,
+                row_elems=row_elems,
+            )
+            twoshot.prepare_graph()
+        except Exception as exc:
+            init_error = exc
+        if not self._all_ranks_succeeded(init_error):
+            if twoshot is not None:
+                twoshot.close()
+            logger.warning(
+                "B12X PCIe two-shot bf16 initialization failed on rank %d: %s; "
+                "mid-size tensors will use PyNCCL.",
+                self.rank,
+                init_error,
+            )
+            return
+        assert twoshot is not None
+        self._twoshot = twoshot
+        self.twoshot_max_bytes = max_rows * row_elems * 2
+
+    def _twoshot_accepts(self, inp: torch.Tensor) -> bool:
+        twoshot = self._twoshot
+        return bool(
+            twoshot is not None
+            and inp.nbytes > self.allreduce_max_bytes
+            and inp.nbytes <= self.twoshot_max_bytes
+            and twoshot.accepts(inp)
+        )
+
     def _runtime_stream(self) -> torch.cuda.Stream | None:
         stream = self._capture_stream
         if stream is None:
@@ -295,6 +373,8 @@ class B12xPcieAllReduce:
             return False
         if self._oneshot_accepts(inp):
             return True
+        if self._twoshot_accepts(inp):
+            return True
         return self._dma is not None and self._dma.should_allreduce(inp)
 
     def custom_all_reduce(self, inp: torch.Tensor) -> torch.Tensor | None:
@@ -304,14 +384,19 @@ class B12xPcieAllReduce:
         runtime = self._runtime
         assert runtime is not None
         use_oneshot = self._oneshot_accepts(inp)
+        use_twoshot = (not use_oneshot) and self._twoshot_accepts(inp)
         if self._is_capturing and not torch.cuda.is_current_stream_capturing():
             if _is_piecewise_cudagraph_runtime():
+                if use_twoshot:
+                    return self._twoshot.all_reduce(inp)
                 return self._all_reduce(inp, use_oneshot=use_oneshot)
             if use_oneshot:
                 prepare = getattr(runtime, "prepare_graph_all_reduce", None)
                 if prepare is not None:
                     prepare(inp, stream=self._runtime_stream())
             return torch.empty_like(inp)
+        if use_twoshot:
+            return self._twoshot.all_reduce(inp)
         return self._all_reduce(inp, use_oneshot=use_oneshot)
 
     def _all_reduce(self, inp: torch.Tensor, *, use_oneshot: bool) -> torch.Tensor:
@@ -390,12 +475,19 @@ class B12xPcieAllReduce:
         self._is_capturing = True
         try:
             with self._runtime.capture(stream=stream):
-                yield
+                if self._twoshot is not None:
+                    with self._twoshot.capture():
+                        yield
+                else:
+                    yield
         finally:
             self._capture_stream = old_stream
             self._is_capturing = old_capturing
 
     def close(self) -> None:
+        if getattr(self, "_twoshot", None) is not None:
+            self._twoshot.close()
+            self._twoshot = None
         if self._dma is not None:
             self._dma.close()
             self._dma = None


### PR DESCRIPTION
## Purpose

Between the B12X one-shot ceiling (84 KB at TP4) and the DMA ring floor, the PCIe all-reduce wrapper hands TP all-reduces to the NCCL ring. On GLM-5.3-Flash TP4 that is every decode all-reduce from about 11 rows up: 98 ring all-reduces per verifier step at 41.7 us (512 KB, M64) and 54.5 us (768 KB, M96). This routes that window to B12X's lossless bf16 two-shot all-reduce (local-inference-lab/b12x#283).

## Behavior

- Payloads above the one-shot ceiling and up to `VLLM_PCIE_TWOSHOT_ALLREDUCE_MAX_SIZE` (default 768 KB, the measured crossover with the ring) go to `PCIeTwoShotBF16` when it accepts the tensor (contiguous bf16, row multiple of the world size). `0`, `off` or `none` disables the route.
- The one-shot keeps priority below its ceiling; the DMA ring keeps everything above the two-shot window. Graph warmup returns the placeholder tensor as before; captured graphs and piecewise runtimes call the two-shot directly. Initialization failures on any rank fall back to the ring on all ranks.
- No new envs.py entry: the limit is read like the existing one-shot override.

## Compatibility

Numerics: the two-shot accumulates in fp32 in a fixed rank order and rounds once, so each output element lies within one bf16 rounding of the exact sum; the bf16 NCCL ring it replaces rounds after every hop. Outputs are deterministic across calls and graph replays. Payloads at C1 (64 KB, one-shot) and at C30 gates (1.97 MB, ring) are untouched, so the greedy Estonia/LAVD results of the serving stack do not move; the affected window is roughly C2 to C12.

Depends on local-inference-lab/b12x#283 (the runtime); without it the wrapper logs that the two-shot is unavailable and keeps the ring.

## Validation

Device-free wrapper tests inside the GLM-5.3 serving image:

```text
python -m pytest tests/distributed/test_b12x_pcie_all_reduce.py -k "not gpu"
19 passed
```

New cases: default limit and disable spellings, mid-size dispatch to the two-shot, one-shot priority below its ceiling, DMA above the two-shot window, runtime rejection, and the graph-warmup placeholder.

Runtime correctness (four RTX PRO 6000 Blackwell): the four-rank test in the b12x pull request checks the one-rounding bound against the exact fp32 sum for 8 to 256 rows, that the two-shot error never exceeds the ring's, determinism, and bitwise-equal graph replay.

Per all-reduce (graph replay, two-shot vs NCCL ring): 128 KB 15.0 vs 16.7 us, 256 KB 20.3 vs 25.6, 384 KB 26.3 vs 33.5, 512 KB 32.8 vs 41.7, 768 KB 44.5 vs 54.5; 1 MB 63.4 vs 61.3 and 2 MB 99.8 vs 98.3, hence the 768 KB default. At 98 all-reduces per step that is about 0.9 ms of a 31 ms step at C8 (M64) and 1.0 ms of a 36 ms step at C12 (M96).

Serving (GLM-5.3-Flash NVFP4 target, MXFP8 DFlash2 K7 draft, TP4, llm_decode_bench ctx0 30-second cells, ordinary sampling, back-to-back A/B/A on the same thermal state). Stack with this route, exact 96/192 graph sizes and the SM120 mHC split policy, versus the same image without them:

| Concurrency | Output tok/s | Verifier steps/s | Steps/s delta |
| --- | ---: | ---: | ---: |
| 1 | 205.1 vs 211.5 | 84.3 vs 84.6 | -0.3% (one-shot payloads, noise) |
| 4 | 457.8 vs 434.0 | 179.6 vs 176.7 | +1.6% |
| 8 | 658.8 vs 617.0 | 267.7 vs 249.7 | +7.2% |
| 12 | 801.2 vs 638.0 | 315.1 vs 260.8 | +20.8% |
| 24 | 1107.9 vs 967.0 | 437.0 vs 379.5 | +15.2% |
| 32 | 1284.2 vs 1293.0 | 500.0 vs 498.4 | +0.3% (ring payloads) |

The two-shot route on its own, against the same stack with the ring: C8 259.9 to 267.7 verifier steps/s (+3.0%, 620 to 659 tok/s) and C12 307 to 315 (+2.6%, 788 to 801 tok/s), matching the per-all-reduce savings above.

Generated with Claude Code; the submitter reviewed the change and ran the validation on the listed hardware.
