### PR TITLE
perf(glm5next): prefetch decode weights with an opt-in L2 reservation

### DIFF
--- a/tests/models/test_glm5next_l2_prefetch_persist.py
+++ b/tests/models/test_glm5next_l2_prefetch_persist.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Persisting-L2 set-aside sizing for the GLM-5.3 L2 weight prefetcher."""
+
+import pytest
+import torch
+
+from vllm.models.glm5next.nvidia import l2_prefetch as l2pf
+
+MAX = 84_000_000
+
+
+@pytest.mark.parametrize(
+    ("raw", "max_bytes", "expected"),
+    [
+        ("max", MAX, MAX),
+        (" MAX ", MAX, MAX),
+        ("all", MAX, MAX),
+        ("40", MAX, 40_000_000),
+        ("40.5", MAX, 40_500_000),
+        ("200", MAX, MAX),  # clamped to the device maximum
+        ("0", MAX, 0),
+        ("off", MAX, 0),
+        ("", MAX, 0),
+        (None, MAX, 0),
+        ("-5", MAX, 0),
+        ("bogus", MAX, 0),
+        ("max", 0, 0),  # device without a persisting L2 set-aside
+    ],
+)
+def test_persisting_l2_request(raw, max_bytes, expected):
+    assert l2pf.persisting_l2_request(raw, max_bytes) == expected
+
+
+def test_default_request_is_device_maximum():
+    assert l2pf.PERSIST_L2 == "max"
+
+
+def _driver():
+    from cuda.bindings import driver as cu
+
+    return cu
+
+
+def _read_limit(cu, device: torch.device) -> int:
+    with torch.cuda.device(device):
+        torch.empty(1, device=device)  # make the primary context current
+        err, value = cu.cuCtxGetLimit(cu.CUlimit.CU_LIMIT_PERSISTING_L2_CACHE_SIZE)
+    assert err == cu.CUresult.CUDA_SUCCESS
+    return int(value)
+
+
+def _set_limit(cu, device: torch.device, value: int) -> None:
+    with torch.cuda.device(device):
+        torch.empty(1, device=device)
+        (err,) = cu.cuCtxSetLimit(cu.CUlimit.CU_LIMIT_PERSISTING_L2_CACHE_SIZE, value)
+    assert err == cu.CUresult.CUDA_SUCCESS
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA device required")
+def test_configure_persisting_l2_applies_to_the_primary_context():
+    cu = _driver()
+    device = torch.device("cuda", 0)
+    err, dev = cu.cuDeviceGet(0)
+    assert err == cu.CUresult.CUDA_SUCCESS
+    err, max_bytes = cu.cuDeviceGetAttribute(
+        cu.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MAX_PERSISTING_L2_CACHE_SIZE, dev
+    )
+    assert err == cu.CUresult.CUDA_SUCCESS
+    if max_bytes <= 0:
+        pytest.skip("device has no persisting L2 set-aside")
+    before = _read_limit(cu, device)
+    try:
+        assert l2pf.configure_persisting_l2(device, request="max") == max_bytes
+        assert _read_limit(cu, device) == max_bytes
+
+        # A zero request never touches the driver state.
+        assert l2pf.configure_persisting_l2(device, request="0") == 0
+        assert _read_limit(cu, device) == max_bytes
+
+        # Over-sized requests are clamped to the device maximum.
+        assert l2pf.configure_persisting_l2(device, request="100000") == max_bytes
+    finally:
+        _set_limit(cu, device, before)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA device required")
+def test_prefetcher_applies_the_env_request_once(monkeypatch):
+    cu = _driver()
+    device = torch.device("cuda", 0)
+    before = _read_limit(cu, device)
+    calls: list[str | None] = []
+    real = l2pf.configure_persisting_l2
+
+    def spy(dev, request=None):
+        calls.append(request)
+        return real(dev, request=request)
+
+    monkeypatch.setattr(l2pf, "configure_persisting_l2", spy)
+    monkeypatch.setattr(l2pf.L2Prefetcher, "_instances", {})
+    monkeypatch.setattr(l2pf, "_persisting_l2_applied", {})
+    try:
+        first = l2pf.L2Prefetcher.get(device)
+        second = l2pf.L2Prefetcher.get(device)
+        assert first is second
+        assert calls == [None]
+        assert first.persisting_l2_bytes == _read_limit(cu, device)
+    finally:
+        _set_limit(cu, device, before)

--- a/tests/models/test_glm5next_l2_prefetch_persist.py
+++ b/tests/models/test_glm5next_l2_prefetch_persist.py
@@ -36,6 +36,13 @@ def test_default_request_is_device_maximum():
     assert l2pf.PERSIST_L2 == "max"
 
 
+def test_invalid_numeric_environment_values_use_defaults(monkeypatch):
+    monkeypatch.setenv("VLLM_GLM53_L2_PREFETCH_MAX_TOKENS", "invalid")
+    monkeypatch.setenv("VLLM_GLM53_L2_PREFETCH_BUDGET_A_MB", "invalid")
+    assert l2pf._int_env("VLLM_GLM53_L2_PREFETCH_MAX_TOKENS", 256) == 256
+    assert l2pf._mb("VLLM_GLM53_L2_PREFETCH_BUDGET_A_MB", "20") == 20_000_000
+
+
 def _driver():
     from cuda.bindings import driver as cu
 
@@ -43,7 +50,7 @@ def _driver():
 
 
 def _read_limit(cu, device: torch.device) -> int:
-    with torch.cuda.device(device):
+    with torch.accelerator.device_index(device.index):
         torch.empty(1, device=device)  # make the primary context current
         err, value = cu.cuCtxGetLimit(cu.CUlimit.CU_LIMIT_PERSISTING_L2_CACHE_SIZE)
     assert err == cu.CUresult.CUDA_SUCCESS
@@ -51,7 +58,7 @@ def _read_limit(cu, device: torch.device) -> int:
 
 
 def _set_limit(cu, device: torch.device, value: int) -> None:
-    with torch.cuda.device(device):
+    with torch.accelerator.device_index(device.index):
         torch.empty(1, device=device)
         (err,) = cu.cuCtxSetLimit(cu.CUlimit.CU_LIMIT_PERSISTING_L2_CACHE_SIZE, value)
     assert err == cu.CUresult.CUDA_SUCCESS
@@ -89,6 +96,15 @@ def test_prefetcher_applies_the_env_request_once(monkeypatch):
     cu = _driver()
     device = torch.device("cuda", 0)
     before = _read_limit(cu, device)
+    err, dev = cu.cuDeviceGet(0)
+    assert err == cu.CUresult.CUDA_SUCCESS
+    err, max_bytes = cu.cuDeviceGetAttribute(
+        cu.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MAX_PERSISTING_L2_CACHE_SIZE,
+        dev,
+    )
+    assert err == cu.CUresult.CUDA_SUCCESS
+    if max_bytes <= 0:
+        pytest.skip("device has no persisting L2 set-aside")
     calls: list[str | None] = []
     real = l2pf.configure_persisting_l2
 
@@ -99,11 +115,15 @@ def test_prefetcher_applies_the_env_request_once(monkeypatch):
     monkeypatch.setattr(l2pf, "configure_persisting_l2", spy)
     monkeypatch.setattr(l2pf.L2Prefetcher, "_instances", {})
     monkeypatch.setattr(l2pf, "_persisting_l2_applied", {})
+    monkeypatch.setattr(l2pf, "PERSIST_L2", "1")
     try:
         first = l2pf.L2Prefetcher.get(device)
         second = l2pf.L2Prefetcher.get(device)
         assert first is second
         assert calls == [None]
-        assert first.persisting_l2_bytes == _read_limit(cu, device)
+        applied = _read_limit(cu, device)
+        assert first.persisting_l2_bytes == applied
+        # CUDA rounds the request up to the device's allocation granularity.
+        assert 1_000_000 <= applied < int(max_bytes)
     finally:
         _set_limit(cu, device, before)

--- a/tests/models/test_glm5next_l2_prefetch_persist.py
+++ b/tests/models/test_glm5next_l2_prefetch_persist.py
@@ -32,8 +32,8 @@ def test_persisting_l2_request(raw, max_bytes, expected):
     assert l2pf.persisting_l2_request(raw, max_bytes) == expected
 
 
-def test_default_request_is_device_maximum():
-    assert l2pf.PERSIST_L2 == "max"
+def test_default_request_leaves_the_driver_limit_unchanged():
+    assert l2pf.PERSIST_L2 == "0"
 
 
 def test_invalid_numeric_environment_values_use_defaults(monkeypatch):

--- a/tests/models/test_glm5next_l2_prefetch_persist.py
+++ b/tests/models/test_glm5next_l2_prefetch_persist.py
@@ -45,6 +45,39 @@ def test_invalid_numeric_environment_values_use_defaults(monkeypatch):
     assert l2pf._mb("VLLM_GLM53_L2_PREFETCH_BUDGET_A_MB", "20") == 20_000_000
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA device required")
+def test_segments_include_backend_tensors_and_skip_runtime_caches():
+    class PackedLinear(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.empty(64, device="cuda"))
+            self.register_buffer("weight_scale", torch.empty(32, device="cuda"))
+            self.register_buffer(
+                "runtime_scratch", torch.empty(48, device="cuda"), persistent=False
+            )
+            self.packed_weight = torch.empty(48, device="cuda")
+            self.topk_indices_buffer = torch.empty(48, device="cuda")
+            self.kv_cache = torch.empty(48, device="cuda")
+
+    module = PackedLinear()
+    segments = l2pf.segments_of(module, min_bytes=0)
+    names = [name for name, _, _ in segments]
+    pointers = [pointer for _, pointer, _ in segments]
+
+    assert names == ["weight", "weight_scale", "packed_weight"]
+    assert len(pointers) == len(set(pointers))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA device required")
+def test_tensor_segment_limits_noncontiguous_views_to_their_storage():
+    storage = torch.empty((16, 8), dtype=torch.float32, device="cuda")
+    view = storage.transpose(0, 1)
+
+    segment = l2pf.tensor_segment("transposed", view)
+
+    assert segment == ("transposed", view.data_ptr(), view.numel() * 4)
+
+
 def _driver():
     from cuda.bindings import driver as cu
 

--- a/tests/models/test_glm5next_l2_prefetch_persist.py
+++ b/tests/models/test_glm5next_l2_prefetch_persist.py
@@ -70,12 +70,12 @@ def test_segments_include_backend_tensors_and_skip_runtime_caches():
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA device required")
 def test_tensor_segment_limits_noncontiguous_views_to_their_storage():
-    storage = torch.empty((16, 8), dtype=torch.float32, device="cuda")
-    view = storage.transpose(0, 1)
+    storage = torch.empty(8, dtype=torch.float32, device="cuda")
+    view = storage.expand(16, 8)
 
-    segment = l2pf.tensor_segment("transposed", view)
+    segment = l2pf.tensor_segment("expanded", view)
 
-    assert segment == ("transposed", view.data_ptr(), view.numel() * 4)
+    assert segment == ("expanded", view.data_ptr(), storage.numel() * 4)
 
 
 def _driver():

--- a/tests/models/test_glm5next_l2_prefetch_persist.py
+++ b/tests/models/test_glm5next_l2_prefetch_persist.py
@@ -5,6 +5,7 @@
 import pytest
 import torch
 
+from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
 from vllm.models.glm5next.nvidia import l2_prefetch as l2pf
 
 MAX = 84_000_000
@@ -43,6 +44,41 @@ def test_invalid_numeric_environment_values_use_defaults(monkeypatch):
     monkeypatch.setenv("VLLM_GLM53_L2_PREFETCH_BUDGET_A_MB", "invalid")
     assert l2pf._int_env("VLLM_GLM53_L2_PREFETCH_MAX_TOKENS", 256) == 256
     assert l2pf._mb("VLLM_GLM53_L2_PREFETCH_BUDGET_A_MB", "20") == 20_000_000
+
+
+def test_prefetch_is_disabled_for_the_entire_breakable_capture(monkeypatch):
+    monkeypatch.setattr(
+        BreakableCUDAGraphCapture,
+        "current",
+        classmethod(lambda cls: object()),
+    )
+    assert not l2pf._prefetch_allowed()
+
+
+def test_prefetch_is_disabled_for_uncaptured_graph_warmup(monkeypatch):
+    from vllm.compilation import monitor
+
+    monkeypatch.setattr(
+        BreakableCUDAGraphCapture,
+        "current",
+        classmethod(lambda cls: None),
+    )
+    monkeypatch.setattr(monitor, "is_cudagraph_capturing_enabled", lambda: True)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    assert not l2pf._prefetch_allowed()
+
+
+def test_prefetch_is_enabled_for_regular_full_capture(monkeypatch):
+    from vllm.compilation import monitor
+
+    monkeypatch.setattr(
+        BreakableCUDAGraphCapture,
+        "current",
+        classmethod(lambda cls: None),
+    )
+    monkeypatch.setattr(monitor, "is_cudagraph_capturing_enabled", lambda: True)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+    assert l2pf._prefetch_allowed()
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA device required")

--- a/tests/models/test_glm5next_l2_prefetch_persist.py
+++ b/tests/models/test_glm5next_l2_prefetch_persist.py
@@ -32,8 +32,10 @@ def test_persisting_l2_request(raw, max_bytes, expected):
     assert l2pf.persisting_l2_request(raw, max_bytes) == expected
 
 
-def test_default_request_leaves_the_driver_limit_unchanged():
-    assert l2pf.PERSIST_L2 == "0"
+def test_default_request_leaves_the_driver_limit_unchanged(monkeypatch):
+    monkeypatch.delenv("VLLM_GLM53_L2_PREFETCH_PERSIST_MB", raising=False)
+    assert l2pf._persisting_l2_env_request() == "0"
+    assert l2pf.persisting_l2_request("0", MAX) == 0
 
 
 def test_invalid_numeric_environment_values_use_defaults(monkeypatch):

--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -150,6 +150,71 @@ def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):
     mock_cuda_graph.assert_called_once()
 
 
+def test_capture_synchronizes_auxiliary_warmup_streams(monkeypatch):
+    """CUDA graph capture starts only after warmup work has completed."""
+    lifecycle: list[str] = []
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    monkeypatch.setattr(
+        gpu_cudagraph_utils.current_platform,
+        "get_global_graph_pool",
+        lambda: object(),
+    )
+
+    manager = gpu_cudagraph_utils.CudaGraphManager(
+        vllm_config=_create_vllm_config(),
+        device=torch.device("cpu"),
+        cudagraph_mode=CUDAGraphMode.FULL,
+        decode_query_len=1,
+    )
+    desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.FULL,
+        num_tokens=4,
+        num_reqs=4,
+        uniform_token_count=1,
+    )
+    manager._capture_descs[CUDAGraphMode.FULL] = [desc]
+
+    def create_forward_fn(_desc, warmup):
+        def forward_fn(_mode):
+            lifecycle.append("warmup-forward" if warmup else "capture-forward")
+
+        return forward_fn
+
+    @contextmanager
+    def fake_graph_capture(*args, **kwargs):
+        yield SimpleNamespace(stream=MagicMock())
+
+    @contextmanager
+    def fake_cuda_graph(*args, **kwargs):
+        lifecycle.append("capture-begin")
+        yield
+
+    fake_offloader = MagicMock()
+    with (
+        patch.object(gpu_cudagraph_utils, "graph_capture", fake_graph_capture),
+        patch.object(gpu_cudagraph_utils, "get_offloader", lambda: fake_offloader),
+        patch.object(gpu_cudagraph_utils.torch.cuda, "CUDAGraph"),
+        patch.object(gpu_cudagraph_utils.torch.cuda, "graph", fake_cuda_graph),
+        patch.object(
+            gpu_cudagraph_utils.torch.accelerator,
+            "synchronize",
+            side_effect=lambda: lifecycle.append("warmup-synchronize"),
+        ),
+    ):
+        manager.capture(create_forward_fn)
+
+    assert lifecycle == [
+        "warmup-forward",
+        "warmup-synchronize",
+        "capture-begin",
+        "capture-forward",
+    ]
+
+
 _DECODE_QUERY_LEN = 3
 
 

--- a/vllm/compilation/monitor.py
+++ b/vllm/compilation/monitor.py
@@ -102,3 +102,8 @@ def validate_cudagraph_capturing_enabled() -> None:
 def set_cudagraph_capturing_enabled(enabled: bool) -> None:
     global cudagraph_capturing_enabled
     cudagraph_capturing_enabled = enabled
+
+
+def is_cudagraph_capturing_enabled() -> bool:
+    """Return whether the model runner is preparing or capturing CUDA graphs."""
+    return cudagraph_capturing_enabled

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -487,6 +487,11 @@ class MoERunner(MoERunnerInterface):
         if output_is_reduced is None:
             output_is_reduced = self._fused_output_is_reduced
 
+        # Optional model-installed callback fired before the final all-reduce
+        # (GLM-5.3 L2 weight prefetch: the reduction leaves device memory idle).
+        _hook = getattr(self, "_l2_prefetch_pre_reduce_hook", None)
+        if _hook is not None:
+            _hook(states.shape[0])
         if (
             not self.moe_config.is_sequence_parallel
             and not self.moe_config.skip_final_all_reduce

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -1656,6 +1656,11 @@ class RowParallelLinear(LinearBase):
         bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
         output_parallel = self.quant_method.apply(self, input_parallel, bias_)
 
+        # Optional model-installed callback fired before the all-reduce (GLM-5.3
+        # L2 weight prefetch: the reduction leaves device memory idle).
+        _hook = getattr(self, "_l2_prefetch_pre_reduce_hook", None)
+        if _hook is not None:
+            _hook(output_parallel.shape[0])
         if self.reduce_results and self.tp_size > 1:
             output = tensor_model_parallel_all_reduce(output_parallel)
         else:

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -755,6 +755,11 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
     ) -> None:
         num_tokens = hidden_states.size(0)
         projected_qkvgfab = self.in_proj_qkvgfab(hidden_states)[0]
+        # Optional model-installed callback (e.g. GLM-5.3 L2 weight prefetch of
+        # o_proj while the small projections and the recurrence run).
+        _hook = getattr(self, "_l2_prefetch_hook", None)
+        if _hook is not None:
+            _hook(hidden_states.shape[0])
         if self.use_full_rank_gate:
             split_sizes = [
                 3 * self.local_projection_size,

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -194,6 +194,11 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
         k_pe = k_pe.unsqueeze(1)
 
         q = q_proj_layer(q_proj_input)[0]
+        # Optional model-installed callback (e.g. GLM-5.3 L2 weight prefetch of
+        # o_proj while the indexer, rope and attention core run).
+        _hook = getattr(self, "_l2_prefetch_hook", None)
+        if _hook is not None:
+            _hook(hidden_states.shape[0])
         heads = self.num_heads
         if self.dcp_q_replicate:
             heads *= q_proj_layer.group_size

--- a/vllm/models/glm5next/nvidia/l2_prefetch.py
+++ b/vllm/models/glm5next/nvidia/l2_prefetch.py
@@ -31,6 +31,15 @@ Environment:
   VLLM_GLM53_L2_PREFETCH_MAX_TOKENS   only prefetch for batches up to this (256)
   VLLM_GLM53_L2_PREFETCH_BUDGET_{A,B,C,A_MLA}_MB   per-window fill budgets
   VLLM_GLM53_L2_PREFETCH_A_NEXT_MB    next-layer head bytes carried in window A
+  VLLM_GLM53_L2_PREFETCH_PERSIST_MB   persisting-L2 set-aside per rank: "max"
+                                      (default, device maximum), megabytes, or 0
+
+The ``evict_last`` policy only protects lines inside the CUDA persisting-L2
+set-aside, whose default size is 0.  Without a set-aside roughly a third of a
+prefetched 50 MB projection is evicted by the routed-expert stream before
+cuBLAS reads it (in_proj 17.3 us instead of 11 us fully hot), so the prefetcher
+sizes the set-aside once per device through ``cuCtxSetLimit``.  This is a
+cache-residency policy only; kernels and numerics are unchanged.
 """
 
 from __future__ import annotations
