### PR TITLE
perf(attention): split-KV paged decode attention for the GLM-5.3 DFlash draft

### DIFF
--- a/tests/v1/attention/test_dflash_attn.py
+++ b/tests/v1/attention/test_dflash_attn.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Split-KV draft attention against FlashAttention 2 at the DFlash draft shape."""
+
+import os
+
+import pytest
+import torch
+
+H, HKV, D, BLOCK, WINDOW = 8, 2, 128, 256, 2048
+SCALE = D**-0.5
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (12, 0),
+    reason="SM120 split-KV draft attention",
+)
+
+
+def _module():
+    from vllm.v1.attention.backends import dflash_attn
+
+    if not dflash_attn.is_available(torch.device("cuda", 0)):
+        pytest.skip("dflash_attn library could not be built or loaded")
+    return dflash_attn
+
+
+def _case(seqlens, qlens, strided, device):
+    batch = len(seqlens)
+    nblk = [(length + BLOCK - 1) // BLOCK for length in seqlens]
+    total_blocks = sum(nblk) + 2
+    if strided:  # backend layout: [num_blocks, hkv, block, 2D] -> transposed views
+        kv = torch.randn(
+            total_blocks, HKV, BLOCK, 2 * D, device=device, dtype=torch.bfloat16
+        )
+        k, v = kv.transpose(1, 2).split(D, dim=-1)
+    else:
+        k = torch.randn(
+            total_blocks, BLOCK, HKV, D, device=device, dtype=torch.bfloat16
+        )
+        v = torch.randn_like(k)
+    block_table = torch.zeros(batch, max(nblk), dtype=torch.int32, device=device)
+    nxt = 1
+    for b in range(batch):
+        block_table[b, : nblk[b]] = torch.arange(
+            nxt, nxt + nblk[b], dtype=torch.int32, device=device
+        )
+        nxt += nblk[b]
+    tokens = sum(qlens)
+    q = torch.randn(tokens, H, D, device=device, dtype=torch.bfloat16)
+    cu = torch.tensor(
+        [0] + torch.cumsum(torch.tensor(qlens), 0).tolist(),
+        dtype=torch.int32,
+        device=device,
+    )
+    seqused = torch.tensor(seqlens, dtype=torch.int32, device=device)
+    return q, k, v, block_table, cu, seqused
+
+
+CASES = [
+    ([100], [8]),
+    ([2047], [8]),
+    ([2048], [8]),
+    ([2056], [8]),
+    ([3000], [8]),
+    ([9000], [8]),
+    ([50, 2500, 4096, 7], [8, 8, 8, 8]),
+    ([300, 6000], [5, 3]),
+    ([8], [8]),
+]
+
+
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("strided", [True, False])
+@pytest.mark.parametrize(("seqlens", "qlens"), CASES)
+def test_split_kv_matches_flash_attn(seqlens, qlens, strided, causal):
+    dfa = _module()
+    from vllm.vllm_flash_attn import flash_attn_varlen_func
+
+    device = torch.device("cuda", 0)
+    torch.manual_seed(1234 + sum(seqlens))
+    q, k, v, block_table, cu, seqused = _case(seqlens, qlens, strided, device)
+    window = (WINDOW - 1, 0) if causal else (WINDOW - 1, WINDOW - 1)
+    ref = flash_attn_varlen_func(
+        q=q,
+        k=k,
+        v=v,
+        cu_seqlens_q=cu,
+        max_seqlen_q=max(qlens),
+        seqused_k=seqused,
+        max_seqlen_k=max(seqlens),
+        softmax_scale=SCALE,
+        causal=causal,
+        window_size=window,
+        block_table=block_table,
+        fa_version=2,
+    )
+    op = dfa.DFlashDecodeAttention(device, HKV, max_batch=len(seqlens), window=WINDOW)
+    out = torch.empty_like(q)
+    op(q, k, v, block_table, seqused, cu, SCALE, out, causal=causal)
+    torch.cuda.synchronize()
+    assert not torch.isnan(out).any()
+    err = (out.float() - ref.float()).abs().max().item()
+    rel = err / max(1e-6, ref.float().abs().max().item())
+    assert rel < 2e-2, f"relative error {rel:.3e} vs FlashAttention 2"
+    again = torch.empty_like(q)
+    op(q, k, v, block_table, seqused, cu, SCALE, again, causal=causal)
+    torch.cuda.synchronize()
+    assert torch.equal(out, again), "split-KV attention must be deterministic"
+
+
+def test_graph_replay_matches_eager():
+    dfa = _module()
+    device = torch.device("cuda", 0)
+    torch.manual_seed(7)
+    q, k, v, block_table, cu, seqused = _case([2048, 777], [8, 8], True, device)
+    op = dfa.DFlashDecodeAttention(device, HKV, max_batch=2, window=WINDOW)
+    eager = torch.empty_like(q)
+    op(q, k, v, block_table, seqused, cu, SCALE, eager, causal=False)
+    torch.cuda.synchronize()
+    captured = torch.empty_like(q)
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        op(q, k, v, block_table, seqused, cu, SCALE, captured, causal=False)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        op(q, k, v, block_table, seqused, cu, SCALE, captured, causal=False)
+    for _ in range(3):
+        captured.zero_()
+        graph.replay()
+        torch.cuda.synchronize()
+        assert torch.equal(captured, eager)
+
+
+def test_workspace_rejects_oversized_batch():
+    dfa = _module()
+    device = torch.device("cuda", 0)
+    q, k, v, block_table, cu, seqused = _case([64, 64], [8, 8], True, device)
+    op = dfa.DFlashDecodeAttention(device, HKV, max_batch=1, window=WINDOW)
+    with pytest.raises(ValueError):
+        op(q, k, v, block_table, seqused, cu, SCALE, torch.empty_like(q))
+    assert os.getenv("VLLM_GLM53_DFLASH_ATTN", "0") in ("0", "1")

--- a/vllm/v1/attention/backends/dflash_attn/__init__.py
+++ b/vllm/v1/attention/backends/dflash_attn/__init__.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Split-KV paged decode attention for the GLM-5.3 DFlash draft on SM120.
+
+The DFlash2 draft's five layers attend over a 2048-token sliding window with
+eight query tokens per request and GQA 4 (8 heads over 2 KV heads, head size
+128). FlashAttention 2 serves that as one varlen call with a single KV split:
+45 to 49 us per layer at concurrency 1. ``dflash_attn.cu`` splits the window
+into 128-key chunks (one CTA per chunk, KV head and request; 32 rows = 8
+queries x GQA 4; ``mma.sync`` m16n8k16 for QK^T and PV; fp32 partials) and a
+second kernel combines the partials: 13 us per layer.
+
+The library is loaded from ``VLLM_GLM53_DFLASH_ATTN_LIB`` when set, otherwise
+``dflash_attn.cu`` is compiled once with the CUDA toolkit's ``nvcc`` into the
+vLLM cache directory. Without a toolkit ``is_available()`` is False and the
+FlashAttention path is used.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import torch
+
+import vllm.envs as envs
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+CHUNK = 128  # keys per split
+ROWS = 32  # 8 query tokens x GQA 4
+HEAD_DIM = 128
+GQA = 4
+MAX_QUERY_LEN = 8
+
+_SOURCE = Path(__file__).with_name("dflash_attn.cu")
+_lib: ctypes.CDLL | None = None
+_lib_error: str | None = None
+
+
+def _nvcc() -> str | None:
+    for candidate in (
+        os.getenv("CUDA_NVCC"),
+        shutil.which("nvcc"),
+        os.path.join(os.getenv("CUDA_HOME", "/usr/local/cuda"), "bin", "nvcc"),
+    ):
+        if candidate and os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def _arch_flag(device: torch.device) -> str:
+    major, minor = torch.cuda.get_device_capability(device)
+    return f"-gencode=arch=compute_{major}{minor}a,code=sm_{major}{minor}a"
+
+
+def _build(device: torch.device) -> str:
+    nvcc = _nvcc()
+    if nvcc is None:
+        raise RuntimeError("nvcc not found (set CUDA_NVCC or CUDA_HOME)")
+    arch = _arch_flag(device)
+    digest = hashlib.sha256(_SOURCE.read_bytes() + arch.encode()).hexdigest()[:16]
+    out_dir = Path(envs.VLLM_CACHE_ROOT) / "dflash_attn" / digest
+    out = out_dir / "libdflash_attn.so"
+    if out.is_file():
+        return str(out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=out_dir, suffix=".so", delete=False) as tmp:
+        tmp_path = tmp.name
+    cmd = [
+        nvcc,
+        "-O3",
+        "-std=c++17",
+        "--shared",
+        "-Xcompiler",
+        "-fPIC",
+        "-cudart",
+        "static",
+        arch,
+        str(_SOURCE),
+        "-o",
+        tmp_path,
+    ]
+    logger.info("[dflash_attn] building %s", out)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        os.unlink(tmp_path)
+        raise RuntimeError(f"nvcc failed: {result.stderr.strip()[-2000:]}")
+    os.replace(tmp_path, out)
+    return str(out)
+
+
+def _load(device: torch.device) -> ctypes.CDLL:
+    global _lib, _lib_error
+    if _lib is not None:
+        return _lib
+    if _lib_error is not None:
+        raise RuntimeError(_lib_error)
+    try:
+        path = os.getenv("VLLM_GLM53_DFLASH_ATTN_LIB") or _build(device)
+        lib = ctypes.CDLL(path)
+        argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_int,  # q, q_stride_t
+            ctypes.c_void_p,
+            ctypes.c_void_p,  # k cache, v cache
+            ctypes.c_longlong,
+            ctypes.c_longlong,
+            ctypes.c_longlong,  # strides
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,  # block size, hkv, H
+            ctypes.c_void_p,
+            ctypes.c_int,  # block table, its row stride
+            ctypes.c_void_p,
+            ctypes.c_void_p,  # seqused_k, cu_seqlens_q
+            ctypes.c_float,
+            ctypes.c_int,
+            ctypes.c_int,  # scale, window, causal
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_void_p,  # partials o/m/l
+            ctypes.c_int,
+            ctypes.c_int,  # max_splits, batch
+            ctypes.c_void_p,
+            ctypes.c_void_p,  # out, stream
+        ]
+        for name in ("dflash_attn_launch", "dflash_attn_launch_mma"):
+            fn = getattr(lib, name)
+            fn.argtypes = argtypes
+            fn.restype = ctypes.c_int
+        _lib = lib
+        logger.info("[dflash_attn] loaded %s", path)
+        return lib
+    except Exception as exc:  # noqa: BLE001
+        _lib_error = f"split-KV draft attention unavailable: {exc}"
+        logger.warning("[dflash_attn] %s", _lib_error)
+        raise RuntimeError(_lib_error) from exc
+
+
+def is_available(device: torch.device) -> bool:
+    if not torch.cuda.is_available() or device.type != "cuda":
+        return False
+    try:
+        _load(device)
+    except RuntimeError:
+        return False
+    return True
+
+
+class DFlashDecodeAttention:
+    """Workspace holder and launcher; one per (device, KV heads, window)."""
+
+    def __init__(
+        self,
+        device: torch.device,
+        hkv: int,
+        max_batch: int,
+        window: int,
+        mma: bool = True,
+    ):
+        if window <= 0:
+            raise ValueError("window must be positive")
+        self.mma = mma
+        self.max_splits = (window + MAX_QUERY_LEN + CHUNK - 1) // CHUNK
+        self.hkv, self.window, self.max_batch = int(hkv), int(window), int(max_batch)
+        n = self.max_batch * self.hkv * self.max_splits
+        self.part_o = torch.zeros(
+            (n, ROWS, HEAD_DIM), dtype=torch.float32, device=device
+        )
+        self.part_m = torch.full((n, ROWS), -1e30, dtype=torch.float32, device=device)
+        self.part_l = torch.zeros((n, ROWS), dtype=torch.float32, device=device)
+        self._lib = _load(device)
+
+    def __call__(
+        self,
+        q: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        block_table: torch.Tensor,
+        seqused_k: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        scale: float,
+        out: torch.Tensor,
+        num_reqs: int | None = None,
+        causal: bool = True,
+    ) -> torch.Tensor:
+        """q/out: [T, H, D] bf16 contiguous; caches: [num_blocks, block, hkv, D]
+        bf16 views with a unit last stride (K and V identically strided);
+        block_table [B, max_blocks] int32; seqused_k [B] int32; cu [B+1] int32."""
+        batch = int(cu_seqlens_q.numel() - 1) if num_reqs is None else int(num_reqs)
+        if batch > self.max_batch:
+            raise ValueError(f"batch {batch} exceeds workspace {self.max_batch}")
+        heads = q.shape[1]
+        if heads != self.hkv * GQA or q.shape[2] != HEAD_DIM:
+            raise ValueError("unsupported head geometry")
+        if not (q.is_contiguous() and out.is_contiguous()):
+            raise ValueError("q and out must be contiguous")
+        if k_cache.dtype != torch.bfloat16 or k_cache.shape[2] != self.hkv:
+            raise ValueError("unsupported KV cache")
+        if k_cache.shape[3] != HEAD_DIM or k_cache.stride(3) != 1:
+            raise ValueError("unsupported KV cache layout")
+        if v_cache.stride() != k_cache.stride() or v_cache.shape != k_cache.shape:
+            raise ValueError("K and V caches must share layout")
+        s_blk, s_pos, s_h = (int(x) for x in k_cache.stride()[:3])
+        fn = (
+            self._lib.dflash_attn_launch_mma
+            if self.mma
+            else self._lib.dflash_attn_launch
+        )
+        rc = fn(
+            q.data_ptr(),
+            heads * HEAD_DIM,
+            k_cache.data_ptr(),
+            v_cache.data_ptr(),
+            s_blk,
+            s_pos,
+            s_h,
+            int(k_cache.shape[1]),
+            self.hkv,
+            heads,
+            block_table.data_ptr(),
+            int(block_table.stride(0)),
+            seqused_k.data_ptr(),
+            cu_seqlens_q.data_ptr(),
+            float(scale),
+            self.window,
+            1 if causal else 0,
+            self.part_o.data_ptr(),
+            self.part_m.data_ptr(),
+            self.part_l.data_ptr(),
+            self.max_splits,
+            batch,
+            out.data_ptr(),
+            torch.cuda.current_stream(q.device).cuda_stream,
+        )
+        if rc != 0:
+            raise RuntimeError(f"dflash_attn launch failed: {rc}")
+        return out
+
+
+__all__ = [
+    "DFlashDecodeAttention",
+    "is_available",
+    "CHUNK",
+    "ROWS",
+    "HEAD_DIM",
+    "GQA",
+    "MAX_QUERY_LEN",
+]

--- a/vllm/v1/attention/backends/dflash_attn/dflash_attn.cu
+++ b/vllm/v1/attention/backends/dflash_attn/dflash_attn.cu
@@ -1,0 +1,415 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+// Split-KV paged decode attention for the DFlash draft (bf16 KV, head_dim 128, GQA 4, <= 8 queries per request,
+// causal + left sliding window). Kernel 1: one CTA per (128-key chunk, kv head, request) computes fp32 partials
+// (O, m, l) for the 32 rows = 8 queries x 4 q-heads. Kernel 2 merges the chunks. Draft-only numerics.
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <stdint.h>
+#include <math.h>
+
+#define D 128
+#define ROWS 32
+#define QMAX 8
+#define GQA 4
+#define CHUNK 128
+#define NTHREADS 128
+#define NEG (-1e30f)
+
+struct Params {
+    const __nv_bfloat16* q; int q_stride_t;          // [T, H, D], stride per token (elements)
+    const __nv_bfloat16* kc; const __nv_bfloat16* vc; // strided caches: row(blk,pos,h) = base + blk*s_blk + pos*s_pos + h*s_h
+    long long s_blk, s_pos, s_h;
+    int bs; int hkv; int H;
+    const int* block_table; int bt_stride;           // [B, max_blocks]
+    const int* seqused; const int* cu_q;
+    float scale; int window;                          // window W: key kp visible iff kp > qpos - W (W <= 0: no window)
+    int causal;                                       // 1: kp <= qpos; 0: bidirectional inside the window (DFlash block attention)
+    float* part_o; float* part_m; float* part_l;      // [B][HKV][MAXS][ROWS][D] / [B][HKV][MAXS][ROWS]
+    int max_splits;
+    __nv_bfloat16* out;                               // [T, H, D]
+};
+
+__device__ __forceinline__ float dot8(uint4 a, uint4 b) {
+    const __nv_bfloat162* pa = reinterpret_cast<const __nv_bfloat162*>(&a);
+    const __nv_bfloat162* pb = reinterpret_cast<const __nv_bfloat162*>(&b);
+    float acc = 0.f;
+#pragma unroll
+    for (int i = 0; i < 4; ++i) { float2 fa = __bfloat1622float2(pa[i]); float2 fb = __bfloat1622float2(pb[i]); acc = fmaf(fa.x, fb.x, acc); acc = fmaf(fa.y, fb.y, acc); }
+    return acc;
+}
+
+extern __shared__ __align__(16) unsigned char smem_raw[];
+
+__global__ void __launch_bounds__(NTHREADS)
+attn_partial_kernel(Params p) {
+    __nv_bfloat16* Qs = reinterpret_cast<__nv_bfloat16*>(smem_raw);                 // [ROWS][D]   8 KB
+    float* S = reinterpret_cast<float*>(smem_raw + ROWS * D * 2);                    // [ROWS][CHUNK] 16 KB
+    __nv_bfloat16* Vs = reinterpret_cast<__nv_bfloat16*>(smem_raw + ROWS * D * 2 + ROWS * CHUNK * 4); // [CHUNK][D] 32 KB
+    float* ms = reinterpret_cast<float*>(smem_raw + ROWS * D * 2 + ROWS * CHUNK * 4 + CHUNK * D * 2);  // [ROWS]
+    float* ls = ms + ROWS;
+    const int tid = threadIdx.x, lane = tid & 31, warp = tid >> 5;
+    const int s = blockIdx.x, g = blockIdx.y, b = blockIdx.z;
+    const int q0 = p.cu_q[b], qlen = p.cu_q[b + 1] - q0, kend = p.seqused[b];
+    int kbeg = 0;
+    if (p.window > 0) { kbeg = kend - qlen - p.window + 1; if (kbeg < 0) kbeg = 0; }
+    const int kbase = kbeg + s * CHUNK;
+    const size_t pidx = ((size_t)(b * p.hkv + g) * p.max_splits + s);
+    float* po = p.part_o + pidx * ROWS * D;
+    if (kbase >= kend || qlen <= 0) {
+        if (tid < ROWS) { p.part_m[pidx * ROWS + tid] = NEG; p.part_l[pidx * ROWS + tid] = 0.f; }
+        for (int i = tid; i < ROWS * D; i += NTHREADS) po[i] = 0.f;
+        return;
+    }
+    // Q rows r = j*8 + i  (j = q-head within the group, i = query index)
+    for (int idx = tid; idx < ROWS * (D / 8); idx += NTHREADS) {
+        const int r = idx / (D / 8), c = idx - r * (D / 8), i = r & 7, j = r >> 3;
+        uint4 v = make_uint4(0u, 0u, 0u, 0u);
+        if (i < qlen) v = *reinterpret_cast<const uint4*>(p.q + (size_t)(q0 + i) * p.q_stride_t + (size_t)(g * GQA + j) * D + c * 8);
+        *reinterpret_cast<uint4*>(Qs + r * D + c * 8) = v;
+    }
+    // this thread's key
+    const int kp = kbase + tid;
+    const bool valid = kp < kend;
+    uint4 kreg[D / 8];
+    if (valid) {
+        const int blk = p.block_table[(size_t)b * p.bt_stride + kp / p.bs], off = kp - (kp / p.bs) * p.bs;
+        const long long rowoff = (long long)blk * p.s_blk + (long long)off * p.s_pos + (long long)g * p.s_h;
+        const uint4* kr = reinterpret_cast<const uint4*>(p.kc + rowoff);
+        const uint4* vr = reinterpret_cast<const uint4*>(p.vc + rowoff);
+#pragma unroll
+        for (int c = 0; c < D / 8; ++c) kreg[c] = __ldg(kr + c);
+#pragma unroll
+        for (int c = 0; c < D / 8; ++c) *reinterpret_cast<uint4*>(Vs + tid * D + c * 8) = __ldg(vr + c);
+    } else {
+#pragma unroll
+        for (int c = 0; c < D / 8; ++c) { kreg[c] = make_uint4(0u, 0u, 0u, 0u); *reinterpret_cast<uint4*>(Vs + tid * D + c * 8) = make_uint4(0u, 0u, 0u, 0u); }
+    }
+    __syncthreads();
+    // scores S[r][tid]
+#pragma unroll 4
+    for (int r = 0; r < ROWS; ++r) {
+        const uint4* qr = reinterpret_cast<const uint4*>(Qs + r * D);
+        float acc = 0.f;
+#pragma unroll
+        for (int c = 0; c < D / 8; ++c) acc += dot8(qr[c], kreg[c]);
+        const int i = r & 7, qpos = kend - qlen + i;
+        const bool ok = valid && (i < qlen) && (!p.causal || kp <= qpos) && (p.window <= 0 || kp > qpos - p.window);
+        S[r * CHUNK + tid] = ok ? acc * p.scale : NEG;
+    }
+    __syncthreads();
+    // row stats + P (in place): warp w owns rows w*8 .. w*8+7; lane holds S[r][lane*4 .. +3]
+    for (int rr = 0; rr < 8; ++rr) {
+        const int r = warp * 8 + rr;
+        float* srow = S + r * CHUNK;
+        float v0 = srow[lane * 4], v1 = srow[lane * 4 + 1], v2 = srow[lane * 4 + 2], v3 = srow[lane * 4 + 3];
+        float m = fmaxf(fmaxf(v0, v1), fmaxf(v2, v3));
+#pragma unroll
+        for (int off = 16; off > 0; off >>= 1) m = fmaxf(m, __shfl_xor_sync(0xffffffffu, m, off));
+        float l = 0.f;
+        if (m > -1e29f) {
+            v0 = __expf(v0 - m); v1 = __expf(v1 - m); v2 = __expf(v2 - m); v3 = __expf(v3 - m);
+            l = v0 + v1 + v2 + v3;
+        } else { v0 = v1 = v2 = v3 = 0.f; m = NEG; }
+#pragma unroll
+        for (int off = 16; off > 0; off >>= 1) l += __shfl_xor_sync(0xffffffffu, l, off);
+        srow[lane * 4] = v0; srow[lane * 4 + 1] = v1; srow[lane * 4 + 2] = v2; srow[lane * 4 + 3] = v3;
+        if (lane == 0) { ms[r] = m; ls[r] = l; }
+    }
+    __syncthreads();
+    // O partial: thread = dim
+    const int d = tid;
+    for (int r = 0; r < ROWS; ++r) {
+        const float* prow = S + r * CHUNK;
+        float acc = 0.f;
+#pragma unroll 8
+        for (int t = 0; t < CHUNK; ++t) acc = fmaf(prow[t], __bfloat162float(Vs[t * D + d]), acc);
+        po[r * D + d] = acc;
+    }
+    if (tid < ROWS) { p.part_m[pidx * ROWS + tid] = ms[tid]; p.part_l[pidx * ROWS + tid] = ls[tid]; }
+}
+
+// grid: (ROWS, HKV, B), block: 128 threads (= dims)
+__global__ void __launch_bounds__(NTHREADS)
+attn_combine_kernel(Params p) {
+    const int r = blockIdx.x, g = blockIdx.y, b = blockIdx.z, d = threadIdx.x;
+    const int q0 = p.cu_q[b], qlen = p.cu_q[b + 1] - q0;
+    const int i = r & 7, j = r >> 3;
+    if (i >= qlen) return;
+    const size_t base = (size_t)(b * p.hkv + g) * p.max_splits;
+    float M = NEG;
+    for (int s = 0; s < p.max_splits; ++s) M = fmaxf(M, p.part_m[(base + s) * ROWS + r]);
+    float L = 0.f, o = 0.f;
+    if (M > -1e29f) {
+        for (int s = 0; s < p.max_splits; ++s) {
+            const float m = p.part_m[(base + s) * ROWS + r];
+            if (m > -1e29f) {
+                const float w = __expf(m - M);
+                L = fmaf(p.part_l[(base + s) * ROWS + r], w, L);
+                o = fmaf(p.part_o[((base + s) * ROWS + r) * D + d], w, o);
+            }
+        }
+    }
+    const float val = (L > 0.f) ? o / L : 0.f;
+    p.out[(size_t)(q0 + i) * p.q_stride_t + (size_t)(g * GQA + j) * D + d] = __float2bfloat16(val);
+}
+
+extern "C" int dflash_attn_launch(const void* q, int q_stride_t, const void* kc, const void* vc, long long s_blk, long long s_pos, long long s_h, int bs, int hkv, int H,
+                                  const void* block_table, int bt_stride, const void* seqused, const void* cu_q,
+                                  float scale, int window, int causal, void* part_o, void* part_m, void* part_l, int max_splits,
+                                  int B, void* out, cudaStream_t stream) {
+    Params p;
+    p.q = (const __nv_bfloat16*)q; p.q_stride_t = q_stride_t; p.kc = (const __nv_bfloat16*)kc; p.vc = (const __nv_bfloat16*)vc;
+    p.s_blk = s_blk; p.s_pos = s_pos; p.s_h = s_h;
+    p.bs = bs; p.hkv = hkv; p.H = H; p.block_table = (const int*)block_table; p.bt_stride = bt_stride;
+    p.seqused = (const int*)seqused; p.cu_q = (const int*)cu_q; p.scale = scale; p.window = window; p.causal = causal;
+    p.part_o = (float*)part_o; p.part_m = (float*)part_m; p.part_l = (float*)part_l; p.max_splits = max_splits;
+    p.out = (__nv_bfloat16*)out;
+    const size_t smem = ROWS * D * 2 + ROWS * CHUNK * 4 + CHUNK * D * 2 + 2 * ROWS * 4;
+    static bool attr_set = false;
+    if (!attr_set) {
+        cudaGetLastError();
+        if (cudaFuncSetAttribute((const void*)attn_partial_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, (int)smem) != cudaSuccess) return 100;
+        attr_set = true;
+    }
+    attn_partial_kernel<<<dim3(max_splits, hkv, B), NTHREADS, smem, stream>>>(p);
+    cudaError_t e = cudaGetLastError(); if (e != cudaSuccess) return 200 + (int)e;
+    attn_combine_kernel<<<dim3(ROWS, hkv, B), NTHREADS, 0, stream>>>(p);
+    e = cudaGetLastError(); return e == cudaSuccess ? 0 : 300 + (int)e;
+}
+
+// ======================= tensor-core partial kernel (mma.sync m16n8k16 bf16) =======================
+__device__ __forceinline__ void mma16816(float* c, const uint32_t* a, const uint32_t* b) {
+    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+        : "+f"(c[0]), "+f"(c[1]), "+f"(c[2]), "+f"(c[3]) : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]));
+}
+__device__ __forceinline__ uint32_t pack_bf16x2(float lo, float hi) {
+    __nv_bfloat162 v = __floats2bfloat162_rn(lo, hi);
+    return *reinterpret_cast<uint32_t*>(&v);
+}
+
+__global__ void __launch_bounds__(NTHREADS)
+attn_partial_mma_kernel(Params p) {
+    // padded row strides (elements) so that rows g=0..7 of a fragment load land in distinct banks
+    constexpr int LD = D + 8;            // bf16 rows: 272 B = 68 words -> bank offset 4 per row
+    constexpr int LDK = CHUNK + 8;       // Vt rows (keys): 272 B
+    constexpr int LDO = D + 4;           // fp32 rows: 528 B = 132 words -> bank offset 4 per row
+    __nv_bfloat16* Qs = reinterpret_cast<__nv_bfloat16*>(smem_raw);                                   // [32][LD]
+    __nv_bfloat16* Ks = reinterpret_cast<__nv_bfloat16*>(smem_raw + ROWS * LD * 2);                   // [128][LD]
+    __nv_bfloat16* Vt = reinterpret_cast<__nv_bfloat16*>(smem_raw + (ROWS + CHUNK) * LD * 2);         // [128 dims][LDK]
+    float* Oacc = reinterpret_cast<float*>(smem_raw + (ROWS + CHUNK) * LD * 2 + D * LDK * 2);         // [32][LDO]
+    float* wm = Oacc + ROWS * LDO;                                                                     // [4][32]
+    float* wl = wm + 4 * ROWS;                                                                    // [4][32]
+    const int tid = threadIdx.x, lane = tid & 31, warp = tid >> 5, g = lane >> 2, q = lane & 3;
+    const int s = blockIdx.x, gk = blockIdx.y, b = blockIdx.z;
+    const int q0 = p.cu_q[b], qlen = p.cu_q[b + 1] - q0, kend = p.seqused[b];
+    int kbeg = 0;
+    if (p.window > 0) { kbeg = kend - qlen - p.window + 1; if (kbeg < 0) kbeg = 0; }
+    const int kbase = kbeg + s * CHUNK;
+    const size_t pidx = ((size_t)(b * p.hkv + gk) * p.max_splits + s);
+    float* po = p.part_o + pidx * ROWS * D;
+    if (kbase >= kend || qlen <= 0) {
+        if (tid < ROWS) { p.part_m[pidx * ROWS + tid] = NEG; p.part_l[pidx * ROWS + tid] = 0.f; }
+        for (int i = tid; i < ROWS * D; i += NTHREADS) po[i] = 0.f;
+        return;
+    }
+    // stage Q rows (r = j*8 + i)
+    for (int idx = tid; idx < ROWS * (D / 8); idx += NTHREADS) {
+        const int r = idx / (D / 8), c = idx - r * (D / 8), i = r & 7, j = r >> 3;
+        uint4 v = make_uint4(0u, 0u, 0u, 0u);
+        if (i < qlen) v = *reinterpret_cast<const uint4*>(p.q + (size_t)(q0 + i) * p.q_stride_t + (size_t)(gk * GQA + j) * D + c * 8);
+        *reinterpret_cast<uint4*>(Qs + r * LD + c * 8) = v;
+    }
+    // stage K row (natural) and V row (transposed) for key t = tid
+    {
+        const int kp = kbase + tid;
+        uint4 kv[D / 8], vv[D / 8];
+        if (kp < kend) {
+            const int blk = p.block_table[(size_t)b * p.bt_stride + kp / p.bs], off = kp - (kp / p.bs) * p.bs;
+            const long long rowoff = (long long)blk * p.s_blk + (long long)off * p.s_pos + (long long)gk * p.s_h;
+            const uint4* kr = reinterpret_cast<const uint4*>(p.kc + rowoff);
+            const uint4* vr = reinterpret_cast<const uint4*>(p.vc + rowoff);
+#pragma unroll
+            for (int c = 0; c < D / 8; ++c) { kv[c] = __ldg(kr + c); vv[c] = __ldg(vr + c); }
+        } else {
+#pragma unroll
+            for (int c = 0; c < D / 8; ++c) { kv[c] = make_uint4(0u, 0u, 0u, 0u); vv[c] = make_uint4(0u, 0u, 0u, 0u); }
+        }
+#pragma unroll
+        for (int c = 0; c < D / 8; ++c) *reinterpret_cast<uint4*>(Ks + tid * LD + c * 8) = kv[c];
+#pragma unroll
+        for (int c = 0; c < D / 8; ++c) {
+            const __nv_bfloat16* e = reinterpret_cast<const __nv_bfloat16*>(&vv[c]);
+#pragma unroll
+            for (int k = 0; k < 8; ++k) Vt[(c * 8 + k) * LDK + tid] = e[k];
+        }
+    }
+    __syncthreads();
+    // ---- S = Q K^T for this warp's 32 keys: sfrag[mt][nt][4] ----
+    const int kw0 = warp * 32;
+    float sfrag[2][4][4];
+#pragma unroll
+    for (int mt = 0; mt < 2; ++mt)
+#pragma unroll
+        for (int nt = 0; nt < 4; ++nt)
+#pragma unroll
+            for (int e = 0; e < 4; ++e) sfrag[mt][nt][e] = 0.f;
+#pragma unroll
+    for (int ks = 0; ks < D / 16; ++ks) {
+        uint32_t a[2][4];
+#pragma unroll
+        for (int mt = 0; mt < 2; ++mt) {
+            const int r0 = mt * 16 + g;
+            a[mt][0] = *reinterpret_cast<const uint32_t*>(Qs + r0 * LD + ks * 16 + 2 * q);
+            a[mt][1] = *reinterpret_cast<const uint32_t*>(Qs + (r0 + 8) * LD + ks * 16 + 2 * q);
+            a[mt][2] = *reinterpret_cast<const uint32_t*>(Qs + r0 * LD + ks * 16 + 8 + 2 * q);
+            a[mt][3] = *reinterpret_cast<const uint32_t*>(Qs + (r0 + 8) * LD + ks * 16 + 8 + 2 * q);
+        }
+#pragma unroll
+        for (int nt = 0; nt < 4; ++nt) {
+            const int key = kw0 + nt * 8 + g;
+            uint32_t bb[2];
+            bb[0] = *reinterpret_cast<const uint32_t*>(Ks + key * LD + ks * 16 + 2 * q);
+            bb[1] = *reinterpret_cast<const uint32_t*>(Ks + key * LD + ks * 16 + 8 + 2 * q);
+#pragma unroll
+            for (int mt = 0; mt < 2; ++mt) mma16816(sfrag[mt][nt], a[mt], bb);
+        }
+    }
+    // ---- scale + mask; per-row max over this warp's keys ----
+    float rmax[2][2];   // [mt][half]: rows mt*16+g, mt*16+g+8
+#pragma unroll
+    for (int mt = 0; mt < 2; ++mt) { rmax[mt][0] = NEG; rmax[mt][1] = NEG; }
+#pragma unroll
+    for (int mt = 0; mt < 2; ++mt)
+#pragma unroll
+        for (int nt = 0; nt < 4; ++nt)
+#pragma unroll
+            for (int e = 0; e < 4; ++e) {
+                const int R = mt * 16 + g + 8 * (e >> 1), kk = kw0 + nt * 8 + 2 * q + (e & 1);
+                const int i = R & 7, qpos = kend - qlen + i, kp = kbase + kk;
+                const bool ok = (kp < kend) && (i < qlen) && (!p.causal || kp <= qpos) && (p.window <= 0 || kp > qpos - p.window);
+                const float v = ok ? sfrag[mt][nt][e] * p.scale : NEG;
+                sfrag[mt][nt][e] = v;
+                rmax[mt][e >> 1] = fmaxf(rmax[mt][e >> 1], v);
+            }
+#pragma unroll
+    for (int mt = 0; mt < 2; ++mt)
+#pragma unroll
+        for (int h = 0; h < 2; ++h) {
+            float m = rmax[mt][h];
+            m = fmaxf(m, __shfl_xor_sync(0xffffffffu, m, 1));
+            m = fmaxf(m, __shfl_xor_sync(0xffffffffu, m, 2));
+            rmax[mt][h] = m;
+            if (q == 0) wm[warp * ROWS + mt * 16 + g + 8 * h] = m;
+        }
+    __syncthreads();
+    float mrow[2][2], lsum[2][2];
+#pragma unroll
+    for (int mt = 0; mt < 2; ++mt)
+#pragma unroll
+        for (int h = 0; h < 2; ++h) {
+            const int R = mt * 16 + g + 8 * h;
+            float m = wm[R]; m = fmaxf(m, wm[ROWS + R]); m = fmaxf(m, wm[2 * ROWS + R]); m = fmaxf(m, wm[3 * ROWS + R]);
+            mrow[mt][h] = m; lsum[mt][h] = 0.f;
+        }
+    // p = exp(s - m) (0 where masked or the row is fully masked), partial row sums
+#pragma unroll
+    for (int mt = 0; mt < 2; ++mt)
+#pragma unroll
+        for (int nt = 0; nt < 4; ++nt)
+#pragma unroll
+            for (int e = 0; e < 4; ++e) {
+                const int h = e >> 1;
+                const float m = mrow[mt][h];
+                float pv = 0.f;
+                if (m > -1e29f && sfrag[mt][nt][e] > -1e29f) pv = __expf(sfrag[mt][nt][e] - m);
+                sfrag[mt][nt][e] = pv;
+                lsum[mt][h] += pv;
+            }
+#pragma unroll
+    for (int mt = 0; mt < 2; ++mt)
+#pragma unroll
+        for (int h = 0; h < 2; ++h) {
+            float l = lsum[mt][h];
+            l += __shfl_xor_sync(0xffffffffu, l, 1);
+            l += __shfl_xor_sync(0xffffffffu, l, 2);
+            if (q == 0) wl[warp * ROWS + mt * 16 + g + 8 * h] = l;
+        }
+    // ---- O_w = P_w V_w : ofrag[mt][nt(16)][4] ----
+    uint32_t pa[2][2][4];   // [mt][ks2] A fragments from P (bf16)
+#pragma unroll
+    for (int mt = 0; mt < 2; ++mt)
+#pragma unroll
+        for (int ks2 = 0; ks2 < 2; ++ks2) {
+            pa[mt][ks2][0] = pack_bf16x2(sfrag[mt][2 * ks2][0], sfrag[mt][2 * ks2][1]);
+            pa[mt][ks2][1] = pack_bf16x2(sfrag[mt][2 * ks2][2], sfrag[mt][2 * ks2][3]);
+            pa[mt][ks2][2] = pack_bf16x2(sfrag[mt][2 * ks2 + 1][0], sfrag[mt][2 * ks2 + 1][1]);
+            pa[mt][ks2][3] = pack_bf16x2(sfrag[mt][2 * ks2 + 1][2], sfrag[mt][2 * ks2 + 1][3]);
+        }
+    float ofrag[2][16][4];
+#pragma unroll
+    for (int mt = 0; mt < 2; ++mt)
+#pragma unroll
+        for (int nt = 0; nt < 16; ++nt)
+#pragma unroll
+            for (int e = 0; e < 4; ++e) ofrag[mt][nt][e] = 0.f;
+#pragma unroll
+    for (int ks2 = 0; ks2 < 2; ++ks2) {
+#pragma unroll
+        for (int nt = 0; nt < 16; ++nt) {
+            const int dim = nt * 8 + g;
+            uint32_t bb[2];
+            bb[0] = *reinterpret_cast<const uint32_t*>(Vt + dim * LDK + kw0 + ks2 * 16 + 2 * q);
+            bb[1] = *reinterpret_cast<const uint32_t*>(Vt + dim * LDK + kw0 + ks2 * 16 + 8 + 2 * q);
+#pragma unroll
+            for (int mt = 0; mt < 2; ++mt) mma16816(ofrag[mt][nt], pa[mt][ks2], bb);
+        }
+    }
+    // ---- deterministic cross-warp sum of O into Oacc ----
+#pragma unroll 1
+    for (int w = 0; w < 4; ++w) {
+        if (warp == w) {
+#pragma unroll
+            for (int mt = 0; mt < 2; ++mt)
+#pragma unroll
+                for (int nt = 0; nt < 16; ++nt)
+#pragma unroll
+                    for (int e = 0; e < 4; ++e) {
+                        const int R = mt * 16 + g + 8 * (e >> 1), C = nt * 8 + 2 * q + (e & 1);
+                        if (w == 0) Oacc[R * LDO + C] = ofrag[mt][nt][e];
+                        else Oacc[R * LDO + C] += ofrag[mt][nt][e];
+                    }
+        }
+        __syncthreads();
+    }
+    for (int i = tid; i < ROWS * D; i += NTHREADS) po[i] = Oacc[(i / D) * LDO + (i % D)];
+    if (tid < ROWS) {
+        float m = wm[tid]; m = fmaxf(m, wm[ROWS + tid]); m = fmaxf(m, wm[2 * ROWS + tid]); m = fmaxf(m, wm[3 * ROWS + tid]);
+        const float l = wl[tid] + wl[ROWS + tid] + wl[2 * ROWS + tid] + wl[3 * ROWS + tid];
+        p.part_m[pidx * ROWS + tid] = m; p.part_l[pidx * ROWS + tid] = (m > -1e29f) ? l : 0.f;
+    }
+}
+
+extern "C" int dflash_attn_launch_mma(const void* q, int q_stride_t, const void* kc, const void* vc, long long s_blk, long long s_pos, long long s_h, int bs, int hkv, int H,
+                                      const void* block_table, int bt_stride, const void* seqused, const void* cu_q,
+                                      float scale, int window, int causal, void* part_o, void* part_m, void* part_l, int max_splits,
+                                      int B, void* out, cudaStream_t stream) {
+    Params p;
+    p.q = (const __nv_bfloat16*)q; p.q_stride_t = q_stride_t; p.kc = (const __nv_bfloat16*)kc; p.vc = (const __nv_bfloat16*)vc;
+    p.s_blk = s_blk; p.s_pos = s_pos; p.s_h = s_h;
+    p.bs = bs; p.hkv = hkv; p.H = H; p.block_table = (const int*)block_table; p.bt_stride = bt_stride;
+    p.seqused = (const int*)seqused; p.cu_q = (const int*)cu_q; p.scale = scale; p.window = window; p.causal = causal;
+    p.part_o = (float*)part_o; p.part_m = (float*)part_m; p.part_l = (float*)part_l; p.max_splits = max_splits;
+    p.out = (__nv_bfloat16*)out;
+    const size_t smem = (size_t)(ROWS + CHUNK) * (D + 8) * 2 + (size_t)D * (CHUNK + 8) * 2 + (size_t)ROWS * (D + 4) * 4 + 2 * 4 * ROWS * 4;
+    static bool attr_set = false;
+    if (!attr_set) {
+        cudaGetLastError();
+        if (cudaFuncSetAttribute((const void*)attn_partial_mma_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, (int)smem) != cudaSuccess) return 100;
+        attr_set = true;
+    }
+    attn_partial_mma_kernel<<<dim3(max_splits, hkv, B), NTHREADS, smem, stream>>>(p);
+    cudaError_t e = cudaGetLastError(); if (e != cudaSuccess) return 200 + (int)e;
+    attn_combine_kernel<<<dim3(ROWS, hkv, B), NTHREADS, 0, stream>>>(p);
+    e = cudaGetLastError(); return e == cudaSuccess ? 0 : 300 + (int)e;
+}

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -4,6 +4,7 @@
 
 import copy
 import functools
+import os
 from dataclasses import dataclass
 from typing import ClassVar
 
@@ -298,6 +299,152 @@ def _maybe_symmetrize_window(
     if window is not None and window[0] >= 0 and window[1] == 0 and non_causal:
         return (window[0], window[0])
     return window
+
+
+# ---------------------------------------------------------------------------
+# GLM-5.3 DFlash draft: split-KV paged decode attention fast path.
+# Opt-in with VLLM_GLM53_DFLASH_ATTN=1; every other configuration keeps the
+# FlashAttention call below. See vllm/v1/attention/backends/dflash_attn.
+# ---------------------------------------------------------------------------
+_DFLASH_ATTN = os.getenv("VLLM_GLM53_DFLASH_ATTN", "0") == "1"
+_DFLASH_ATTN_MAX_REQS = int(os.getenv("VLLM_GLM53_DFLASH_ATTN_MAX_REQS", "12"))
+_DFLASH_WS_REQS = int(os.getenv("VLLM_GLM53_DFLASH_ATTN_WS_REQS", "64"))
+_dflash_ops: dict[tuple[int, int, int], object] = {}
+_dflash_stats = {"hits": 0, "fallbacks": 0, "unavailable": False}
+
+
+def _dflash_get_op(impl, key_cache):
+    from vllm.v1.attention.backends import dflash_attn as dfa
+
+    sw = impl.sliding_window
+    key = (key_cache.device.index, impl.num_kv_heads, sw[0] + 1)
+    op = _dflash_ops.get(key)
+    if op is None:
+        op = dfa.DFlashDecodeAttention(
+            key_cache.device,
+            impl.num_kv_heads,
+            max_batch=_DFLASH_WS_REQS,
+            window=sw[0] + 1,
+        )
+        _dflash_ops[key] = op
+        logger.info(
+            "[dflash_attn] split-KV draft attention enabled: hkv=%d window=%d "
+            "max_reqs=%d ws_reqs=%d",
+            impl.num_kv_heads,
+            sw[0] + 1,
+            _DFLASH_ATTN_MAX_REQS,
+            _DFLASH_WS_REQS,
+        )
+    return op
+
+
+def _dflash_fast_path_ok(
+    impl,
+    md,
+    key_cache,
+    causal,
+    is_dynamic_causal,
+    mm_mask_mod,
+    rswa_mask_mod_fn,
+    cu_seqlens_q,
+):
+    if not _DFLASH_ATTN or _dflash_stats["unavailable"]:
+        return False
+    from vllm.v1.attention.backends import dflash_attn as dfa
+
+    sw = getattr(impl, "sliding_window", None)
+    b_pad = int(cu_seqlens_q.shape[0]) - 1
+    shape_ok = (
+        sw is not None
+        and sw[0] > 0
+        and sw[1] == 0
+        and key_cache.dtype == torch.bfloat16
+        and impl.head_size == dfa.HEAD_DIM
+        and impl.num_heads == dfa.GQA * impl.num_kv_heads
+    )
+    # Allocate the workspace (and build/load the library) on the first eager
+    # call: warmup runs at large batch first, and graph capture at small batch
+    # must find it ready.
+    if shape_ok and not torch.cuda.is_current_stream_capturing():
+        if not dfa.is_available(key_cache.device):
+            _dflash_stats["unavailable"] = True
+            return False
+        _dflash_get_op(impl, key_cache)
+    nreq = int(getattr(md, "num_decode_reqs", 0) or 0) + int(
+        getattr(md, "num_prefill_reqs", 0) or 0
+    )
+    if nreq <= 0:
+        nreq = b_pad
+    reason = None
+    if getattr(impl, "vllm_flash_attn_version", 0) != 2:
+        reason = "fa_version"
+    elif is_dynamic_causal or causal not in (True, False):
+        reason = f"causal={causal!r}"
+    elif mm_mask_mod is not None or rswa_mask_mod_fn is not None:
+        reason = "mask_mod"
+    elif not shape_ok:
+        reason = (
+            f"shape h={impl.num_heads} hkv={impl.num_kv_heads} d={impl.head_size} "
+            f"sliding_window={sw} kv={key_cache.dtype}"
+        )
+    elif md.max_query_len > dfa.MAX_QUERY_LEN or md.max_query_len < 1:
+        reason = f"max_query_len={md.max_query_len}"
+    elif getattr(impl, "alibi_slopes", None) is not None or getattr(
+        impl, "logits_soft_cap", None
+    ):
+        reason = "alibi/softcap"
+    elif nreq > _DFLASH_ATTN_MAX_REQS:
+        reason = f"nreq={nreq}"
+    elif b_pad > _DFLASH_WS_REQS:
+        reason = f"B_pad={b_pad}"
+    else:
+        key = (key_cache.device.index, impl.num_kv_heads, sw[0] + 1)
+        if key not in _dflash_ops:
+            reason = "first call during capture"
+    if reason is not None:
+        _dflash_stats["fallbacks"] += 1
+        if _dflash_stats["fallbacks"] <= 3:
+            logger.info(
+                "[dflash_attn] fallback #%d: %s (B_pad=%d nreq=%d max_query_len=%s "
+                "capturing=%s)",
+                _dflash_stats["fallbacks"],
+                reason,
+                b_pad,
+                nreq,
+                getattr(md, "max_query_len", None),
+                torch.cuda.is_current_stream_capturing(),
+            )
+        return False
+    return True
+
+
+def _dflash_run(
+    impl,
+    q,
+    key_cache,
+    value_cache,
+    block_table,
+    seqused_k,
+    cu_seqlens_q,
+    out,
+    causal=True,
+):
+    op = _dflash_get_op(impl, key_cache)
+    op(
+        q,
+        key_cache,
+        value_cache,
+        block_table,
+        seqused_k,
+        cu_seqlens_q,
+        impl.scale,
+        out,
+        num_reqs=int(cu_seqlens_q.shape[0]) - 1,
+        causal=bool(causal),
+    )
+    _dflash_stats["hits"] += 1
+    if _dflash_stats["hits"] == 200:
+        logger.info("[dflash_attn] fast path taken %d times", _dflash_stats["hits"])
 
 
 class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetadata]):
@@ -1086,6 +1233,28 @@ class FlashAttentionImpl(AttentionImpl):
                     )
                     causal = not has_window
 
+                if _dflash_fast_path_ok(
+                    self,
+                    attn_metadata,
+                    key_cache,
+                    causal,
+                    is_dynamic_causal,
+                    mm_mask_mod,
+                    rswa_mask_mod_fn,
+                    cu_seqlens_q,
+                ):
+                    _dflash_run(
+                        self,
+                        query[:num_actual_tokens],
+                        key_cache,
+                        value_cache,
+                        block_table,
+                        seqused_k,
+                        cu_seqlens_q,
+                        output[:num_actual_tokens],
+                        causal=causal,
+                    )
+                    return output
                 flash_attn_varlen_func(
                     q=query[:num_actual_tokens],
                     k=key_cache,


### PR DESCRIPTION
## Purpose

The DFlash2 draft's five layers attend over a 2048-token sliding window with eight query tokens per request and GQA 4 (8 heads over 2 KV heads, head size 128). FlashAttention 2 serves that as one varlen call with a single KV split: 45 to 49 us per layer at concurrency 1, about 0.24 ms of a 10.8 ms verifier step. This adds a split-KV paged decode kernel for exactly that shape, behind an opt-in switch, so the maintainer can evaluate it with the rest of the R22 stack.

## Behavior

- `vllm/v1/attention/backends/dflash_attn/`: the kernel source (`dflash_attn.cu`: 128-key chunks, one CTA per chunk, KV head and request; 32 rows = 8 queries x GQA 4; `mma.sync` m16n8k16 for QK^T and PV; K and transposed V in padded shared memory; fp32 partials combined by a second kernel; causal and symmetric-window modes; strided KV views) and a loader that compiles it once with the toolkit's `nvcc` into `VLLM_CACHE_ROOT/dflash_attn/<hash>/` (or loads `VLLM_GLM53_DFLASH_ATTN_LIB`) and launches it through ctypes.
- FlashAttention backend: with `VLLM_GLM53_DFLASH_ATTN=1` the decode call takes the kernel when the layer is FA2, bf16 KV, head size 128, GQA 4, a positive sliding window, no mask mods, at most 8 query tokens and at most `VLLM_GLM53_DFLASH_ATTN_MAX_REQS` (12) requests; anything else, and the first call during capture, falls back to the existing `flash_attn_varlen_func` call with the reason logged. Default off: nothing changes for other models or backends.
- The workspace is allocated on the first eager call so graph capture at small batch finds it ready.

## Packaging note

The fork runs without vLLM's compiled `_C` extension, so the kernel is not wired into CMake; compiling the shipped source with `nvcc` at first use keeps it self-contained (the serving image carries CUDA 13.3). Moving it into b12x as a CuTe DSL kernel or into the CMake build is the maintainer's call; the loader isolates that choice.

## Numerics

Draft-side only: the target verifier and rejection sampling are untouched. The kernel matches FlashAttention 2 to bf16 rounding (relative error at most 6e-3 across the tested shapes, exact when the window fits one chunk) and is deterministic. No acceptance loss was visible: Sieve coding peak 500 median / 532 max on the stack with it versus 478 / 511 without (both runs include the other R22 changes).

## Validation

Tests, run inside the GLM-5.3 serving image on one RTX PRO 6000 Blackwell (the loader built the library with the image's nvcc during the run):

```text
python -m pytest tests/v1/attention/test_dflash_attn.py
38 passed
```

Nine window/length cases (100 to 9000 keys, mixed batches, partial query lengths) x strided and dense KV layouts x causal and DFlash's non-causal window, each checked against `flash_attn_varlen_func` and for determinism; graph capture/replay equal to eager; workspace bound check.

Kernel time (graph replay, RTX PRO 6000 Blackwell, boosted clocks):

| Shape | FlashAttention 2 | Split-KV |
| --- | ---: | ---: |
| 1 request, 2048 keys | 44.9 us | 13.4 us |
| 8 requests, 4096 keys | 48 us | 24 us |

Serving (GLM-5.3-Flash NVFP4 target, MXFP8 DFlash2 K7 draft, TP4, llm_decode_bench ctx0 30-second cells): five draft layers save about 0.17 ms per verifier step at C1. Fresh-boot four-cell sequences in the same thermal state: 89.23/87.39/87.52/87.15 verifier steps/s with the kernel versus 87.58/87.10/86.24/85.18 without (+1.5% median, 235 vs 228 output tok/s). The first boots fell back silently because the DFlash window is non-causal; the fallback-reason log line in this change is what caught it.

Overlap: `flash_attn.py` is also touched by the open Kimi-K3 series (#563 to #577); this change adds three helper functions and a three-line dispatch in the decode branch.

Generated with Claude Code; the submitter reviewed the change and ran the validation on the listed hardware.
