### PR TITLE
perf(glm5next): run the KDA gate projections on a side stream

### DIFF
--- a/tests/models/test_glm5next_kda_gate_stream.py
+++ b/tests/models/test_glm5next_kda_gate_stream.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The GLM-5.3 KDA gate side stream: same result as the sequential forward,
+gate projections off the main stream, graph-capturable."""
+
+import pytest
+import torch
+
+from vllm.models.glm5next.nvidia import kda as kda_module
+from vllm.models.glm5next.nvidia.kda import Glm5NextLinearAttention
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+HIDDEN, HEADS, HEAD_DIM, GATE_RANK = 64, 2, 16, 8
+PROJ = HEADS * HEAD_DIM
+
+
+class _Linear:
+    """Stands in for a vLLM linear layer: returns (y, None) and records the
+    CUDA stream it ran on."""
+
+    def __init__(self, name, weight, log):
+        self.name, self.weight, self.log = name, weight, log
+
+    def __call__(self, x):
+        self.log.append((self.name, torch.cuda.current_stream(x.device).cuda_stream))
+        return x @ self.weight, None
+
+
+def _make_layer(device, log, generator):
+    def w(rows, cols):
+        return (torch.randn(rows, cols, generator=generator) / rows**0.5).to(
+            device, torch.bfloat16
+        )
+
+    layer = Glm5NextLinearAttention.__new__(Glm5NextLinearAttention)
+    torch.nn.Module.__init__(layer)
+    layer.use_full_rank_gate = False
+    layer.local_projection_size = PROJ
+    layer.local_num_heads = HEADS
+    layer.head_dim = HEAD_DIM
+    layer.in_proj_qkvgfab = _Linear(
+        "in_proj", w(HIDDEN, 3 * PROJ + HEADS + HEAD_DIM), log
+    )
+    layer.g_a_proj = _Linear("g_a", w(HIDDEN, GATE_RANK), log)
+    layer.g_b_proj = _Linear("g_b", w(GATE_RANK, PROJ), log)
+    layer.f_b_proj = _Linear("f_b", w(HEAD_DIM, PROJ), log)
+    layer.o_proj = _Linear("o_proj", w(PROJ, HIDDEN), log)
+
+    def core(*, mixed_qkv, g1, g2, beta, core_attn_out):
+        n = mixed_qkv.shape[0]
+        q = mixed_qkv[:, :PROJ].reshape(1, n, HEADS, HEAD_DIM)
+        core_attn_out.copy_(q * g2 + g1 * beta.reshape(1, n, HEADS, 1))
+
+    layer._forward = core
+    return layer
+
+
+def _run(layer, hidden_states):
+    out = layer(hidden_states, positions=None)
+    torch.cuda.synchronize(hidden_states.device)
+    return out
+
+
+def test_gate_side_stream_matches_sequential_forward(monkeypatch):
+    device = torch.device("cuda", 0)
+    generator = torch.Generator().manual_seed(11)
+    log: list[tuple[str, int]] = []
+    layer = _make_layer(device, log, generator)
+    x = (torch.randn(8, HIDDEN, generator=generator)).to(device, torch.bfloat16)
+
+    monkeypatch.setattr(kda_module, "_GATE_SIDE_STREAM", True)
+    overlapped = _run(layer, x)
+    main = torch.cuda.current_stream(device).cuda_stream
+    streams = dict(log)
+    assert streams["g_a"] != main and streams["g_b"] == streams["g_a"]
+    assert streams["in_proj"] == main and streams["o_proj"] == main
+    log.clear()
+
+    monkeypatch.setattr(kda_module, "_GATE_SIDE_STREAM", False)
+    sequential = _run(layer, x)
+    assert all(stream == main for _, stream in log)
+    assert torch.equal(overlapped, sequential)
+
+
+def test_gate_side_stream_is_graph_capturable(monkeypatch):
+    device = torch.device("cuda", 0)
+    generator = torch.Generator().manual_seed(5)
+    log: list[tuple[str, int]] = []
+    layer = _make_layer(device, log, generator)
+    static = (torch.randn(4, HIDDEN, generator=generator)).to(device, torch.bfloat16)
+    monkeypatch.setattr(kda_module, "_GATE_SIDE_STREAM", True)
+    eager = _run(layer, static)
+
+    stream = torch.cuda.Stream(device=device)
+    stream.wait_stream(torch.cuda.current_stream(device))
+    with torch.cuda.stream(stream):
+        for _ in range(2):
+            layer(static, positions=None)
+    torch.cuda.current_stream(device).wait_stream(stream)
+    torch.cuda.synchronize(device)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        captured = layer(static, positions=None)
+    for _ in range(3):
+        graph.replay()
+        torch.cuda.synchronize(device)
+        assert torch.equal(captured, eager)

--- a/vllm/models/glm5next/nvidia/kda.py
+++ b/vllm/models/glm5next/nvidia/kda.py
@@ -1,12 +1,37 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""GLM-5.3 KDA modeling adapter."""
+"""GLM-5.3 KDA modeling adapter.
+
+Decode-latency variant of the shared KDA forward: the two low-rank output-gate
+projections (``g_a_proj`` then ``g_b_proj``) depend only on the layer input, so
+they are issued on a side CUDA stream and overlap the large fused
+``in_proj_qkvgfab`` GEMM instead of trailing it on the main stream. Kernels,
+shapes and reduction orders are unchanged, so results are bitwise identical to
+the sequential path; only the stream fork/join edges are new. The fork/join
+uses ``wait_stream``, which CUDA graph capture records as dependency edges.
+``VLLM_GLM53_KDA_GATE_SIDE_STREAM=0`` restores the sequential forward.
+"""
+
+import os
 
 import torch