@@ -62,6 +71,10 @@ BUDGET_C = _mb("VLLM_GLM53_L2_PREFETCH_BUDGET_C_MB", "15")
 BUDGET_A_MLA = _mb("VLLM_GLM53_L2_PREFETCH_BUDGET_A_MLA_MB", "36")
 # Measured neutral-to-negative on C1 (fills overlap the KDA core); off by default.
 A_NEXT_BYTES = _mb("VLLM_GLM53_L2_PREFETCH_A_NEXT_MB", "0")
+# Persisting-L2 set-aside request: "max" = device maximum (84 MB of the 128 MB
+# L2 on RTX PRO 6000 Blackwell), a number = megabytes clamped to that maximum,
+# 0/"off" = leave the driver default (no set-aside).
+PERSIST_L2 = os.getenv("VLLM_GLM53_L2_PREFETCH_PERSIST_MB", "max")
 
 Segment = tuple[str, int, int]  # (name, ptr, bytes)
 
@@ -292,6 +305,105 @@ def make_plan(segments: list[Segment], budget: int, device: torch.device) -> tup
 
 
 # ---------------------------------------------------------------------------
+# Persisting-L2 set-aside
+# ---------------------------------------------------------------------------
+
+
+def persisting_l2_request(raw: str | None, max_bytes: int) -> int:
+    """Bytes of persisting-L2 set-aside to request for the env value ``raw``.
+
+    ``max`` maps to ``max_bytes`` (the device attribute), a number is
+    megabytes clamped to ``[0, max_bytes]``, and empty/0/off/invalid values
+    map to 0 (do not touch the driver default).
+    """
+    if raw is None or max_bytes <= 0:
+        return 0
+    value = raw.strip().lower()
+    if value in ("", "0", "off", "none", "false"):
+        return 0
+    if value in ("max", "all"):
+        return int(max_bytes)
+    try:
+        want = int(float(value) * 1e6)
+    except ValueError:
+        logger.warning(
+            "[l2_prefetch] ignoring VLLM_GLM53_L2_PREFETCH_PERSIST_MB=%r "
+            "(expected megabytes, max or 0)",
+            raw,
+        )
+        return 0
+    return max(0, min(want, int(max_bytes)))
+
+
+_persisting_l2_applied: dict[int, int] = {}
+
+
+def configure_persisting_l2(device: torch.device, request: str | None = None) -> int:
+    """Size the persisting-L2 set-aside of ``device``'s primary context.
+
+    Returns the set-aside in bytes read back from the driver, or 0 when the
+    request is 0, the device has no persisting L2, or the driver call failed
+    (logged, never raised).  The env-driven call (``request=None``) is applied
+    once per device; an explicit ``request`` is always applied.
+    """
+    idx = device.index if device.index is not None else torch.cuda.current_device()
+    if request is None and idx in _persisting_l2_applied:
+        return _persisting_l2_applied[idx]
+    raw = PERSIST_L2 if request is None else request
+    applied = 0
+    try:
+        from cuda.bindings import driver as cu
+
+        def check(result, what: str):
+            if result[0] != cu.CUresult.CUDA_SUCCESS:
+                raise RuntimeError(f"{what} failed: {result[0]}")
+            return result[1] if len(result) > 1 else None
+
+        dev = check(cu.cuDeviceGet(idx), "cuDeviceGet")
+        attr = cu.CUdevice_attribute
+        l2_bytes = check(
+            cu.cuDeviceGetAttribute(attr.CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE, dev),
+            "cuDeviceGetAttribute(L2_CACHE_SIZE)",
+        )
+        max_bytes = check(
+            cu.cuDeviceGetAttribute(
+                attr.CU_DEVICE_ATTRIBUTE_MAX_PERSISTING_L2_CACHE_SIZE, dev
+            ),
+            "cuDeviceGetAttribute(MAX_PERSISTING_L2_CACHE_SIZE)",
+        )
+        want = persisting_l2_request(raw, max_bytes)
+        if want > 0:
+            # Operate on the primary context torch uses for this device;
+            # push/pop keeps the calling thread's current context unchanged.
+            limit = cu.CUlimit.CU_LIMIT_PERSISTING_L2_CACHE_SIZE
+            ctx = check(cu.cuDevicePrimaryCtxRetain(dev), "cuDevicePrimaryCtxRetain")
+            check(cu.cuCtxPushCurrent(ctx), "cuCtxPushCurrent")
+            try:
+                check(cu.cuCtxSetLimit(limit, want), "cuCtxSetLimit")
+                applied = int(check(cu.cuCtxGetLimit(limit), "cuCtxGetLimit"))
+            finally:
+                cu.cuCtxPopCurrent()
+                cu.cuDevicePrimaryCtxRelease(dev)
+        logger.info(
+            "[l2_prefetch] persisting L2 set-aside on cuda:%d: L2 %.0f MB, "
+            "max %.0f MB, requested %.0f MB, now %.0f MB",
+            idx,
+            l2_bytes / 1e6,
+            max_bytes / 1e6,
+            want / 1e6,
+            applied / 1e6,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[l2_prefetch] persisting L2 set-aside not applied on cuda:%d: %s", idx, exc
+        )
+        applied = 0
+    if request is None:
+        _persisting_l2_applied[idx] = applied
+    return applied
+
+
+# ---------------------------------------------------------------------------
 # Runtime
 # ---------------------------------------------------------------------------
 
