### PR TITLE
fix(hybrid): preserve cache reuse and decode under prefill pressure

### DIFF
--- a/tests/models/deepseek_v32/test_sequence_parallel.py
+++ b/tests/models/deepseek_v32/test_sequence_parallel.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 import torch
 from torch import nn
 
+from vllm.models.deepseek_v32 import attention as deepseek_v32_attention
 from vllm.models.deepseek_v32.nvidia import model as deepseek_v32_model
 from vllm.models.deepseek_v32.nvidia import mtp as deepseek_v32_mtp
 
@@ -80,6 +81,26 @@ def _mock_sequence_parallel_collectives(monkeypatch, module):
         "sp_all_gather",
         lambda tensor: torch.cat([tensor, tensor], dim=0),
     )
+
+
+def test_sparse_mla_dcp_gathers_query_without_pcp():
+    q_nope = torch.arange(8, dtype=torch.float32).view(1, 2, 4)
+    q_pe = torch.arange(4, dtype=torch.float32).view(1, 2, 2)
+    query_gather = Mock(side_effect=lambda query: torch.cat([query, query], dim=1))
+    dcp_manager = SimpleNamespace(query_gather=query_gather)
+
+    gathered = deepseek_v32_attention._gather_mqa_query_for_dcp(
+        (q_nope, q_pe),
+        use_pcp=False,
+        dcp_world_size=2,
+        pcp_world_size=1,
+        dcp_manager=dcp_manager,
+    )
+
+    local_query = torch.cat((q_nope, q_pe), dim=-1)
+    torch.testing.assert_close(gathered, torch.cat((local_query, local_query), dim=1))
+    assert query_gather.call_count == 1
+    torch.testing.assert_close(query_gather.call_args.args[0], local_query)
 
 
 def test_decoder_layer_keeps_dense_states_sequence_sharded(monkeypatch):

--- a/tests/v1/attention/test_dcp_ops.py
+++ b/tests/v1/attention/test_dcp_ops.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.v1.attention.ops.dcp import mask_dcp_empty_shards_
+
+
+def test_mask_dcp_empty_shards_with_no_local_sequences() -> None:
+    lse = torch.zeros((4, 1), dtype=torch.float32)
+    seq_lens = torch.empty((0,), dtype=torch.int32)
+    query_start_loc = torch.zeros((1,), dtype=torch.int32)
+
+    mask_dcp_empty_shards_(lse, seq_lens, query_start_loc)
+
+    assert torch.isneginf(lse).all()

--- a/tests/v1/core/test_lp14_hybrid_cache.py
+++ b/tests/v1/core/test_lp14_hybrid_cache.py
@@ -1,0 +1,388 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""LP14 regressions for EAGLE hybrid prefix-cache replay boundaries."""
+
+
+
+import pytest
+import torch
+
+from tests.v1.core.test_prefix_caching import make_kv_cache_manager, make_request
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import init_none_hash
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+    MLAAttentionSpec,
+    SlidingWindowSpec,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.fixture(autouse=True)
+def _init_hash() -> None:
+    init_none_hash(sha256)
+
+
+@pytest.mark.parametrize("annotation", [None, "full_only", "both"])
+def test_mamba_retains_eagle_reachable_boundary(annotation: str | None) -> None:
+    block_size = 32
+    num_spec = 3
+    manager = make_kv_cache_manager(
+        kv_cache_config=KVCacheConfig(
+            num_blocks=100,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["full"],
+                    FullAttentionSpec(
+                        block_size=block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float16,
+                    ),
+                    is_eagle_group=annotation in ("full_only", "both"),
+                ),
+                KVCacheGroupSpec(
+                    ["mamba"],
+                    MambaSpec(
+                        block_size=block_size,
+                        shapes=((1, 1),),
+                        dtypes=(torch.float32,),
+                        mamba_cache_mode="align",
+                        num_speculative_blocks=num_spec,
+                    ),
+                    is_eagle_group=annotation == "both",
+                ),
+            ],
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+    token_ids = [i for i in range(3) for _ in range(block_size)] + [3] * 31
+    producer = make_request("producer", token_ids, block_size, sha256)
+    computed, num_computed, _ = manager.get_computed_blocks(producer)
+    for chunk_end in (32, 64, 96, 127):
+        blocks = manager.allocate_slots(
+            producer,
+            chunk_end - producer.num_computed_tokens,
+            num_computed,
+            computed,
+            num_lookahead_tokens=num_spec,
+        )
+        assert blocks is not None, (request.request_id, request.num_computed_tokens, manager.usage)
+        producer.num_computed_tokens = chunk_end
+    manager.free(producer)
+
+    replay = make_request("replay", token_ids, block_size, sha256)
+    _, hit_tokens, _ = manager.get_computed_blocks(replay)
+    assert hit_tokens == 2 * block_size
+
+
+def test_mamba_eagle_backoff_uses_alignment_unit() -> None:
+    mamba_block = 32
+    alignment = 64
+    manager = make_kv_cache_manager(
+        kv_cache_config=KVCacheConfig(
+            num_blocks=200,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["full"],
+                    FullAttentionSpec(
+                        block_size=alignment,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float16,
+                    ),
+                    is_eagle_group=True,
+                ),
+                KVCacheGroupSpec(
+                    ["mamba"],
+                    MambaSpec(
+                        block_size=mamba_block,
+                        shapes=((1, 1),),
+                        dtypes=(torch.float32,),
+                        mamba_cache_mode="align",
+                    ),
+                    is_eagle_group=True,
+                ),
+            ],
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=mamba_block,
+        retention_interval=0,
+        use_eagle=True,
+    )
+    token_ids = [i for i in range(7) for _ in range(mamba_block)] + [7] * 31
+    producer = make_request("producer", token_ids, mamba_block, sha256)
+    computed, num_computed, _ = manager.get_computed_blocks(producer)
+    for chunk_end in (64, 128, 192, 255):
+        blocks = manager.allocate_slots(
+            producer,
+            chunk_end - producer.num_computed_tokens,
+            num_computed,
+            computed,
+        )
+        assert blocks is not None, (request.request_id, request.num_computed_tokens, manager.usage)
+        producer.num_computed_tokens = chunk_end
+    manager.free(producer)
+
+    replay = make_request("replay", token_ids, mamba_block, sha256)
+    _, hit_tokens, _ = manager.get_computed_blocks(replay)
+    assert hit_tokens == 2 * alignment
+
+
+def _compute_in_chunks(manager, request, chunk_size: int) -> None:
+    while request.num_computed_tokens < request.num_tokens:
+        chunk = min(chunk_size, request.num_tokens - request.num_computed_tokens)
+        blocks = manager.allocate_slots(request, chunk)
+        assert blocks is not None, (request.request_id, request.num_computed_tokens, manager.usage)
+        request.num_computed_tokens += chunk
+        manager.new_step_starts()
+    manager.cache_blocks(request, request.num_computed_tokens)
+    manager.free(request)
+    manager.new_step_starts()
+
+
+def test_dcp1_dflash_growing_history_reuses_warm_boundary() -> None:
+    """DCP1 must retain the boundary below the EAGLE-dropped candidate."""
+
+    block_size = 2304
+    manager = make_kv_cache_manager(
+        KVCacheConfig(
+            num_blocks=2000,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["target"],
+                    MLAAttentionSpec(
+                        block_size=block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float16,
+                        tokens_per_state=4,
+                    ),
+                ),
+                KVCacheGroupSpec(
+                    ["mamba"],
+                    MambaSpec(
+                        block_size=block_size,
+                        shapes=((1, 1),),
+                        dtypes=(torch.float32,),
+                        mamba_cache_mode="align",
+                    ),
+                ),
+                KVCacheGroupSpec(
+                    ["draft"],
+                    SlidingWindowSpec(
+                        block_size=block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float16,
+                        sliding_window=2048,
+                        dcp_replicated=False,
+                        extra_retained_tokens=2048,
+                    ),
+                ),
+            ],
+            prefix_cache_retention_interval=0,
+        ),
+        max_model_len=524288,
+        max_in_flight_tokens=8192,
+        enable_caching=True,
+        use_eagle=True,
+        hash_block_size=block_size,
+        scheduler_block_size=block_size,
+        dcp_world_size=1,
+    )
+    warm_tokens = list(range(122871))
+    producer = make_request("warm", warm_tokens, block_size, sha256)
+    _compute_in_chunks(manager, producer, block_size)
+
+    growing_tokens = [*warm_tokens[:122869], *range(200000, 212279)]
+    replay = make_request("turn_1", growing_tokens, block_size, sha256)
+    _, per_group = manager.coordinator.find_longest_cache_hit_per_group(
+        replay.block_hashes, replay.num_tokens - 1
+    )
+    _, hit_tokens, _ = manager.get_computed_blocks(replay)
+    assert per_group == (119808, 122112, 119808), per_group
+    assert hit_tokens == 119808, hit_tokens
+
+
+
+def _make_dcp1_glm_manager(num_blocks: int = 10000):
+    block_size = 2304
+    return make_kv_cache_manager(
+        KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["target"],
+                    MLAAttentionSpec(
+                        block_size=block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float16,
+                        tokens_per_state=4,
+                    ),
+                ),
+                KVCacheGroupSpec(
+                    ["mamba"],
+                    MambaSpec(
+                        block_size=block_size,
+                        shapes=((1, 1),),
+                        dtypes=(torch.float32,),
+                        mamba_cache_mode="align",
+                    ),
+                ),
+                KVCacheGroupSpec(
+                    ["draft"],
+                    SlidingWindowSpec(
+                        block_size=block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float16,
+                        sliding_window=2048,
+                        dcp_replicated=False,
+                        extra_retained_tokens=2048,
+                    ),
+                ),
+            ],
+            prefix_cache_retention_interval=0,
+        ),
+        max_model_len=524288,
+        max_in_flight_tokens=8192,
+        enable_caching=True,
+        use_eagle=True,
+        hash_block_size=block_size,
+        scheduler_block_size=block_size,
+        dcp_world_size=1,
+    )
+
+
+def _resume_compute_and_release(manager, request, expected_hit: int) -> None:
+    computed, hit_tokens, shared_boundary = manager.get_computed_blocks(request)
+    assert hit_tokens == expected_hit
+    request.shared_prefix_boundary = shared_boundary
+    first = True
+    while request.num_computed_tokens < request.num_tokens:
+        already = hit_tokens if first else request.num_computed_tokens
+        chunk = min(2304, request.num_tokens - already)
+        blocks = manager.allocate_slots(
+            request,
+            chunk,
+            num_new_computed_tokens=hit_tokens if first else 0,
+            new_computed_blocks=computed if first else None,
+        )
+        assert blocks is not None, (request.request_id, request.num_computed_tokens, manager.usage)
+        request.num_computed_tokens = already + chunk
+        manager.new_step_starts()
+        first = False
+    manager.cache_blocks(request, request.num_computed_tokens)
+    manager.free(request)
+    manager.new_step_starts()
+
+
+def test_dcp1_twenty_growing_histories_reuse_each_turn() -> None:
+    manager = _make_dcp1_glm_manager()
+    histories: list[tuple[list[int], list[list[int]]]] = []
+    for agent in range(20):
+        start = agent * 1_000_000
+        warm = list(range(start, start + 122871))
+        turn_1 = [*warm[:122869], *range(start + 200000, start + 212279)]
+        turn_2 = [*turn_1, *range(start + 300000, start + 312269)]
+        turn_3 = [*turn_2, *range(start + 400000, start + 412269)]
+        histories.append((warm, [turn_1, turn_2, turn_3]))
+
+    for agent, (warm, _) in enumerate(histories):
+        request = make_request(f"agent_{agent}_warm", warm, 2304, sha256)
+        _compute_in_chunks(manager, request, 2304)
+
+    expected_hits = (119808, 131328, 142848)
+    total_hits = 0
+    for turn, expected in enumerate(expected_hits):
+        for agent, (_, turns) in enumerate(histories):
+            request = make_request(
+                f"agent_{agent}_turn_{turn}", turns[turn], 2304, sha256
+            )
+            _resume_compute_and_release(manager, request, expected)
+            total_hits += expected
+
+    assert total_hits == 7_879_680
+
+
+
+def test_dcp4_dflash_growing_history_reuses_warm_boundary() -> None:
+    block_size = 2304
+    manager = make_kv_cache_manager(
+        KVCacheConfig(
+            num_blocks=4000,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["target"],
+                    MLAAttentionSpec(
+                        block_size=block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float16,
+                        tokens_per_state=4,
+                    ),
+                    is_eagle_group=True,
+                ),
+                KVCacheGroupSpec(
+                    ["mamba"],
+                    MambaSpec(
+                        block_size=block_size,
+                        shapes=((1, 1),),
+                        dtypes=(torch.float32,),
+                        mamba_cache_mode="align",
+                    ),
+                    is_eagle_group=True,
+                ),
+                KVCacheGroupSpec(
+                    ["draft"],
+                    SlidingWindowSpec(
+                        block_size=block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float16,
+                        sliding_window=2048,
+                        dcp_replicated=True,
+                        extra_retained_tokens=2048,
+                    ),
+                    is_eagle_group=True,
+                ),
+            ],
+            prefix_cache_retention_interval=0,
+        ),
+        max_model_len=524288,
+        max_in_flight_tokens=8192,
+        enable_caching=True,
+        use_eagle=False,
+        hash_block_size=block_size,
+        scheduler_block_size=4 * block_size,
+        dcp_world_size=4,
+    )
+    warm_tokens = list(range(122871))
+    producer = make_request("dcp4_warm", warm_tokens, block_size, sha256)
+    _compute_in_chunks(manager, producer, block_size)
+
+    growing_tokens = [*warm_tokens[:122869], *range(200000, 212279)]
+    replay = make_request("dcp4_turn_1", growing_tokens, block_size, sha256)
+    _, per_group = manager.coordinator.find_longest_cache_hit_per_group(
+        replay.block_hashes, replay.num_tokens - 1
+    )
+    _, hit_tokens, _ = manager.get_computed_blocks(replay)
+    assert per_group == (119808, 122112, 119808), per_group
+    assert hit_tokens == 117504, hit_tokens
+    assert min(per_group) - hit_tokens == block_size

--- a/tests/v1/core/test_lp14_hybrid_cache.py
+++ b/tests/v1/core/test_lp14_hybrid_cache.py
@@ -2,8 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """LP14 regressions for EAGLE hybrid prefix-cache replay boundaries."""
 
-
-
 import pytest
 import torch
 
@@ -76,7 +74,11 @@ def test_mamba_retains_eagle_reachable_boundary(annotation: str | None) -> None:
             computed,
             num_lookahead_tokens=num_spec,
         )
-        assert blocks is not None, (request.request_id, request.num_computed_tokens, manager.usage)
+        assert blocks is not None, (
+            producer.request_id,
+            producer.num_computed_tokens,
+            manager.usage,
+        )
         producer.num_computed_tokens = chunk_end
     manager.free(producer)
 
@@ -131,7 +133,11 @@ def test_mamba_eagle_backoff_uses_alignment_unit() -> None:
             num_computed,
             computed,
         )
-        assert blocks is not None, (request.request_id, request.num_computed_tokens, manager.usage)
+        assert blocks is not None, (
+            producer.request_id,
+            producer.num_computed_tokens,
+            manager.usage,
+        )
         producer.num_computed_tokens = chunk_end
     manager.free(producer)
 
@@ -144,7 +150,11 @@ def _compute_in_chunks(manager, request, chunk_size: int) -> None:
     while request.num_computed_tokens < request.num_tokens:
         chunk = min(chunk_size, request.num_tokens - request.num_computed_tokens)
         blocks = manager.allocate_slots(request, chunk)
-        assert blocks is not None, (request.request_id, request.num_computed_tokens, manager.usage)
+        assert blocks is not None, (
+            request.request_id,
+            request.num_computed_tokens,
+            manager.usage,
+        )
         request.num_computed_tokens += chunk
         manager.new_step_starts()
     manager.cache_blocks(request, request.num_computed_tokens)
@@ -217,7 +227,6 @@ def test_dcp1_dflash_growing_history_reuses_warm_boundary() -> None:
     assert hit_tokens == 119808, hit_tokens
 
 
-
 def _make_dcp1_glm_manager(num_blocks: int = 10000):
     block_size = 2304
     return make_kv_cache_manager(
@@ -283,7 +292,11 @@ def _resume_compute_and_release(manager, request, expected_hit: int) -> None:
             num_new_computed_tokens=hit_tokens if first else 0,
             new_computed_blocks=computed if first else None,
         )
-        assert blocks is not None, (request.request_id, request.num_computed_tokens, manager.usage)
+        assert blocks is not None, (
+            request.request_id,
+            request.num_computed_tokens,
+            manager.usage,
+        )
         request.num_computed_tokens = already + chunk
         manager.new_step_starts()
         first = False
@@ -318,7 +331,6 @@ def test_dcp1_twenty_growing_histories_reuse_each_turn() -> None:
             total_hits += expected
 
     assert total_hits == 7_879_680
-
 
 
 def test_dcp4_dflash_growing_history_reuses_warm_boundary() -> None:

--- a/tests/v1/core/test_lp15_upstream_cache_regressions.py
+++ b/tests/v1/core/test_lp15_upstream_cache_regressions.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""LP15 controls adapted from official vLLM hybrid-cache PRs.
+
+PRs 52244 and 53802 cover exact prompt-boundary registration. PR 52371
+pins the EAGLE/Mamba reconciliation loss, and PR 53945 adds a fine-grained
+resume checkpoint. LP15 production does not enable fine-grained hashing, so
+the aligned cases are hard regressions while the optional fine-grained case
+stays an explicit upstream xfail.
+"""
+
+import pytest
+import torch
+
+from tests.v1.core.test_prefix_caching import make_kv_cache_manager, make_request
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import init_none_hash
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
+
+
+@pytest.fixture(autouse=True)
+def _init_hash() -> None:
+    init_none_hash(sha256)
+
+
+def _manager(block_size: int, hash_block_size: int):
+    return make_kv_cache_manager(
+        kv_cache_config=KVCacheConfig(
+            num_blocks=256,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["full"],
+                    FullAttentionSpec(
+                        block_size=block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                    ),
+                    is_eagle_group=True,
+                ),
+                KVCacheGroupSpec(
+                    ["mamba"],
+                    MambaSpec(
+                        block_size=block_size,
+                        shapes=((1, 1),),
+                        dtypes=(torch.float32,),
+                        mamba_cache_mode="align",
+                    ),
+                ),
+            ],
+        ),
+        max_model_len=4096,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        use_eagle=True,
+    )
+
+
+def _seed(manager, request, stops: tuple[int, ...]) -> None:
+    computed, num_computed, _ = manager.get_computed_blocks(request)
+    first = True
+    for stop in stops:
+        step = stop - request.num_computed_tokens
+        blocks = manager.allocate_slots(
+            request,
+            step,
+            num_computed if first else 0,
+            computed if first else None,
+        )
+        assert blocks is not None
+        request.num_computed_tokens = stop
+        manager.new_step_starts()
+        first = False
+    manager.cache_blocks(request, request.num_computed_tokens)
+    manager.free(request)
+    manager.new_step_starts()
+
+
+def _hits(manager, token_ids: list[int]) -> tuple[int, tuple[int, ...]]:
+    follower = make_request("follower", token_ids, manager.block_pool.hash_block_size, sha256)
+    _, joint, _ = manager.get_computed_blocks(follower)
+    _, per_group = manager.coordinator.find_longest_cache_hit_per_group(
+        follower.block_hashes, follower.num_tokens - 1
+    )
+    return joint, tuple(per_group)
+
+
+def test_exact_aligned_prompt_retains_post_eagle_resume_state() -> None:
+    block = 16
+    manager = _manager(block, block)
+    owner = make_request("owner", [7] * 48, block, sha256)
+    _seed(manager, owner, (16, 32, 48))
+
+    joint, per_group = _hits(manager, [7] * 48 + [9] * 8)
+
+    assert per_group == (32, 48)
+    assert joint == 32
+
+
+def test_shared_system_boundary_retains_post_eagle_resume_state() -> None:
+    block = 16
+    manager = _manager(block, block)
+    owner = make_request("owner", [7] * 32 + [8] * 16, block, sha256)
+    _seed(manager, owner, (16, 32, 48))
+
+    joint, per_group = _hits(manager, [7] * 32 + [9] * 8)
+
+    assert per_group == (16, 32)
+    assert joint == 16
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "official PR 53945 fine-grained resume checkpoints remain opt-in and "
+        "LP15 production keeps hash and scheduler alignment equal"
+    ),
+)
+def test_fine_grained_resume_checkpoint_is_not_claimed() -> None:
+    block = 16
+    hash_unit = 4
+    manager = _manager(block, hash_unit)
+    owner = make_request("owner", [7] * 48, hash_unit, sha256)
+    _seed(manager, owner, (12, 16, 28, 32, 44, 48))
+
+    joint, per_group = _hits(manager, [7] * 48 + [9] * 8)
+
+    assert min(per_group) >= 44
+    assert joint == 44