+from einops import rearrange
 
 from vllm.model_executor.layers.mamba.gdn.kimi_gdn_linear_attn import (
     KimiGatedDeltaNetAttention,
 )
+
+_GATE_SIDE_STREAM = os.getenv("VLLM_GLM53_KDA_GATE_SIDE_STREAM", "1") != "0"
+_side_streams: dict[int, torch.cuda.Stream] = {}
+
+
+def _gate_stream(device: torch.device) -> torch.cuda.Stream:
+    index = device.index if device.index is not None else torch.cuda.current_device()
+    stream = _side_streams.get(index)
+    if stream is None:
+        stream = torch.cuda.Stream(device=torch.device("cuda", index))
+        _side_streams[index] = stream
+    return stream
 
 
 class Glm5NextLinearAttention(KimiGatedDeltaNetAttention):
@@ -21,8 +46,66 @@ class Glm5NextLinearAttention(KimiGatedDeltaNetAttention):
         positions: torch.Tensor,
     ) -> torch.Tensor:
         output = torch.empty_like(hidden_states)
-        super().forward(hidden_states, positions, output)
+        if _GATE_SIDE_STREAM and not self.use_full_rank_gate:
+            self._forward_gate_overlap(hidden_states, output)
+        else:
+            super().forward(hidden_states, positions, output)
         return output