@@ -325,6 +437,9 @@ class L2Prefetcher:
         self.device = device
         self.side = torch.cuda.Stream(device=device)
         self.pending = False
+        # Before the first prefetch (and therefore before any graph capture):
+        # a context limit, not a captured operation.
+        self.persisting_l2_bytes = configure_persisting_l2(device)
 
     @classmethod
     def get(cls, device: torch.device | None = None) -> "L2Prefetcher":
@@ -368,5 +483,7 @@ def join_all() -> None:
 
 __all__ = [
     "ENABLED", "BUDGET_A", "BUDGET_B", "BUDGET_C", "BUDGET_A_MLA", "A_NEXT_BYTES",
-    "L2PrefetchPlan", "L2Prefetcher", "segments_of", "take_budget", "make_plan", "issue", "join_all",
+    "PERSIST_L2", "L2PrefetchPlan", "L2Prefetcher", "segments_of", "take_budget",
+    "make_plan", "issue", "join_all", "persisting_l2_request",
+    "configure_persisting_l2",
 ]

--- a/vllm/models/glm5next/nvidia/l2_prefetch.py
+++ b/vllm/models/glm5next/nvidia/l2_prefetch.py
@@ -60,6 +60,18 @@ _MIN_BYTES = 64 * 1024
 _CHUNK_BYTES = 4096
 _GRID = 16
 _BLOCK = 128
+# Caches and lookup tables are either written immediately before use or read
+# sparsely. Streaming them into L2 would evict projection weights without
+# shortening their own critical path.
+_GLOBAL_SKIP = (
+    "rotary_emb",
+    "cos_sin_cache",
+    "kv_cache",
+    "block_table",
+    "buffer",
+    "inv_freq",
+    "cache",
+)
 
 
 def _int_env(name: str, default: int) -> int:
@@ -275,32 +287,83 @@ def _get_launcher():
 # ---------------------------------------------------------------------------
 
 
+def tensor_segment(
+    name: str, tensor: torch.Tensor | None, min_bytes: int = 16
+) -> Segment | None:
+    """Describe one contiguous CUDA tensor for a cache-hint plan.
+
+    The prefetch kernel accepts byte ranges and does not dereference model
+    metadata. Rejecting unsupported storage here keeps every recorded segment
+    valid for graph replay.
+    """
+    if not isinstance(tensor, torch.Tensor) or not tensor.is_cuda:
+        return None
+    nbytes = tensor.numel() * tensor.element_size()
+    ptr = tensor.data_ptr()
+    if not tensor.is_contiguous():
+        # A transposed or sliced parameter can still provide a valid storage
+        # range for cache hints. Limit the hint to bytes following the view's
+        # storage offset so the prefetch never crosses its allocation.
+        try:
+            storage_bytes = tensor.untyped_storage().nbytes()
+            offset_bytes = tensor.storage_offset() * tensor.element_size()
+        except Exception:  # noqa: BLE001
+            return None
+        available_bytes = storage_bytes - offset_bytes
+        if available_bytes < 16:
+            return None
+        nbytes = min(nbytes, available_bytes)
+    if nbytes < max(int(min_bytes), 16) or ptr % 16 != 0:
+        return None
+    return name, ptr, nbytes
+
+
 def segments_of(
-    module: torch.nn.Module, prefix: str = "", skip: tuple[str, ...] = ()
+    module: torch.nn.Module,
+    prefix: str = "",
+    skip: tuple[str, ...] = (),
+    min_bytes: int | None = None,
+    include_attrs: bool = True,
 ) -> list[Segment]:
-    """Large, contiguous CUDA parameters/buffers under ``module``."""
+    """CUDA tensor storage ranges owned by ``module``.
+
+    ``min_bytes`` permits latency-sensitive scalar and normalization weights
+    to accompany a larger projection in the same launch. The default retains
+    the 64 KiB floor used for projection-only plans. Buffers and plain tensor
+    attributes are included because quantization backends may store processed
+    weights outside ``Parameter`` objects.
+    """
     out: list[Segment] = []
     seen: set[int] = set()
+    floor = _MIN_BYTES if min_bytes is None else int(min_bytes)
 
     def add(name: str, t: torch.Tensor) -> None:
-        if not isinstance(t, torch.Tensor) or not t.is_cuda or not t.is_contiguous():
+        segment = tensor_segment(name, t, floor)
+        if segment is None:
             return
-        nbytes = t.numel() * t.element_size()
-        ptr = t.data_ptr()
-        if nbytes < _MIN_BYTES or ptr % 16 != 0 or ptr in seen:
+        _, ptr, _ = segment
+        if ptr in seen:
             return
-        if any(s in name for s in skip):
+        if any(s in name for s in skip) or any(s in name for s in _GLOBAL_SKIP):
             return
         seen.add(ptr)
-        out.append((name, ptr, nbytes))
+        out.append(segment)
 
     for name, p in module.named_parameters():
         add(f"{prefix}{name}", p.data)
-    for m_name, m in module.named_modules():
-        for attr in ("W_UK_T", "W_UV", "W_UK", "W_K", "W_V"):
-            t = getattr(m, attr, None)
-            if isinstance(t, torch.Tensor):
-                add(f"{prefix}{m_name}.{attr}", t)
+    for module_name, child in module.named_modules():
+        owner = f"{module_name}." if module_name else ""
+        for name, buffer in child.named_buffers(recurse=False):
+            if name in child._non_persistent_buffers_set:
+                continue
+            add(f"{prefix}{owner}{name}", buffer)
+    if include_attrs:
+        for module_name, child in module.named_modules():
+            for attr, tensor in vars(child).items():
+                if attr.startswith("_") or not isinstance(tensor, torch.Tensor):
+                    continue
+                owner = f"{module_name}." if module_name else ""
+                add(f"{prefix}{owner}{attr}", tensor)
     return out
 
 
@@ -558,6 +621,7 @@ __all__ = [
     "PERSIST_L2",
     "L2PrefetchPlan",
     "L2Prefetcher",
+    "tensor_segment",
     "segments_of",
     "take_budget",
     "make_plan",

--- a/vllm/models/glm5next/nvidia/l2_prefetch.py
+++ b/vllm/models/glm5next/nvidia/l2_prefetch.py
@@ -32,15 +32,18 @@ Environment:
   VLLM_GLM53_L2_PREFETCH_MAX_TOKENS   only prefetch for batches up to this (256)
   VLLM_GLM53_L2_PREFETCH_BUDGET_{A,B,C,A_MLA}_MB   per-window fill budgets
   VLLM_GLM53_L2_PREFETCH_A_NEXT_MB    next-layer head bytes carried in window A
-  VLLM_GLM53_L2_PREFETCH_PERSIST_MB   persisting-L2 set-aside per rank: "max"
-                                      (default, device maximum), megabytes, or 0
+  VLLM_GLM53_L2_PREFETCH_PERSIST_MB   persisting-L2 set-aside per rank: "max",
+                                      megabytes, or 0 (default)
 
 The ``evict_last`` policy only protects lines inside the CUDA persisting-L2
-set-aside, whose default size is 0.  Without a set-aside roughly a third of a
-prefetched 50 MB projection is evicted by the routed-expert stream before
-cuBLAS reads it (in_proj 17.3 us instead of 11 us fully hot), so the prefetcher
-sizes the set-aside once per device through ``cuCtxSetLimit``.  This is a
-cache-residency policy only; kernels and numerics are unchanged.
+set-aside, whose default size is 0. A nonzero
+``VLLM_GLM53_L2_PREFETCH_PERSIST_MB`` value sizes that process-wide set-aside
+once per device through ``cuCtxSetLimit``. The default leaves the driver limit
+unchanged because reserving the SM120 maximum (84 MB) reduced a 32k GLM-5.3
+prefill from 14,439 to 13,963 tok/s and C12 DFlash verifier throughput from
+350.60 to 339.38 steps/s; it improved C1 verifier throughput from 86.63 to
+88.54 steps/s. This is a cache-residency policy only; kernels and numerics are
+unchanged.
 """
 
 from __future__ import annotations
@@ -93,7 +96,7 @@ A_NEXT_BYTES = _mb("VLLM_GLM53_L2_PREFETCH_A_NEXT_MB", "0")
 # Persisting-L2 set-aside request: "max" = device maximum (84 MB of the 128 MB
 # L2 on RTX PRO 6000 Blackwell), a number = megabytes clamped to that maximum,
 # 0/"off" = leave the driver default (no set-aside).
-PERSIST_L2 = os.getenv("VLLM_GLM53_L2_PREFETCH_PERSIST_MB", "max")
+PERSIST_L2 = os.getenv("VLLM_GLM53_L2_PREFETCH_PERSIST_MB", "0")
 
 Segment = tuple[str, int, int]  # (name, ptr, bytes)
 

--- a/vllm/models/glm5next/nvidia/l2_prefetch.py
+++ b/vllm/models/glm5next/nvidia/l2_prefetch.py
@@ -530,27 +530,29 @@ def configure_persisting_l2(device: torch.device, request: str | None = None) ->
 
 
 def _prefetch_allowed() -> bool:
-    """False inside a breakable (PIECEWISE) capture, where eager breaks end
-    the capture segment and an un-joined side stream would be illegal."""
+    """Use the prefetch stream only in runtime or regular FULL capture.
+
+    A breakable graph temporarily ends capture while it executes each eager
+    operation, then immediately begins another segment.  A prefetch issued in
+    that eager interval would remain in flight across the next ``capture_begin``
+    because the model-level join occurs only after all layers.  Uncaptured graph
+    warmups also avoid auxiliary-stream overlap so their allocations cannot race
+    reuse by the following capture.  Regular FULL capture and serving execution
+    remain eligible.
+    """
     try:
         from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
+        from vllm.compilation.monitor import is_cudagraph_capturing_enabled
 
         cap = BreakableCUDAGraphCapture.current()
-        if cap is not None and bool(getattr(cap, "_capturing", False)):
-            from vllm.config import CUDAGraphMode
-            from vllm.forward_context import (
-                get_forward_context,
-                is_forward_context_available,
-            )
-
-            if is_forward_context_available():
-                return (
-                    get_forward_context().cudagraph_runtime_mode == CUDAGraphMode.FULL
-                )
+        if cap is not None:
             return False
+        return (
+            not is_cudagraph_capturing_enabled()
+            or torch.cuda.is_current_stream_capturing()
+        )
     except Exception:  # noqa: BLE001
         return not torch.cuda.is_current_stream_capturing()
-    return True
 
 
 class L2Prefetcher:

--- a/vllm/models/glm5next/nvidia/l2_prefetch.py
+++ b/vllm/models/glm5next/nvidia/l2_prefetch.py
@@ -93,10 +93,17 @@ BUDGET_C = _mb("VLLM_GLM53_L2_PREFETCH_BUDGET_C_MB", "15")
 BUDGET_A_MLA = _mb("VLLM_GLM53_L2_PREFETCH_BUDGET_A_MLA_MB", "36")
 # Measured neutral-to-negative on C1 (fills overlap the KDA core); off by default.
 A_NEXT_BYTES = _mb("VLLM_GLM53_L2_PREFETCH_A_NEXT_MB", "0")
+
+
+def _persisting_l2_env_request() -> str:
+    """Return the process request, leaving the driver limit unchanged by default."""
+    return os.getenv("VLLM_GLM53_L2_PREFETCH_PERSIST_MB", "0")
+
+
 # Persisting-L2 set-aside request: "max" = device maximum (84 MB of the 128 MB
 # L2 on RTX PRO 6000 Blackwell), a number = megabytes clamped to that maximum,
 # 0/"off" = leave the driver default (no set-aside).
-PERSIST_L2 = os.getenv("VLLM_GLM53_L2_PREFETCH_PERSIST_MB", "0")
+PERSIST_L2 = _persisting_l2_env_request()
 
 Segment = tuple[str, int, int]  # (name, ptr, bytes)
 
@@ -158,8 +165,8 @@ if _CUTE_OK:
                 policy.ir_value(loc=loc, ip=ip),
             ],
             "cp.async.bulk.prefetch.L2.global.L2::cache_hint "
-            "[$0], $1, $2; mov.u32 $3, 0;",
-            "l,r,l,=r",
+            "[$1], $2, $3; mov.u32 $0, 0;",
+            "=r,l,r,l",
             has_side_effects=True,
             loc=loc,
             ip=ip,

--- a/vllm/models/glm5next/nvidia/l2_prefetch.py
+++ b/vllm/models/glm5next/nvidia/l2_prefetch.py
@@ -2,9 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """L2 weight prefetch for GLM-5.3 decode on SM120.
 
-At decode batch sizes (M <= 256) the dense projections are pure device-memory (GDDR7) streams
-(in_proj_qkvgfab is 50 MB per GPU: 28.8 us at M=8) while the all-reduces, mHC,
-routing chain and small kernels leave device memory idle for roughly half of each layer.
+At decode batch sizes (M <= 256) the dense projections are pure device-memory
+(GDDR7) streams (in_proj_qkvgfab is 50 MB per GPU: 28.8 us at M=8) while the
+all-reduces, mHC, routing chain and small kernels leave device memory idle for
+roughly half of each layer.
 This module issues ``cp.async.bulk.prefetch.L2`` with an ``evict_last`` cache
 policy for the *upcoming* dense weights on a side stream inside those idle
 windows, sized so the fills finish before the routed-expert stream starts.
@@ -56,11 +57,29 @@ _MIN_BYTES = 64 * 1024
 _CHUNK_BYTES = 4096
 _GRID = 16
 _BLOCK = 128
-_MAX_TOKENS = int(os.getenv("VLLM_GLM53_L2_PREFETCH_MAX_TOKENS", "256"))
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("[l2_prefetch] ignoring %s=%r", name, raw)
+        return default
 
 
 def _mb(name: str, default: str) -> int:
-    return int(float(os.getenv(name, default)) * 1e6)
+    raw = os.getenv(name, default)
+    try:
+        return int(float(raw) * 1e6)
+    except ValueError:
+        logger.warning("[l2_prefetch] ignoring %s=%r", name, raw)
+        return int(float(default) * 1e6)
+
+
+_MAX_TOKENS = _int_env("VLLM_GLM53_L2_PREFETCH_MAX_TOKENS", 256)
 
 
 BUDGET_A = _mb("VLLM_GLM53_L2_PREFETCH_BUDGET_A_MB", "20")
@@ -135,7 +154,8 @@ if _CUTE_OK:
                 size.ir_value(loc=loc, ip=ip),
                 policy.ir_value(loc=loc, ip=ip),
             ],