--- a/tests/v1/core/test_lp15_upstream_cache_regressions.py
+++ b/tests/v1/core/test_lp15_upstream_cache_regressions.py
@@ -83,7 +83,9 @@ def _seed(manager, request, stops: tuple[int, ...]) -> None:
 
 
 def _hits(manager, token_ids: list[int]) -> tuple[int, tuple[int, ...]]:
-    follower = make_request("follower", token_ids, manager.block_pool.hash_block_size, sha256)
+    follower = make_request(
+        "follower", token_ids, manager.block_pool.hash_block_size, sha256
+    )
     _, joint, _ = manager.get_computed_blocks(follower)
     _, per_group = manager.coordinator.find_longest_cache_hit_per_group(
         follower.block_hashes, follower.num_tokens - 1

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -4599,9 +4599,10 @@ def test_dflash_multi_history_retains_cacheable_replay_boundaries():
     assert result.reconciled_hit_tokens >= 0.90 * result.cacheable_prefix_tokens
     assert result.reconciled_hit_tokens == min(result.per_group_hit_tokens.values())
     assert result.dense_intermediate_checkpoints == 0
-    assert min(
-        result.per_group_hit_tokens, key=result.per_group_hit_tokens.get
-    ) == "group_0_mlaattentionspec"
+    assert (
+        min(result.per_group_hit_tokens, key=result.per_group_hit_tokens.get)
+        == "group_0_mlaattentionspec"
+    )
     assert result.lookup_stats.cacheable_prefix_tokens == result.cacheable_prefix_tokens
     assert result.lookup_stats.reconciled_hit_tokens == result.reconciled_hit_tokens
     assert result.lookup_stats.prefix_cache_group_hits == result.per_group_hit_tokens

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -29,6 +29,7 @@ from vllm.sampling_params import SamplingParams
 from vllm.utils.hashing import sha256, sha256_cbor
 from vllm.v1.core.block_pool import BlockHashToBlockMap, BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager, Request
+from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     BlockHashWithGroupId,
@@ -4438,3 +4439,155 @@ def test_swa_shared_prefix_reuse_under_zero_retention():
     assert last_req_hit(retention=0, pin=False) == 0
     # retention=0 with the pin keeps the junction window -> reuse restored.
     assert last_req_hit(retention=0, pin=True) == 4 * block_size
+
+
+def make_glm53_dflash_manager(num_blocks: int) -> KVCacheManager:
+    hash_block_size = 2304
+    config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["target"],
+                MLAAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                    tokens_per_state=4,
+                ),
+                is_eagle_group=True,
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=hash_block_size,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+                is_eagle_group=True,
+            ),
+            KVCacheGroupSpec(
+                ["draft"],
+                SlidingWindowSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                    sliding_window=2048,
+                    dcp_replicated=True,
+                    extra_retained_tokens=2048,
+                ),
+                is_eagle_group=True,
+            ),
+        ],
+        prefix_cache_retention_interval=0,
+    )
+    return make_kv_cache_manager(
+        config,
+        max_model_len=524288,
+        max_in_flight_tokens=8192,
+        enable_caching=True,
+        use_eagle=False,
+        hash_block_size=hash_block_size,
+        scheduler_block_size=4 * hash_block_size,
+        dcp_world_size=4,
+        metrics_collector=KVCacheMetricsCollector(sample_rate=1.0),
+    )
+
+
+def make_distinct_history_requests(agents: int, turns: int) -> list[list[Request]]:
+    block_size = 2304
+    prompt_tokens = 59 * block_size
+    histories = []
+    for agent in range(agents):
+        token_ids = list(range(agent * prompt_tokens, (agent + 1) * prompt_tokens))
+        histories.append(
+            [
+                make_request(
+                    f"agent_{agent}_turn_{turn}", token_ids, block_size, sha256
+                )
+                for turn in range(turns)
+            ]
+        )
+    return histories
+
+
+def _compute_and_release(manager: KVCacheManager, request: Request) -> None:
+    while request.num_computed_tokens < request.num_tokens:
+        chunk = min(2304, request.num_tokens - request.num_computed_tokens)
+        blocks = manager.allocate_slots(request, chunk)
+        assert blocks is not None
+        request.num_computed_tokens += chunk
+    manager.cache_blocks(request, request.num_computed_tokens)
+    manager.free(request)
+
+
+def exercise_history_replays(
+    manager: KVCacheManager, histories: list[list[Request]]
+) -> SimpleNamespace:
+    for agent, turns in enumerate(histories):
+        warm = make_request(
+            f"agent_{agent}_warm", list(turns[0].prompt_token_ids), 2304, sha256
+        )
+        _compute_and_release(manager, warm)
+
+    # Hold enough uncached working blocks to force LRU eviction of a small,
+    # deterministic part of the warmed history set while replays are measured.
+    pressure_blocks = manager.block_pool.get_new_blocks(2000)
+
+    per_group_hits = [0] * manager.num_kv_cache_groups
+    reconciled_hits = 0
+    for turns in histories:
+        for request in turns:
+            _, group_hits = manager.coordinator.find_longest_cache_hit_per_group(
+                request.block_hashes, request.num_tokens - 1
+            )
+            _, hit_tokens, _ = manager.get_computed_blocks(request)
+            reconciled_hits += hit_tokens
+            for group_id, group_hit in enumerate(group_hits):
+                per_group_hits[group_id] += group_hit
+
+    dense_intermediate_checkpoints = 0
+    for turns in histories:
+        request = turns[0]
+        for group_id in (1, 2):
+            cached = [
+                i
+                for i, block_hash in enumerate(request.block_hashes)
+                if manager.block_pool.get_cached_block(
+                    block_hash, kv_cache_group_ids=[group_id]
+                )
+                is not None
+            ]
+            dense_intermediate_checkpoints += sum(i < 54 for i in cached)
+
+    manager.block_pool.free_blocks(pressure_blocks)
+
+    lookup_stats = manager.metrics_collector.drain_prefix_lookup_stats()
+    labels = manager.coordinator.prefix_cache_group_labels
+    return SimpleNamespace(
+        cacheable_prefix_tokens=len(histories) * len(histories[0]) * 57 * 2304,
+        reconciled_hit_tokens=reconciled_hits,
+        per_group_hit_tokens=dict(zip(labels, per_group_hits)),
+        dense_intermediate_checkpoints=dense_intermediate_checkpoints,
+        lookup_stats=lookup_stats,
+    )
+
+
+def test_dflash_multi_history_retains_cacheable_replay_boundaries():
+    manager = make_glm53_dflash_manager(num_blocks=2400)
+    requests = make_distinct_history_requests(agents=20, turns=3)
+    result = exercise_history_replays(manager, requests)
+    assert result.cacheable_prefix_tokens == 7_879_680
+    assert result.reconciled_hit_tokens >= 0.90 * result.cacheable_prefix_tokens
+    assert result.reconciled_hit_tokens == min(result.per_group_hit_tokens.values())
+    assert result.dense_intermediate_checkpoints == 0
+    assert min(
+        result.per_group_hit_tokens, key=result.per_group_hit_tokens.get
+    ) == "group_0_mlaattentionspec"
+    assert result.lookup_stats.cacheable_prefix_tokens == result.cacheable_prefix_tokens
+    assert result.lookup_stats.reconciled_hit_tokens == result.reconciled_hit_tokens
+    assert result.lookup_stats.prefix_cache_group_hits == result.per_group_hit_tokens
+    assert sum(result.lookup_stats.boundary_evictions.values()) > 0

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -4545,6 +4545,7 @@ def exercise_history_replays(
                 request.block_hashes, request.num_tokens - 1
             )
             _, hit_tokens, _ = manager.get_computed_blocks(request)
+            manager.record_prefix_cache_stats(request, hit_tokens)
             reconciled_hits += hit_tokens
             for group_id, group_hit in enumerate(group_hits):
                 per_group_hits[group_id] += group_hit
@@ -4574,6 +4575,20 @@ def exercise_history_replays(
         dense_intermediate_checkpoints=dense_intermediate_checkpoints,
         lookup_stats=lookup_stats,
     )
+
+
+def test_hybrid_metrics_emit_once_at_admission():
+    manager = make_glm53_dflash_manager(num_blocks=2400)
+    request = make_distinct_history_requests(agents=1, turns=1)[0][0]
+
+    _, hit_tokens, _ = manager.get_computed_blocks(request)
+    manager.get_computed_blocks(request)
+    before_admission = manager.metrics_collector.drain_prefix_lookup_stats()
+    assert before_admission.cacheable_prefix_tokens == 0
+
+    manager.record_prefix_cache_stats(request, hit_tokens)
+    admitted = manager.metrics_collector.drain_prefix_lookup_stats()
+    assert admitted.cacheable_prefix_tokens == 57 * 2304
 
 
 def test_dflash_multi_history_retains_cacheable_replay_boundaries():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3492,6 +3492,110 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     assert [len(blocks) for blocks in computed_blocks.blocks] == [3, 12]
 
 
+def test_dcp_hybrid_dflash_reuses_chunked_prompt_boundary():
+    """DCP-sharded target + Mamba + replicated DFlash keeps one common hit."""
+    hash_block_size = 2304
+    scheduler_block_size = hash_block_size * 4
+    kv_cache_config = KVCacheConfig(
+        num_blocks=2000,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["target"],
+                MLAAttentionSpec(
+                    # DCP4 expands this to the 9,216-token effective target
+                    # page used by GLM-5.3 Flash at runtime.
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                    tokens_per_state=4,
+                ),
+                is_eagle_group=True,
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=hash_block_size,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+                is_eagle_group=True,
+            ),
+            KVCacheGroupSpec(
+                ["draft"],
+                SlidingWindowSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                    sliding_window=2048,
+                    dcp_replicated=True,
+                    extra_retained_tokens=2048,
+                ),
+                is_eagle_group=True,
+            ),
+        ],
+        prefix_cache_retention_interval=0,
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=524288,
+        max_in_flight_tokens=4096,
+        enable_caching=True,
+        # Replicated DFlash storage requires dense checkpoints independently
+        # of the aggregate coordinator flag.
+        use_eagle=False,
+        hash_block_size=hash_block_size,
+        scheduler_block_size=scheduler_block_size,
+        dcp_world_size=4,
+    )
+
+    token_ids = list(range(10355))
+    fill = make_request("fill", token_ids, hash_block_size, sha256)
+    for chunk in (
+        hash_block_size,
+        hash_block_size,
+        hash_block_size,
+        hash_block_size,
+        len(token_ids) - 4 * hash_block_size,
+    ):
+        blocks = manager.allocate_slots(fill, chunk)
+        assert blocks is not None
+        fill.num_computed_tokens += chunk
+    # Mirror the scheduler's post-forward cache registration for the final
+    # partial prompt chunk before the request is released.
+    manager.cache_blocks(fill, fill.num_computed_tokens)
+    manager.free(fill)
+
+    # Sparse retention keeps only the two group-local blocks needed at the
+    # common DFlash replay boundary. The previous dense fallback retained all
+    # four historical blocks in both the Mamba and draft groups.
+    for group_id in (1, 2):
+        for block_index in range(4):
+            cached = manager.block_pool.get_cached_block(
+                fill.block_hashes[block_index],
+                kv_cache_group_ids=[group_id],
+            )
+            if block_index in (2, 3):
+                assert cached is not None
+            else:
+                assert cached is None
+
+    replay = make_request("replay", token_ids, hash_block_size, sha256)
+    _, per_group_hits = manager.coordinator.find_longest_cache_hit_per_group(
+        replay.block_hashes, replay.num_tokens - 1
+    )
+    assert per_group_hits == (
+        hash_block_size * 3,
+        hash_block_size * 4,
+        hash_block_size * 3,
+    )
+    _, num_computed_tokens, _ = manager.get_computed_blocks(replay)
+    assert num_computed_tokens == hash_block_size * 3
+
+
 def test_block_lookup_cache_single_block_per_key():
     cache = BlockHashToBlockMap()
     key0 = BlockHashWithGroupId(b"hash0")

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -6280,6 +6280,43 @@ def test_mixed_prefill_budget_reserves_waiter_then_rotates_running(
     ]
 
 