+
+    def _forward_gate_overlap(
+        self,
+        hidden_states: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        num_tokens = hidden_states.size(0)
+        main = torch.cuda.current_stream(hidden_states.device)
+        side = _gate_stream(hidden_states.device)
+
+        # Fork: the gate projections read only hidden_states.
+        side.wait_stream(main)
+        # Keep hidden_states alive for the side stream (allocator safety in
+        # eager/warmup mode; a no-op inside graph capture).
+        hidden_states.record_stream(side)
+        with torch.cuda.stream(side):
+            g_proj_states = self.g_b_proj(self.g_a_proj(hidden_states)[0])[0]
+
+        projected_qkvgfab = self.in_proj_qkvgfab(hidden_states)[0]
+        # Same optional callback the shared forward offers after its first
+        # projection (e.g. the L2 weight prefetch of o_proj).
+        hook = getattr(self, "_l2_prefetch_hook", None)
+        if hook is not None:
+            hook(num_tokens)
+        mixed_qkv, beta, f_a = projected_qkvgfab.split(
+            [
+                3 * self.local_projection_size,
+                self.local_num_heads,
+                self.head_dim,
+            ],
+            dim=-1,
+        )
+        g1 = self.f_b_proj(f_a)[0]
+        beta = beta.unsqueeze(0)
+        g1 = rearrange(g1, "n (h d) -> 1 n h d", d=self.head_dim)
+
+        # Join before anything reads the gate states.
+        main.wait_stream(side)
+        g_proj_states.record_stream(main)
+        g2 = rearrange(g_proj_states, "... (h d) -> ... h d", d=self.head_dim)
+
+        core_attn_out = torch.empty(
+            (1, num_tokens, self.local_num_heads, self.head_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        self._forward(
+            mixed_qkv=mixed_qkv,
+            g1=g1,
+            g2=g2,
+            beta=beta,
+            core_attn_out=core_attn_out,
+        )
+        core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
+        output[:] = self.o_proj(core_attn_out)[0]
 
 
 __all__ = ["Glm5NextLinearAttention"]


### PR DESCRIPTION
## Purpose

The GLM-5.3 KDA layer's two low-rank output-gate projections (`g_a_proj` then `g_b_proj`) depend only on the layer input but trail the large fused `in_proj_qkvgfab` GEMM on the main stream. Run them on a side CUDA stream so they overlap that GEMM. This is part of the R22 serving stack and is filed so the maintainer can evaluate it with the rest; its isolated gain has not been measured (see below).

## Behavior

- `Glm5NextLinearAttention.forward` forks a per-device side stream before `in_proj_qkvgfab`, runs `g_b_proj(g_a_proj(x))` there, and joins before the gate states are read. Kernels, shapes and reduction orders are unchanged, so the output is bitwise identical to the shared sequential forward; only the fork/join edges are new, and CUDA graph capture records them as dependencies.
- The optional `_l2_prefetch_hook` of the shared forward (#576) is honoured at the same point.
- Full-rank-gate configurations keep the shared forward. `VLLM_GLM53_KDA_GATE_SIDE_STREAM=0` restores it for all configurations.

## Validation

Tests inside the GLM-5.3 serving image on one RTX PRO 6000 Blackwell (a stub layer with recorded streams):

```text
python -m pytest tests/models/test_glm5next_kda_gate_stream.py
2 passed
```

They check that the gate projections run on a stream other than the main one and every other projection on the main stream, that the result equals the sequential forward bitwise, and that the overlapped forward captures into a CUDA graph and replays equal to eager.

Measurements: in the greedy C1 torch-profiler trace of the serving stack (GLM-5.3-Flash NVFP4 target, MXFP8 DFlash2 K7 draft, TP4) the gate side stream carries 0.70 ms of GEMM time per verifier step that previously sat on the main stream (main stream 6.1 ms, second stream 4.35 ms, prefetch 2.05 ms, gate side stream 0.70 ms). The only end-to-end comparison on record is confounded: the #576 files as-is (CuTe prefetch kernel, no gate side stream) measured 89.7 verifier steps/s at C1 against 91.1 for the overlay stack with it, but that pair also differs in the prefetch kernel implementation. An A/B with `VLLM_GLM53_KDA_GATE_SIDE_STREAM=0` on the same boot is the outstanding measurement; the change is filed for completeness of the R22 stack.

Precision: identical kernels and inputs; bitwise-equal output by construction and by test. The R10n greedy gates (Estonia 29/30; LAVD 28 exact, 0 near, 1 fail, 1 truncated) ran with this change live.

Merge simulation against #576 completes without conflicts; #495 touches `kda.py` in a different region (its conflicts with the current branch are in files this change does not touch).

Generated with Claude Code; the submitter reviewed the change and ran the validation on the listed hardware.