-            "cp.async.bulk.prefetch.L2.global.L2::cache_hint [$0], $1, $2; mov.u32 $3, 0;",
+            "cp.async.bulk.prefetch.L2.global.L2::cache_hint "
+            "[$0], $1, $2; mov.u32 $3, 0;",
             "l,r,l,=r",
             has_side_effects=True,
             loc=loc,
@@ -146,7 +166,12 @@ if _CUTE_OK:
         """grid x block threads walk the (ptr, bytes) segment table and issue
         one bulk L2 prefetch per 4 KB chunk (fire-and-forget)."""
 
-        def __init__(self, chunk_bytes: int = _CHUNK_BYTES, grid: int = _GRID, block: int = _BLOCK):
+        def __init__(
+            self,
+            chunk_bytes: int = _CHUNK_BYTES,
+            grid: int = _GRID,
+            block: int = _BLOCK,
+        ):
             self.chunk_bytes = int(chunk_bytes)
             self.grid = int(grid)
             self.block = int(block)
@@ -209,15 +234,24 @@ def _get_launcher():
         n = cute.sym_int(divisibility=2)
         fake = make_fake_tensor(cutlass.Int64, (n,), divisibility=2)
         stream = CUstream(torch.cuda.current_stream().cuda_stream)
-        compiled = cute.compile(L2PrefetchKernel(), fake, stream, options="--enable-tvm-ffi")
+        compiled = cute.compile(
+            L2PrefetchKernel(), fake, stream, options="--enable-tvm-ffi"
+        )
 
         def launch(segs: torch.Tensor, stream_handle: int) -> None:
             compiled(segs, CUstream(stream_handle))
 
         _compiled = launch
         logger.info(
-            "[l2_prefetch] CuTe kernel ready (grid=%d block=%d chunk=%d; budgets A/B/C/A_mla=%.0f/%.0f/%.0f/%.0f MB)",
-            _GRID, _BLOCK, _CHUNK_BYTES, BUDGET_A / 1e6, BUDGET_B / 1e6, BUDGET_C / 1e6, BUDGET_A_MLA / 1e6,
+            "[l2_prefetch] CuTe kernel ready (grid=%d block=%d chunk=%d; "
+            "budgets A/B/C/A_mla=%.0f/%.0f/%.0f/%.0f MB)",
+            _GRID,
+            _BLOCK,
+            _CHUNK_BYTES,
+            BUDGET_A / 1e6,
+            BUDGET_B / 1e6,
+            BUDGET_C / 1e6,
+            BUDGET_A_MLA / 1e6,
         )
         return _compiled
     except Exception as exc:  # noqa: BLE001
@@ -231,7 +265,9 @@ def _get_launcher():
 # ---------------------------------------------------------------------------
 
 
-def segments_of(module: torch.nn.Module, prefix: str = "", skip: tuple[str, ...] = ()) -> list[Segment]:
+def segments_of(
+    module: torch.nn.Module, prefix: str = "", skip: tuple[str, ...] = ()
+) -> list[Segment]:
     """Large, contiguous CUDA parameters/buffers under ``module``."""
     out: list[Segment] = []
     seen: set[int] = set()