+def test_partial_prefill_limit_keeps_excess_waiter_queued(lp11_model_path):
+    scheduler, (p0, p1) = _prepare_lp11_prefills(
+        lp11_model_path,
+        num_prefills=2,
+        mixed_prefill_budget=4608,
+    )
+    scheduler.max_num_partial_prefills = 2
+    assert len(scheduler._inflight_prefills) == 2
+    (waiter,) = create_requests(
+        num_requests=1,
+        num_tokens=12000,
+        req_ids=["waiter"],
+    )
+    scheduler.add_request(waiter)
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens == {
+        "decode": 1,
+        p0.request_id: 2304,
+        p1.request_id: 2304,
+    }
+    assert waiter not in scheduler.running
+    assert waiter in scheduler.waiting
+    assert len(scheduler._inflight_prefills) == 2
+
+
+def test_max_num_partial_prefills_validation():
+    with pytest.raises(ValueError, match="max_num_partial_prefills"):
+        SchedulerConfig(
+            max_model_len=32768,
+            is_encoder_decoder=False,
+            max_num_seqs=2,
+            max_num_partial_prefills=3,
+        )
+
+
 def test_mixed_prefill_budget_does_not_limit_prefill_only_step(lp11_model_path):
     scheduler = create_scheduler(
         model=lp11_model_path,

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -6206,9 +6206,7 @@ def _empty_output_for_schedule(output: SchedulerOutput) -> ModelRunnerOutput:
     return ModelRunnerOutput(
         req_ids=req_ids,
         req_id_to_index={req_id: index for index, req_id in enumerate(req_ids)},
-        sampled_token_ids=[
-            [0] if req_id == "decode" else [] for req_id in req_ids
-        ],
+        sampled_token_ids=[[0] if req_id == "decode" else [] for req_id in req_ids],
         logprobs=None,
         prompt_logprobs_dict={},
         pooler_output=[],
@@ -6391,9 +6389,7 @@ def test_mixed_prefill_budget_selects_2304_token_running_quanta():
 
     scheduler._prefill_budget_quantum = 1
     scheduler._prefill_budget_rotation = 0
-    assert Scheduler._select_running_prefill_limits(
-        scheduler, request_ids, 8192
-    ) == {
+    assert Scheduler._select_running_prefill_limits(scheduler, request_ids, 8192) == {
         "p0": 2731,
         "p1": 2731,
         "p2": 2730,
@@ -6463,11 +6459,14 @@ def test_decode_burst_controller_balances_prefill_and_decode(lp11_model_path):
 
     waiter.arrival_time = time.time() - 30.001
     fairness_output = scheduler.schedule()
-    assert sum(
-        count
-        for request_id, count in fairness_output.num_scheduled_tokens.items()
-        if request_id in prefill_ids
-    ) == 2304
+    assert (
+        sum(
+            count
+            for request_id, count in fairness_output.num_scheduled_tokens.items()
+            if request_id in prefill_ids
+        )
+        == 2304
+    )
 
     final_stats = scheduler.drain_decode_prefill_stats()
     stats = {

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -6169,7 +6169,8 @@ def test_encoder_input_skipped_when_connector_already_has_the_item(ec_role: str)
 @pytest.fixture
 def lp11_model_path(tmp_path):
     (tmp_path / "config.json").write_text(
-        '{"architectures": ["OPTForCausalLM"], "model_type": "opt"}'
+        '{"architectures": ["OPTForCausalLM"], "model_type": "opt", '
+        '"max_position_embeddings": 32768}'
     )
     return str(tmp_path)
 
@@ -6213,31 +6214,70 @@ def _empty_output_for_schedule(output: SchedulerOutput) -> ModelRunnerOutput:
     )
 
 
-def test_mixed_prefill_budget_is_shared_across_waiting_requests(lp11_model_path):
+def _prepare_lp11_prefills(
+    lp11_model_path,
+    num_prefills: int,
+    mixed_prefill_budget: int,
+):
     scheduler = create_scheduler(
         model=lp11_model_path,
         skip_tokenizer_init=True,
         device="cpu",
-        max_num_seqs=8,
-        max_num_batched_tokens=64,
-        max_model_len=256,
-        max_num_prefill_tokens_per_step=16,
+        max_num_seqs=4,
+        max_num_batched_tokens=8192,
+        max_model_len=32768,
+        long_prefill_token_threshold=2304,
+        max_num_prefill_tokens_per_step=0,
     )
     _establish_decode_request(scheduler)
 
     prefills = create_requests(
-        num_requests=4,
-        num_tokens=160,
-        req_ids=["p0", "p1", "p2", "p3"],
+        num_requests=num_prefills,
+        num_tokens=12000,
+        req_ids=[f"p{index}" for index in range(num_prefills)],
     )
     for request in prefills:
         scheduler.add_request(request)
 
     output = scheduler.schedule()
+    scheduler.update_from_output(output, _empty_output_for_schedule(output))
+    assert all(request in scheduler.running for request in prefills)
 
-    assert "decode" in output.num_scheduled_tokens
-    assert [output.num_scheduled_tokens[r.request_id] for r in prefills] == [4] * 4
-    assert sum(output.num_scheduled_tokens[r.request_id] for r in prefills) == 16
+    scheduler.max_num_prefill_tokens_per_step = mixed_prefill_budget
+    scheduler._prefill_budget_quantum = 2304
+    scheduler._prefill_budget_rotation = 0
+    return scheduler, prefills
+
+
+def test_mixed_prefill_budget_reserves_waiter_then_rotates_running(
+    lp11_model_path,
+):
+    scheduler, (p0, p1) = _prepare_lp11_prefills(
+        lp11_model_path,
+        num_prefills=2,
+        mixed_prefill_budget=4608,
+    )
+    (waiter,) = create_requests(
+        num_requests=1,
+        num_tokens=12000,
+        req_ids=["waiter"],
+    )
+    scheduler.add_request(waiter)
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens == {
+        "decode": 1,
+        p0.request_id: 2304,
+        waiter.request_id: 2304,
+    }
+    assert p1.request_id not in output.num_scheduled_tokens
+    assert [request.request_id for request in scheduler.running] == [
+        "decode",
+        "p0",
+        "p1",
+        "waiter",
+    ]
 
 
 def test_mixed_prefill_budget_does_not_limit_prefill_only_step(lp11_model_path):
@@ -6245,92 +6285,42 @@ def test_mixed_prefill_budget_does_not_limit_prefill_only_step(lp11_model_path):
         model=lp11_model_path,
         skip_tokenizer_init=True,
         device="cpu",
-        max_num_batched_tokens=64,
-        max_model_len=256,
-        max_num_prefill_tokens_per_step=16,
+        max_num_batched_tokens=8192,
+        max_model_len=32768,
+        max_num_prefill_tokens_per_step=2304,
     )
     (request,) = create_requests(
         num_requests=1,
-        num_tokens=64,
+        num_tokens=8192,
         req_ids=["prefill"],
     )
     scheduler.add_request(request)
 
     output = scheduler.schedule()
 
-    assert output.num_scheduled_tokens[request.request_id] == 64
+    assert output.num_scheduled_tokens[request.request_id] == 8192
 
 
-def test_mixed_prefill_budget_reserves_a_waiting_slot(lp11_model_path):
-    scheduler = create_scheduler(
-        model=lp11_model_path,
-        skip_tokenizer_init=True,
-        device="cpu",
-        max_num_seqs=4,
-        max_num_batched_tokens=64,
-        max_model_len=256,
-        max_num_prefill_tokens_per_step=16,
-    )
-    _establish_decode_request(scheduler)
-    p0, p1 = create_requests(
-        num_requests=2,
-        num_tokens=160,
-        req_ids=["p0", "p1"],
-    )
-    scheduler.add_request(p0)
-    scheduler.add_request(p1)
-    output = scheduler.schedule()
-    scheduler.update_from_output(output, _empty_output_for_schedule(output))
-    assert p0 in scheduler.running and p1 in scheduler.running
-
-    (p2,) = create_requests(
-        num_requests=1,
-        num_tokens=160,
-        req_ids=["p2"],
-    )
-    scheduler.add_request(p2)
-    output = scheduler.schedule()
-
-    assert "decode" in output.num_scheduled_tokens
-    assert all(
-        req_id in output.num_scheduled_tokens for req_id in ("p0", "p1", "p2")
-    )
-    assert (
-        sum(
-            output.num_scheduled_tokens[req_id] for req_id in ("p0", "p1", "p2")
-        )
-        <= 16
+def test_mixed_prefill_budget_rotates_one_quantum_after_slots_fill(
+    lp11_model_path,
+):
+    scheduler, prefills = _prepare_lp11_prefills(
+        lp11_model_path,
+        num_prefills=3,
+        mixed_prefill_budget=2304,
     )
 
-
-def test_mixed_prefill_budget_rotates_extra_tokens_without_reordering(lp11_model_path):
-    scheduler = create_scheduler(
-        model=lp11_model_path,
-        skip_tokenizer_init=True,
-        device="cpu",
-        max_num_seqs=4,
-        max_num_batched_tokens=64,
-        max_model_len=256,
-        max_num_prefill_tokens_per_step=16,
-    )
-    _establish_decode_request(scheduler)
-    prefills = create_requests(
-        num_requests=3,
-        num_tokens=160,
-        req_ids=["p0", "p1", "p2"],
-    )
-    for request in prefills:
-        scheduler.add_request(request)
-
-    largest_share_ids = []
+    selected_ids = []
     for _ in range(3):
         output = scheduler.schedule()
-        shares = {
-            request.request_id: output.num_scheduled_tokens[request.request_id]
+        selected = [
+            request.request_id
             for request in prefills
-        }
-        assert sorted(shares.values()) == [5, 5, 6]
-        largest_share_ids.append(max(shares, key=shares.get))
+            if request.request_id in output.num_scheduled_tokens
+        ]
+        assert len(selected) == 1
+        assert output.num_scheduled_tokens[selected[0]] == 2304
+        selected_ids.extend(selected)
         assert [request.request_id for request in scheduler.running] == [
             "decode",
             "p0",
@@ -6339,35 +6329,34 @@ def test_mixed_prefill_budget_rotates_extra_tokens_without_reordering(lp11_model
         ]
         scheduler.update_from_output(output, _empty_output_for_schedule(output))
 
-    assert largest_share_ids == ["p0", "p1", "p2"]
+    assert selected_ids == ["p0", "p1", "p2"]
 
 
-def test_mixed_prefill_budget_distributes_mamba_aligned_candidate_values():
+def test_mixed_prefill_budget_selects_2304_token_running_quanta():
     scheduler = Mock(
-        need_mamba_block_aligned_split=True,
-        mamba_block_size=256,
+        _prefill_budget_quantum=2304,
         _prefill_budget_rotation=0,
     )
+    request_ids = ["p0", "p1", "p2"]
 
-    small = Scheduler._distribute_prefill_token_budget(scheduler, 2304, 7)
-    assert sum(small) == 2304
-    assert sorted(small) == [256, 256, 256, 256, 256, 512, 512]
-    assert small[:2] == [512, 512]
+    assert Scheduler._select_running_prefill_limits(scheduler, request_ids, 1) == {
+        "p0": 2304
+    }
+    assert Scheduler._select_running_prefill_limits(scheduler, request_ids, 2) == {
+        "p1": 2304,
+        "p2": 2304,
+    }
+    assert Scheduler._select_running_prefill_limits(scheduler, request_ids, 1) == {
+        "p0": 2304
+    }
 
-    large = Scheduler._distribute_prefill_token_budget(scheduler, 4608, 7)
-    assert sum(large) == 4608
-    assert sorted(large) == [512, 512, 512, 768, 768, 768, 768]
-    assert large[2:6] == [768, 768, 768, 768]
 
-    assert all(tokens % 256 == 0 for tokens in small + large)
-
-
-@pytest.mark.parametrize("value", [-1, 65])
+@pytest.mark.parametrize("value", [-1, 8193])
 def test_max_num_prefill_tokens_per_step_validation(value: int):
     with pytest.raises(ValueError):
         SchedulerConfig(
-            max_model_len=256,
+            max_model_len=32768,
             is_encoder_decoder=False,
-            max_num_batched_tokens=64,
+            max_num_batched_tokens=8192,
             max_num_prefill_tokens_per_step=value,
         )

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -6164,3 +6164,210 @@ def test_encoder_input_skipped_when_connector_already_has_the_item(ec_role: str)
 
     assert output.num_scheduled_tokens[req_id] > 0
     assert not output.scheduled_encoder_inputs.get(req_id)
+
+
+@pytest.fixture
+def lp11_model_path(tmp_path):
+    (tmp_path / "config.json").write_text(
+        '{"architectures": ["OPTForCausalLM"], "model_type": "opt"}'
+    )
+    return str(tmp_path)
+
+
+def _establish_decode_request(scheduler, req_id: str = "decode"):
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=8,
+        max_tokens=200,
+        req_ids=[req_id],
+    )
+    scheduler.add_request(request)
+    output = scheduler.schedule()
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=[req_id],
+            req_id_to_index={req_id: 0},
+            sampled_token_ids=[[0]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+    assert request in scheduler.running
+    assert not request.is_prefill_chunk
+    return request
+
+
+def _empty_output_for_schedule(output: SchedulerOutput) -> ModelRunnerOutput:
+    req_ids = list(output.num_scheduled_tokens)
+    return ModelRunnerOutput(
+        req_ids=req_ids,
+        req_id_to_index={req_id: index for index, req_id in enumerate(req_ids)},
+        sampled_token_ids=[
+            [0] if req_id == "decode" else [] for req_id in req_ids
+        ],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+
+def test_mixed_prefill_budget_is_shared_across_waiting_requests(lp11_model_path):
+    scheduler = create_scheduler(
+        model=lp11_model_path,
+        skip_tokenizer_init=True,
+        device="cpu",
+        max_num_seqs=8,
+        max_num_batched_tokens=64,
+        max_model_len=256,
+        max_num_prefill_tokens_per_step=16,
+    )
+    _establish_decode_request(scheduler)
+
+    prefills = create_requests(
+        num_requests=4,
+        num_tokens=160,
+        req_ids=["p0", "p1", "p2", "p3"],
+    )
+    for request in prefills:
+        scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert "decode" in output.num_scheduled_tokens
+    assert [output.num_scheduled_tokens[r.request_id] for r in prefills] == [4] * 4
+    assert sum(output.num_scheduled_tokens[r.request_id] for r in prefills) == 16
+
+
+def test_mixed_prefill_budget_does_not_limit_prefill_only_step(lp11_model_path):
+    scheduler = create_scheduler(
+        model=lp11_model_path,
+        skip_tokenizer_init=True,
+        device="cpu",
+        max_num_batched_tokens=64,
+        max_model_len=256,
+        max_num_prefill_tokens_per_step=16,
+    )
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=64,
+        req_ids=["prefill"],
+    )
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens[request.request_id] == 64
+
+
+def test_mixed_prefill_budget_reserves_a_waiting_slot(lp11_model_path):
+    scheduler = create_scheduler(
+        model=lp11_model_path,
+        skip_tokenizer_init=True,
+        device="cpu",
+        max_num_seqs=4,
+        max_num_batched_tokens=64,
+        max_model_len=256,
+        max_num_prefill_tokens_per_step=16,
+    )
+    _establish_decode_request(scheduler)
+    p0, p1 = create_requests(
+        num_requests=2,
+        num_tokens=160,
+        req_ids=["p0", "p1"],
+    )
+    scheduler.add_request(p0)
+    scheduler.add_request(p1)
+    output = scheduler.schedule()
+    scheduler.update_from_output(output, _empty_output_for_schedule(output))
+    assert p0 in scheduler.running and p1 in scheduler.running
+
+    (p2,) = create_requests(
+        num_requests=1,
+        num_tokens=160,
+        req_ids=["p2"],
+    )
+    scheduler.add_request(p2)
+    output = scheduler.schedule()
+
+    assert "decode" in output.num_scheduled_tokens
+    assert all(
+        req_id in output.num_scheduled_tokens for req_id in ("p0", "p1", "p2")
+    )
+    assert (
+        sum(
+            output.num_scheduled_tokens[req_id] for req_id in ("p0", "p1", "p2")
+        )
+        <= 16
+    )
+
+
+def test_mixed_prefill_budget_rotates_extra_tokens_without_reordering(lp11_model_path):
+    scheduler = create_scheduler(
+        model=lp11_model_path,
+        skip_tokenizer_init=True,
+        device="cpu",
+        max_num_seqs=4,
+        max_num_batched_tokens=64,
+        max_model_len=256,
+        max_num_prefill_tokens_per_step=16,
+    )
+    _establish_decode_request(scheduler)
+    prefills = create_requests(
+        num_requests=3,
+        num_tokens=160,
+        req_ids=["p0", "p1", "p2"],
+    )
+    for request in prefills:
+        scheduler.add_request(request)
+
+    largest_share_ids = []
+    for _ in range(3):
+        output = scheduler.schedule()
+        shares = {
+            request.request_id: output.num_scheduled_tokens[request.request_id]
+            for request in prefills
+        }
+        assert sorted(shares.values()) == [5, 5, 6]
+        largest_share_ids.append(max(shares, key=shares.get))
+        assert [request.request_id for request in scheduler.running] == [
+            "decode",
+            "p0",
+            "p1",
+            "p2",
+        ]
+        scheduler.update_from_output(output, _empty_output_for_schedule(output))
+
+    assert largest_share_ids == ["p0", "p1", "p2"]
+
+
+def test_mixed_prefill_budget_distributes_mamba_aligned_candidate_values():
+    scheduler = Mock(
+        need_mamba_block_aligned_split=True,
+        mamba_block_size=256,
+        _prefill_budget_rotation=0,
+    )
+
+    small = Scheduler._distribute_prefill_token_budget(scheduler, 2304, 7)
+    assert sum(small) == 2304
+    assert sorted(small) == [256, 256, 256, 256, 256, 512, 512]
+    assert small[:2] == [512, 512]
+
+    large = Scheduler._distribute_prefill_token_budget(scheduler, 4608, 7)
+    assert sum(large) == 4608
+    assert sorted(large) == [512, 512, 512, 768, 768, 768, 768]
+    assert large[2:6] == [768, 768, 768, 768]
+
+    assert all(tokens % 256 == 0 for tokens in small + large)
+
+
+@pytest.mark.parametrize("value", [-1, 65])
+def test_max_num_prefill_tokens_per_step_validation(value: int):
+    with pytest.raises(ValueError):
+        SchedulerConfig(
+            max_model_len=256,
+            is_encoder_decoder=False,
+            max_num_batched_tokens=64,
+            max_num_prefill_tokens_per_step=value,
+        )

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -6437,10 +6437,16 @@ def test_decode_burst_controller_balances_prefill_and_decode(lp11_model_path):
     prefill_ids = {request.request_id for request in prefills}
 
     outputs = []
+    interval_stats = []
     for _ in range(5):
         output = scheduler.schedule()
         outputs.append(output)
-        scheduler.update_from_output(output, _empty_output_for_schedule(output))
+        engine_outputs = scheduler.update_from_output(
+            output, _empty_output_for_schedule(output)
+        )
+        stats = next(iter(engine_outputs.values())).scheduler_stats
+        assert stats is not None
+        interval_stats.append(stats)
 
     prefill_tokens = [
         sum(
@@ -6463,7 +6469,18 @@ def test_decode_burst_controller_balances_prefill_and_decode(lp11_model_path):
         if request_id in prefill_ids
     ) == 2304
 
-    stats = scheduler.drain_decode_prefill_stats()
+    final_stats = scheduler.drain_decode_prefill_stats()
+    stats = {
+        "scheduled_prefill_tokens": sum(
+            row.scheduled_prefill_tokens for row in interval_stats
+        )
+        + final_stats["scheduled_prefill_tokens"],
+        "active_partial_prefills": final_stats["active_partial_prefills"],
+        "decode_only_steps": sum(row.decode_only_steps for row in interval_stats)
+        + final_stats["decode_only_steps"],
+        "fairness_bypasses": sum(row.fairness_bypasses for row in interval_stats)
+        + final_stats["fairness_bypasses"],
+    }
     assert stats == {
         "scheduled_prefill_tokens": 4608,
         "active_partial_prefills": 2,

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -6350,6 +6350,16 @@ def test_mixed_prefill_budget_selects_2304_token_running_quanta():
         "p0": 2304
     }
 
+    scheduler._prefill_budget_quantum = 1
+    scheduler._prefill_budget_rotation = 0
+    assert Scheduler._select_running_prefill_limits(
+        scheduler, request_ids, 8192
+    ) == {
+        "p0": 2731,
+        "p1": 2731,
+        "p2": 2730,
+    }
+
 
 @pytest.mark.parametrize("value", [-1, 8193])
 def test_max_num_prefill_tokens_per_step_validation(value: int):

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import dataclasses
+import time
 from concurrent.futures import Future
 from unittest.mock import Mock
 
@@ -6326,6 +6327,7 @@ def test_mixed_prefill_budget_does_not_limit_prefill_only_step(lp11_model_path):
         max_model_len=32768,
         max_num_prefill_tokens_per_step=2304,
     )
+    scheduler.decode_prefill_min_decode_steps = 4
     (request,) = create_requests(
         num_requests=1,
         num_tokens=8192,
@@ -6407,3 +6409,64 @@ def test_max_num_prefill_tokens_per_step_validation(value: int):
             max_num_batched_tokens=8192,
             max_num_prefill_tokens_per_step=value,
         )
+
+
+def test_decode_burst_requires_mixed_prefill_budget():
+    with pytest.raises(ValueError, match="max_num_prefill_tokens_per_step"):
+        SchedulerConfig(
+            max_model_len=32768,
+            is_encoder_decoder=False,
+            decode_prefill_min_decode_steps=4,
+        )
+
+
+def test_decode_burst_controller_balances_prefill_and_decode(lp11_model_path):
+    scheduler, prefills = _prepare_lp11_prefills(
+        lp11_model_path, num_prefills=2, mixed_prefill_budget=2304
+    )
+    scheduler.max_num_partial_prefills = 2
+    scheduler.decode_prefill_min_decode_steps = 4
+    scheduler.decode_prefill_max_wait_ms = 30_000
+    scheduler.drain_decode_prefill_stats()
+    (waiter,) = create_requests(
+        num_requests=1,
+        num_tokens=12000,
+        req_ids=["waiter"],
+    )
+    scheduler.add_request(waiter)
+    prefill_ids = {request.request_id for request in prefills}
+
+    outputs = []
+    for _ in range(5):
+        output = scheduler.schedule()
+        outputs.append(output)
+        scheduler.update_from_output(output, _empty_output_for_schedule(output))
+
+    prefill_tokens = [
+        sum(
+            count
+            for request_id, count in output.num_scheduled_tokens.items()
+            if request_id in prefill_ids
+        )
+        for output in outputs
+    ]
+    assert prefill_tokens[:4] == [0, 0, 0, 0]
+    assert prefill_tokens[4] == 2304
+    assert all(output.num_scheduled_tokens["decode"] > 0 for output in outputs)
+    assert waiter in scheduler.waiting
+
+    waiter.arrival_time = time.time() - 30.001
+    fairness_output = scheduler.schedule()
+    assert sum(
+        count
+        for request_id, count in fairness_output.num_scheduled_tokens.items()
+        if request_id in prefill_ids
+    ) == 2304
+
+    stats = scheduler.drain_decode_prefill_stats()
+    assert stats == {
+        "scheduled_prefill_tokens": 4608,
+        "active_partial_prefills": 2,
+        "decode_only_steps": 4,
+        "fairness_bypasses": 1,
+    }

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -7,6 +7,7 @@ import vllm.envs as envs
 from tests.v1.kv_connector.unit.utils import MockKVConfig
 from vllm.config import (
     CacheConfig,
+    DeviceConfig,
     ECTransferConfig,
     KVTransferConfig,
     ModelConfig,
@@ -55,6 +56,8 @@ def create_scheduler(
     enable_chunked_prefill: bool = True,
     enable_prefix_caching: bool = False,
     long_prefill_token_threshold: int = 0,
+    max_num_prefill_tokens_per_step: int = 0,
+    device: str = "auto",
     disable_chunked_mm_input: bool = False,
     use_kv_connector: None | bool | str | MockKVConfig = None,
     kv_role: str = "kv_both",
@@ -106,6 +109,7 @@ def create_scheduler(
         max_num_batched_tokens=max_num_batched_tokens,
         max_model_len=max_model_len,
         long_prefill_token_threshold=long_prefill_token_threshold,
+        max_num_prefill_tokens_per_step=max_num_prefill_tokens_per_step,
         disable_chunked_mm_input=disable_chunked_mm_input,
         enable_chunked_prefill=enable_chunked_prefill,
         async_scheduling=async_scheduling,
@@ -182,6 +186,7 @@ def create_scheduler(
     )
 
     vllm_config = VllmConfig(
+        device_config=DeviceConfig(device=device),
         scheduler_config=scheduler_config,
         model_config=model_config,
         cache_config=cache_config,

--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -3,6 +3,7 @@
 from vllm.v1.core.sched.output import ScheduledEncoderInputStats, SchedulerOutput
 from vllm.v1.engine import EngineCoreOutputs, FinishReason
 from vllm.v1.metrics.stats import (
+    HybridPrefixCacheStats,
     IterationStats,
     PrefillStats,
     PromptTokenStats,
@@ -34,6 +35,10 @@ def test_scheduler_iteration_details_serialization():
         scheduler_stats=SchedulerStats(
             kv_cache_usage=0.5,
             iteration_details=iteration_details,
+            scheduled_prefill_tokens=2304,
+            active_partial_prefills=2,
+            decode_only_steps=4,
+            fairness_bypasses=1,
         )
     )
 
@@ -43,6 +48,29 @@ def test_scheduler_iteration_details_serialization():
     assert decoded.scheduler_stats is not None
     assert decoded.scheduler_stats.kv_cache_usage == 0.5
     assert decoded.scheduler_stats.iteration_details == iteration_details
+    assert decoded.scheduler_stats.scheduled_prefill_tokens == 2304
+    assert decoded.scheduler_stats.active_partial_prefills == 2
+    assert decoded.scheduler_stats.decode_only_steps == 4
+    assert decoded.scheduler_stats.fairness_bypasses == 1
+
+
+def test_hybrid_prefix_cache_stats_serialization():
+    stats = HybridPrefixCacheStats(
+        cacheable_prefix_tokens=119808,
+        reconciled_hit_tokens=117504,
+        prefix_cache_group_hits={"full_attention:0": 119808, "mamba:1": 117504},
+        boundary_registrations={"mamba:1": 2},
+        boundary_evictions={"mamba:1": 1},
+    )
+    outputs = EngineCoreOutputs(
+        scheduler_stats=SchedulerStats(hybrid_prefix_cache_stats=stats)
+    )
+
+    encoded = MsgpackEncoder().encode(outputs)
+    decoded = MsgpackDecoder(EngineCoreOutputs).decode(encoded)
+
+    assert decoded.scheduler_stats is not None
+    assert decoded.scheduler_stats.hybrid_prefix_cache_stats == stats
 
 
 def test_compute_iteration_details_includes_encoder_stats():

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -159,6 +159,20 @@ class SchedulerConfig:
     current step may still be admitted when the limit is full.
     """
 
+    decode_prefill_min_decode_steps: int = Field(default=0, ge=0)
+    """Minimum decode-only steps between mixed-prefill steps.
+
+    Zero disables decode-burst scheduling. This applies only while decode is
+    eligible. Prefill-only steps continue to use max_num_batched_tokens.
+    """
+
+    decode_prefill_max_wait_ms: int = Field(default=0, ge=0)
+    """Maximum waiter age before bypassing a decode burst, in milliseconds.
+
+    Zero disables the fairness deadline. The deadline has an effect only when
+    decode-burst scheduling is enabled.
+    """
+
     async_scheduling: bool | None = None
     """If set to False, disable async scheduling. Async scheduling helps to
     avoid gaps in GPU utilization, leading to better latency and throughput.
@@ -308,6 +322,15 @@ class SchedulerConfig:
                 "max_num_partial_prefills "
                 f"({self.max_num_partial_prefills}) cannot be greater than "
                 f"max_num_seqs ({self.max_num_seqs})."
+            )
+
+        if (
+            self.decode_prefill_min_decode_steps > 0
+            and self.max_num_prefill_tokens_per_step == 0
+        ):
+            raise ValueError(
+                "decode_prefill_min_decode_steps requires "
+                "max_num_prefill_tokens_per_step to be greater than zero."
             )
 
         return self

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -144,6 +144,14 @@ class SchedulerConfig:
     """Schedule prefill work once every N engine steps while decode requests
     are running. Data-parallel engines align the cadence across DP ranks."""
 
+    max_num_prefill_tokens_per_step: int = Field(default=0, ge=0)
+    """Maximum local prefill tokens scheduled in a step with eligible decode.
+
+    The budget is shared across running prefill chunks and waiting admissions.
+    Zero disables the separate mixed-step budget. Prefill-only steps continue
+    to use max_num_batched_tokens.
+    """
+
     async_scheduling: bool | None = None
     """If set to False, disable async scheduling. Async scheduling helps to
     avoid gaps in GPU utilization, leading to better latency and throughput.
@@ -279,6 +287,13 @@ class SchedulerConfig:
                 "long_prefill_token_threshold "
                 f"({self.long_prefill_token_threshold}) cannot be greater "
                 f"than the max_model_len ({max_model_len})."
+            )
+
+        if self.max_num_prefill_tokens_per_step > self.max_num_batched_tokens:
+            raise ValueError(
+                "max_num_prefill_tokens_per_step "
+                f"({self.max_num_prefill_tokens_per_step}) cannot be greater "
+                f"than max_num_batched_tokens ({self.max_num_batched_tokens})."
             )
 
         return self

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -152,6 +152,13 @@ class SchedulerConfig:
     to use max_num_batched_tokens.
     """
 
+    max_num_partial_prefills: int = Field(default=0, ge=0)
+    """Maximum requests allowed to remain partially prefilling.
+
+    Zero disables the separate limit. A request that can finish prefill in the
+    current step may still be admitted when the limit is full.
+    """
+
     async_scheduling: bool | None = None
     """If set to False, disable async scheduling. Async scheduling helps to
     avoid gaps in GPU utilization, leading to better latency and throughput.
@@ -294,6 +301,13 @@ class SchedulerConfig:
                 "max_num_prefill_tokens_per_step "
                 f"({self.max_num_prefill_tokens_per_step}) cannot be greater "
                 f"than max_num_batched_tokens ({self.max_num_batched_tokens})."
+            )
+
+        if self.max_num_partial_prefills > self.max_num_seqs:
+            raise ValueError(
+                "max_num_partial_prefills "
+                f"({self.max_num_partial_prefills}) cannot be greater than "
+                f"max_num_seqs ({self.max_num_seqs})."
             )
 
         return self

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -637,6 +637,7 @@ class EngineArgs:
     max_num_prefill_tokens_per_step: int = (
         SchedulerConfig.max_num_prefill_tokens_per_step
     )
+    max_num_partial_prefills: int = SchedulerConfig.max_num_partial_prefills
 
     watermark: float = SchedulerConfig.watermark
 
@@ -1594,6 +1595,10 @@ class EngineArgs:
             **scheduler_kwargs["max_num_prefill_tokens_per_step"],
         )
         scheduler_group.add_argument(
+            "--max-num-partial-prefills",
+            **scheduler_kwargs["max_num_partial_prefills"],
+        )
+        scheduler_group.add_argument(
             "--disable-hybrid-kv-cache-manager",
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"],
         )
@@ -2377,6 +2382,7 @@ class EngineArgs:
             max_num_prefill_tokens_per_step=(
                 self.max_num_prefill_tokens_per_step
             ),
+            max_num_partial_prefills=self.max_num_partial_prefills,
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -638,6 +638,10 @@ class EngineArgs:
         SchedulerConfig.max_num_prefill_tokens_per_step
     )
     max_num_partial_prefills: int = SchedulerConfig.max_num_partial_prefills
+    decode_prefill_min_decode_steps: int = (
+        SchedulerConfig.decode_prefill_min_decode_steps
+    )
+    decode_prefill_max_wait_ms: int = SchedulerConfig.decode_prefill_max_wait_ms
 
     watermark: float = SchedulerConfig.watermark
 
@@ -1599,6 +1603,14 @@ class EngineArgs:
             **scheduler_kwargs["max_num_partial_prefills"],
         )
         scheduler_group.add_argument(
+            "--decode-prefill-min-decode-steps",
+            **scheduler_kwargs["decode_prefill_min_decode_steps"],
+        )
+        scheduler_group.add_argument(
+            "--decode-prefill-max-wait-ms",
+            **scheduler_kwargs["decode_prefill_max_wait_ms"],
+        )
+        scheduler_group.add_argument(
             "--disable-hybrid-kv-cache-manager",
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"],
         )
@@ -2383,6 +2395,10 @@ class EngineArgs:
                 self.max_num_prefill_tokens_per_step
             ),
             max_num_partial_prefills=self.max_num_partial_prefills,
+            decode_prefill_min_decode_steps=(
+                self.decode_prefill_min_decode_steps
+            ),
+            decode_prefill_max_wait_ms=self.decode_prefill_max_wait_ms,
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2391,13 +2391,9 @@ class EngineArgs:
             scheduler_reserve_full_isl=self.scheduler_reserve_full_isl,
             watermark=self.watermark,
             prefill_schedule_interval=self.prefill_schedule_interval,
-            max_num_prefill_tokens_per_step=(
-                self.max_num_prefill_tokens_per_step
-            ),
+            max_num_prefill_tokens_per_step=(self.max_num_prefill_tokens_per_step),
             max_num_partial_prefills=self.max_num_partial_prefills,
-            decode_prefill_min_decode_steps=(
-                self.decode_prefill_min_decode_steps
-            ),
+            decode_prefill_min_decode_steps=(self.decode_prefill_min_decode_steps),
             decode_prefill_max_wait_ms=self.decode_prefill_max_wait_ms,
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -634,6 +634,9 @@ class EngineArgs:
 
     scheduler_reserve_full_isl: bool = SchedulerConfig.scheduler_reserve_full_isl
     prefill_schedule_interval: int = SchedulerConfig.prefill_schedule_interval
+    max_num_prefill_tokens_per_step: int = (
+        SchedulerConfig.max_num_prefill_tokens_per_step
+    )
 
     watermark: float = SchedulerConfig.watermark
 
@@ -1587,6 +1590,10 @@ class EngineArgs:
             **scheduler_kwargs["prefill_schedule_interval"],
         )
         scheduler_group.add_argument(
+            "--max-num-prefill-tokens-per-step",
+            **scheduler_kwargs["max_num_prefill_tokens_per_step"],
+        )
+        scheduler_group.add_argument(
             "--disable-hybrid-kv-cache-manager",
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"],
         )
@@ -2367,6 +2374,9 @@ class EngineArgs:
             scheduler_reserve_full_isl=self.scheduler_reserve_full_isl,
             watermark=self.watermark,
             prefill_schedule_interval=self.prefill_schedule_interval,
+            max_num_prefill_tokens_per_step=(
+                self.max_num_prefill_tokens_per_step
+            ),
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -567,19 +567,28 @@ class DeepseekV32Attention(MLAAttention):
         else:
             mqa_q_arg = (ql_nope[:num_actual], mqa_q[:num_actual])
 
-        if self.use_pcp and self.impl.dcp_world_size > self.impl.pcp_world_size:
-            if isinstance(mqa_q_arg, tuple):
-                mqa_q_arg = torch.cat(mqa_q_arg, dim=-1)
-            mqa_q_arg = get_tp_group().all_gather(mqa_q_arg, dim=1)
+        if self.impl.dcp_world_size > 1:
+            assert self.dcp_manager is not None
+            if self.use_pcp:
+                if self.impl.dcp_world_size > self.impl.pcp_world_size:
+                    if isinstance(mqa_q_arg, tuple):
+                        mqa_q_arg = torch.cat(mqa_q_arg, dim=-1)
+                    mqa_q_arg = get_tp_group().all_gather(mqa_q_arg, dim=1)
+            else:
+                if isinstance(mqa_q_arg, tuple):
+                    mqa_q_arg = torch.cat(mqa_q_arg, dim=-1)
+                assert self.dcp_manager.query_gather is not None
+                mqa_q_arg = self.dcp_manager.query_gather(mqa_q_arg)
         attn_out, lse = self.impl.forward_mqa(  # type: ignore[attr-defined]
             mqa_q_arg, kv_cache, attn_metadata, self
         )
 
-        if self.use_pcp and self.impl.dcp_world_size > 1:
+        if self.impl.dcp_world_size > 1:
             assert lse is not None and self.dcp_manager is not None
+            decode_metadata = getattr(attn_metadata, "decode", None)
             seq_lens = (
-                attn_metadata.decode.seq_lens
-                if attn_metadata.decode is not None
+                decode_metadata.seq_lens
+                if decode_metadata is not None
                 else cast(torch.Tensor, attn_metadata.seq_lens)[  # type: ignore[attr-defined]
                     : attn_metadata.num_decodes
                 ]
@@ -593,7 +602,8 @@ class DeepseekV32Attention(MLAAttention):
                 seq_lens=seq_lens,
                 query_start_loc=query_start_loc,
             )
-            attn_out = finalize_mla_pcp_decode(attn_out, self.num_heads)
+            if self.use_pcp:
+                attn_out = finalize_mla_pcp_decode(attn_out, self.num_heads)
 
         # NOTE(woosuk): While the below does not need to be in the eager region,
         # we put it here to avoid copying the attention output. Move this back to the

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import torch
 import torch.nn as nn
@@ -43,6 +43,27 @@ from vllm.v1.attention.ops.pcp import (
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadata
+
+
+def _gather_mqa_query_for_dcp(
+    mqa_q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+    *,
+    use_pcp: bool,
+    dcp_world_size: int,
+    pcp_world_size: int,
+    dcp_manager: Any,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    if dcp_world_size <= 1:
+        return mqa_q
+    if isinstance(mqa_q, tuple):
+        mqa_q = torch.cat(mqa_q, dim=-1)
+    if use_pcp:
+        if dcp_world_size > pcp_world_size:
+            return get_tp_group().all_gather(mqa_q, dim=1)
+        return mqa_q
+    assert dcp_manager is not None
+    assert dcp_manager.query_gather is not None
+    return dcp_manager.query_gather(mqa_q)
 
 
 class DeepseekV32Indexer(nn.Module):
@@ -567,18 +588,13 @@ class DeepseekV32Attention(MLAAttention):
         else:
             mqa_q_arg = (ql_nope[:num_actual], mqa_q[:num_actual])
 
-        if self.impl.dcp_world_size > 1:
-            assert self.dcp_manager is not None
-            if self.use_pcp:
-                if self.impl.dcp_world_size > self.impl.pcp_world_size:
-                    if isinstance(mqa_q_arg, tuple):
-                        mqa_q_arg = torch.cat(mqa_q_arg, dim=-1)
-                    mqa_q_arg = get_tp_group().all_gather(mqa_q_arg, dim=1)
-            else:
-                if isinstance(mqa_q_arg, tuple):
-                    mqa_q_arg = torch.cat(mqa_q_arg, dim=-1)
-                assert self.dcp_manager.query_gather is not None
-                mqa_q_arg = self.dcp_manager.query_gather(mqa_q_arg)
+        mqa_q_arg = _gather_mqa_query_for_dcp(
+            mqa_q_arg,
+            use_pcp=self.use_pcp,
+            dcp_world_size=self.impl.dcp_world_size,
+            pcp_world_size=self.impl.pcp_world_size,
+            dcp_manager=self.dcp_manager,
+        )
         attn_out, lse = self.impl.forward_mqa(  # type: ignore[attr-defined]
             mqa_q_arg, kv_cache, attn_metadata, self
         )

--- a/vllm/v1/attention/ops/dcp.py
+++ b/vllm/v1/attention/ops/dcp.py
@@ -49,6 +49,11 @@ def mask_dcp_empty_shards_(
         or query_start_loc.shape[0] != seq_lens.shape[0] + 1
     ):
         raise ValueError("query_start_loc must contain one boundary per sequence")
+    if seq_lens.numel() == 0:
+        # A DCP rank can receive no local sequences during draft prefill. Its
+        # contribution must be ignored by the cross-rank LSE reduction.
+        lse.fill_(float("-inf"))
+        return
 
     row_indices = torch.arange(
         lse.shape[0], device=lse.device, dtype=query_start_loc.dtype

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -268,6 +268,7 @@ class BlockPool:
         new_hashes: list[ExternalBlockHash] | None = (
             [] if self.enable_kv_cache_events else None
         )
+        newly_cached_indices: list[int] = []
         for i, blk in enumerate(new_full_blocks):
             # Some blocks may be null or masked out when enabling sparse attention
             # like sliding window attention, or Mamba models with prefix-caching
@@ -281,6 +282,13 @@ class BlockPool:
             block_hash_with_group_id = make_block_hash_with_group_id(
                 block_hash, kv_cache_group_id
             )
+            if (
+                blk.block_hash == block_hash_with_group_id
+                and blk.block_hash_num_tokens == num_hash_tokens
+            ):
+                # Sparse boundary promotion can revisit an already registered
+                # block while adding a newly reachable neighbor.
+                continue
             if blk.block_hash is not None:
                 # The only valid case where a "new full block" already has a
                 # hash is partial->full promotion of the same cache block.
@@ -295,6 +303,7 @@ class BlockPool:
                 blk,
                 num_tokens=num_hash_tokens,
             )
+            newly_cached_indices.append(num_cached_blocks + i)
             if new_hashes is not None:
                 new_hashes.append(maybe_convert_block_hash(block_hash))
 
@@ -313,14 +322,9 @@ class BlockPool:
             # Generate extra keys for each block individually.
             # Each block may have different extra_keys (e.g., different MM
             # features, or cache_salt only for the first block).
-            # Skip null/masked-out blocks to match the length of new_hashes.
             extra_keys_list: list[tuple[Any, ...] | None] = []
             curr_mm_idx = 0
-            for i in range(num_cached_blocks, num_full_blocks):
-                if blocks[i].is_null:
-                    continue
-                if block_mask is not None and not block_mask[i - num_cached_blocks]:
-                    continue
+            for i in newly_cached_indices:
                 block_start = i * block_size
                 block_end = block_start + block_size
                 extra_keys, curr_mm_idx = generate_block_hash_extra_keys(

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -194,6 +194,8 @@ class BlockPool:
         self.kv_event_queue: list[KVCacheEvent] = []
 
         self.metrics_collector = metrics_collector
+        self.prefix_cache_group_labels: tuple[str, ...] = ()
+        self.replay_boundary_labels_by_block: dict[int, set[str]] = {}
 
     def get_cached_block(
         self, block_hash: BlockHash, kv_cache_group_ids: list[int]
@@ -231,6 +233,7 @@ class BlockPool:
         block_size: int,
         kv_cache_group_id: int,
         block_mask: list[bool] | None = None,
+        replay_boundary_mask: list[bool] | None = None,
     ) -> None:
         """Cache a list of full blocks for prefix caching.
         This function takes a list of blocks that will have their block hash
@@ -255,11 +258,16 @@ class BlockPool:
                 consults a subset of blocks (e.g. SWA tail-window), so blocks
                 that can never serve a hit stay out of the prefix-cache hash
                 map.
+            replay_boundary_mask: Optional mask identifying the cached blocks
+                that are required to replay a sparse boundary.
         """
         if num_cached_blocks >= num_full_blocks:
             return
         new_full_blocks = blocks[num_cached_blocks:num_full_blocks]
         assert block_mask is None or len(block_mask) == len(new_full_blocks)
+        assert replay_boundary_mask is None or len(replay_boundary_mask) == len(
+            new_full_blocks
+        )
         block_hashes = resolve_block_hashes(
             request.block_hashes, self.hash_block_size, block_size
         )
@@ -303,6 +311,15 @@ class BlockPool:
                 blk,
                 num_tokens=num_hash_tokens,
             )
+            if replay_boundary_mask is not None and replay_boundary_mask[i]:
+                label = self.prefix_cache_group_labels[kv_cache_group_id]
+                labels = self.replay_boundary_labels_by_block.setdefault(
+                    blk.block_id, set()
+                )
+                if label not in labels:
+                    labels.add(label)
+                    if self.metrics_collector:
+                        self.metrics_collector.on_replay_boundary_registered(label)
             newly_cached_indices.append(num_cached_blocks + i)
             if new_hashes is not None:
                 new_hashes.append(maybe_convert_block_hash(block_hash))
@@ -647,6 +664,8 @@ class BlockPool:
         for block_hash in self._remove_cached_block_hashes(src_block):
             # `num_tokens` only applies to the first (primary) insertion.
             self._insert_block_hash(block_hash, dst_block, num_tokens=num_tokens)
+        if labels := self.replay_boundary_labels_by_block.pop(src_block.block_id, None):
+            self.replay_boundary_labels_by_block[dst_block.block_id] = labels
 
     def get_new_blocks(self, num_blocks: int) -> list[KVCacheBlock]:
         """Get new blocks from the free block pool.
@@ -691,6 +710,13 @@ class BlockPool:
         Returns:
             True if the block is evicted, False otherwise.
         """
+        boundary_labels = self.replay_boundary_labels_by_block.pop(
+            block.block_id, ()
+        )
+        if self.metrics_collector:
+            for label in boundary_labels:
+                self.metrics_collector.on_replay_boundary_evicted(label)
+
         # Clean up metrics tracking first to prevent leaks
         if self.metrics_collector:
             self.metrics_collector.on_block_evicted(block)
@@ -786,6 +812,7 @@ class BlockPool:
         # Remove all hashes so that no new blocks will hit.
         self.cached_block_hash_to_block = BlockHashToBlockMap()
         self.cached_block_hashes_by_block.clear()
+        self.replay_boundary_labels_by_block.clear()
 
         # Remove all hashes from all blocks.
         for block in self.blocks:

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -710,9 +710,7 @@ class BlockPool:
         Returns:
             True if the block is evicted, False otherwise.
         """
-        boundary_labels = self.replay_boundary_labels_by_block.pop(
-            block.block_id, ()
-        )
+        boundary_labels = self.replay_boundary_labels_by_block.pop(block.block_id, ())
         if self.metrics_collector:
             for label in boundary_labels:
                 self.metrics_collector.on_replay_boundary_evicted(label)

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -94,6 +94,11 @@ class KVCacheCoordinator(ABC):
         )
         self.scheduler_block_size = scheduler_block_size
         self.num_reprefillable_tokens = max(0, num_prefill_lookahead - 1)
+        self.metrics_collector = metrics_collector
+        self.prefix_cache_group_labels = tuple(
+            f"group_{group_id}_{type(group.kv_cache_spec).__name__.lower()}"
+            for group_id, group in enumerate(kv_cache_config.kv_cache_groups)
+        )
 
         self.block_pool = BlockPool(
             num_gpu_blocks=kv_cache_config.num_blocks,
@@ -102,6 +107,7 @@ class KVCacheCoordinator(ABC):
             enable_kv_cache_events=enable_kv_cache_events,
             metrics_collector=metrics_collector,
         )
+        self.block_pool.prefix_cache_group_labels = self.prefix_cache_group_labels
 
         # KV cache group indices that get the EAGLE last-block drop.
         self.eagle_group_ids: set[int] = {
@@ -658,16 +664,28 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     ", ".join(sorted(unsupported_partial_hit_managers)),
                 )
         prefix_cache_alignment_tokens = self._cache_hit_alignment_tokens
+        full_attention_alignment_tokens = max(
+            (
+                manager.block_size
+                for manager in self.single_type_managers
+                if isinstance(manager.kv_cache_spec, FullAttentionSpec)
+            ),
+            default=prefix_cache_alignment_tokens,
+        )
         for manager in self.single_type_managers:
             manager.prefix_cache_alignment_tokens = prefix_cache_alignment_tokens
-            if self.has_replicated_sliding_group and isinstance(
-                manager.kv_cache_spec, MambaSpec
+            if self.has_replicated_sliding_group and (
+                isinstance(manager.kv_cache_spec, MambaSpec)
+                or (
+                    isinstance(manager.kv_cache_spec, SlidingWindowSpec)
+                    and manager.kv_cache_spec.dcp_replicated
+                )
             ):
-                # The DFlash group drops one EAGLE lookahead unit. Retain the
-                # target recurrent state at that common replay boundary without
-                # making every historical Mamba checkpoint dense.
-                manager.extra_replay_boundary_offsets = (
-                    -prefix_cache_alignment_tokens,
+                # The target page and EAGLE quantum define the common DFlash
+                # replay boundary. Retain only the recurrent state and draft
+                # window needed there.
+                manager.replay_boundary_alignment_tokens = (
+                    full_attention_alignment_tokens
                 )
         self.verify_and_split_kv_cache_groups()
 
@@ -919,6 +937,23 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         cache_hit_blocks = tuple(
             blocks if blocks is not None else [] for blocks in hit_blocks_by_group
         )
+        if self.metrics_collector is not None:
+            _, independent_hits = self.find_longest_cache_hit_per_group(
+                block_hashes, max_cache_hit_length
+            )
+            cacheable_prefix_tokens = round_down(
+                max_cache_hit_length, self._cache_hit_alignment_tokens
+            )
+            if self.eagle_group_ids and cacheable_prefix_tokens > 0:
+                cacheable_prefix_tokens = max(
+                    0,
+                    cacheable_prefix_tokens - self._cache_hit_alignment_tokens,
+                )
+            self.metrics_collector.on_prefix_cache_lookup(
+                cacheable_prefix_tokens,
+                hit_length,
+                dict(zip(self.prefix_cache_group_labels, independent_hits)),
+            )
         return cache_hit_blocks, hit_length, num_uncached_common_prefix_tokens
 
     def find_longest_cache_hit_per_group(

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -155,13 +155,15 @@ class KVCacheCoordinator(ABC):
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
 
-        # Sparse retention must key off "some group's lookup applies the EAGLE
-        # drop", not "this group holds draft layers": the coordinator reconciles
-        # every group to ONE hit length, so a drop anywhere shortens the
-        # candidate offered to all of them. A group that kept only its own
-        # boundary state would then sit above every reachable candidate.
+        # A full-attention EAGLE drop shortens the candidate offered to every
+        # group. SWA's own proof-block pop instead lands back on that candidate.
+        lookup_drops_eagle_block = any(
+            group_id in self.eagle_group_ids
+            and isinstance(group.kv_cache_spec, FullAttentionSpec)
+            for group_id, group in enumerate(kv_cache_config.kv_cache_groups)
+        )
         for manager in self.single_type_managers:
-            manager.lookup_drops_eagle_block = bool(self.eagle_group_ids)
+            manager.lookup_drops_eagle_block = lookup_drops_eagle_block
 
         # A positive retention interval must be a multiple of the base hit granularity
         # (``scheduler_block_size``) to land on real cache-hit boundaries.
@@ -682,11 +684,10 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         )
         for manager in self.single_type_managers:
             manager.prefix_cache_alignment_tokens = prefix_cache_alignment_tokens
-            if self.has_replicated_sliding_group and (
-                isinstance(manager.kv_cache_spec, MambaSpec)
-                or (
-                    isinstance(manager.kv_cache_spec, SlidingWindowSpec)
-                    and manager.kv_cache_spec.dcp_replicated
+            if (
+                manager.lookup_drops_eagle_block
+                and isinstance(
+                    manager.kv_cache_spec, (MambaSpec, SlidingWindowSpec)
                 )
             ):
                 # The target page and EAGLE quantum define the common DFlash

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -987,6 +987,9 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 kv_cache_spec=spec,
                 drop_eagle_block=use_eagle,
                 alignment_tokens=self._cache_hit_alignment_tokens,
+                dcp_world_size=(
+                    self.dcp_world_size if isinstance(spec, FullAttentionSpec) else 1
+                ),
             )
             for gid, blks in zip(group_ids, blocks):
                 hit_blocks[gid] = blks

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -95,9 +95,7 @@ class KVCacheCoordinator(ABC):
         self.scheduler_block_size = scheduler_block_size
         self.num_reprefillable_tokens = max(0, num_prefill_lookahead - 1)
         self.metrics_collector = metrics_collector
-        self.last_prefix_lookup_metrics: tuple[
-            int, int, dict[str, int]
-        ] | None = None
+        self.last_prefix_lookup_metrics: tuple[int, int, dict[str, int]] | None = None
         self.prefix_cache_group_labels = tuple(
             f"group_{group_id}_{type(group.kv_cache_spec).__name__.lower()}"
             for group_id, group in enumerate(kv_cache_config.kv_cache_groups)
@@ -687,11 +685,8 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         )
         for manager in self.single_type_managers:
             manager.prefix_cache_alignment_tokens = prefix_cache_alignment_tokens
-            if (
-                manager.lookup_drops_eagle_block
-                and isinstance(
-                    manager.kv_cache_spec, (MambaSpec, SlidingWindowSpec)
-                )
+            if manager.lookup_drops_eagle_block and isinstance(
+                manager.kv_cache_spec, (MambaSpec, SlidingWindowSpec)
             ):
                 # The target page and EAGLE quantum define the common DFlash
                 # replay boundary. Retain only the recurrent state and draft

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -95,6 +95,9 @@ class KVCacheCoordinator(ABC):
         self.scheduler_block_size = scheduler_block_size
         self.num_reprefillable_tokens = max(0, num_prefill_lookahead - 1)
         self.metrics_collector = metrics_collector
+        self.last_prefix_lookup_metrics: tuple[
+            int, int, dict[str, int]
+        ] | None = None
         self.prefix_cache_group_labels = tuple(
             f"group_{group_id}_{type(group.kv_cache_spec).__name__.lower()}"
             for group_id, group in enumerate(kv_cache_config.kv_cache_groups)
@@ -958,7 +961,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     0,
                     cacheable_prefix_tokens - self._cache_hit_alignment_tokens,
                 )
-            self.metrics_collector.on_prefix_cache_lookup(
+            self.last_prefix_lookup_metrics = (
                 cacheable_prefix_tokens,
                 hit_length,
                 dict(zip(self.prefix_cache_group_labels, independent_hits)),

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -320,6 +320,7 @@ class KVCacheCoordinator(ABC):
                 request,
                 num_tokens_to_cache,
                 retention_interval=self.retention_interval,
+                reached_tokens=num_computed_tokens,
             )
 
     def free(self, request_id: str) -> None:
@@ -656,6 +657,18 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     "cache managers require block-aligned lookups: %s.",
                     ", ".join(sorted(unsupported_partial_hit_managers)),
                 )
+        prefix_cache_alignment_tokens = self._cache_hit_alignment_tokens
+        for manager in self.single_type_managers:
+            manager.prefix_cache_alignment_tokens = prefix_cache_alignment_tokens
+            if self.has_replicated_sliding_group and isinstance(
+                manager.kv_cache_spec, MambaSpec
+            ):
+                # The DFlash group drops one EAGLE lookahead unit. Retain the
+                # target recurrent state at that common replay boundary without
+                # making every historical Mamba checkpoint dense.
+                manager.extra_replay_boundary_offsets = (
+                    -prefix_cache_alignment_tokens,
+                )
         self.verify_and_split_kv_cache_groups()
 
     @property
@@ -771,6 +784,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 request,
                 num_tokens_to_cache,
                 retention_interval=self.retention_interval,
+                reached_tokens=num_computed_tokens,
             )
 
     def find_longest_cache_hit(

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -155,6 +155,14 @@ class KVCacheCoordinator(ABC):
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
 
+        # Sparse retention must key off "some group's lookup applies the EAGLE
+        # drop", not "this group holds draft layers": the coordinator reconciles
+        # every group to ONE hit length, so a drop anywhere shortens the
+        # candidate offered to all of them. A group that kept only its own
+        # boundary state would then sit above every reachable candidate.
+        for manager in self.single_type_managers:
+            manager.lookup_drops_eagle_block = bool(self.eagle_group_ids)
+
         # A positive retention interval must be a multiple of the base hit granularity
         # (``scheduler_block_size``) to land on real cache-hit boundaries.
         # 0 = keep only the latest replay boundary; None = dense;

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -227,11 +227,10 @@ class KVCacheManager:
         if not self.prefix_cache_lookup_enabled(request):
             self._pending_prefix_lookup_metrics.pop(request.request_id, None)
             return
-        if self.metrics_collector is not None:
-            if lookup := self._pending_prefix_lookup_metrics.pop(
-                request.request_id, None
-            ):
-                self.metrics_collector.on_prefix_cache_lookup(*lookup)
+        if self.metrics_collector is not None and (
+            lookup := self._pending_prefix_lookup_metrics.pop(request.request_id, None)
+        ):
+            self.metrics_collector.on_prefix_cache_lookup(*lookup)
         if not self.log_stats:
             return
         assert self.prefix_cache_stats is not None

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -145,6 +145,9 @@ class KVCacheManager:
         self.use_eagle = use_eagle
         self.log_stats = log_stats
         self.metrics_collector = metrics_collector
+        self._pending_prefix_lookup_metrics: dict[
+            str, tuple[int, int, dict[str, int]]
+        ] = {}
         # FIXME: make prefix cache stats conditional on log_stats. We still need
         # this comment because when the log stats is enabled there are still
         # potential configs we could expose in the future.
@@ -219,8 +222,17 @@ class KVCacheManager:
         return self.enable_caching and not request.skip_reading_prefix_cache
 
     def record_prefix_cache_stats(self, request: Request, num_hits: int) -> None:
-        # Don't count a request that skipped the cache lookup.
-        if not self.log_stats or not self.prefix_cache_lookup_enabled(request):
+        # Emit hybrid diagnostics at admission, matching the legacy counter.
+        # Waiting requests can be looked up repeatedly before they are admitted.
+        if not self.prefix_cache_lookup_enabled(request):
+            self._pending_prefix_lookup_metrics.pop(request.request_id, None)
+            return
+        if self.metrics_collector is not None:
+            if lookup := self._pending_prefix_lookup_metrics.pop(
+                request.request_id, None
+            ):
+                self.metrics_collector.on_prefix_cache_lookup(*lookup)
+        if not self.log_stats:
             return
         assert self.prefix_cache_stats is not None
         self.prefix_cache_stats.record(
@@ -265,6 +277,13 @@ class KVCacheManager:
                 request.block_hashes, max_cache_hit_length
             )
         )
+        if (
+            self.metrics_collector is not None
+            and self.coordinator.last_prefix_lookup_metrics is not None
+        ):
+            self._pending_prefix_lookup_metrics[request.request_id] = (
+                self.coordinator.last_prefix_lookup_metrics
+            )
 
         # When kv_cache_report_mode is "full", emit BlockStored events
         # for the reused prefix cache blocks so that external consumers
@@ -575,6 +594,7 @@ class KVCacheManager:
         Args:
             request: The request to free the blocks.
         """
+        self._pending_prefix_lookup_metrics.pop(request.request_id, None)
         pins = self._partial_tail_pins.pop(request.request_id, None)
         if pins:
             self.block_pool.free_blocks(pins)

--- a/vllm/v1/core/kv_cache_metrics.py
+++ b/vllm/v1/core/kv_cache_metrics.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from vllm.v1.core.kv_cache_utils import KVCacheBlock
 
-from vllm.v1.metrics.stats import KVCacheEvictionEvent
+from vllm.v1.metrics.stats import HybridPrefixCacheStats, KVCacheEvictionEvent
 
 
 class BlockMetricsState:
@@ -55,6 +55,7 @@ class KVCacheMetricsCollector:
         self.block_metrics: dict[int, BlockMetricsState] = {}
 
         self._eviction_events: list[KVCacheEvictionEvent] = []
+        self._prefix_lookup_stats = HybridPrefixCacheStats()
 
     def should_sample_block(self) -> bool:
         return random.random() < self.sample_rate
@@ -85,12 +86,46 @@ class KVCacheMetricsCollector:
             )
         )
 
+    def on_prefix_cache_lookup(
+        self,
+        cacheable_prefix_tokens: int,
+        reconciled_hit_tokens: int,
+        per_group_hit_tokens: dict[str, int],
+    ) -> None:
+        """Record one bounded, content-free hybrid prefix-cache lookup."""
+        stats = self._prefix_lookup_stats
+        stats.cacheable_prefix_tokens += cacheable_prefix_tokens
+        stats.reconciled_hit_tokens += reconciled_hit_tokens
+        for label, hit_tokens in per_group_hit_tokens.items():
+            stats.prefix_cache_group_hits[label] = (
+                stats.prefix_cache_group_hits.get(label, 0) + hit_tokens
+            )
+
+    def on_replay_boundary_registered(self, group_label: str) -> None:
+        stats = self._prefix_lookup_stats
+        stats.boundary_registrations[group_label] = (
+            stats.boundary_registrations.get(group_label, 0) + 1
+        )
+
+    def on_replay_boundary_evicted(self, group_label: str) -> None:
+        stats = self._prefix_lookup_stats
+        stats.boundary_evictions[group_label] = (
+            stats.boundary_evictions.get(group_label, 0) + 1
+        )
+
     def reset(self) -> None:
         """Clear all state on cache reset."""
         self.block_metrics.clear()
         self._eviction_events.clear()
+        self._prefix_lookup_stats = HybridPrefixCacheStats()
 
     def drain_events(self) -> list[KVCacheEvictionEvent]:
         events = self._eviction_events
         self._eviction_events = []
         return events
+
+    def drain_prefix_lookup_stats(self) -> HybridPrefixCacheStats:
+        """Drain aggregate hybrid prefix-cache diagnostics."""
+        stats = self._prefix_lookup_stats
+        self._prefix_lookup_stats = HybridPrefixCacheStats()
+        return stats

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -3035,16 +3035,31 @@ class Scheduler(SchedulerInterface):
             if self.kv_metrics_collector is not None
             else []
         )
+        hybrid_prefix_cache_stats = (
+            self.kv_metrics_collector.drain_prefix_lookup_stats()
+            if self.kv_metrics_collector is not None
+            else None
+        )
         spec_stats = spec_decoding_stats
         connector_stats_payload = (
             kv_connector_stats.data if kv_connector_stats else None
         )
+        decode_prefill_stats = self.drain_decode_prefill_stats()
         return SchedulerStats(
             num_running_reqs=len(self.running),
             num_waiting_reqs=len(self.waiting),
             num_skipped_waiting_reqs=len(self.skipped_waiting),
             kv_cache_usage=self.kv_cache_manager.usage,
+            scheduled_prefill_tokens=decode_prefill_stats[
+                "scheduled_prefill_tokens"
+            ],
+            active_partial_prefills=decode_prefill_stats[
+                "active_partial_prefills"
+            ],
+            decode_only_steps=decode_prefill_stats["decode_only_steps"],
+            fairness_bypasses=decode_prefill_stats["fairness_bypasses"],
             prefix_cache_stats=prefix_cache_stats,
+            hybrid_prefix_cache_stats=hybrid_prefix_cache_stats,
             connector_prefix_cache_stats=connector_prefix_cache_stats,
             kv_cache_eviction_events=eviction_events,
             spec_decoding_stats=spec_stats,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -338,6 +338,16 @@ class Scheduler(SchedulerInterface):
         self.max_num_partial_prefills = (
             self.scheduler_config.max_num_partial_prefills
         )
+        self.decode_prefill_min_decode_steps = (
+            self.scheduler_config.decode_prefill_min_decode_steps
+        )
+        self.decode_prefill_max_wait_ms = (
+            self.scheduler_config.decode_prefill_max_wait_ms
+        )
+        self._decode_prefill_steps_since_prefill = 0
+        self._decode_prefill_scheduled_prefill_tokens = 0
+        self._decode_prefill_decode_only_steps = 0
+        self._decode_prefill_fairness_bypasses = 0
         self._prefill_budget_rotation = 0
         self.scheduler_reserve_full_isl = (
             self.scheduler_config.scheduler_reserve_full_isl
@@ -598,6 +608,50 @@ class Scheduler(SchedulerInterface):
             self._prefill_budget_rotation = (start + 1) % len(request_ids)
         return limits
 
+    @staticmethod
+    def _request_has_pending_prefill(request: Request) -> bool:
+        return request.is_prefill_chunk or (
+            request.status in (RequestStatus.WAITING, RequestStatus.PREEMPTED)
+            and request.num_computed_tokens < request.num_tokens - 1
+        )
+
+    def _has_pending_prefill(self) -> bool:
+        return any(
+            self._request_has_pending_prefill(request)
+            for request in (*self.running, *self.waiting, *self.skipped_waiting)
+        )
+
+    def _oldest_prefill_waiter_age_ms(self, now: float) -> float:
+        arrival_times = (
+            request.arrival_time
+            for request in (*self.waiting, *self.skipped_waiting)
+            if self._request_has_pending_prefill(request)
+        )
+        oldest_arrival = min(arrival_times, default=now)
+        return max((now - oldest_arrival) * 1000, 0.0)
+
+    @property
+    def decode_prefill_active_partial_prefills(self) -> int:
+        return len(self._inflight_prefills)
+
+    def drain_decode_prefill_stats(self) -> dict[str, int]:
+        """Return and reset decode-prefill interval counters.
+
+        The active-partial-prefill value is a gauge and is not reset.
+        """
+        stats = {
+            "scheduled_prefill_tokens": (
+                self._decode_prefill_scheduled_prefill_tokens
+            ),
+            "active_partial_prefills": self.decode_prefill_active_partial_prefills,
+            "decode_only_steps": self._decode_prefill_decode_only_steps,
+            "fairness_bypasses": self._decode_prefill_fairness_bypasses,
+        }
+        self._decode_prefill_scheduled_prefill_tokens = 0
+        self._decode_prefill_decode_only_steps = 0
+        self._decode_prefill_fairness_bypasses = 0
+        return stats
+
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         self.current_step += 1
         # NOTE(woosuk) on the scheduling algorithm:
@@ -633,6 +687,7 @@ class Scheduler(SchedulerInterface):
         scheduled_spec_decode_tokens: dict[str, list[int]] = {}
         # Whether the running batch contains any prefill requests.
         prefill_scheduled = False
+        all_scheduled_prefill_req_ids: set[str] = set()
 
         # For logging.
         scheduled_timestamp = time.monotonic()
@@ -648,9 +703,26 @@ class Scheduler(SchedulerInterface):
             and self.current_step >= request.next_decode_eligible_step
             for request in self.running
         )
-        defer_prefills = (
+        legacy_defer_prefills = (
             throttle_prefills and not self.prefill_capacity_bound
         ) and has_eligible_decode
+        has_pending_prefill = self._has_pending_prefill()
+        decode_prefill_enabled = self.decode_prefill_min_decode_steps > 0
+        fairness_due = (
+            decode_prefill_enabled
+            and self.decode_prefill_max_wait_ms > 0
+            and self._oldest_prefill_waiter_age_ms(time.time())
+            >= self.decode_prefill_max_wait_ms
+        )
+        decode_burst_defer_prefills = (
+            decode_prefill_enabled
+            and has_eligible_decode
+            and has_pending_prefill
+            and self._decode_prefill_steps_since_prefill
+            < self.decode_prefill_min_decode_steps
+            and not fairness_due
+        )
+        defer_prefills = legacy_defer_prefills or decode_burst_defer_prefills
 
         prefill_budget_remaining: int | None = None
         running_prefill_limits: dict[str, int] = {}
@@ -863,6 +935,9 @@ class Scheduler(SchedulerInterface):
                                 scheduled_prefill_req_ids.remove(
                                     preempted_req_id
                                 )
+                            all_scheduled_prefill_req_ids.discard(
+                                preempted_req_id
+                            )
                             req_to_new_blocks.pop(preempted_req_id)
                             scheduled_spec_decode_tokens.pop(preempted_req_id, None)
                             preempted_encoder_inputs = scheduled_encoder_inputs.pop(
@@ -899,6 +974,8 @@ class Scheduler(SchedulerInterface):
             request_id = request.request_id
             req_to_new_blocks[request_id] = new_blocks
             num_scheduled_tokens[request_id] = num_new_tokens
+            if request.is_prefill_chunk:
+                all_scheduled_prefill_req_ids.add(request_id)
             token_budget -= num_new_tokens
             input_budget -= num_new_tokens + draft_slots
             if running_prefill_limit is not None:
@@ -1375,6 +1452,8 @@ class Scheduler(SchedulerInterface):
                     request_id
                 )
                 num_scheduled_tokens[request_id] = num_new_tokens
+                if has_local_prefill and num_new_tokens > 0:
+                    all_scheduled_prefill_req_ids.add(request_id)
                 token_budget -= num_new_tokens
                 input_budget -= num_new_tokens + draft_slots
                 if waiting_prefill_limit is not None:
@@ -1556,6 +1635,29 @@ class Scheduler(SchedulerInterface):
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
             ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
         )
+
+        scheduled_prefill_tokens = sum(
+            num_scheduled_tokens[request_id]
+            for request_id in all_scheduled_prefill_req_ids
+        )
+        self._decode_prefill_scheduled_prefill_tokens += scheduled_prefill_tokens
+        scheduled_decode_tokens = (
+            total_num_scheduled_tokens - scheduled_prefill_tokens
+        )
+        if decode_prefill_enabled:
+            if scheduled_prefill_tokens > 0:
+                self._decode_prefill_steps_since_prefill = 0
+                if fairness_due:
+                    self._decode_prefill_fairness_bypasses += 1
+            elif (
+                has_eligible_decode
+                and has_pending_prefill
+                and scheduled_decode_tokens > 0
+            ):
+                self._decode_prefill_steps_since_prefill += 1
+                self._decode_prefill_decode_only_steps += 1
+            elif not has_eligible_decode:
+                self._decode_prefill_steps_since_prefill = 0
 
         # NOTE(Kuntai): this function is designed for multiple purposes:
         # 1. Plan the KV cache store

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -348,6 +348,25 @@ class Scheduler(SchedulerInterface):
         self.need_mamba_block_aligned_split = (
             self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
         )
+        mamba_block_sizes = [
+            group.kv_cache_spec.block_size
+            for group in kv_cache_config.kv_cache_groups
+            if isinstance(group.kv_cache_spec, MambaSpec)
+        ]
+        self.mamba_block_size = math.lcm(*mamba_block_sizes)
+        self._prefill_budget_quantum = (
+            self.mamba_block_size if self.need_mamba_block_aligned_split else 1
+        )
+        if (
+            self.need_mamba_block_aligned_split
+            and self.max_num_prefill_tokens_per_step
+            and self.max_num_prefill_tokens_per_step % self._prefill_budget_quantum
+            != 0
+        ):
+            raise ValueError(
+                "max_num_prefill_tokens_per_step must be a multiple of "
+                f"the Mamba block size ({self._prefill_budget_quantum})"
+            )
         glm5_next_mtp_has_independent_draft_state = (
             speculative_config is not None
             and speculative_config.method == "mtp"
@@ -548,40 +567,24 @@ class Scheduler(SchedulerInterface):
             num_new_tokens -= self.num_prefill_lookahead - remaining
         return max(num_new_tokens, 0)
 
-    def _distribute_prefill_token_budget(
+    def _select_running_prefill_limits(
         self,
-        budget: int,
-        num_candidates: int,
-    ) -> list[int]:
-        if budget <= 0 or num_candidates <= 0:
-            return []
+        request_ids: list[str],
+        num_quanta: int,
+    ) -> dict[str, int]:
+        if num_quanta <= 0 or not request_ids:
+            return {}
 
-        alignment = (
-            self.mamba_block_size if self.need_mamba_block_aligned_split else 1
-        )
-        budget_units = budget // alignment
-        base_units, extra_units = divmod(budget_units, num_candidates)
-        limits = [base_units * alignment for _ in range(num_candidates)]
-
-        if base_units == 0:
-            # Keep the earliest candidates eligible when the budget cannot
-            # cover every candidate. This retains FCFS admission order.
-            extra_indices = range(extra_units)
-        else:
-            # Rotate only the ownership of remainder units. Request and queue
-            # order stay unchanged, while equal-priority prefills take turns
-            # receiving the larger chunk.
-            start = self._prefill_budget_rotation % num_candidates
-            extra_indices = (
-                (start + offset) % num_candidates for offset in range(extra_units)
+        start = self._prefill_budget_rotation % len(request_ids)
+        limits: dict[str, int] = {}
+        for offset in range(num_quanta):
+            request_id = request_ids[(start + offset) % len(request_ids)]
+            limits[request_id] = (
+                limits.get(request_id, 0) + self._prefill_budget_quantum
             )
-            if extra_units:
-                self._prefill_budget_rotation = (
-                    start + extra_units
-                ) % num_candidates
-
-        for index in extra_indices:
-            limits[index] += alignment
+        self._prefill_budget_rotation = (
+            start + num_quanta
+        ) % len(request_ids)
         return limits
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
@@ -654,6 +657,9 @@ class Scheduler(SchedulerInterface):
                 token_budget,
                 input_budget,
             )
+            mixed_prefill_quanta = (
+                mixed_prefill_budget // self._prefill_budget_quantum
+            )
             running_prefill_ids = [
                 request.request_id
                 for request in self.running
@@ -662,23 +668,21 @@ class Scheduler(SchedulerInterface):
             ]
             num_running = len(self.running) + self.num_waiting_for_streaming_input
             free_sequence_slots = max(self.max_num_running_reqs - num_running, 0)
-            waiting_slots = min(
-                free_sequence_slots,
-                len(self.waiting) + len(self.skipped_waiting),
+            reserve_waiting_quantum = int(
+                mixed_prefill_quanta > 0
+                and free_sequence_slots > 0
+                and bool(self.waiting or self.skipped_waiting)
             )
-            limits = self._distribute_prefill_token_budget(
-                mixed_prefill_budget,
-                len(running_prefill_ids) + waiting_slots,
+            waiting_prefill_limits = (
+                [self._prefill_budget_quantum] if reserve_waiting_quantum else []
             )
-            running_prefill_limits = dict(
-                zip(
-                    running_prefill_ids,
-                    limits[: len(running_prefill_ids)],
-                    strict=True,
-                )
+            running_prefill_limits = self._select_running_prefill_limits(
+                running_prefill_ids,
+                mixed_prefill_quanta - reserve_waiting_quantum,
             )
-            waiting_prefill_limits = limits[len(running_prefill_ids) :]
-            prefill_budget_remaining = sum(limits)
+            prefill_budget_remaining = sum(running_prefill_limits.values()) + sum(
+                waiting_prefill_limits
+            )
 
         # First, schedule the RUNNING requests.
         req_index = 0

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -576,15 +576,23 @@ class Scheduler(SchedulerInterface):
             return {}
 
         start = self._prefill_budget_rotation % len(request_ids)
-        limits: dict[str, int] = {}
-        for offset in range(num_quanta):
+        base_quanta, remainder = divmod(num_quanta, len(request_ids))
+        limits = {
+            request_id: base_quanta * self._prefill_budget_quantum
+            for request_id in request_ids
+            if base_quanta > 0
+        }
+        for offset in range(remainder):
             request_id = request_ids[(start + offset) % len(request_ids)]
             limits[request_id] = (
                 limits.get(request_id, 0) + self._prefill_budget_quantum
             )
-        self._prefill_budget_rotation = (
-            start + num_quanta
-        ) % len(request_ids)
+        if remainder:
+            self._prefill_budget_rotation = (
+                start + remainder
+            ) % len(request_ids)
+        elif base_quanta:
+            self._prefill_budget_rotation = (start + 1) % len(request_ids)
         return limits
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -335,6 +335,9 @@ class Scheduler(SchedulerInterface):
         self.max_num_prefill_tokens_per_step = (
             self.scheduler_config.max_num_prefill_tokens_per_step
         )
+        self.max_num_partial_prefills = (
+            self.scheduler_config.max_num_partial_prefills
+        )
         self._prefill_budget_rotation = 0
         self.scheduler_reserve_full_isl = (
             self.scheduler_config.scheduler_reserve_full_isl
@@ -676,9 +679,14 @@ class Scheduler(SchedulerInterface):
             ]
             num_running = len(self.running) + self.num_waiting_for_streaming_input
             free_sequence_slots = max(self.max_num_running_reqs - num_running, 0)
+            partial_prefill_slot_available = (
+                self.max_num_partial_prefills == 0
+                or len(self._inflight_prefills) < self.max_num_partial_prefills
+            )
             reserve_waiting_quantum = int(
                 mixed_prefill_quanta > 0
                 and free_sequence_slots > 0
+                and partial_prefill_slot_available
                 and bool(self.waiting or self.skipped_waiting)
             )
             waiting_prefill_limits = (
@@ -1227,6 +1235,17 @@ class Scheduler(SchedulerInterface):
                     if num_new_tokens == 0:
                         # The request cannot be scheduled.
                         break
+
+                will_remain_partial = (
+                    has_local_prefill
+                    and num_computed_tokens + num_new_tokens < request.num_tokens
+                )
+                if (
+                    will_remain_partial
+                    and self.max_num_partial_prefills > 0
+                    and len(self._inflight_prefills) >= self.max_num_partial_prefills
+                ):
+                    break
 
                 # During async KV load, no forward pass is run yet.
                 # Allocate speculative lookahead slots later to avoid

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -332,6 +332,10 @@ class Scheduler(SchedulerInterface):
         # prefill batch fully drained the waiting queue. Prefill throttling
         # is disabled in this case.
         self.prefill_capacity_bound = False
+        self.max_num_prefill_tokens_per_step = (
+            self.scheduler_config.max_num_prefill_tokens_per_step
+        )
+        self._prefill_budget_rotation = 0
         self.scheduler_reserve_full_isl = (
             self.scheduler_config.scheduler_reserve_full_isl
         )
@@ -544,6 +548,42 @@ class Scheduler(SchedulerInterface):
             num_new_tokens -= self.num_prefill_lookahead - remaining
         return max(num_new_tokens, 0)
 
+    def _distribute_prefill_token_budget(
+        self,
+        budget: int,
+        num_candidates: int,
+    ) -> list[int]:
+        if budget <= 0 or num_candidates <= 0:
+            return []
+
+        alignment = (
+            self.mamba_block_size if self.need_mamba_block_aligned_split else 1
+        )
+        budget_units = budget // alignment
+        base_units, extra_units = divmod(budget_units, num_candidates)
+        limits = [base_units * alignment for _ in range(num_candidates)]
+
+        if base_units == 0:
+            # Keep the earliest candidates eligible when the budget cannot
+            # cover every candidate. This retains FCFS admission order.
+            extra_indices = range(extra_units)
+        else:
+            # Rotate only the ownership of remainder units. Request and queue
+            # order stay unchanged, while equal-priority prefills take turns
+            # receiving the larger chunk.
+            start = self._prefill_budget_rotation % num_candidates
+            extra_indices = (
+                (start + offset) % num_candidates for offset in range(extra_units)
+            )
+            if extra_units:
+                self._prefill_budget_rotation = (
+                    start + extra_units
+                ) % num_candidates
+
+        for index in extra_indices:
+            limits[index] += alignment
+        return limits
+
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         self.current_step += 1
         # NOTE(woosuk) on the scheduling algorithm:
@@ -598,6 +638,48 @@ class Scheduler(SchedulerInterface):
             throttle_prefills and not self.prefill_capacity_bound
         ) and has_eligible_decode
 
+        prefill_budget_remaining: int | None = None
+        running_prefill_limits: dict[str, int] = {}
+        waiting_prefill_limits: list[int] = []
+        waiting_prefill_limit_index = 0
+        scheduled_prefill_req_ids: set[str] = set()
+        mixed_prefill_tokens_scheduled = 0
+        if (
+            self.max_num_prefill_tokens_per_step > 0
+            and has_eligible_decode
+            and not defer_prefills
+        ):
+            mixed_prefill_budget = min(
+                self.max_num_prefill_tokens_per_step,
+                token_budget,
+                input_budget,
+            )
+            running_prefill_ids = [
+                request.request_id
+                for request in self.running
+                if request.is_prefill_chunk
+                and self.current_step >= request.next_decode_eligible_step
+            ]
+            num_running = len(self.running) + self.num_waiting_for_streaming_input
+            free_sequence_slots = max(self.max_num_running_reqs - num_running, 0)
+            waiting_slots = min(
+                free_sequence_slots,
+                len(self.waiting) + len(self.skipped_waiting),
+            )
+            limits = self._distribute_prefill_token_budget(
+                mixed_prefill_budget,
+                len(running_prefill_ids) + waiting_slots,
+            )
+            running_prefill_limits = dict(
+                zip(
+                    running_prefill_ids,
+                    limits[: len(running_prefill_ids)],
+                    strict=True,
+                )
+            )
+            waiting_prefill_limits = limits[len(running_prefill_ids) :]
+            prefill_budget_remaining = sum(limits)
+
         # First, schedule the RUNNING requests.
         req_index = 0
         while req_index < len(self.running) and token_budget > 0:
@@ -633,6 +715,15 @@ class Scheduler(SchedulerInterface):
                 req_index += 1
                 continue
 
+            running_prefill_limit = None
+            if request.is_prefill_chunk and prefill_budget_remaining is not None:
+                running_prefill_limit = running_prefill_limits.get(
+                    request.request_id, 0
+                )
+                if running_prefill_limit <= 0 or prefill_budget_remaining <= 0:
+                    req_index += 1
+                    continue
+
             num_new_tokens = (
                 request.num_tokens_with_spec
                 + request.num_output_placeholders
@@ -643,6 +734,12 @@ class Scheduler(SchedulerInterface):
             num_new_tokens = min(
                 num_new_tokens, token_budget, input_budget - draft_slots
             )
+            if running_prefill_limit is not None:
+                num_new_tokens = min(
+                    num_new_tokens,
+                    running_prefill_limit,
+                    prefill_budget_remaining,
+                )
 
             # Make sure the input position does not exceed the max model len.
             # This is necessary when using spec decoding.
@@ -739,6 +836,13 @@ class Scheduler(SchedulerInterface):
                             restored = num_scheduled_tokens.pop(preempted_req_id)
                             token_budget += restored
                             input_budget += restored + draft_slots
+                            if preempted_req_id in scheduled_prefill_req_ids:
+                                assert prefill_budget_remaining is not None
+                                prefill_budget_remaining += restored
+                                mixed_prefill_tokens_scheduled -= restored
+                                scheduled_prefill_req_ids.remove(
+                                    preempted_req_id
+                                )
                             req_to_new_blocks.pop(preempted_req_id)
                             scheduled_spec_decode_tokens.pop(preempted_req_id, None)
                             preempted_encoder_inputs = scheduled_encoder_inputs.pop(
@@ -777,6 +881,11 @@ class Scheduler(SchedulerInterface):
             num_scheduled_tokens[request_id] = num_new_tokens
             token_budget -= num_new_tokens
             input_budget -= num_new_tokens + draft_slots
+            if running_prefill_limit is not None:
+                assert prefill_budget_remaining is not None
+                prefill_budget_remaining -= num_new_tokens
+                mixed_prefill_tokens_scheduled += num_new_tokens
+                scheduled_prefill_req_ids.add(request_id)
             req_index += 1
 
             # Speculative decode related.
@@ -992,17 +1101,40 @@ class Scheduler(SchedulerInterface):
                 external_load_encoder_input = []
                 new_encoder_compute_budget = encoder_compute_budget
                 pad_spec_decode = False
+                waiting_prefill_limit = None
+                has_local_prefill = (
+                    not load_kv_async
+                    and num_computed_tokens < request.num_tokens - 1
+                )
 
                 if load_kv_async:
                     # KVTransfer: loading remote KV, do not allocate for new work.
                     assert num_external_computed_tokens > 0
                     num_new_tokens = 0
-                elif defer_prefills and num_computed_tokens < request.num_tokens - 1:
+                elif defer_prefills and has_local_prefill:
                     # DP prefill balancing: defer this step's local prefill
                     # compute to a cadence-aligned step.
                     break
                 else:
                     request_token_budget = min(token_budget, input_budget - draft_slots)
+                    if has_local_prefill and prefill_budget_remaining is not None:
+                        if (
+                            waiting_prefill_limit_index
+                            >= len(waiting_prefill_limits)
+                            or prefill_budget_remaining <= 0
+                        ):
+                            break
+                        waiting_prefill_limit = waiting_prefill_limits[
+                            waiting_prefill_limit_index
+                        ]
+                        waiting_prefill_limit_index += 1
+                        if waiting_prefill_limit <= 0:
+                            break
+                        request_token_budget = min(
+                            request_token_budget,
+                            waiting_prefill_limit,
+                            prefill_budget_remaining,
+                        )
                     # Number of tokens to be scheduled.
                     # We use `request.num_tokens` instead of
                     # `request.num_prompt_tokens` to consider the resumed
@@ -1214,6 +1346,11 @@ class Scheduler(SchedulerInterface):
                 num_scheduled_tokens[request_id] = num_new_tokens
                 token_budget -= num_new_tokens
                 input_budget -= num_new_tokens + draft_slots
+                if waiting_prefill_limit is not None:
+                    assert prefill_budget_remaining is not None
+                    prefill_budget_remaining -= num_new_tokens
+                    mixed_prefill_tokens_scheduled += num_new_tokens
+                    scheduled_prefill_req_ids.add(request_id)
                 request.status = RequestStatus.RUNNING
                 request.num_computed_tokens = num_computed_tokens
                 if pad_spec_decode:
@@ -1251,6 +1388,13 @@ class Scheduler(SchedulerInterface):
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
         assert total_num_scheduled_tokens <= self.max_num_scheduled_tokens
+
+        if prefill_budget_remaining is not None:
+            assert prefill_budget_remaining >= 0
+            assert (
+                mixed_prefill_tokens_scheduled
+                <= self.max_num_prefill_tokens_per_step
+            )
 
         assert token_budget >= 0
         assert input_budget >= 0

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
+import math
 import time
 from collections import defaultdict, deque
 from collections.abc import Iterable
@@ -335,9 +336,7 @@ class Scheduler(SchedulerInterface):
         self.max_num_prefill_tokens_per_step = (
             self.scheduler_config.max_num_prefill_tokens_per_step
         )
-        self.max_num_partial_prefills = (
-            self.scheduler_config.max_num_partial_prefills
-        )
+        self.max_num_partial_prefills = self.scheduler_config.max_num_partial_prefills
         self.decode_prefill_min_decode_steps = (
             self.scheduler_config.decode_prefill_min_decode_steps
         )
@@ -373,8 +372,7 @@ class Scheduler(SchedulerInterface):
         if (
             self.need_mamba_block_aligned_split
             and self.max_num_prefill_tokens_per_step
-            and self.max_num_prefill_tokens_per_step % self._prefill_budget_quantum
-            != 0
+            and self.max_num_prefill_tokens_per_step % self._prefill_budget_quantum != 0
         ):
             raise ValueError(
                 "max_num_prefill_tokens_per_step must be a multiple of "
@@ -601,9 +599,7 @@ class Scheduler(SchedulerInterface):
                 limits.get(request_id, 0) + self._prefill_budget_quantum
             )
         if remainder:
-            self._prefill_budget_rotation = (
-                start + remainder
-            ) % len(request_ids)
+            self._prefill_budget_rotation = (start + remainder) % len(request_ids)
         elif base_quanta:
             self._prefill_budget_rotation = (start + 1) % len(request_ids)
         return limits
@@ -640,9 +636,7 @@ class Scheduler(SchedulerInterface):
         The active-partial-prefill value is a gauge and is not reset.
         """
         stats = {
-            "scheduled_prefill_tokens": (
-                self._decode_prefill_scheduled_prefill_tokens
-            ),
+            "scheduled_prefill_tokens": (self._decode_prefill_scheduled_prefill_tokens),
             "active_partial_prefills": self.decode_prefill_active_partial_prefills,
             "decode_only_steps": self._decode_prefill_decode_only_steps,
             "fairness_bypasses": self._decode_prefill_fairness_bypasses,
@@ -740,9 +734,7 @@ class Scheduler(SchedulerInterface):
                 token_budget,
                 input_budget,
             )
-            mixed_prefill_quanta = (
-                mixed_prefill_budget // self._prefill_budget_quantum
-            )
+            mixed_prefill_quanta = mixed_prefill_budget // self._prefill_budget_quantum
             running_prefill_ids = [
                 request.request_id
                 for request in self.running
@@ -827,6 +819,7 @@ class Scheduler(SchedulerInterface):
                 num_new_tokens, token_budget, input_budget - draft_slots
             )
             if running_prefill_limit is not None:
+                assert prefill_budget_remaining is not None
                 num_new_tokens = min(
                     num_new_tokens,
                     running_prefill_limit,
@@ -932,12 +925,8 @@ class Scheduler(SchedulerInterface):
                                 assert prefill_budget_remaining is not None
                                 prefill_budget_remaining += restored
                                 mixed_prefill_tokens_scheduled -= restored
-                                scheduled_prefill_req_ids.remove(
-                                    preempted_req_id
-                                )
-                            all_scheduled_prefill_req_ids.discard(
-                                preempted_req_id
-                            )
+                                scheduled_prefill_req_ids.remove(preempted_req_id)
+                            all_scheduled_prefill_req_ids.discard(preempted_req_id)
                             req_to_new_blocks.pop(preempted_req_id)
                             scheduled_spec_decode_tokens.pop(preempted_req_id, None)
                             preempted_encoder_inputs = scheduled_encoder_inputs.pop(
@@ -1200,8 +1189,7 @@ class Scheduler(SchedulerInterface):
                 pad_spec_decode = False
                 waiting_prefill_limit = None
                 has_local_prefill = (
-                    not load_kv_async
-                    and num_computed_tokens < request.num_tokens - 1
+                    not load_kv_async and num_computed_tokens < request.num_tokens - 1
                 )
 
                 if load_kv_async:
@@ -1216,8 +1204,7 @@ class Scheduler(SchedulerInterface):
                     request_token_budget = min(token_budget, input_budget - draft_slots)
                     if has_local_prefill and prefill_budget_remaining is not None:
                         if (
-                            waiting_prefill_limit_index
-                            >= len(waiting_prefill_limits)
+                            waiting_prefill_limit_index >= len(waiting_prefill_limits)
                             or prefill_budget_remaining <= 0
                         ):
                             break
@@ -1502,8 +1489,7 @@ class Scheduler(SchedulerInterface):
         if prefill_budget_remaining is not None:
             assert prefill_budget_remaining >= 0
             assert (
-                mixed_prefill_tokens_scheduled
-                <= self.max_num_prefill_tokens_per_step
+                mixed_prefill_tokens_scheduled <= self.max_num_prefill_tokens_per_step
             )
 
         assert token_budget >= 0
@@ -1641,9 +1627,7 @@ class Scheduler(SchedulerInterface):
             for request_id in all_scheduled_prefill_req_ids
         )
         self._decode_prefill_scheduled_prefill_tokens += scheduled_prefill_tokens
-        scheduled_decode_tokens = (
-            total_num_scheduled_tokens - scheduled_prefill_tokens
-        )
+        scheduled_decode_tokens = total_num_scheduled_tokens - scheduled_prefill_tokens
         if decode_prefill_enabled:
             if scheduled_prefill_tokens > 0:
                 self._decode_prefill_steps_since_prefill = 0
@@ -3050,12 +3034,8 @@ class Scheduler(SchedulerInterface):
             num_waiting_reqs=len(self.waiting),
             num_skipped_waiting_reqs=len(self.skipped_waiting),
             kv_cache_usage=self.kv_cache_manager.usage,
-            scheduled_prefill_tokens=decode_prefill_stats[
-                "scheduled_prefill_tokens"
-            ],
-            active_partial_prefills=decode_prefill_stats[
-                "active_partial_prefills"
-            ],
+            scheduled_prefill_tokens=decode_prefill_stats["scheduled_prefill_tokens"],
+            active_partial_prefills=decode_prefill_stats["active_partial_prefills"],
             decode_only_steps=decode_prefill_stats["decode_only_steps"],
             fairness_bypasses=decode_prefill_stats["fairness_bypasses"],
             prefix_cache_stats=prefix_cache_stats,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -75,9 +75,10 @@ class SingleTypeKVCacheManager(ABC):
         # every group supports fine-grained prefix lookup.
         self.prefix_cache_alignment_tokens = scheduler_block_size
         # Additional offsets from prompt and shared-prefix boundaries that this
-        # group must retain. Hybrid coordinators use this for a target Mamba
-        # state that precedes a DFlash EAGLE lookahead block.
+        # group must retain. Hybrid coordinators can also align sparse replay
+        # boundaries to the target attention page before EAGLE backoff.
         self.extra_replay_boundary_offsets: tuple[int, ...] = ()
+        self.replay_boundary_alignment_tokens: int | None = None
         # The block size for this manager; used for actual block allocation.
         self.block_size = kv_cache_spec.block_size
         self.dcp_world_size = dcp_world_size
@@ -457,10 +458,29 @@ class SingleTypeKVCacheManager(ABC):
         # Token boundaries whose reachable tail must be retained under sparse
         # retention: the replay boundary (``num_prompt - 1``, capped by
         # ``get_computed_blocks``) and any detected shared-prefix junction.
-        base_boundaries = [request.num_prompt_tokens - 1]
+        prompt_replay_boundary = request.num_prompt_tokens - 1
+        if (
+            self.use_eagle
+            and isinstance(self.kv_cache_spec, SlidingWindowSpec)
+            and request.num_prompt_tokens % self.prefix_cache_alignment_tokens == 0
+        ):
+            # At an exact prompt boundary there is no lookup-visible EAGLE
+            # block to the right. Retain the preceding replay window instead.
+            prompt_replay_boundary -= self.prefix_cache_alignment_tokens
+        base_boundaries = [prompt_replay_boundary]
         if request.shared_prefix_boundary:
             base_boundaries.append(request.shared_prefix_boundary)
         candidate_boundaries = list(base_boundaries)
+        if self.replay_boundary_alignment_tokens is not None:
+            for boundary in base_boundaries:
+                shifted = (
+                    boundary
+                    // self.replay_boundary_alignment_tokens
+                    * self.replay_boundary_alignment_tokens
+                    - self.prefix_cache_alignment_tokens
+                )
+                if shifted > 0:
+                    candidate_boundaries.append(shifted)
         for boundary in base_boundaries:
             candidate_boundaries.extend(
                 shifted
@@ -473,7 +493,13 @@ class SingleTypeKVCacheManager(ABC):
         if reached_tokens is None:
             reached_tokens = max(num_tokens, request.num_computed_tokens)
         reachable_boundaries = [
-            boundary for boundary in candidate_boundaries if boundary < reached_tokens
+            boundary
+            for boundary in candidate_boundaries
+            if boundary < reached_tokens
+            or (
+                boundary == reached_tokens
+                and isinstance(self.kv_cache_spec, MambaSpec)
+            )
         ]
 
         # A sparse boundary can become reachable after its blocks were first
@@ -499,6 +525,15 @@ class SingleTypeKVCacheManager(ABC):
             retention_interval=retention_interval,
             reachable_boundaries=reachable_boundaries,
         )
+        replay_boundary_mask = self.reachable_block_mask(
+            start_block=scan_start_block,
+            end_block=num_full_blocks,
+            alignment_tokens=self.prefix_cache_alignment_tokens,
+            kv_cache_spec=self.kv_cache_spec,
+            use_eagle=self.use_eagle,
+            retention_interval=0,
+            reachable_boundaries=reachable_boundaries,
+        )
         self.block_pool.cache_full_blocks(
             request=request,
             blocks=self.req_to_blocks[request.request_id],
@@ -507,6 +542,7 @@ class SingleTypeKVCacheManager(ABC):
             block_size=self.block_size,
             kv_cache_group_id=self.kv_cache_group_id,
             block_mask=block_mask,
+            replay_boundary_mask=replay_boundary_mask,
         )
 
         self.num_cached_block[request.request_id] = num_full_blocks

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1492,9 +1492,11 @@ class MambaManager(SingleTypeKVCacheManager):
         mask = [False] * (end_block - start_block)
 
         # (1) Segment-boundary states. A Mamba hit needs exactly the single
-        # state block ending on the boundary (no window, and draft models have
-        # no mamba layers, so no eagle shift). Block ``i`` ends at token
-        # ``(i + 1) * block_size``.
+        # state block ending on the boundary (no window). Segment tails get no
+        # EAGLE shift: under the EAGLE drop the fixed point settles on the next
+        # lower tail, costing at most one segment of hit length, unlike the
+        # reachable boundaries below where the unshifted state is the only one.
+        # Block ``i`` ends at token ``(i + 1) * block_size``.
         segment_tokens = None if retention_interval == 0 else retention_interval
         if segment_tokens is not None:
             per_segment = segment_tokens // block_size
@@ -1511,11 +1513,24 @@ class MambaManager(SingleTypeKVCacheManager):
         # capped by ``get_computed_blocks``) and any shared-prefix junction, both
         # of which segments would otherwise skip under sparse retention. A Mamba
         # hit needs exactly the single state block ending on the boundary.
+        #
+        # Under EAGLE/MTP the full-attention lookup drops one block below what
+        # it matched, so until the request decodes past the block boundary
+        # after ``boundary_tokens`` the only candidate the coordinator can
+        # offer this group is one block below the boundary. Keep that state
+        # too; keeping only the boundary state leaves every retained state one
+        # block above every reachable candidate, and the reconciled hit is
+        # always zero.
         for boundary_tokens in reachable_boundaries:
             aligned = boundary_tokens // alignment_tokens * alignment_tokens
             boundary_block = aligned // block_size - 1
-            if start_block <= boundary_block < end_block:
-                mask[boundary_block - start_block] = True
+            for kept in (
+                (boundary_block, boundary_block - 1)
+                if use_eagle
+                else (boundary_block,)
+            ):
+                if start_block <= kept < end_block:
+                    mask[kept - start_block] = True
 
         return mask
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -528,8 +528,7 @@ class SingleTypeKVCacheManager(ABC):
             for boundary in candidate_boundaries
             if boundary < reached_tokens
             or (
-                boundary == reached_tokens
-                and isinstance(self.kv_cache_spec, MambaSpec)
+                boundary == reached_tokens and isinstance(self.kv_cache_spec, MambaSpec)
             )
         ]
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -547,13 +547,21 @@ class SingleTypeKVCacheManager(ABC):
         )
         if scan_start_block >= num_full_blocks:
             return
+        retention_use_eagle = self.use_eagle or self.lookup_drops_eagle_block
+        if (
+            isinstance(self.kv_cache_spec, MambaSpec)
+            and self.replay_boundary_alignment_tokens is not None
+        ):
+            # The coordinator already added the one-alignment-unit lower
+            # candidate. Applying reachable_hit_positions() again would retain
+            # a second, unreachable predecessor state.
+            retention_use_eagle = False
         block_mask = self.reachable_block_mask(
             start_block=scan_start_block,
             end_block=num_full_blocks,
             alignment_tokens=self.scheduler_block_size,
             kv_cache_spec=self.kv_cache_spec,
-            # Retention, unlike lookup, cares whether the drop happens anywhere.
-            use_eagle=self.use_eagle or self.lookup_drops_eagle_block,
+            use_eagle=retention_use_eagle,
             retention_interval=retention_interval,
             reachable_boundaries=reachable_boundaries,
         )
@@ -562,7 +570,7 @@ class SingleTypeKVCacheManager(ABC):
             end_block=num_full_blocks,
             alignment_tokens=self.prefix_cache_alignment_tokens,
             kv_cache_spec=self.kv_cache_spec,
-            use_eagle=self.use_eagle,
+            use_eagle=retention_use_eagle,
             retention_interval=0,
             reachable_boundaries=reachable_boundaries,
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -71,6 +71,13 @@ class SingleTypeKVCacheManager(ABC):
                 block until the request finishes.
         """
         self.scheduler_block_size = scheduler_block_size
+        # The coordinator may lower this to the shared hash granularity when
+        # every group supports fine-grained prefix lookup.
+        self.prefix_cache_alignment_tokens = scheduler_block_size
+        # Additional offsets from prompt and shared-prefix boundaries that this
+        # group must retain. Hybrid coordinators use this for a target Mamba
+        # state that precedes a DFlash EAGLE lookahead block.
+        self.extra_replay_boundary_offsets: tuple[int, ...] = ()
         # The block size for this manager; used for actual block allocation.
         self.block_size = kv_cache_spec.block_size
         self.dcp_world_size = dcp_world_size
@@ -426,6 +433,7 @@ class SingleTypeKVCacheManager(ABC):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        reached_tokens: int | None = None,
     ) -> None:
         """
         Cache the blocks for the request.
@@ -437,23 +445,53 @@ class SingleTypeKVCacheManager(ABC):
             retention_interval: Sparse local-checkpoint granularity. ``None``
                 keeps dense checkpointing; ``0`` keeps only the latest replay
                 boundary; a positive multiple of ``scheduler_block_size`` keeps
-                a tail once per that-sized segment. Only SWA acts on it.
+                a tail once per that-sized segment. SWA and aligned Mamba
+                managers act on it.
+            reached_tokens: Optimistic finalized progress for this scheduling
+                step before cache alignment. Defaults to the greater of
+                ``num_tokens`` and processed request progress.
         """
         num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
         num_full_blocks = num_tokens // self.block_size
 
-        if num_cached_blocks >= num_full_blocks:
-            return
-
         # Token boundaries whose reachable tail must be retained under sparse
         # retention: the replay boundary (``num_prompt - 1``, capped by
         # ``get_computed_blocks``) and any detected shared-prefix junction.
-        reachable_boundaries = [request.num_prompt_tokens - 1]
+        base_boundaries = [request.num_prompt_tokens - 1]
         if request.shared_prefix_boundary:
-            reachable_boundaries.append(request.shared_prefix_boundary)
+            base_boundaries.append(request.shared_prefix_boundary)
+        candidate_boundaries = list(base_boundaries)
+        for boundary in base_boundaries:
+            candidate_boundaries.extend(
+                shifted
+                for offset in self.extra_replay_boundary_offsets
+                if (shifted := boundary + offset) > 0
+            )
+        # Filter derived boundaries independently. A DFlash target backoff
+        # checkpoint becomes reachable before its parent prompt boundary.
+        # ``num_tokens`` can be cache-aligned below actual request progress.
+        if reached_tokens is None:
+            reached_tokens = max(num_tokens, request.num_computed_tokens)
+        reachable_boundaries = [
+            boundary for boundary in candidate_boundaries if boundary < reached_tokens
+        ]
 
+        # A sparse boundary can become reachable after its blocks were first
+        # visited and deliberately left unhashed. Re-scan those allocated
+        # blocks once the boundary is reached so its tail can be promoted.
+        scan_start_block = (
+            0
+            if (
+                retention_interval is not None
+                and isinstance(self.kv_cache_spec, (MambaSpec, SlidingWindowSpec))
+                and reachable_boundaries
+            )
+            else num_cached_blocks
+        )
+        if scan_start_block >= num_full_blocks:
+            return
         block_mask = self.reachable_block_mask(
-            start_block=num_cached_blocks,
+            start_block=scan_start_block,
             end_block=num_full_blocks,
             alignment_tokens=self.scheduler_block_size,
             kv_cache_spec=self.kv_cache_spec,
@@ -464,7 +502,7 @@ class SingleTypeKVCacheManager(ABC):
         self.block_pool.cache_full_blocks(
             request=request,
             blocks=self.req_to_blocks[request.request_id],
-            num_cached_blocks=num_cached_blocks,
+            num_cached_blocks=scan_start_block,
             num_full_blocks=num_full_blocks,
             block_size=self.block_size,
             kv_cache_group_id=self.kv_cache_group_id,
@@ -783,8 +821,14 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        reached_tokens: int | None = None,
     ) -> None:
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            reached_tokens=reached_tokens,
+        )
         hash_block_size = self.block_pool.hash_block_size
         if self.block_size == hash_block_size:
             return
@@ -1058,8 +1102,12 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         if retention_interval is not None:
             for boundary_tokens in reachable_boundaries:
                 aligned = boundary_tokens // alignment_tokens * alignment_tokens
-                end = aligned // block_size + shift
-                for j in range(max(start_block, end - need), min(end_block, end)):
+                # The EAGLE lookahead block can extend past the finalized
+                # prompt tail. Clamp first so sparse retention keeps the full
+                # reachable window before that tail instead of retaining only
+                # the last block of a window that cannot exist yet.
+                end = min(aligned // block_size + shift, end_block)
+                for j in range(max(start_block, end - need), end):
                     mask[j - start_block] = True
 
         return mask
@@ -1716,9 +1764,15 @@ class MambaManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        reached_tokens: int | None = None,
     ) -> None:
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            reached_tokens=reached_tokens,
+        )
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
         if self.mamba_cache_mode == "align":
             partial_hash = self._cache_partial_tail_block(request, num_tokens)
@@ -1811,6 +1865,7 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        reached_tokens: int | None = None,
     ) -> None:
         # We do not cache blocks for cross-attention to be shared between
         # requests, so this method is not relevant.

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -33,6 +33,32 @@ from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
 
 
+def reachable_hit_positions(
+    boundary_tokens: int,
+    alignment_tokens: int,
+    use_eagle: bool,
+) -> tuple[int, ...]:
+    """Token positions a cache hit can land on for one reachable boundary.
+
+    A lookup floors the boundary to ``alignment_tokens``. Under EAGLE the
+    full-attention finder additionally subtracts ``min(alignment_tokens,
+    its own block_size)`` and re-floors to the alignment, which lands on
+    exactly one alignment unit below the boundary either way. That lower
+    position is the ONLY one this group can be asked for until the request
+    decodes past the next boundary, so sparse-retention masks must treat both
+    as reachable: retaining only the boundary leaves every kept state above
+    every candidate a lookup can produce, and the reconciled hit is always 0.
+
+    Expressing the back-off in tokens rather than blocks is what makes this
+    correct when a group's block size differs from the alignment: one block is
+    the right step only when they are equal.
+    """
+    aligned = boundary_tokens // alignment_tokens * alignment_tokens
+    if not use_eagle:
+        return (aligned,)
+    return (aligned, max(aligned - alignment_tokens, 0))
+
+
 class SingleTypeKVCacheManager(ABC):
     """
     An abstract base class for a manager that handle the kv cache management
@@ -110,11 +136,16 @@ class SingleTypeKVCacheManager(ABC):
         self.kv_cache_group_id = kv_cache_group_id
         self._null_block = block_pool.null_block
 
-        # Whether this group's prefix-cache hits drop the EAGLE/MTP lookahead
-        # block. Only consulted by managers whose hit logic is sparse within an
-        # aligned segment (SWA). Initialized lazily by the coordinator after
+        # Whether THIS group's own prefix-cache lookup drops the EAGLE/MTP
+        # lookahead block. Initialized lazily by the coordinator after
         # determining the attention groups.
         self.use_eagle = False
+
+        # Whether ANY group's lookup applies that drop, which is what sparse
+        # retention must key off: the coordinator reconciles every group to one
+        # hit length, so a drop anywhere shortens the candidate offered here.
+        # See ``reachable_hit_positions``. Set by the coordinator.
+        self.lookup_drops_eagle_block = False
 
         # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
         # managers (full attention, mamba "align"); harmlessly empty elsewhere.
@@ -521,7 +552,8 @@ class SingleTypeKVCacheManager(ABC):
             end_block=num_full_blocks,
             alignment_tokens=self.scheduler_block_size,
             kv_cache_spec=self.kv_cache_spec,
-            use_eagle=self.use_eagle,
+            # Retention, unlike lookup, cares whether the drop happens anywhere.
+            use_eagle=self.use_eagle or self.lookup_drops_eagle_block,
             retention_interval=retention_interval,
             reachable_boundaries=reachable_boundaries,
         )
@@ -1512,25 +1544,15 @@ class MambaManager(SingleTypeKVCacheManager):
         # (2) Reachable-boundary states: the replay boundary (``num_prompt - 1``,
         # capped by ``get_computed_blocks``) and any shared-prefix junction, both
         # of which segments would otherwise skip under sparse retention. A Mamba
-        # hit needs exactly the single state block ending on the boundary.
-        #
-        # Under EAGLE/MTP the full-attention lookup drops one block below what
-        # it matched, so until the request decodes past the block boundary
-        # after ``boundary_tokens`` the only candidate the coordinator can
-        # offer this group is one block below the boundary. Keep that state
-        # too; keeping only the boundary state leaves every retained state one
-        # block above every reachable candidate, and the reconciled hit is
-        # always zero.
+        # hit needs exactly the single state block ending on the reachable
+        # position, so retain one block per position rather than a run.
         for boundary_tokens in reachable_boundaries:
-            aligned = boundary_tokens // alignment_tokens * alignment_tokens
-            boundary_block = aligned // block_size - 1
-            for kept in (
-                (boundary_block, boundary_block - 1)
-                if use_eagle
-                else (boundary_block,)
+            for position in reachable_hit_positions(
+                boundary_tokens, alignment_tokens, use_eagle
             ):
-                if start_block <= kept < end_block:
-                    mask[kept - start_block] = True
+                boundary_block = position // block_size - 1
+                if start_block <= boundary_block < end_block:
+                    mask[boundary_block - start_block] = True
 
         return mask
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -558,7 +558,7 @@ class SingleTypeKVCacheManager(ABC):
         block_mask = self.reachable_block_mask(
             start_block=scan_start_block,
             end_block=num_full_blocks,
-            alignment_tokens=self.scheduler_block_size,
+            alignment_tokens=self.prefix_cache_alignment_tokens,
             kv_cache_spec=self.kv_cache_spec,
             use_eagle=retention_use_eagle,
             retention_interval=retention_interval,

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -568,6 +568,42 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             gauge_kv_cache_usage, per_engine_labelvalues
         )
 
+        counter_decode_prefill_scheduled_tokens = self._counter_cls(
+            name="vllm:decode_prefill_scheduled_tokens",
+            documentation=(
+                "Prefill tokens scheduled while decode-burst control is enabled."
+            ),
+            labelnames=labelnames,
+        )
+        self.counter_decode_prefill_scheduled_tokens = create_metric_per_engine(
+            counter_decode_prefill_scheduled_tokens, per_engine_labelvalues
+        )
+        gauge_decode_prefill_active_partial_prefills = self._gauge_cls(
+            name="vllm:decode_prefill_active_partial_prefills",
+            documentation="Active requests that remain partially prefilling.",
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_decode_prefill_active_partial_prefills = create_metric_per_engine(
+            gauge_decode_prefill_active_partial_prefills, per_engine_labelvalues
+        )
+        counter_decode_prefill_decode_only_steps = self._counter_cls(
+            name="vllm:decode_prefill_decode_only_steps",
+            documentation="Scheduler steps where decode-burst control deferred prefill.",
+            labelnames=labelnames,
+        )
+        self.counter_decode_prefill_decode_only_steps = create_metric_per_engine(
+            counter_decode_prefill_decode_only_steps, per_engine_labelvalues
+        )
+        counter_decode_prefill_fairness_bypasses = self._counter_cls(
+            name="vllm:decode_prefill_fairness_bypasses",
+            documentation="Prefill releases caused by the oldest-waiter deadline.",
+            labelnames=labelnames,
+        )
+        self.counter_decode_prefill_fairness_bypasses = create_metric_per_engine(
+            counter_decode_prefill_fairness_bypasses, per_engine_labelvalues
+        )
+
         if envs.VLLM_COMPUTE_NANS_IN_LOGITS:
             counter_corrupted_requests = self._counter_cls(
                 name="vllm:corrupted_requests",
@@ -599,6 +635,49 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         )
         self.counter_prefix_cache_hits = create_metric_per_engine(
             counter_prefix_cache_hits, per_engine_labelvalues
+        )
+
+        counter_prefix_cache_cacheable_tokens = self._counter_cls(
+            name="vllm:prefix_cache_cacheable_tokens",
+            documentation=(
+                "Prefix tokens that could be reused after mandatory alignment "
+                "and speculative-decoding replay adjustment."
+            ),
+            labelnames=labelnames,
+        )
+        self.counter_prefix_cache_cacheable_tokens = create_metric_per_engine(
+            counter_prefix_cache_cacheable_tokens, per_engine_labelvalues
+        )
+
+        counter_prefix_cache_reconciled_hits = self._counter_cls(
+            name="vllm:prefix_cache_reconciled_hits",
+            documentation=(
+                "Prefix-cache hit tokens available in every hybrid cache group."
+            ),
+            labelnames=labelnames,
+        )
+        self.counter_prefix_cache_reconciled_hits = create_metric_per_engine(
+            counter_prefix_cache_reconciled_hits, per_engine_labelvalues
+        )
+
+        self.counter_prefix_cache_group_hits = self._counter_cls(
+            name="vllm:prefix_cache_group_hits",
+            documentation="Prefix-cache hit tokens by bounded hybrid cache group.",
+            labelnames=labelnames + ["kv_cache_group"],
+        )
+        self.counter_prefix_cache_boundary_registrations = self._counter_cls(
+            name="vllm:prefix_cache_boundary_registrations",
+            documentation=(
+                "Replay-boundary cache registrations by bounded hybrid cache group."
+            ),
+            labelnames=labelnames + ["kv_cache_group"],
+        )
+        self.counter_prefix_cache_boundary_evictions = self._counter_cls(
+            name="vllm:prefix_cache_boundary_evictions",
+            documentation=(
+                "Registered replay-boundary evictions by bounded hybrid cache group."
+            ),
+            labelnames=labelnames + ["kv_cache_group"],
         )
 
         #
@@ -1121,6 +1200,18 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 scheduler_stats.num_skipped_waiting_reqs
             )
             self.gauge_kv_cache_usage[engine_idx].set(scheduler_stats.kv_cache_usage)
+            self.counter_decode_prefill_scheduled_tokens[engine_idx].inc(
+                scheduler_stats.scheduled_prefill_tokens
+            )
+            self.gauge_decode_prefill_active_partial_prefills[engine_idx].set(
+                scheduler_stats.active_partial_prefills
+            )
+            self.counter_decode_prefill_decode_only_steps[engine_idx].inc(
+                scheduler_stats.decode_only_steps
+            )
+            self.counter_decode_prefill_fairness_bypasses[engine_idx].inc(
+                scheduler_stats.fairness_bypasses
+            )
 
             self.counter_prefix_cache_queries[engine_idx].inc(
                 scheduler_stats.prefix_cache_stats.queries
@@ -1128,6 +1219,28 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             self.counter_prefix_cache_hits[engine_idx].inc(
                 scheduler_stats.prefix_cache_stats.hits
             )
+
+            hybrid_stats = scheduler_stats.hybrid_prefix_cache_stats
+            if hybrid_stats is not None:
+                self.counter_prefix_cache_cacheable_tokens[engine_idx].inc(
+                    hybrid_stats.cacheable_prefix_tokens
+                )
+                self.counter_prefix_cache_reconciled_hits[engine_idx].inc(
+                    hybrid_stats.reconciled_hit_tokens
+                )
+                engine_labels = self.per_engine_labelvalues[engine_idx]
+                for group, hits in hybrid_stats.prefix_cache_group_hits.items():
+                    self.counter_prefix_cache_group_hits.labels(
+                        *engine_labels, group
+                    ).inc(hits)
+                for group, count in hybrid_stats.boundary_registrations.items():
+                    self.counter_prefix_cache_boundary_registrations.labels(
+                        *engine_labels, group
+                    ).inc(count)
+                for group, count in hybrid_stats.boundary_evictions.items():
+                    self.counter_prefix_cache_boundary_evictions.labels(
+                        *engine_labels, group
+                    ).inc(count)
 
             if scheduler_stats.connector_prefix_cache_stats is not None:
                 self.counter_connector_prefix_cache_queries[engine_idx].inc(

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -589,7 +589,9 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         )
         counter_decode_prefill_decode_only_steps = self._counter_cls(
             name="vllm:decode_prefill_decode_only_steps",
-            documentation="Scheduler steps where decode-burst control deferred prefill.",
+            documentation=(
+                "Scheduler steps where decode-burst control deferred prefill."
+            ),
             labelnames=labelnames,
         )
         self.counter_decode_prefill_decode_only_steps = create_metric_per_engine(

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -143,6 +143,17 @@ class PrefixCacheStats(BaseCacheStats):
 
 
 @dataclass
+class HybridPrefixCacheStats:
+    """Bounded, content-free hybrid prefix-cache lookup totals."""
+
+    cacheable_prefix_tokens: int = 0
+    reconciled_hit_tokens: int = 0
+    prefix_cache_group_hits: dict[str, int] = field(default_factory=dict)
+    boundary_registrations: dict[str, int] = field(default_factory=dict)
+    boundary_evictions: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
 class MultiModalCacheStats(BaseCacheStats):
     """
     Stores multi-modal cache hit statistics.
@@ -198,7 +209,13 @@ class SchedulerStats:
     kv_cache_usage: float = 0.0
     iteration_details: SchedulerIterationDetails | None = None
 
+    scheduled_prefill_tokens: int = 0
+    active_partial_prefills: int = 0
+    decode_only_steps: int = 0
+    fairness_bypasses: int = 0
+
     prefix_cache_stats: PrefixCacheStats = field(default_factory=PrefixCacheStats)
+    hybrid_prefix_cache_stats: HybridPrefixCacheStats | None = None
     connector_prefix_cache_stats: PrefixCacheStats | None = None
 
     kv_cache_eviction_events: list[KVCacheEvictionEvent] = field(default_factory=list)


### PR DESCRIPTION
## Purpose

Preserve hybrid prefix-cache reuse and active decode progress when many long prefills compete with decode. This draft consolidates the source behavior validated in the LP15 high-concurrency investigation onto the current `dev/jovian-judgement` base.

This is intentionally a draft integration PR. It keeps the existing focused PRs open while maintainers decide whether to review the combined behavior or split it by concern.

## Root causes

The incident required fixes in two interacting paths:

1. A fixed mixed-prefill quantum still ran too frequently under active decode. It protected one scheduler step but could repeatedly fragment prefill and collapse job goodput.
2. Hybrid cache groups did not retain and reconcile the same replay boundary under DFlash, Mamba, EAGLE, and DCP. Aggregate counters hid which group limited the common hit, and repeated scheduler lookups could inflate new diagnostics before admission.

The r15 rebase exposed two more shared-path details. Full-attention cache lookup must use the coordinator DCP width, while replicated or non-full groups use width one. Sparse retention must align its primary mask to `prefix_cache_alignment_tokens`, not the larger scheduler page.

## Changes

### Decode and prefill scheduling

- Add zero-default adaptive mixed-prefill budgeting and bounded rotation.
- Limit active partial prefills without changing the disabled behavior.
- Add a zero-default decode-burst controller with an oldest-waiter fairness deadline.
- Preserve full prefill budget when no decode is eligible.

### Hybrid prefix cache

- Retain DFlash and Mamba replay states reachable after EAGLE drops a block.
- Align sparse retention and lookup to the common prefix-cache boundary.
- Reconcile per-group hits with the correct DCP width.
- Record cacheable tokens, reconciled hits, per-group hits, registrations, and evictions only at admission.
- Keep metric labels bounded by configured cache groups and emit no request content or identifiers.

### DCP correctness

- Mask ranks with no local sequences before DCP reduction.
- Gather sparse MLA queries when DCP is active without PCP.
- Add a CPU regression around the sparse MLA query-gather helper.

## Related PRs

- #546 is merged and is not duplicated here.
- #529 covers aligned DFlash cache geometry and replicated-DCP handling. The current base and r15 already contain newer equivalents, so this draft includes only missing common-boundary behavior.
- #556 supplies the Mamba EAGLE retention work with original authorship preserved.
- #560 supplies empty-rank masking and sparse MLA gathering with original authorship preserved.

This draft does not close or modify those PRs.

## r15 baseline

Validation uses the immutable image:

```text
voipmonitor/vllm@sha256:d9ca4c299fdb8e6176d70f36c8f98a687474eef807b7a71fe6fee9f154208fe0
```

Its source lock names `dev/jovian-judgement@9c4dd05487629eccb26d7166459867a3db9b099f`, which is also this PR's Git base. The image's exact composition commit is not published to either GitHub fork, so it is used as the installed-source and dependency baseline rather than as an unreproducible Git parent.

Exact draft head and tree:

```text
commit 8dbf46366e1934d80fa6ff84c4abfda1c154ef1a
tree   7a7e08789b4c7211cdd650baf62cd63610165f3a
```

## Validation

Pinned r15 CPU-only container, networking disabled, no GPU devices:

```text
25 passed, 256 deselected, 1 xfailed
```

The xfail is the optional fine-grained resume checkpoint that this branch does not claim to implement. Added regressions cover decode-burst fairness, partial-prefill bounds, DFlash and Mamba replay boundaries, DCP1 and DCP4 group reconciliation, admission-only metrics, empty DCP ranks, and sparse MLA query gathering.

Changed-file pre-commit 4.3.0 passed Ruff, formatting, mypy, typos, SPDX, forbidden imports, configuration defaults, CUDA API guards, and all applicable repository hooks. `git diff --check` and the source-only scope check also passed.

A separate source-locked LP15 image completed a matched 20-agent DCP1 screen and reverse-order repeat against the prior LP8 runtime. It delivered 2.304x and 2.388x job goodput, with p99 ITL at 37.3% and 36.8% of baseline. That evidence motivated this port, but it is not an r15 GPU qualification claim.

## Compatibility and gaps

- All new scheduler controls default to zero.
- No public default, sampling behavior, model output, KV dtype, or backend selection changes when the controls are disabled.
- The metrics have fixed names and bounded cache-group labels.
- TP1, TP2, TP8, ROCm, live DSpark, and r15 GPU serving were not tested here.
- DCP4 high-concurrency promotion remains unclaimed.
- The full repository suite was not run in the network-disabled image because unrelated tests require model downloads. The complete PR-added regression set passed.

## AI assistance

OpenAI Codex assisted with investigation, source reconstruction, tests, and this draft description. The human submitter reviewed the source and accepts the recorded validation and limitations.