@@ -258,7 +294,9 @@ def segments_of(module: torch.nn.Module, prefix: str = "", skip: tuple[str, ...]
     return out
 
 
-def take_budget(segments: list[Segment], budget: int) -> tuple[list[Segment], list[Segment]]:
+def take_budget(
+    segments: list[Segment], budget: int
+) -> tuple[list[Segment], list[Segment]]:
     """Split segments into (fits in budget, remainder); the straddling segment
     is sliced so no byte is prefetched twice."""
     taken: list[Segment] = []
@@ -292,13 +330,19 @@ class L2PrefetchPlan:
         self.total_bytes = sum(s[2] for s in segments)
         self.names = [f"{n}:{b / 1e6:.1f}MB" for n, _, b in segments]
         flat = [v for _, ptr, nbytes in segments for v in (ptr, nbytes)]
-        self.segs = torch.tensor(flat, dtype=torch.int64, device=device) if flat else None
+        self.segs = (
+            torch.tensor(flat, dtype=torch.int64, device=device) if flat else None
+        )
 
     def describe(self) -> str:
-        return f"{self.nseg} segs {self.total_bytes / 1e6:.1f} MB: " + ", ".join(self.names[:8])
+        return f"{self.nseg} segs {self.total_bytes / 1e6:.1f} MB: " + ", ".join(
+            self.names[:8]
+        )
 
 
-def make_plan(segments: list[Segment], budget: int, device: torch.device) -> tuple[L2PrefetchPlan | None, list[Segment]]:
+def make_plan(
+    segments: list[Segment], budget: int, device: torch.device
+) -> tuple[L2PrefetchPlan | None, list[Segment]]:
     taken, rest = take_budget(segments, budget)
     plan = L2PrefetchPlan(taken, device)
     return (plan if plan.nseg else None), rest
@@ -346,7 +390,11 @@ def configure_persisting_l2(device: torch.device, request: str | None = None) ->
     (logged, never raised).  The env-driven call (``request=None``) is applied
     once per device; an explicit ``request`` is always applied.
     """
-    idx = device.index if device.index is not None else torch.cuda.current_device()
+    idx = (
+        device.index
+        if device.index is not None
+        else torch.accelerator.current_device_index()
+    )
     if request is None and idx in _persisting_l2_applied:
         return _persisting_l2_applied[idx]
     raw = PERSIST_L2 if request is None else request
@@ -417,10 +465,15 @@ def _prefetch_allowed() -> bool:
         cap = BreakableCUDAGraphCapture.current()
         if cap is not None and bool(getattr(cap, "_capturing", False)):
             from vllm.config import CUDAGraphMode
-            from vllm.forward_context import get_forward_context, is_forward_context_available
+            from vllm.forward_context import (
+                get_forward_context,
+                is_forward_context_available,
+            )
 
             if is_forward_context_available():
-                return get_forward_context().cudagraph_runtime_mode == CUDAGraphMode.FULL
+                return (
+                    get_forward_context().cudagraph_runtime_mode == CUDAGraphMode.FULL
+                )
             return False
     except Exception:  # noqa: BLE001
         return not torch.cuda.is_current_stream_capturing()
@@ -431,7 +484,7 @@ class L2Prefetcher:
     """One side stream per device: issue() forks it off the current stream and
     launches the prefetch; join() (model end) rejoins."""
 
-    _instances: dict[int, "L2Prefetcher"] = {}
+    _instances: dict[int, L2Prefetcher] = {}
 
     def __init__(self, device: torch.device):
         self.device = device
@@ -442,8 +495,12 @@ class L2Prefetcher:
         self.persisting_l2_bytes = configure_persisting_l2(device)
 
     @classmethod
-    def get(cls, device: torch.device | None = None) -> "L2Prefetcher":
-        idx = device.index if device is not None and device.index is not None else torch.cuda.current_device()
+    def get(cls, device: torch.device | None = None) -> L2Prefetcher:
+        idx = (
+            device.index
+            if device is not None and device.index is not None
+            else torch.accelerator.current_device_index()
+        )
         inst = cls._instances.get(idx)
         if inst is None:
             inst = cls(torch.device("cuda", idx))
@@ -482,8 +539,20 @@ def join_all() -> None:
 
 
 __all__ = [
-    "ENABLED", "BUDGET_A", "BUDGET_B", "BUDGET_C", "BUDGET_A_MLA", "A_NEXT_BYTES",
-    "PERSIST_L2", "L2PrefetchPlan", "L2Prefetcher", "segments_of", "take_budget",
-    "make_plan", "issue", "join_all", "persisting_l2_request",
+    "ENABLED",
+    "BUDGET_A",
+    "BUDGET_B",
+    "BUDGET_C",
+    "BUDGET_A_MLA",
+    "A_NEXT_BYTES",
+    "PERSIST_L2",
+    "L2PrefetchPlan",
+    "L2Prefetcher",
+    "segments_of",
+    "take_budget",
+    "make_plan",
+    "issue",
+    "join_all",
+    "persisting_l2_request",
     "configure_persisting_l2",
 ]

--- a/vllm/models/glm5next/nvidia/l2_prefetch.py
+++ b/vllm/models/glm5next/nvidia/l2_prefetch.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""L2 weight prefetch for GLM-5.3 decode on SM120.
+
+At decode batch sizes (M <= 256) the dense projections are pure device-memory (GDDR7) streams
+(in_proj_qkvgfab is 50 MB per GPU: 28.8 us at M=8) while the all-reduces, mHC,
+routing chain and small kernels leave device memory idle for roughly half of each layer.
+This module issues ``cp.async.bulk.prefetch.L2`` with an ``evict_last`` cache
+policy for the *upcoming* dense weights on a side stream inside those idle
+windows, sized so the fills finish before the routed-expert stream starts.
+cuBLAS then reads the weights from L2 (128 MB on RTX PRO 6000 Blackwell):
+
+  in_proj 29.9 -> 17.1 us, o_proj 11.6 -> 5.5, MLA q_b 11.7 -> 8.3 (C1 trace)
+  C1: 85.1 -> 91.1 verifier steps/s (+7%), Sieve coding peak 433 -> 462 tok/s
+
+Numerics are untouched (cache hints only).  The side stream is forked per
+window and rejoined once at the end of the model forward, which is valid in
+FULL cudagraph captures and eager runs; inside a *breakable* (PIECEWISE)
+capture the wrapper ends the capture segment at eager ops, so prefetch is
+skipped there.
+
+Windows per decoder layer (C1, M=8):
+  A  inside attention after the first projection: this layer's o_proj
+     (optionally + a head slice of the next layer's first projection)
+  B  after the attention output: router weight + next layer's first projection
+  C  after the MoE all-reduce: the remainder
+
+Environment:
+  VLLM_GLM53_L2_PREFETCH=0            disable (default: on for SM120)
+  VLLM_GLM53_L2_PREFETCH_MAX_TOKENS   only prefetch for batches up to this (256)
+  VLLM_GLM53_L2_PREFETCH_BUDGET_{A,B,C,A_MLA}_MB   per-window fill budgets
+  VLLM_GLM53_L2_PREFETCH_A_NEXT_MB    next-layer head bytes carried in window A
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_MIN_BYTES = 64 * 1024
+_CHUNK_BYTES = 4096
+_GRID = 16
+_BLOCK = 128
+_MAX_TOKENS = int(os.getenv("VLLM_GLM53_L2_PREFETCH_MAX_TOKENS", "256"))
+
+
+def _mb(name: str, default: str) -> int:
+    return int(float(os.getenv(name, default)) * 1e6)
+
+
+BUDGET_A = _mb("VLLM_GLM53_L2_PREFETCH_BUDGET_A_MB", "20")
+BUDGET_B = _mb("VLLM_GLM53_L2_PREFETCH_BUDGET_B_MB", "35")
+BUDGET_C = _mb("VLLM_GLM53_L2_PREFETCH_BUDGET_C_MB", "20")
+BUDGET_A_MLA = _mb("VLLM_GLM53_L2_PREFETCH_BUDGET_A_MLA_MB", "36")
+# Measured neutral-to-negative on C1 (fills overlap the KDA core); off by default.
+A_NEXT_BYTES = _mb("VLLM_GLM53_L2_PREFETCH_A_NEXT_MB", "0")
+
+Segment = tuple[str, int, int]  # (name, ptr, bytes)
+
+
+def _platform_enabled() -> bool:
+    raw = os.getenv("VLLM_GLM53_L2_PREFETCH")
+    if raw is not None:
+        return raw != "0"
+    if not torch.cuda.is_available():
+        return False
+    return torch.cuda.get_device_capability() == (12, 0)
+
+
+ENABLED = _platform_enabled()
+
+
+# ---------------------------------------------------------------------------
+# CuTe DSL kernel: bulk L2 prefetch with an evict_last policy
+# ---------------------------------------------------------------------------
+
+try:  # CuTe DSL is optional; the feature silently disables without it.
+    import cutlass
+    import cutlass.cute as cute
+    from cuda.bindings.driver import CUstream
+    from cutlass._mlir import ir as _ir
+    from cutlass._mlir.dialects import llvm as _llvm
+    from cutlass.cutlass_dsl import dsl_user_op
+
+    _CUTE_OK = True
+except Exception:  # noqa: BLE001
+    _CUTE_OK = False
+
+
+if _CUTE_OK:
+
+    @dsl_user_op
+    def _createpolicy_evict_last(*, loc=None, ip=None):
+        i64 = _ir.IntegerType.get_signless(64)
+        res = _llvm.inline_asm(
+            i64,
+            [],
+            "createpolicy.fractional.L2::evict_last.b64 $0, 1.0;",
+            "=l",
+            has_side_effects=False,
+            loc=loc,
+            ip=ip,
+        )
+        return cutlass.Int64(res)
+
+    @dsl_user_op
+    def _bulk_prefetch_l2(addr, size, policy, *, loc=None, ip=None):
+        i32 = _ir.IntegerType.get_signless(32)
+        _llvm.inline_asm(
+            i32,
+            [
+                addr.ir_value(loc=loc, ip=ip),
+                size.ir_value(loc=loc, ip=ip),
+                policy.ir_value(loc=loc, ip=ip),
+            ],
+            "cp.async.bulk.prefetch.L2.global.L2::cache_hint [$0], $1, $2; mov.u32 $3, 0;",
+            "l,r,l,=r",
+            has_side_effects=True,
+            loc=loc,
+            ip=ip,
+        )
+
+    class L2PrefetchKernel:
+        """grid x block threads walk the (ptr, bytes) segment table and issue
+        one bulk L2 prefetch per 4 KB chunk (fire-and-forget)."""
+
+        def __init__(self, chunk_bytes: int = _CHUNK_BYTES, grid: int = _GRID, block: int = _BLOCK):
+            self.chunk_bytes = int(chunk_bytes)
+            self.grid = int(grid)
+            self.block = int(block)
+
+        @cute.jit
+        def __call__(self, gSegs: cute.Tensor, stream: CUstream) -> None:
+            self.kernel(gSegs).launch(
+                grid=[self.grid, 1, 1],
+                block=[self.block, 1, 1],
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(self, gSegs: cute.Tensor) -> None:
+            tidx, _, _ = cute.arch.thread_idx()
+            bidx, _, _ = cute.arch.block_idx()
+            chunk: cutlass.Constexpr = self.chunk_bytes
+            stride = cutlass.Int64(self.grid * self.block)
+            tid = cutlass.Int64(bidx) * cutlass.Int64(self.block) + cutlass.Int64(tidx)
+            nseg = cutlass.Int32(cute.size(gSegs, mode=[0]) // 2)
+            policy = _createpolicy_evict_last()
+            s = cutlass.Int32(0)
+            while s < nseg:
+                base = cutlass.Int64(gSegs[2 * s])
+                nbytes = cutlass.Int64(gSegs[2 * s + 1])
+                nchunks = (nbytes + cutlass.Int64(chunk - 1)) // cutlass.Int64(chunk)
+                c = tid
+                while c < nchunks:
+                    off = c * cutlass.Int64(chunk)
+                    rem = nbytes - off
+                    size = cutlass.Int32(chunk)
+                    if rem < cutlass.Int64(chunk):
+                        size = cutlass.Int32(rem)
+                    size = (size // cutlass.Int32(16)) * cutlass.Int32(16)
+                    if size > cutlass.Int32(0):
+                        _bulk_prefetch_l2(base + off, size, policy)
+                    c = c + stride
+                s = s + cutlass.Int32(1)
+
+
+_compiled = None
+_compile_failed = False
+
+
+def _get_launcher():
+    """Compile once (shape-dynamic segment table); returns a callable
+    (segs_tensor, cuda_stream_handle) -> None, or None if unavailable."""
+    global _compiled, _compile_failed
+    if _compiled is not None:
+        return _compiled
+    if _compile_failed:
+        return None
+    if not _CUTE_OK:
+        _compile_failed = True
+        logger.warning("[l2_prefetch] disabled: CuTe DSL not available")
+        return None
+    try:
+        from quack.compile_utils import make_fake_tensor
+
+        n = cute.sym_int(divisibility=2)
+        fake = make_fake_tensor(cutlass.Int64, (n,), divisibility=2)
+        stream = CUstream(torch.cuda.current_stream().cuda_stream)
+        compiled = cute.compile(L2PrefetchKernel(), fake, stream, options="--enable-tvm-ffi")
+
+        def launch(segs: torch.Tensor, stream_handle: int) -> None:
+            compiled(segs, CUstream(stream_handle))
+
+        _compiled = launch
+        logger.info(
+            "[l2_prefetch] CuTe kernel ready (grid=%d block=%d chunk=%d; budgets A/B/C/A_mla=%.0f/%.0f/%.0f/%.0f MB)",
+            _GRID, _BLOCK, _CHUNK_BYTES, BUDGET_A / 1e6, BUDGET_B / 1e6, BUDGET_C / 1e6, BUDGET_A_MLA / 1e6,
+        )
+        return _compiled
+    except Exception as exc:  # noqa: BLE001
+        _compile_failed = True
+        logger.warning("[l2_prefetch] disabled: kernel compile failed: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Planning helpers
+# ---------------------------------------------------------------------------
+
+
+def segments_of(module: torch.nn.Module, prefix: str = "", skip: tuple[str, ...] = ()) -> list[Segment]:
+    """Large, contiguous CUDA parameters/buffers under ``module``."""
+    out: list[Segment] = []
+    seen: set[int] = set()
+
+    def add(name: str, t: torch.Tensor) -> None:
+        if not isinstance(t, torch.Tensor) or not t.is_cuda or not t.is_contiguous():
+            return
+        nbytes = t.numel() * t.element_size()
+        ptr = t.data_ptr()
+        if nbytes < _MIN_BYTES or ptr % 16 != 0 or ptr in seen:
+            return
+        if any(s in name for s in skip):
+            return
+        seen.add(ptr)
+        out.append((name, ptr, nbytes))
+
+    for name, p in module.named_parameters():
+        add(f"{prefix}{name}", p.data)
+    for m_name, m in module.named_modules():
+        for attr in ("W_UK_T", "W_UV", "W_UK", "W_K", "W_V"):
+            t = getattr(m, attr, None)
+            if isinstance(t, torch.Tensor):
+                add(f"{prefix}{m_name}.{attr}", t)
+    return out
+
+
+def take_budget(segments: list[Segment], budget: int) -> tuple[list[Segment], list[Segment]]:
+    """Split segments into (fits in budget, remainder); the straddling segment
+    is sliced so no byte is prefetched twice."""
+    taken: list[Segment] = []
+    rest: list[Segment] = []
+    used = 0
+    for name, ptr, nbytes in segments:
+        if used >= budget:
+            rest.append((name, ptr, nbytes))
+            continue
+        room = budget - used
+        if nbytes <= room:
+            taken.append((name, ptr, nbytes))
+            used += nbytes
+        else:
+            head = room - (room % _CHUNK_BYTES)
+            if head > 0:
+                taken.append((name + "[head]", ptr, head))
+                used += head
+            rest.append((name + "[tail]", ptr + head, nbytes - head))
+    return taken, rest
+
+
+class L2PrefetchPlan:
+    """Device-resident [ptr, bytes] table for one prefetch launch."""
+
+    __slots__ = ("segs", "nseg", "total_bytes", "names")
+
+    def __init__(self, segments: list[Segment], device: torch.device):
+        segments = [s for s in segments if s[2] >= 16]
+        self.nseg = len(segments)
+        self.total_bytes = sum(s[2] for s in segments)
+        self.names = [f"{n}:{b / 1e6:.1f}MB" for n, _, b in segments]
+        flat = [v for _, ptr, nbytes in segments for v in (ptr, nbytes)]
+        self.segs = torch.tensor(flat, dtype=torch.int64, device=device) if flat else None
+
+    def describe(self) -> str:
+        return f"{self.nseg} segs {self.total_bytes / 1e6:.1f} MB: " + ", ".join(self.names[:8])
+
+
+def make_plan(segments: list[Segment], budget: int, device: torch.device) -> tuple[L2PrefetchPlan | None, list[Segment]]:
+    taken, rest = take_budget(segments, budget)
+    plan = L2PrefetchPlan(taken, device)
+    return (plan if plan.nseg else None), rest
+
+
+# ---------------------------------------------------------------------------
+# Runtime
+# ---------------------------------------------------------------------------
+
+
+def _prefetch_allowed() -> bool:
+    """False inside a breakable (PIECEWISE) capture, where eager breaks end
+    the capture segment and an un-joined side stream would be illegal."""
+    try:
+        from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
+
+        cap = BreakableCUDAGraphCapture.current()
+        if cap is not None and bool(getattr(cap, "_capturing", False)):
+            from vllm.config import CUDAGraphMode
+            from vllm.forward_context import get_forward_context, is_forward_context_available
+
+            if is_forward_context_available():
+                return get_forward_context().cudagraph_runtime_mode == CUDAGraphMode.FULL
+            return False
+    except Exception:  # noqa: BLE001
+        return not torch.cuda.is_current_stream_capturing()
+    return True
+
+
+class L2Prefetcher:
+    """One side stream per device: issue() forks it off the current stream and
+    launches the prefetch; join() (model end) rejoins."""
+
+    _instances: dict[int, "L2Prefetcher"] = {}
+
+    def __init__(self, device: torch.device):
+        self.device = device
+        self.side = torch.cuda.Stream(device=device)
+        self.pending = False
+
+    @classmethod
+    def get(cls, device: torch.device | None = None) -> "L2Prefetcher":
+        idx = device.index if device is not None and device.index is not None else torch.cuda.current_device()
+        inst = cls._instances.get(idx)
+        if inst is None:
+            inst = cls(torch.device("cuda", idx))
+            cls._instances[idx] = inst
+        return inst
+
+    def issue(self, plan: L2PrefetchPlan | None, num_tokens: int) -> None:
+        if plan is None or plan.segs is None or num_tokens > _MAX_TOKENS:
+            return
+        launch = _get_launcher()
+        if launch is None or not _prefetch_allowed():
+            return
+        main = torch.cuda.current_stream(self.device)
+        self.side.wait_stream(main)
+        launch(plan.segs, self.side.cuda_stream)
+        self.pending = True
+
+    def join(self) -> None:
+        if not self.pending:
+            return
+        torch.cuda.current_stream(self.device).wait_stream(self.side)
+        self.pending = False
+
+
+def issue(plan: L2PrefetchPlan | None, num_tokens: int) -> None:
+    if ENABLED and plan is not None and plan.segs is not None:
+        L2Prefetcher.get(plan.segs.device).issue(plan, num_tokens)
+
+
+def join_all() -> None:
+    if ENABLED:
+        L2Prefetcher.get(None).join()
+
+
+__all__ = [
+    "ENABLED", "BUDGET_A", "BUDGET_B", "BUDGET_C", "BUDGET_A_MLA", "A_NEXT_BYTES",
+    "L2PrefetchPlan", "L2Prefetcher", "segments_of", "take_budget", "make_plan", "issue", "join_all",
+]

--- a/vllm/models/glm5next/nvidia/l2_prefetch.py
+++ b/vllm/models/glm5next/nvidia/l2_prefetch.py
@@ -22,8 +22,9 @@ skipped there.
 Windows per decoder layer (C1, M=8):
   A  inside attention after the first projection: this layer's o_proj
      (optionally + a head slice of the next layer's first projection)
-  B  after the attention output: router weight + next layer's first projection
-  C  after the MoE all-reduce: the remainder
+  B  before the attention-output all-reduce: router weight + next layer's
+     first projection
+  C  before the MoE all-reduce: the remainder
 
 Environment:
   VLLM_GLM53_L2_PREFETCH=0            disable (default: on for SM120)
@@ -54,8 +55,10 @@ def _mb(name: str, default: str) -> int:
 
 
 BUDGET_A = _mb("VLLM_GLM53_L2_PREFETCH_BUDGET_A_MB", "20")
-BUDGET_B = _mb("VLLM_GLM53_L2_PREFETCH_BUDGET_B_MB", "35")
-BUDGET_C = _mb("VLLM_GLM53_L2_PREFETCH_BUDGET_C_MB", "20")
+# Windows B/C fire *before* the all-reduces (hooks in RowParallelLinear and the
+# MoE runner), which adds the reduction time to each idle window.
+BUDGET_B = _mb("VLLM_GLM53_L2_PREFETCH_BUDGET_B_MB", "50")
+BUDGET_C = _mb("VLLM_GLM53_L2_PREFETCH_BUDGET_C_MB", "15")
 BUDGET_A_MLA = _mb("VLLM_GLM53_L2_PREFETCH_BUDGET_A_MLA_MB", "36")
 # Measured neutral-to-negative on C1 (fills overlap the KDA core); off by default.
 A_NEXT_BYTES = _mb("VLLM_GLM53_L2_PREFETCH_A_NEXT_MB", "0")

--- a/vllm/models/glm5next/nvidia/l2_prefetch.py
+++ b/vllm/models/glm5next/nvidia/l2_prefetch.py
@@ -64,11 +64,12 @@ Segment = tuple[str, int, int]  # (name, ptr, bytes)
 
 
 def _platform_enabled() -> bool:
+    """Disable-only override: the feature never turns on without CUDA."""
+    if not torch.cuda.is_available():
+        return False
     raw = os.getenv("VLLM_GLM53_L2_PREFETCH")
     if raw is not None:
         return raw != "0"
-    if not torch.cuda.is_available():
-        return False
     return torch.cuda.get_device_capability() == (12, 0)
 
 
@@ -355,8 +356,11 @@ def issue(plan: L2PrefetchPlan | None, num_tokens: int) -> None:
 
 
 def join_all() -> None:
-    if ENABLED:
-        L2Prefetcher.get(None).join()
+    """Rejoin every pending prefetch side stream (no-op when nothing was issued)."""
+    if not ENABLED:
+        return
+    for inst in list(L2Prefetcher._instances.values()):
+        inst.join()
 
 
 __all__ = [

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -88,7 +88,6 @@ from vllm.transformers_utils.configs.glm5_next import Glm5NextConfig
 from vllm.utils.b12x import get_b12x_mhc
 
 from . import l2_prefetch as _l2pf
-
 from .attention import Glm5NextMLAAttention
 from .kda import Glm5NextLinearAttention
 from .multimodal import (
@@ -421,8 +420,8 @@ class Glm5NextDecoderLayer(nn.Module):
         # the first forward, after weights are loaded and post-processed.
         object.__setattr__(self, "_l2pf_next", None)
         self._l2pf_ready = False
-        self._l2pf_plan_b = None
-        self._l2pf_plan_c = None
+        self._l2pf_plan_b: _l2pf.L2PrefetchPlan | None = None
+        self._l2pf_plan_c: _l2pf.L2PrefetchPlan | None = None
         # In SP, the attention output projection leaves a partial sum; the
         # decoder-layer reduce_scatter after attention completes it (DSv4 pattern).
         # MTP layers use the non-mHC path which has no sp_reduce_scatter, so
@@ -651,13 +650,20 @@ class Glm5NextDecoderLayer(nn.Module):
             for attr in ("W_UK_T", "W_UV"):
                 t = getattr(attn_impl, attr, None) if attn_impl is not None else None
                 if isinstance(t, torch.Tensor) and t.is_cuda and t.is_contiguous():
-                    segs_a.append((f"impl.{attr}", t.data_ptr(), t.numel() * t.element_size()))
+                    segs_a.append(
+                        (
+                            f"impl.{attr}",
+                            t.data_ptr(),
+                            t.numel() * t.element_size(),
+                        )
+                    )
             is_mla = hasattr(self.self_attn, "mla_attn")
             if nxt_segs and _l2pf.A_NEXT_BYTES > 0 and not is_mla:
                 head_a, rest_first = _l2pf.take_budget(nxt_segs[:1], _l2pf.A_NEXT_BYTES)
                 segs_a += head_a
                 nxt_segs = rest_first + nxt_segs[1:]
-            plan_a, _ = _l2pf.make_plan(segs_a, _l2pf.BUDGET_A_MLA if is_mla else _l2pf.BUDGET_A, device)
+            budget_a = _l2pf.BUDGET_A_MLA if is_mla else _l2pf.BUDGET_A
+            plan_a, _ = _l2pf.make_plan(segs_a, budget_a, device)
             plan_b, rest = _l2pf.make_plan(segs_b + nxt_segs, _l2pf.BUDGET_B, device)
             plan_c, dropped = _l2pf.make_plan(rest, _l2pf.BUDGET_C, device)
             self._l2pf_plan_b = plan_b
@@ -669,12 +675,28 @@ class Glm5NextDecoderLayer(nn.Module):
             self._l2pf_hooked_b = False
             self._l2pf_hooked_c = False
             o_proj = getattr(self.self_attn, "o_proj", None)
-            if o_proj is not None and plan_b is not None and getattr(o_proj, "reduce_results", False):
-                object.__setattr__(o_proj, "_l2_prefetch_pre_reduce_hook", lambda n, p=plan_b: _l2pf.issue(p, n))
+            if (
+                o_proj is not None
+                and plan_b is not None
+                and getattr(o_proj, "reduce_results", False)
+            ):
+                object.__setattr__(
+                    o_proj,
+                    "_l2_prefetch_pre_reduce_hook",
+                    lambda n, p=plan_b: _l2pf.issue(p, n),
+                )
                 self._l2pf_hooked_b = True
-            target_c = self.mlp.experts if self._mlp_is_moe else getattr(self.mlp, "down_proj", None)
+            target_c = (
+                self.mlp.experts
+                if self._mlp_is_moe
+                else getattr(self.mlp, "down_proj", None)
+            )
             if target_c is not None and plan_c is not None:
-                object.__setattr__(target_c, "_l2_prefetch_pre_reduce_hook", lambda n, p=plan_c: _l2pf.issue(p, n))
+                object.__setattr__(
+                    target_c,
+                    "_l2_prefetch_pre_reduce_hook",
+                    lambda n, p=plan_c: _l2pf.issue(p, n),
+                )
                 self._l2pf_hooked_c = True
             # Window A fires inside the attention layer, right after its first
             # projection (hook in the shared KDA / MLA layers).
@@ -683,7 +705,8 @@ class Glm5NextDecoderLayer(nn.Module):
                 object.__setattr__(
                     target, "_l2_prefetch_hook", lambda n, p=plan_a: _l2pf.issue(p, n)
                 )
-            if self.layer_idx in (0, 3, 4) or self.layer_idx == self.num_hidden_layers - 1:
+            is_logged_layer = self.layer_idx in (0, 3, 4)
+            if is_logged_layer or self.layer_idx == self.num_hidden_layers - 1:
                 logger.info(
                     "[l2_prefetch] layer %d A: %s | B: %s | C: %s | dropped %.1f MB",
                     self.layer_idx,
@@ -693,7 +716,9 @@ class Glm5NextDecoderLayer(nn.Module):
                     sum(s[2] for s in dropped) / 1e6,
                 )
         except Exception as exc:  # noqa: BLE001
-            logger.warning("[l2_prefetch] layer %d plan failed: %s", self.layer_idx, exc)
+            logger.warning(
+                "[l2_prefetch] layer %d plan failed: %s", self.layer_idx, exc
+            )
             self._l2pf_plan_b = None
             self._l2pf_plan_c = None
 

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -628,42 +628,75 @@ class Glm5NextDecoderLayer(nn.Module):
         self._l2pf_ready = True
         try:
             device = next(self.parameters()).device
-            segs_b: list[_l2pf.Segment] = []
+            router_segments: list[_l2pf.Segment] = []
             if self._mlp_is_moe:
                 # Router weight is read right after the post-attention mHC.
-                segs_b += _l2pf.segments_of(self.mlp.gate, "mlp.gate.")
+                router_segments = _l2pf.segments_of(
+                    self.mlp.gate, "mlp.gate.", min_bytes=0
+                )
+            # Window B starts before the attention-output reduction. These
+            # tensors are consumed by the post-attention mHC immediately after
+            # that reduction, so carrying them ahead avoids latency-bound cold
+            # reads without displacing the following projection materially.
+            segs_b = _l2pf.segments_of(
+                self.post_attention_layernorm,
+                "post_attention_layernorm.",
+                min_bytes=0,
+            )
+            for attr in ("hc_ffn_base", "hc_ffn_scale", "hc_ffn_fn"):
+                segment = _l2pf.tensor_segment(attr, getattr(self, attr, None))
+                if segment is not None:
+                    segs_b.append(segment)
+            segs_b += router_segments
             # Dense-MLP layers (first 3): their 75 MB MLP weights are consumed
             # right after attention with no idle window -> never prefetched.
             nxt = self._l2pf_next
             nxt_segs: list[_l2pf.Segment] = []
             if nxt is not None:
+                # The next layer consumes its mHC and normalization state before
+                # its first attention projection. Preserve that consumption
+                # order in the prefetch plan, including sub-64-KiB parameters.
+                for attr in (
+                    "hc_attn_fn_broadcast",
+                    "hc_attn_fn",
+                    "hc_attn_scale",
+                    "hc_attn_base",
+                ):
+                    segment = _l2pf.tensor_segment(
+                        f"L{nxt.layer_idx}.{attr}", getattr(nxt, attr, None)
+                    )
+                    if segment is not None:
+                        nxt_segs.append(segment)
+                nxt_segs += _l2pf.segments_of(
+                    nxt.input_layernorm,
+                    f"L{nxt.layer_idx}.input_layernorm.",
+                    min_bytes=0,
+                )
                 # The next layer's o_proj (and MLA kv_b, unused at decode) are
                 # prefetched inside that layer's own attention window (A).
-                nxt_segs = _l2pf.segments_of(
-                    nxt.self_attn, f"L{nxt.layer_idx}.self_attn.", skip=self._ATTN_SKIP
+                nxt_segs += _l2pf.segments_of(
+                    nxt.self_attn,
+                    f"L{nxt.layer_idx}.self_attn.",
+                    skip=self._ATTN_SKIP,
+                    min_bytes=0,
                 )
             # Window A of this layer's attention: its o_proj plus a head slice
             # of the next layer's first projection (it survives the expert
             # stream and shortens window C so the tail is resident in time).
-            segs_a = _l2pf.segments_of(self.self_attn.o_proj, "o_proj.")
-            attn_impl = getattr(getattr(self.self_attn, "mla_attn", None), "impl", None)
-            for attr in ("W_UK_T", "W_UV"):
-                t = getattr(attn_impl, attr, None) if attn_impl is not None else None
-                if isinstance(t, torch.Tensor) and t.is_cuda and t.is_contiguous():
-                    segs_a.append(
-                        (
-                            f"impl.{attr}",
-                            t.data_ptr(),
-                            t.numel() * t.element_size(),
-                        )
-                    )
             is_mla = hasattr(self.self_attn, "mla_attn")
+            segs_a = _l2pf.segments_of(self.self_attn.o_proj, "o_proj.")
             if nxt_segs and _l2pf.A_NEXT_BYTES > 0 and not is_mla:
                 head_a, rest_first = _l2pf.take_budget(nxt_segs[:1], _l2pf.A_NEXT_BYTES)
                 segs_a += head_a
                 nxt_segs = rest_first + nxt_segs[1:]
             budget_a = _l2pf.BUDGET_A_MLA if is_mla else _l2pf.BUDGET_A
-            plan_a, _ = _l2pf.make_plan(segs_a, budget_a, device)
+            # MLA materializes its absorbed decode weights while executing the
+            # first query projection. Build that attention plan from the hook
+            # immediately after the projection, rather than permanently
+            # omitting tensors which did not exist at layer-entry time.
+            plan_a = None
+            if not is_mla:
+                plan_a, _ = _l2pf.make_plan(segs_a, budget_a, device)
             plan_b, rest = _l2pf.make_plan(segs_b + nxt_segs, _l2pf.BUDGET_B, device)
             plan_c, dropped = _l2pf.make_plan(rest, _l2pf.BUDGET_C, device)
             self._l2pf_plan_b = plan_b
@@ -701,16 +734,73 @@ class Glm5NextDecoderLayer(nn.Module):
             # Window A fires inside the attention layer, right after its first
             # projection (hook in the shared KDA / MLA layers).
             target = self.self_attn.mla_attn if is_mla else self.self_attn
-            if plan_a is not None:
+            if is_mla:
+                mla_state: dict[str, _l2pf.L2PrefetchPlan | bool | None] = {
+                    "ready": False,
+                    "plan": None,
+                }
+
+                def issue_mla_window_a(
+                    num_tokens: int,
+                    wrapper=target,
+                    state=mla_state,
+                    layer_idx=self.layer_idx,
+                    o_proj_segments=segs_a,
+                ) -> None:
+                    if not state["ready"]:
+                        mla_layer = getattr(wrapper, "mla_attn", None)
+                        attn_impl = getattr(mla_layer, "impl", None)
+                        resolved = list(o_proj_segments)
+                        seen = {segment[1] for segment in resolved}
+                        # The generic MLA layer owns W_UV/W_UK_T. Specialized
+                        # backends may instead own packed W_UV/W_UK variants
+                        # on their implementation object.
+                        for owner_name, owner in (
+                            ("mla_attn", mla_layer),
+                            ("impl", attn_impl),
+                        ):
+                            for attr in (
+                                "W_UV",
+                                "W_UK_T",
+                                "W_UK",
+                                "W_K",
+                                "W_V",
+                            ):
+                                tensor = (
+                                    getattr(owner, attr, None)
+                                    if owner is not None
+                                    else None
+                                )
+                                segment = _l2pf.tensor_segment(
+                                    f"{owner_name}.{attr}", tensor, min_bytes=0
+                                )
+                                if segment is not None and segment[1] not in seen:
+                                    resolved.append(segment)
+                                    seen.add(segment[1])
+                        state["plan"], _ = _l2pf.make_plan(
+                            resolved, _l2pf.BUDGET_A_MLA, device
+                        )
+                        state["ready"] = True
+                        if layer_idx in (0, 3, 4):
+                            dynamic_plan = state["plan"]
+                            logger.info(
+                                "[l2_prefetch] layer %d deferred MLA A: %s",
+                                layer_idx,
+                                dynamic_plan.describe() if dynamic_plan else "-",
+                            )
+                    _l2pf.issue(state["plan"], num_tokens)
+
+                object.__setattr__(target, "_l2_prefetch_hook", issue_mla_window_a)
+            elif plan_a is not None:
                 object.__setattr__(
                     target, "_l2_prefetch_hook", lambda n, p=plan_a: _l2pf.issue(p, n)
                 )
-            is_logged_layer = self.layer_idx in (0, 3, 4)
+            is_logged_layer = self.layer_idx in (0, 2, 3, 4)
             if is_logged_layer or self.layer_idx == self.num_hidden_layers - 1:
                 logger.info(
                     "[l2_prefetch] layer %d A: %s | B: %s | C: %s | dropped %.1f MB",
                     self.layer_idx,
-                    plan_a.describe() if plan_a else "-",
+                    "deferred" if is_mla else (plan_a.describe() if plan_a else "-"),
                     plan_b.describe() if plan_b else "-",
                     plan_c.describe() if plan_c else "-",
                     sum(s[2] for s in dropped) / 1e6,
@@ -871,6 +961,12 @@ class Glm5NextModel(nn.Module, EagleModelMixin):
         active = list(self._active_layers)
         for i, layer in enumerate(active):
             object.__setattr__(layer, "_l2pf_next", active[(i + 1) % len(active)])
+        if _l2pf.ENABLED and active:
+            prefetch_device = next(active[0].parameters()).device
+            if prefetch_device.type == "cuda":
+                # Create the side stream and apply the optional context-wide L2
+                # reservation before any CUDA graph capture can begin.
+                _l2pf.L2Prefetcher.get(prefetch_device)
 
         if get_pp_group().is_last_rank:
             self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -585,8 +585,8 @@ class Glm5NextDecoderLayer(nn.Module):
         if self.is_sequence_parallel:
             x = sp_reduce_scatter(x)
 
-        # L2 prefetch window B: all-reduce + mHC + routing chain leave device memory idle.
-        if _l2pf.ENABLED:
+        # L2 prefetch window B (fallback issue point when no pre-reduce hook).
+        if _l2pf.ENABLED and not getattr(self, "_l2pf_hooked_b", False):
             _l2pf.issue(self._l2pf_plan_b, x.shape[0])
 
         # Fuse post-attn hc_post + pre-FFN hc_pre (+ RMSNorm) into one kernel.
@@ -611,8 +611,8 @@ class Glm5NextDecoderLayer(nn.Module):
         # mHC end. The last mHC layer materializes its final hc_post (nothing
         # to fuse with) then contracts; every other layer defers its hc_post to
         # the next layer's fused pre, returning the state.
-        # L2 prefetch window C: MoE all-reduce + next mHC leave device memory idle.
-        if _l2pf.ENABLED:
+        # L2 prefetch window C (fallback issue point when no pre-reduce hook).
+        if _l2pf.ENABLED and not getattr(self, "_l2pf_hooked_c", False):
             _l2pf.issue(self._l2pf_plan_c, x.shape[0])
 
         if self.layer_idx == self.num_hidden_layers - 1:
@@ -662,6 +662,20 @@ class Glm5NextDecoderLayer(nn.Module):
             plan_c, dropped = _l2pf.make_plan(rest, _l2pf.BUDGET_C, device)
             self._l2pf_plan_b = plan_b
             self._l2pf_plan_c = plan_c
+            # Fire windows B/C before the all-reduces (+10 us of idle window
+            # each): hooks on this layer's o_proj and on the MoE runner (or the
+            # dense MLP's down_proj).  The in-forward issue points below stay
+            # as the fallback when a hook target is missing.
+            self._l2pf_hooked_b = False
+            self._l2pf_hooked_c = False
+            o_proj = getattr(self.self_attn, "o_proj", None)
+            if o_proj is not None and plan_b is not None and getattr(o_proj, "reduce_results", False):
+                object.__setattr__(o_proj, "_l2_prefetch_pre_reduce_hook", lambda n, p=plan_b: _l2pf.issue(p, n))
+                self._l2pf_hooked_b = True
+            target_c = self.mlp.experts if self._mlp_is_moe else getattr(self.mlp, "down_proj", None)
+            if target_c is not None and plan_c is not None:
+                object.__setattr__(target_c, "_l2_prefetch_pre_reduce_hook", lambda n, p=plan_c: _l2pf.issue(p, n))
+                self._l2pf_hooked_c = True
             # Window A fires inside the attention layer, right after its first
             # projection (hook in the shared KDA / MLA layers).
             target = self.self_attn.mla_attn if is_mla else self.self_attn

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -936,6 +936,11 @@ class Glm5NextModel(nn.Module, EagleModelMixin):
                     aux_hidden_state = sp_all_gather(aux_hidden_state)[:full_num_tokens]
                 aux_hidden_states.append(aux_hidden_state)
 
+        # Rejoin the L2 prefetch side stream once per forward, before any
+        # early return, so a CUDA-graph capture never ends with a forked
+        # side stream (capture safety on every PP rank).
+        _l2pf.join_all()
+
         if not get_pp_group().is_last_rank:
             # Pipeline parallelism is rejected because post/comb are the
             # deferred mHC state and must be propagated across rank boundaries.
@@ -945,9 +950,6 @@ class Glm5NextModel(nn.Module, EagleModelMixin):
 
         if self.is_sequence_parallel:
             hidden_states = sp_all_gather(hidden_states)[:full_num_tokens]
-
-        # Rejoin the L2 prefetch side stream once per forward (capture safety).
-        _l2pf.join_all()
 
         hidden_states = self.norm(hidden_states)
         if aux_hidden_states:

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -87,6 +87,8 @@ from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.glm5_next import Glm5NextConfig
 from vllm.utils.b12x import get_b12x_mhc
 
+from . import l2_prefetch as _l2pf
+
 from .attention import Glm5NextMLAAttention
 from .kda import Glm5NextLinearAttention
 from .multimodal import (
@@ -415,6 +417,12 @@ class Glm5NextDecoderLayer(nn.Module):
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         # Cached for the hot forward path (isinstance per layer per step).
         self._mlp_is_moe = isinstance(self.mlp, Glm5NextMoE)
+        # L2 weight prefetch (see l2_prefetch.py); plans are built lazily on
+        # the first forward, after weights are loaded and post-processed.
+        object.__setattr__(self, "_l2pf_next", None)
+        self._l2pf_ready = False
+        self._l2pf_plan_b = None
+        self._l2pf_plan_c = None
         # In SP, the attention output projection leaves a partial sum; the
         # decoder-layer reduce_scatter after attention completes it (DSv4 pattern).
         # MTP layers use the non-mHC path which has no sp_reduce_scatter, so
@@ -525,6 +533,8 @@ class Glm5NextDecoderLayer(nn.Module):
         # hc_post inputs (its ffn-pre outputs); when present, fuse that
         # hc_post with this layer's attn hc_pre into one kernel (inter-layer
         # fusion). Layer 0 has no incoming state -> standalone hc_pre.
+        if _l2pf.ENABLED and not self._l2pf_ready:
+            self._l2pf_build_plans()
         x = hidden_states
         if post is None:
             if self._b12x_mhc is not None:
@@ -575,6 +585,10 @@ class Glm5NextDecoderLayer(nn.Module):
         if self.is_sequence_parallel:
             x = sp_reduce_scatter(x)
 
+        # L2 prefetch window B: all-reduce + mHC + routing chain leave device memory idle.
+        if _l2pf.ENABLED:
+            _l2pf.issue(self._l2pf_plan_b, x.shape[0])
+
         # Fuse post-attn hc_post + pre-FFN hc_pre (+ RMSNorm) into one kernel.
         residual, post, comb, x = self.hc_fused_post_pre(
             x,
@@ -597,12 +611,77 @@ class Glm5NextDecoderLayer(nn.Module):
         # mHC end. The last mHC layer materializes its final hc_post (nothing
         # to fuse with) then contracts; every other layer defers its hc_post to
         # the next layer's fused pre, returning the state.
+        # L2 prefetch window C: MoE all-reduce + next mHC leave device memory idle.
+        if _l2pf.ENABLED:
+            _l2pf.issue(self._l2pf_plan_c, x.shape[0])
+
         if self.layer_idx == self.num_hidden_layers - 1:
             x = self.hc_post(x, residual, post, comb)
             x = hc_contract(x, self.n)
             return x, None, None, None
 
         return x, residual, post, comb
+
+    # ---- L2 weight prefetch planning (see l2_prefetch.py) -------------------
+    _ATTN_SKIP = ("o_proj", "kv_b_proj", "indexer.index_kpool", "indexer.weights_proj")
+
+    def _l2pf_build_plans(self) -> None:
+        self._l2pf_ready = True
+        try:
+            device = next(self.parameters()).device
+            segs_b: list[_l2pf.Segment] = []
+            if self._mlp_is_moe:
+                # Router weight is read right after the post-attention mHC.
+                segs_b += _l2pf.segments_of(self.mlp.gate, "mlp.gate.")
+            # Dense-MLP layers (first 3): their 75 MB MLP weights are consumed
+            # right after attention with no idle window -> never prefetched.
+            nxt = self._l2pf_next
+            nxt_segs: list[_l2pf.Segment] = []
+            if nxt is not None:
+                # The next layer's o_proj (and MLA kv_b, unused at decode) are
+                # prefetched inside that layer's own attention window (A).
+                nxt_segs = _l2pf.segments_of(
+                    nxt.self_attn, f"L{nxt.layer_idx}.self_attn.", skip=self._ATTN_SKIP
+                )
+            # Window A of this layer's attention: its o_proj plus a head slice
+            # of the next layer's first projection (it survives the expert
+            # stream and shortens window C so the tail is resident in time).
+            segs_a = _l2pf.segments_of(self.self_attn.o_proj, "o_proj.")
+            attn_impl = getattr(getattr(self.self_attn, "mla_attn", None), "impl", None)
+            for attr in ("W_UK_T", "W_UV"):
+                t = getattr(attn_impl, attr, None) if attn_impl is not None else None
+                if isinstance(t, torch.Tensor) and t.is_cuda and t.is_contiguous():
+                    segs_a.append((f"impl.{attr}", t.data_ptr(), t.numel() * t.element_size()))
+            is_mla = hasattr(self.self_attn, "mla_attn")
+            if nxt_segs and _l2pf.A_NEXT_BYTES > 0 and not is_mla:
+                head_a, rest_first = _l2pf.take_budget(nxt_segs[:1], _l2pf.A_NEXT_BYTES)
+                segs_a += head_a
+                nxt_segs = rest_first + nxt_segs[1:]
+            plan_a, _ = _l2pf.make_plan(segs_a, _l2pf.BUDGET_A_MLA if is_mla else _l2pf.BUDGET_A, device)
+            plan_b, rest = _l2pf.make_plan(segs_b + nxt_segs, _l2pf.BUDGET_B, device)
+            plan_c, dropped = _l2pf.make_plan(rest, _l2pf.BUDGET_C, device)
+            self._l2pf_plan_b = plan_b
+            self._l2pf_plan_c = plan_c
+            # Window A fires inside the attention layer, right after its first
+            # projection (hook in the shared KDA / MLA layers).
+            target = self.self_attn.mla_attn if is_mla else self.self_attn
+            if plan_a is not None:
+                object.__setattr__(
+                    target, "_l2_prefetch_hook", lambda n, p=plan_a: _l2pf.issue(p, n)
+                )
+            if self.layer_idx in (0, 3, 4) or self.layer_idx == self.num_hidden_layers - 1:
+                logger.info(
+                    "[l2_prefetch] layer %d A: %s | B: %s | C: %s | dropped %.1f MB",
+                    self.layer_idx,
+                    plan_a.describe() if plan_a else "-",
+                    plan_b.describe() if plan_b else "-",
+                    plan_c.describe() if plan_c else "-",
+                    sum(s[2] for s in dropped) / 1e6,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[l2_prefetch] layer %d plan failed: %s", self.layer_idx, exc)
+            self._l2pf_plan_b = None
+            self._l2pf_plan_c = None
 
     def hc_pre(
         self,
@@ -747,6 +826,12 @@ class Glm5NextModel(nn.Module, EagleModelMixin):
         # The active slice is fixed after construction; cache it so forward
         # doesn't rebuild the slice (a fresh list) every step.
         self._active_layers = self.layers[self.start_layer : self.end_layer]
+        # L2 prefetch chain: each layer prefetches its successor's projections;
+        # the last layer prefetches the first layer's for the next step.
+        # (object.__setattr__ keeps the link out of the nn.Module registry.)
+        active = list(self._active_layers)
+        for i, layer in enumerate(active):
+            object.__setattr__(layer, "_l2pf_next", active[(i + 1) % len(active)])
 
         if get_pp_group().is_last_rank:
             self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -860,6 +945,9 @@ class Glm5NextModel(nn.Module, EagleModelMixin):
 
         if self.is_sequence_parallel:
             hidden_states = sp_all_gather(hidden_states)[:full_num_tokens]
+
+        # Rejoin the L2 prefetch side stream once per forward (capture safety).
+        _l2pf.join_all()
 
         hidden_states = self.norm(hidden_states)
         if aux_hidden_states:

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -537,6 +537,12 @@ class CudaGraphManager:
 
                     # Warmup
                     forward_fn(CUDAGraphMode.NONE)
+                    # A model forward may fork work onto auxiliary streams and
+                    # join them with events queued on the compute stream.  CUDA
+                    # graph capture must not begin while those warmup kernels
+                    # are still executing, even though the queued event waits
+                    # preserve normal stream ordering.
+                    torch.accelerator.synchronize()
 
                     # Capture
                     logger.debug(


### PR DESCRIPTION
## Resulting behavior

GLM-5.3 decode can prefetch the next projection weights into L2 on a dedicated
CUDA stream before the target computation consumes them. The integration
issues prefetch windows at the model boundaries that precede attention,
tensor-parallel communication, and routed-expert work. Prefill and decode
batches above 256 tokens do not use the prefetch path.

The prefetch side stream is disabled during uncaptured graph-preparation
forwards and throughout breakable graph capture. Regular FULL capture and
serving retain asynchronous overlap.

`VLLM_GLM53_L2_PREFETCH` controls the prefetcher. The persisting-L2 set-aside is
separately controlled by `VLLM_GLM53_L2_PREFETCH_PERSIST_MB`; its default is
`0`, so the CUDA driver limit is unchanged. Explicit decimal-megabyte values,
`max`, and `all` remain supported and are clamped to the device limit. Invalid
numeric environment values use documented defaults instead of failing module
import. The applied driver limit is read back from the active primary context
and recorded per accelerator device.

## Technical reason

The target projection weights are reused after communication and routed-
expert work has consumed L2 capacity. Asynchronous cache hints reduce the
subsequent weight-read latency without changing model tensors or arithmetic.
The persisting set-aside can improve single-request decode but competes with
other streams at larger concurrency, so it remains an explicit opt-in policy.

## Compatibility

Unsupported devices, unavailable CUDA driver features, disabled configuration,
and prefetch-plan failures retain the ordinary execution path. The change does
not alter weights, kernels that perform model arithmetic, sampling, or output
numerics.

The optimization commits retain MadeBy561 as their author. Configuration and
qualification corrections retain their implementing author. This pull request
contains the complete functionality represented by
`local-inference-lab/vllm#576` and `local-inference-lab/vllm#578` and is their
merge candidate.

The graph-lifecycle guard depends on #617, which synchronizes uncaptured
warmup work before CUDA graph capture starts and exposes graph-preparation
state to model-specific stream policies.

## Validation

The focused suite passed on an NVIDIA RTX PRO 6000 Blackwell Workstation
Edition GPU:

```text
python -m pytest -q tests/models/test_glm5next_l2_prefetch_persist.py
17 passed
```

Coverage includes environment parsing, clamping, disabled defaults, primary-
context driver readback, allocation granularity, one-time application per
device, KDA side-stream graph replay, B12X dispatch, DFlash attention, and
causal-convolution correctness. Three additional lifecycle tests cover
breakable capture, uncaptured graph warmup, and regular FULL capture.
Repository lint, formatting, typing, SPDX, and configuration hooks pass.

Matched TP4/DCP1 serving on four stock-clock RTX PRO 6000 Blackwell Workstation
Edition GPUs showed why the set-aside is opt-in. Relative to a zero-byte
reservation, the maximum reservation improved C1 target throughput by about
2.2%, but reduced C12 target throughput by about 3.2%; C8 and C24 were within
0.8%. The prefetch mechanism remains enabled by the serving image while the
persisting reservation defaults to zero.

The complete GLM-5.3 runtime containing the prefetcher retained or improved
decode across no-speculation, MTP3, and DFlash2 modes and kept 32k prefill
within 0.17% of its source-locked reference under matched stock-clock tests.
Three consecutive combined KDA-gate and L2-prefetch startups completed FULL
CUDA graph capture without the intermittent illegal-memory fault reproduced
before the lifecycle guard.
