### PR TITLE
integration(glm53-flash): complete NVFP4 and prefix-cache stack

### DIFF
--- a/tests/models/test_glm5next_pooled_indexer.py
+++ b/tests/models/test_glm5next_pooled_indexer.py
@@ -185,17 +185,44 @@ def test_glm53_packed_c4_metadata_uses_parent_stride() -> None:
 
 
 def _packed_main_cache(
-    *, device: torch.device, blocks: int, layers: int, block_size: int, layer: int
+    *,
+    device: torch.device,
+    blocks: int,
+    layers: int,
+    block_size: int,
+    layer: int,
+    record_bytes: int = 528,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    page_bytes = block_size * (528 + 33)
+    semantic_page_bytes = block_size * record_bytes
+    content_page_bytes = ((semantic_page_bytes + 8447) // 8448) * 8448
+    page_bytes = content_page_bytes + block_size * 33
     raw = torch.zeros(blocks * layers * page_bytes, dtype=torch.uint8, device=device)
     main = torch.as_strided(
         raw,
-        size=(blocks, block_size, 528),
-        stride=(layers * page_bytes, 528, 1),
+        size=(blocks, block_size, record_bytes),
+        stride=(layers * page_bytes, record_bytes, 1),
         storage_offset=layer * page_bytes,
     )
     return raw, main
+
+
+def test_glm53_packed_tail_accepts_nvfp4_main_record() -> None:
+    _, main = _packed_main_cache(
+        device=torch.device("cpu"),
+        blocks=2,
+        layers=3,
+        block_size=3328,
+        layer=1,
+        record_bytes=304,
+    )
+
+    index_cache, subpages, parent_stride_pages = (
+        Glm5NextPooledIndexer._index_cache_view(main)
+    )
+
+    assert subpages == 13
+    assert parent_stride_pages == 399
+    assert index_cache.stride() == (8448, 132, 1)
 
 
 def test_glm53_decode_table_capacity_uses_batched_token_limit() -> None:

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -835,6 +835,7 @@ def test_b12x_glm5_next_cache_geometry_is_finalized_before_bind(monkeypatch) -> 
 
     impl = object.__new__(B12xMLASparseImpl)
     impl._is_glm_next = True
+    impl._uses_nvfp4_cache = False
     impl._cache_record_bytes = 528
     impl._module = FakeModule
     impl._kernel_page_size = 64

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -221,6 +221,50 @@ def test_glm5_next_split_cache_auto_aligns_to_dcp_retention(monkeypatch) -> None
     assert config.cache_config.mamba_page_size_padded is None
 
 
+@pytest.mark.parametrize(
+    ("dcp", "scheduled_tokens", "batched_tokens", "expected_block_size"),
+    [
+        (1, None, 4096, 4096),
+        (2, None, 4096, 2048),
+        (4, None, 4096, 1024),
+        (8, None, 4096, 512),
+        (4, 4096, 4352, 1024),
+    ],
+)
+def test_glm5_next_split_cache_auto_falls_back_to_scheduler_budget(
+    monkeypatch,
+    dcp: int,
+    scheduled_tokens: int | None,
+    batched_tokens: int,
+    expected_block_size: int,
+) -> None:
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            architecture="Glm5NextForConditionalGeneration",
+        ),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=dcp),
+        scheduler_config=SimpleNamespace(
+            max_num_scheduled_tokens=scheduled_tokens,
+            max_num_batched_tokens=batched_tokens,
+        ),
+        cache_config=SimpleNamespace(
+            block_size=256,
+            mamba_block_size=None,
+            mamba_cache_mode="align",
+            mamba_page_size_padded=1234,
+            prefix_cache_retention_interval=None,
+        ),
+    )
+    monkeypatch.setenv("VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE", "auto")
+    monkeypatch.setenv("VLLM_GLM53_SPLIT_MAMBA_BLOCK_SIZE", "auto")
+
+    Platform._align_hybrid_block_size(config, B12xGLM5NextMLASparseBackend)
+
+    assert config.cache_config.block_size == expected_block_size
+    assert config.cache_config.mamba_block_size == expected_block_size
+    assert config.cache_config.mamba_page_size_padded is None
+
+
 def test_glm5_next_split_cache_auto_requires_dcp_aligned_retention(
     monkeypatch,
 ) -> None:

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -111,6 +111,16 @@ def test_b12x_sparse_mla_accepts_glm_dsa_contract(monkeypatch) -> None:
     )
 
 
+def test_b12x_dsa_requires_layer_compact_cache_layout() -> None:
+    assert B12xMLASparseBackend.supported_kv_cache_layouts() == (KVCacheLayout.LBNHC,)
+
+
+def test_b12x_glm5_next_requires_block_outermost_cache_layout() -> None:
+    assert B12xGLM5NextMLASparseBackend.supported_kv_cache_layouts() == (
+        KVCacheLayout.BLHNC,
+    )
+
+
 def _glm5_next_config(
     *,
     dcp_size: int = 1,

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -33,6 +33,7 @@ from vllm.v1.attention.backends.mla.b12x_indexer import B12xIndexerBackend
 from vllm.v1.attention.backends.mla.b12x_mla_sparse import (
     B12xGLM5NextMLASparseBackend,
     B12xGLM5NextMLASparseMetadataBuilder,
+    B12xGLMDSAMLASparseBackend,
     B12xMLASparseBackend,
     B12xMLASparseImpl,
     B12xMLASparseMetadata,
@@ -73,6 +74,15 @@ def test_b12x_selector_routes_supported_attention_families() -> None:
     assert indexer_cls is B12xDeepseekV32Indexer
     assert backend_cls is B12xMLASparseBackend
 
+    config.model_config = SimpleNamespace(
+        hf_text_config=SimpleNamespace(model_type="glm_moe_dsa")
+    )
+    indexer_cls, backend_cls = _select_sparse_components(
+        config, None, DeepseekV32Indexer
+    )
+    assert indexer_cls is B12xDeepseekV32Indexer
+    assert backend_cls is B12xGLMDSAMLASparseBackend
+
 
 def test_b12x_sparse_mla_accepts_glm_dsa_contract(monkeypatch) -> None:
     monkeypatch.setattr(b12x_mla_sparse, "get_b12x_sparse_mla", lambda: object())
@@ -109,6 +119,83 @@ def test_b12x_sparse_mla_accepts_glm_dsa_contract(monkeypatch) -> None:
         _canonicalize_sparse_mla_kv_cache_dtype(B12xMLASparseBackend, "auto")
         == "fp8_ds_mla"
     )
+
+    with set_current_vllm_config(config):
+        invalid_reasons = B12xMLASparseBackend.validate_configuration(
+            head_size=576,
+            dtype=torch.bfloat16,
+            kv_cache_dtype="nvfp4_ds_mla",
+            block_size=64,
+            use_mla=True,
+            has_sink=False,
+            use_sparse=True,
+            use_mm_prefix=False,
+            use_per_head_quant_scales=False,
+            device_capability=DeviceCapability(12, 0),
+            attn_type="decoder",
+        )
+
+    assert invalid_reasons == []
+
+
+def test_b12x_glm_dsa_nvfp4_cache_spec(monkeypatch) -> None:
+    monkeypatch.setattr(b12x_mla_sparse, "get_b12x_sparse_mla", lambda: object())
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(model_type="glm_moe_dsa")
+        )
+    )
+    probe = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.uint8,
+        cache_dtype_str="nvfp4_ds_mla",
+    )
+
+    with set_current_vllm_config(config):
+        packed = B12xMLASparseBackend.customize_spec(probe)
+
+    assert packed.state_content_bytes == 368
+    assert packed.page_size_bytes == 64 * 368
+    assert packed.model_version == "glm_moe_dsa"
+    assert B12xMLASparseBackend.customize_spec(packed) == packed
+
+    packed_without_config = B12xGLMDSAMLASparseBackend.customize_spec(probe)
+    assert packed_without_config == packed
+
+
+def test_b12x_nvfp4_rejects_non_glm_dsa_architecture(monkeypatch) -> None:
+    monkeypatch.setattr(b12x_mla_sparse, "get_b12x_sparse_mla", lambda: object())
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(
+                model_type="deepseek_v32",
+                index_topk=2048,
+                kv_lora_rank=512,
+                qk_rope_head_dim=64,
+            )
+        )
+    )
+
+    with set_current_vllm_config(config):
+        invalid_reasons = B12xMLASparseBackend.validate_configuration(
+            head_size=576,
+            dtype=torch.bfloat16,
+            kv_cache_dtype="nvfp4_ds_mla",
+            block_size=64,
+            use_mla=True,
+            has_sink=False,
+            use_sparse=True,
+            use_mm_prefix=False,
+            use_per_head_quant_scales=False,
+            device_capability=DeviceCapability(12, 0),
+            attn_type="decoder",
+        )
+
+    assert invalid_reasons == [
+        ("B12X nvfp4_ds_mla requires GLM5Next or the GLM-5.2/5.3 DSA architecture")
+    ]
 
 
 def test_b12x_dsa_requires_layer_compact_cache_layout() -> None:
@@ -180,7 +267,7 @@ def test_b12x_glm5_next_cache_spec_and_layout(monkeypatch) -> None:
             attn_type="decoder",
         )
         packed = B12xMLASparseBackend.customize_spec(probe)
-        layouts = B12xMLASparseBackend.supported_kv_cache_layouts()
+        layouts = B12xGLM5NextMLASparseBackend.supported_kv_cache_layouts()
     packed_without_config_context = B12xMLASparseBackend.customize_spec(packed)
 
     assert invalid_reasons == []
@@ -231,6 +318,29 @@ def test_b12x_glm5_next_binds_nvfp4_record_width(monkeypatch) -> None:
     assert planned == [64]
     with pytest.raises(ValueError, match="page_size, 304"):
         impl.bind_kv_cache(torch.empty((2, 64, 528), dtype=torch.uint8))
+
+
+def test_b12x_glm_dsa_binds_nvfp4_fp8_rope_record() -> None:
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._is_glm_next = False
+    impl._uses_glm_dsa_nvfp4_cache = True
+
+    impl.bind_kv_cache(torch.empty((2, 64, 368), dtype=torch.uint8))
+
+    with pytest.raises(ValueError, match="page_size, 368"):
+        impl.bind_kv_cache(torch.empty((2, 64, 432), dtype=torch.uint8))
+
+
+def test_b12x_nvfp4_run_options_match_each_glm_record_abi() -> None:
+    assert b12x_mla_sparse._nvfp4_run_options(is_glm_next=False) == {
+        "scale_format": 2,
+        "fp8_rope": True,
+    }
+    assert b12x_mla_sparse._nvfp4_run_options(is_glm_next=True) == {
+        "scale_format": 2,
+        "fp8_rope": False,
+        "latent_scale_per_token": True,
+    }
 
 
 def test_packed_nvfp4_mla_dtype_bypasses_generic_layout_guard() -> None:
@@ -657,6 +767,36 @@ def test_b12x_glm5_next_cache_writer_ignores_empty_rope() -> None:
     )
 
     assert calls == [(kv_c, kv_cache, slots)]
+
+
+def test_b12x_glm_dsa_nvfp4_cache_writer_keeps_rope() -> None:
+    calls: list[tuple[torch.Tensor, ...]] = []
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._is_glm_next = False
+    impl._uses_glm_dsa_nvfp4_cache = True
+    impl._concat_and_cache_nvfp4_mla_fp8_rope = lambda *args: calls.append(args)
+    kv_c = torch.empty((3, 512), dtype=torch.bfloat16)
+    k_pe = torch.empty((3, 1, 64), dtype=torch.bfloat16)
+    kv_cache = torch.empty((2, 64, 368), dtype=torch.uint8)
+    slots = torch.tensor([0, 64, -1], dtype=torch.int64)
+    scale = torch.ones((), dtype=torch.float32)
+
+    impl.do_kv_cache_update(
+        kv_c,
+        k_pe,
+        kv_cache,
+        slots,
+        "nvfp4_ds_mla",
+        scale,
+    )
+
+    assert len(calls) == 1
+    actual_kv_c, actual_k_pe, actual_cache, actual_slots, actual_scale = calls[0]
+    assert actual_kv_c is kv_c
+    assert torch.equal(actual_k_pe, k_pe.squeeze(1))
+    assert actual_cache is kv_cache
+    assert torch.equal(actual_slots, slots)
+    assert actual_scale is scale
 
 
 def test_b12x_glm5_next_cache_geometry_is_finalized_before_bind(monkeypatch) -> None:

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -197,6 +197,49 @@ def test_b12x_glm5_next_keeps_hybrid_manager_page_unsplit() -> None:
     )
 
 
+def test_glm5_next_split_cache_auto_aligns_to_dcp_retention(monkeypatch) -> None:
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            architecture="Glm5NextForConditionalGeneration",
+        ),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=4),
+        cache_config=SimpleNamespace(
+            block_size=256,
+            mamba_block_size=None,
+            mamba_cache_mode="align",
+            mamba_page_size_padded=1234,
+            prefix_cache_retention_interval=4096,
+        ),
+    )
+    monkeypatch.setenv("VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE", "auto")
+    monkeypatch.setenv("VLLM_GLM53_SPLIT_MAMBA_BLOCK_SIZE", "auto")
+
+    Platform._align_hybrid_block_size(config, B12xGLM5NextMLASparseBackend)
+
+    assert config.cache_config.block_size == 1024
+    assert config.cache_config.mamba_block_size == 1024
+    assert config.cache_config.mamba_page_size_padded is None
+
+
+def test_glm5_next_split_cache_auto_requires_dcp_aligned_retention(
+    monkeypatch,
+) -> None:
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            architecture="Glm5NextForConditionalGeneration",
+        ),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=4),
+        cache_config=SimpleNamespace(
+            mamba_cache_mode="align",
+            prefix_cache_retention_interval=4097,
+        ),
+    )
+    monkeypatch.setenv("VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE", "auto")
+
+    with pytest.raises(ValueError, match="divisible by decode_context_parallel_size"):
+        Platform._align_hybrid_block_size(config, B12xGLM5NextMLASparseBackend)
+
+
 def test_b12x_glm5_next_rejects_unaligned_dcp(monkeypatch) -> None:
     monkeypatch.setattr(b12x_mla_sparse, "get_b12x_sparse_mla", lambda: object())
     with set_current_vllm_config(_glm5_next_config(dcp_size=2)):

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -8,10 +8,11 @@ from typing import Any
 import pytest
 import torch
 
-from vllm.config import AttentionConfig, set_current_vllm_config
+from vllm.config import AttentionConfig, VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.attention.mla_attention import (
     MLAAttention,
     _canonicalize_sparse_mla_kv_cache_dtype,
+    _maybe_view_mla_cache_as_fp8,
 )
 from vllm.model_executor.layers.attention.sparse_mla_attention import (
     SparseMLACommonMetadataBuilder,
@@ -23,7 +24,7 @@ from vllm.models.deepseek_v32.attention import (
     _select_sparse_components,
 )
 from vllm.models.deepseek_v32.b12x import B12xDeepseekV32Indexer
-from vllm.platforms.interface import DeviceCapability
+from vllm.platforms.interface import DeviceCapability, Platform
 from vllm.v1.attention.backends.b12x import B12xPagedAttentionBackend
 from vllm.v1.attention.backends.mla import b12x_indexer as generic_b12x_indexer
 from vllm.v1.attention.backends.mla import b12x_mla_sparse
@@ -148,7 +149,6 @@ def test_b12x_glm5_next_cache_spec_and_layout(monkeypatch) -> None:
         cache_dtype_str="fp8_ds_mla",
         state_content_bytes=656,
     )
-
     unidentified = B12xMLASparseBackend.customize_spec(probe)
     packed_by_glm_backend = B12xGLM5NextMLASparseBackend.customize_spec(probe)
     with set_current_vllm_config(config):
@@ -172,13 +172,84 @@ def test_b12x_glm5_next_cache_spec_and_layout(monkeypatch) -> None:
     assert invalid_reasons == []
     assert unidentified == probe
     assert packed_by_glm_backend.state_content_bytes == 528
-    assert packed_by_glm_backend.page_size_padded == 64 * 528 + 16 * 128 * 2
+    assert packed_by_glm_backend.page_size_bytes == 64 * (528 + 33)
     assert packed_by_glm_backend.model_version == "glm5_next"
     assert packed.state_content_bytes == 528
-    assert packed.page_size_padded == 64 * 528 + 16 * 128 * 2
+    assert packed.page_size_bytes == 64 * (528 + 33)
     assert packed.model_version == "glm5_next"
     assert packed_without_config_context == packed
     assert layouts == (KVCacheLayout.BLHNC,)
+    assert "nvfp4_ds_mla" in B12xMLASparseBackend.supported_kv_cache_dtypes
+
+
+def test_b12x_glm5_next_nvfp4_cache_spec() -> None:
+    probe = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=512,
+        dtype=torch.uint8,
+        cache_dtype_str="nvfp4_ds_mla",
+        state_content_bytes=656,
+    )
+
+    with set_current_vllm_config(_glm5_next_config()):
+        packed = B12xMLASparseBackend.customize_spec(probe)
+
+    assert packed.state_content_bytes == 304
+    assert packed.page_tail_bytes_per_token == 33
+    assert packed.page_size_padded == 3 * 64 * 132
+    assert packed.page_size_bytes == 3 * 64 * 132 + 64 * 33
+    assert packed.model_version == "glm5_next"
+
+
+def test_b12x_glm5_next_binds_nvfp4_record_width(monkeypatch) -> None:
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._is_glm_next = True
+    impl._cache_record_bytes = 304
+    planned: list[int] = []
+    monkeypatch.setattr(impl, "_set_kernel_page_size", planned.append)
+
+    impl.bind_kv_cache(torch.empty((2, 64, 304), dtype=torch.uint8))
+
+    assert planned == [64]
+    with pytest.raises(ValueError, match="page_size, 304"):
+        impl.bind_kv_cache(torch.empty((2, 64, 528), dtype=torch.uint8))
+
+
+def test_packed_nvfp4_mla_dtype_bypasses_generic_layout_guard() -> None:
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(use_mla=True),
+        cache_config=SimpleNamespace(cache_dtype="nvfp4_ds_mla"),
+    )
+
+    assert VllmConfig.validate_nvfp4_kv_cache_with_mla(config) is config
+
+    config.cache_config.cache_dtype = "nvfp4"
+    with pytest.raises(ValueError, match="not supported with MLA"):
+        VllmConfig.validate_nvfp4_kv_cache_with_mla(config)
+
+
+@pytest.mark.parametrize("cache_dtype", ["fp8_ds_mla", "nvfp4_ds_mla"])
+def test_packed_mla_cache_keeps_uint8_forward_view(cache_dtype: str) -> None:
+    cache = torch.empty((2, 64, 304), dtype=torch.uint8)
+
+    forwarded = _maybe_view_mla_cache_as_fp8(cache, cache_dtype)
+
+    assert forwarded is cache
+    assert forwarded.dtype == torch.uint8
+
+
+def test_plain_fp8_mla_cache_uses_native_fp8_forward_view(monkeypatch) -> None:
+    cache = torch.empty((2, 64, 512), dtype=torch.uint8)
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.attention.mla_attention.current_platform.fp8_dtype",
+        lambda: torch.float8_e4m3fn,
+    )
+
+    forwarded = _maybe_view_mla_cache_as_fp8(cache, "fp8")
+
+    assert forwarded.data_ptr() == cache.data_ptr()
+    assert forwarded.dtype == torch.float8_e4m3fn
 
 
 def test_b12x_glm5_next_keeps_hybrid_manager_page_unsplit() -> None:
@@ -190,6 +261,40 @@ def test_b12x_glm5_next_keeps_hybrid_manager_page_unsplit() -> None:
     assert B12xGLM5NextMLASparseBackend.supported_kv_cache_layouts() == (
         KVCacheLayout.BLHNC,
     )
+
+
+def test_b12x_glm5_next_nvfp4_aligns_hybrid_page_to_packed_record(
+    monkeypatch,
+) -> None:
+    mamba_page_size = 1_085_440
+    config = _glm5_next_config(dcp_size=4, cp_interleave=4)
+    config.model_config.is_hybrid = True
+    config.model_config.use_mla = True
+    config.model_config.architecture = "Glm5NextForConditionalGeneration"
+    config.model_config.dtype = torch.bfloat16
+    config.model_config.get_num_kv_heads = lambda parallel_config: 1
+    config.model_config.get_head_size = lambda: 512
+    config.cache_config.cache_dtype = "nvfp4_ds_mla"
+    config.cache_config.block_size = 256
+    config.cache_config.mamba_block_size = None
+    config.cache_config.user_specified_mamba_block_size = False
+    config.cache_config.mamba_cache_mode = "align"
+    config.cache_config.mamba_page_size_padded = None
+
+    model_cls = SimpleNamespace(
+        get_mamba_state_shape_from_config=lambda vllm_config: ((mamba_page_size,),),
+        get_mamba_state_dtype_from_config=lambda vllm_config: (torch.uint8,),
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.models.ModelRegistry.resolve_model_cls",
+        lambda *args, **kwargs: (model_cls, None),
+    )
+
+    Platform._align_hybrid_block_size(config, B12xGLM5NextMLASparseBackend)
+
+    assert config.cache_config.block_size == 3328
+    assert config.cache_config.mamba_block_size == 3328
+    assert config.cache_config.mamba_page_size_padded == 3328 * (304 + 33)
 
 
 def test_b12x_glm5_next_rejects_unaligned_dcp(monkeypatch) -> None:
@@ -392,6 +497,7 @@ def test_b12x_glm5_next_cache_bind_replans_aligned_manager_page(monkeypatch) -> 
 
     impl = object.__new__(B12xMLASparseImpl)
     impl._is_glm_next = True
+    impl._cache_record_bytes = 528
     impl._module = FakeModule
     impl._kernel_page_size = 64
     impl._input_num_heads = 64
@@ -631,7 +737,7 @@ def test_glm_selector_metadata_builder_stages_padded_rows_and_capture(
     monkeypatch.setattr(
         SparseMLACommonMetadataBuilder,
         "build",
-        lambda *args, **kwargs: SimpleNamespace(),
+        lambda *args, **kwargs: SimpleNamespace(num_prefills=0),
     )
     builder = _bare_glm_selector_metadata_builder()
     common = SimpleNamespace(
@@ -707,7 +813,7 @@ def test_glm_selector_metadata_builder_requires_complete_runtime_state(
     monkeypatch.setattr(
         SparseMLACommonMetadataBuilder,
         "build",
-        lambda *args, **kwargs: SimpleNamespace(),
+        lambda *args, **kwargs: SimpleNamespace(num_prefills=0),
     )
     builder = _bare_glm_selector_metadata_builder()
     common = SimpleNamespace(

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -292,9 +292,23 @@ def test_b12x_glm5_next_nvfp4_aligns_hybrid_page_to_packed_record(
 
     Platform._align_hybrid_block_size(config, B12xGLM5NextMLASparseBackend)
 
+    materialized_probe = MLAAttentionSpec(
+        block_size=config.cache_config.block_size,
+        num_kv_heads=1,
+        head_size=512,
+        dtype=torch.uint8,
+        cache_dtype_str="nvfp4_ds_mla",
+        state_content_bytes=656,
+    )
+    with set_current_vllm_config(config):
+        materialized = B12xGLM5NextMLASparseBackend.customize_spec(
+            materialized_probe
+        )
+
     assert config.cache_config.block_size == 3328
     assert config.cache_config.mamba_block_size == 3328
-    assert config.cache_config.mamba_page_size_padded == 3328 * (304 + 33)
+    assert materialized.page_size_bytes == 1_123_584
+    assert config.cache_config.mamba_page_size_padded == materialized.page_size_bytes
 
 
 def test_b12x_glm5_next_rejects_unaligned_dcp(monkeypatch) -> None:

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -23,7 +23,7 @@ from vllm.models.deepseek_v32.attention import (
     _select_sparse_components,
 )
 from vllm.models.deepseek_v32.b12x import B12xDeepseekV32Indexer
-from vllm.platforms.interface import DeviceCapability
+from vllm.platforms.interface import DeviceCapability, Platform
 from vllm.v1.attention.backends.b12x import B12xPagedAttentionBackend
 from vllm.v1.attention.backends.mla import b12x_indexer as generic_b12x_indexer
 from vllm.v1.attention.backends.mla import b12x_mla_sparse

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -222,18 +222,26 @@ def test_glm5_next_split_cache_auto_aligns_to_dcp_retention(monkeypatch) -> None
 
 
 @pytest.mark.parametrize(
-    ("dcp", "scheduled_tokens", "batched_tokens", "expected_block_size"),
+    (
+        "dcp",
+        "retention_interval",
+        "scheduled_tokens",
+        "batched_tokens",
+        "expected_block_size",
+    ),
     [
-        (1, None, 4096, 4096),
-        (2, None, 4096, 2048),
-        (4, None, 4096, 1024),
-        (8, None, 4096, 512),
-        (4, 4096, 4352, 1024),
+        (1, None, None, 4096, 4096),
+        (2, None, None, 4096, 2048),
+        (4, None, None, 4096, 1024),
+        (8, None, None, 4096, 512),
+        (4, 0, None, 4096, 1024),
+        (4, 0, 4096, 4352, 1024),
     ],
 )
 def test_glm5_next_split_cache_auto_falls_back_to_scheduler_budget(
     monkeypatch,
     dcp: int,
+    retention_interval: int | None,
     scheduled_tokens: int | None,
     batched_tokens: int,
     expected_block_size: int,
@@ -252,7 +260,7 @@ def test_glm5_next_split_cache_auto_falls_back_to_scheduler_budget(
             mamba_block_size=None,
             mamba_cache_mode="align",
             mamba_page_size_padded=1234,
-            prefix_cache_retention_interval=None,
+            prefix_cache_retention_interval=retention_interval,
         ),
     )
     monkeypatch.setenv("VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE", "auto")

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -307,9 +307,7 @@ def test_b12x_glm5_next_nvfp4_aligns_hybrid_page_to_packed_record(
         state_content_bytes=656,
     )
     with set_current_vllm_config(config):
-        materialized = B12xGLM5NextMLASparseBackend.customize_spec(
-            materialized_probe
-        )
+        materialized = B12xGLM5NextMLASparseBackend.customize_spec(materialized_probe)
 
     assert config.cache_config.block_size == 3328
     assert config.cache_config.mamba_block_size == 3328
@@ -512,8 +510,98 @@ def test_b12x_glm5_next_selected_indices_use_physical_slots() -> None:
         )
         == 64
     )
-    assert _is_glm_next_ckv_source_layout(cache, page_size=64)
-    assert not _is_glm_next_ckv_source_layout(cache[:, :, ::2], page_size=64)
+    assert _is_glm_next_ckv_source_layout(cache, page_size=64, record_bytes=528)
+    assert not _is_glm_next_ckv_source_layout(
+        cache[:, :, ::2], page_size=64, record_bytes=528
+    )
+
+
+@pytest.mark.parametrize("record_bytes", [528, 304])
+def test_b12x_glm5_next_full_ckv_workspaces_follow_cache_format(
+    record_bytes: int,
+) -> None:
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._max_tokens = 32
+    impl._q_head_dim = 512
+    impl._ckv_local_capacity = 128
+    impl.dcp_world_size = 4
+    impl._cache_record_bytes = record_bytes
+    plan = SimpleNamespace(shapes_and_dtypes=lambda: (((16,), torch.uint8),))
+
+    specs = impl._workspace_specs(plan, input_num_heads=8, include_ckv=True)
+
+    assert specs[-2:] == (
+        ((128, record_bytes), torch.uint8),
+        ((512, record_bytes), torch.uint8),
+    )
+
+
+@pytest.mark.parametrize("record_bytes", [528, 304])
+def test_b12x_glm5_next_full_ckv_gather_preserves_native_records(
+    monkeypatch: pytest.MonkeyPatch,
+    record_bytes: int,
+) -> None:
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._kernel_page_size = 2
+    impl._ckv_local_capacity = 4
+    impl._cache_record_bytes = record_bytes
+    impl.dcp_world_size = 2
+    impl.uses_full_ckv_dcp = lambda *_: True
+
+    kv_cache = (
+        torch.arange(4 * record_bytes, dtype=torch.int64)
+        .to(torch.uint8)
+        .view(2, 2, record_bytes)
+    )
+    local_buffer = torch.full((4, record_bytes), 255, dtype=torch.uint8)
+    gathered_buffer = torch.empty((8, record_bytes), dtype=torch.uint8)
+    metadata = SimpleNamespace(
+        num_actual_tokens=3,
+        dcp_local_total_tokens=3,
+        dcp_padded_total_tokens=4,
+        dcp_local_cu_seq_lens=torch.tensor([0, 3], dtype=torch.int32),
+        block_table=torch.tensor([[0, 1]], dtype=torch.int32),
+        num_reqs=1,
+    )
+
+    def fake_cp_gather_cache(**kwargs: Any) -> None:
+        kwargs["dst"].copy_(kwargs["src_cache"].view(-1, record_bytes)[:3])
+
+    def fake_all_gather(_group: Any, src: torch.Tensor, dst: torch.Tensor) -> None:
+        dst.copy_(src.repeat(2))
+
+    monkeypatch.setattr(b12x_mla_sparse.ops, "cp_gather_cache", fake_cp_gather_cache)
+    monkeypatch.setattr(
+        b12x_mla_sparse, "_dcp_all_gather_current_stream", fake_all_gather
+    )
+    monkeypatch.setattr(b12x_mla_sparse, "get_dcp_group", lambda: object())
+
+    gathered = impl._gather_full_ckv(kv_cache, metadata, local_buffer, gathered_buffer)
+
+    expected_rank = torch.cat(
+        (kv_cache.view(-1, record_bytes)[:3], torch.zeros((1, record_bytes))),
+        dim=0,
+    )
+    assert gathered.shape == (4, 2, record_bytes)
+    assert torch.equal(gathered.view(-1, record_bytes), expected_rank.repeat(2, 1))
+
+
+def test_b12x_glm5_next_full_ckv_gather_rejects_wrong_record_width() -> None:
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._kernel_page_size = 2
+    impl._ckv_local_capacity = 4
+    impl._cache_record_bytes = 304
+    impl.dcp_world_size = 2
+    impl.uses_full_ckv_dcp = lambda *_: True
+    metadata = SimpleNamespace(num_actual_tokens=1)
+
+    with pytest.raises(ValueError, match="requires native 304-byte records"):
+        impl._gather_full_ckv(
+            torch.empty((2, 2, 528), dtype=torch.uint8),
+            metadata,
+            torch.empty((4, 304), dtype=torch.uint8),
+            torch.empty((8, 304), dtype=torch.uint8),
+        )
 
 
 def test_sparse_index_remap_tiling_covers_glm5_next_width() -> None:

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -211,6 +211,7 @@ def test_b12x_glm5_next_binds_nvfp4_record_width(monkeypatch) -> None:
     impl = object.__new__(B12xMLASparseImpl)
     impl._is_glm_next = True
     impl._cache_record_bytes = 304
+    impl._ckv_gather_enabled = False
     planned: list[int] = []
     monkeypatch.setattr(impl, "_set_kernel_page_size", planned.append)
 
@@ -639,6 +640,7 @@ def test_b12x_glm5_next_cache_geometry_is_finalized_before_bind(monkeypatch) -> 
 def test_b12x_glm5_next_full_ckv_bind_requires_geometry_finalization() -> None:
     impl = object.__new__(B12xMLASparseImpl)
     impl._is_glm_next = True
+    impl._cache_record_bytes = 528
     impl._ckv_gather_enabled = True
     impl._kernel_page_size_finalized = False
 

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers.attention.mla_attention import (
     MLAAttention,
     _canonicalize_sparse_mla_kv_cache_dtype,
     _maybe_view_mla_cache_as_fp8,
+    _uses_packed_sparse_mla_workspace,
 )
 from vllm.model_executor.layers.attention.sparse_mla_attention import (
     SparseMLACommonMetadataBuilder,
@@ -256,6 +257,24 @@ def test_plain_fp8_mla_cache_uses_native_fp8_forward_view(monkeypatch) -> None:
 
     assert forwarded.data_ptr() == cache.data_ptr()
     assert forwarded.dtype == torch.float8_e4m3fn
+
+
+@pytest.mark.parametrize(
+    ("resolved_cache_dtype", "expected"),
+    [
+        ("fp8_ds_mla", True),
+        ("nvfp4_ds_mla", True),
+        ("auto", False),
+        (None, False),
+    ],
+)
+def test_packed_workspace_uses_resolved_layer_cache_spec(
+    resolved_cache_dtype: str | None,
+    expected: bool,
+) -> None:
+    spec = SimpleNamespace(cache_dtype_str=resolved_cache_dtype)
+
+    assert _uses_packed_sparse_mla_workspace(spec) is expected
 
 
 def test_b12x_glm5_next_keeps_hybrid_manager_page_unsplit() -> None:

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2362,6 +2362,50 @@ def test_glm5next_split_cache_preserves_physical_pages(
     )
 
 
+def test_glm5next_nvfp4_auto_geometry_capacity() -> None:
+    """DCP4 4K retention geometry recovers the expected 12.67M capacity."""
+    target = MLAAttentionSpec(
+        block_size=1024,
+        num_kv_heads=1,
+        head_size=512,
+        dtype=torch.uint8,
+        cache_dtype_str="nvfp4_ds_mla",
+        state_content_bytes=304,
+        model_version="glm5_next",
+        page_tail_bytes_per_token=33,
+        alignment=64 * 132,
+    )
+    recurrent = MambaSpec(
+        block_size=1024,
+        shapes=((1_085_440,),),
+        dtypes=(torch.uint8,),
+        mamba_cache_mode="align",
+        num_prefill_checkpoint_blocks=1,
+    )
+    groups = [
+        KVCacheGroupSpec([f"recurrent.{i}.{j}" for j in range(width)], recurrent)
+        for i, width in enumerate((9, 9, 8, 8))
+    ]
+    groups.append(KVCacheGroupSpec([f"target.{i}" for i in range(11)], target))
+    config = KVCacheConfig(
+        num_blocks=3873,
+        kv_cache_tensors=[],
+        kv_cache_groups=groups,
+        prefix_cache_retention_interval=4096,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(max_model_len=202_752),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=4),
+        cache_config=SimpleNamespace(mamba_cache_mode="align"),
+    )
+
+    capacity, concurrency = get_kv_cache_capacity(vllm_config, config)
+
+    assert target.page_size_bytes == 346_368
+    assert capacity == 12_665_459
+    assert concurrency == pytest.approx(62.46774193548387)
+
+
 def new_indexer_mla_spec(block_size=16):
     # Sparse-attention indexer k_cache: an MLAAttentionSpec with a much smaller
     # page size than the main MLA attention (uint8, small head), so their pages

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2596,8 +2596,9 @@ def test_dflash_draft_cache_partition_is_pp1_only():
                 attention_backend="FLASH_ATTN",
             ),
             model_config=SimpleNamespace(
-                get_num_layers=lambda parallel_config,
-                target_layers=target_layers: target_layers
+                get_num_layers=lambda parallel_config, target_layers=target_layers: (
+                    target_layers
+                )
             ),
             parallel_config=SimpleNamespace(
                 pipeline_parallel_size=pipeline_parallel_size

--- a/tests/v1/core/test_kv_connector_block_state.py
+++ b/tests/v1/core/test_kv_connector_block_state.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm.v1.core.sched.scheduler import _build_kv_connector_block_state
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
+
+
+def _hybrid_config() -> KVCacheConfig:
+    return KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["attention"],
+                FullAttentionSpec(
+                    block_size=2048,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=512,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float16,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+
+
+def test_connector_block_state_has_snapshot_and_retained_boundaries() -> None:
+    grouped_ids = (
+        [201, 202, 203, 204],
+        [0, 0, 0, 0, 0, 0, 0, 107, 0, 0, 110, 0, 0, 0, 0, 115],
+    )
+    manager = SimpleNamespace(get_block_ids=MagicMock(return_value=grouped_ids))
+
+    state = _build_kv_connector_block_state(
+        _hybrid_config(),
+        manager,
+        ["req"],
+        {"req": [(1, 999, 7680)]},
+        retention_interval=4096,
+    )
+
+    assert state.block_ids == {"req": grouped_ids}
+    assert state.boundary_state_offloads == {
+        "req": [(1, 999, 7680), (1, 107, 4096), (1, 115, 8192)]
+    }
+    manager.get_block_ids.assert_called_once_with("req")
+
+
+def test_connector_block_state_preserves_explicit_boundary_source() -> None:
+    grouped_ids = ([201, 202], [0, 0, 0, 0, 0, 0, 0, 107])
+    manager = SimpleNamespace(get_block_ids=MagicMock(return_value=grouped_ids))
+
+    state = _build_kv_connector_block_state(
+        _hybrid_config(),
+        manager,
+        ["req"],
+        {"req": [(1, 777, 4096)]},
+        retention_interval=4096,
+    )
+
+    assert state.boundary_state_offloads == {"req": [(1, 777, 4096)]}
+
+
+def test_connector_block_state_rejects_misaligned_retention() -> None:
+    manager = SimpleNamespace(get_block_ids=MagicMock(return_value=([], [])))
+
+    with pytest.raises(ValueError, match="must be divisible"):
+        _build_kv_connector_block_state(
+            _hybrid_config(),
+            manager,
+            ["req"],
+            None,
+            retention_interval=4100,
+        )

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -15,13 +15,17 @@ import pytest
 import torch
 
 from vllm.utils.math_utils import cdiv
+from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.core.kv_cache_utils import BlockHash
 from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
     MambaSpec,
+    SlidingWindowSpec,
 )
 from vllm.v1.request import Request
 
@@ -198,6 +202,49 @@ def test_glm_mtp_checkpoint_joins_unaligned_prompt_tail(
         )
         == 3648
     )
+
+
+def test_sliding_window_group_tolerates_finer_alignment() -> None:
+    """A coordinator alignment finer than a sliding-window group's block size
+    must fall back to block-aligned hits instead of crashing the EngineCore.
+
+    Regression for #53505: with a hybrid mamba target configured with a
+    `prefix_match_unit` finer than the draft model's sliding-window block,
+    `alignment_tokens % block_size != 0` used to hit an assert and kill all
+    in-flight requests.
+    """
+    block_size = 560
+    spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=4 * block_size,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=True, hash_block_size=block_size
+    )
+    manager = SlidingWindowManager(
+        spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        scheduler_block_size=block_size,
+        needs_kv_cache_zeroing=False,
+        max_admission_blocks_per_request=10**9,
+    )
+    block_hashes = [BlockHash(str(i).encode()) for i in range(4)]
+    computed_blocks, hit_length = manager.find_longest_cache_hit(
+        block_hashes=block_hashes,
+        max_length=4 * block_size,
+        kv_cache_group_ids=[0],
+        block_pool=block_pool,
+        kv_cache_spec=spec,
+        drop_eagle_block=False,
+        alignment_tokens=16,
+    )
+    assert computed_blocks == ([],)
+    assert hit_length == 0
 
 
 def _run_chunked_prefill(

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -100,9 +100,7 @@ def _split(
         hash_block_size=ATTN_BLOCK_SIZE,
         mamba_has_prefill_checkpoint_blocks=(
             num_prefill_checkpoint_blocks > 0
-            and (
-                not drop_last_prefix_cache_block or allow_speculative_checkpoints
-            )
+            and (not drop_last_prefix_cache_block or allow_speculative_checkpoints)
         ),
     )
     return Scheduler._mamba_block_aligned_split(stub, request, num_new_tokens)
@@ -223,10 +221,7 @@ def test_dflash_does_not_back_off_last_cache_position() -> None:
         _split(request, PROMPT_LEN, drop_last_prefix_cache_block=False)
         == MAMBA_BLOCK_SIZE
     )
-    assert (
-        _split(request, PROMPT_LEN, drop_last_prefix_cache_block=True)
-        == PROMPT_LEN
-    )
+    assert _split(request, PROMPT_LEN, drop_last_prefix_cache_block=True) == PROMPT_LEN
 
 
 def test_sliding_window_group_tolerates_finer_alignment() -> None:

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -206,6 +206,7 @@ def test_glm_mtp_checkpoint_joins_unaligned_prompt_tail(
             allow_speculative_checkpoints=True,
         )
         == 3648
+    )
 
 
 def test_dflash_does_not_back_off_last_cache_position() -> None:

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -84,7 +84,7 @@ def _make_hybrid_kv_cache_manager(
 def _split(
     request: Request,
     num_new_tokens: int,
-    use_eagle: bool = True,
+    drop_last_prefix_cache_block: bool = True,
     partial_hit: bool = False,
     num_prefill_checkpoint_blocks: int = 0,
     allow_speculative_checkpoints: bool = False,
@@ -92,7 +92,7 @@ def _split(
     """Call the real `Scheduler._mamba_block_aligned_split` on a stub self."""
     stub = SimpleNamespace(
         cache_config=SimpleNamespace(block_size=MAMBA_BLOCK_SIZE),
-        use_eagle=use_eagle,
+        drop_last_prefix_cache_block=drop_last_prefix_cache_block,
         max_num_scheduled_tokens=16384,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         # `prefix_match_unit` finer than the block size (#46384).
@@ -100,14 +100,16 @@ def _split(
         hash_block_size=ATTN_BLOCK_SIZE,
         mamba_has_prefill_checkpoint_blocks=(
             num_prefill_checkpoint_blocks > 0
-            and (not use_eagle or allow_speculative_checkpoints)
+            and (
+                not drop_last_prefix_cache_block or allow_speculative_checkpoints
+            )
         ),
     )
     return Scheduler._mamba_block_aligned_split(stub, request, num_new_tokens)
 
 
 @pytest.mark.parametrize(
-    ("prompt_len", "num_new_tokens", "use_eagle", "expected"),
+    ("prompt_len", "num_new_tokens", "drop_last_prefix_cache_block", "expected"),
     [
         (2002, 2002, False, 2002),
         (3602, 2000, False, 2000),
@@ -115,19 +117,22 @@ def _split(
     ],
 )
 def test_internal_checkpoint_split(
-    prompt_len: int, num_new_tokens: int, use_eagle: bool, expected: int
+    prompt_len: int,
+    num_new_tokens: int,
+    drop_last_prefix_cache_block: bool,
+    expected: int,
 ) -> None:
     (request,) = create_requests(1, num_tokens=prompt_len, block_size=ATTN_BLOCK_SIZE)
     assert (
         _split(
             request,
             num_new_tokens,
-            use_eagle=use_eagle,
+            drop_last_prefix_cache_block=drop_last_prefix_cache_block,
             num_prefill_checkpoint_blocks=1,
         )
         == expected
     )
-    if not use_eagle:
+    if not drop_last_prefix_cache_block:
         manager = _make_hybrid_kv_cache_manager(num_prefill_checkpoint_blocks=1)
         assert manager.allocate_slots(request, expected) is not None
         mamba_manager = manager.coordinator.single_type_managers[MAMBA_GROUP_ID]
@@ -157,7 +162,7 @@ def test_dflash_checkpoint_keeps_intermediate_chunks_aligned_and_joins_prompt_ta
         _split(
             request,
             4089,
-            use_eagle=True,
+            drop_last_prefix_cache_block=False,
             num_prefill_checkpoint_blocks=1,
             allow_speculative_checkpoints=True,
         )
@@ -169,7 +174,7 @@ def test_dflash_checkpoint_keeps_intermediate_chunks_aligned_and_joins_prompt_ta
         _split(
             request,
             17,
-            use_eagle=True,
+            drop_last_prefix_cache_block=False,
             num_prefill_checkpoint_blocks=1,
             allow_speculative_checkpoints=True,
         )
@@ -196,11 +201,30 @@ def test_glm_mtp_checkpoint_joins_unaligned_prompt_tail(
         _split(
             request,
             prompt_len - request.num_computed_tokens,
-            use_eagle=True,
+            drop_last_prefix_cache_block=True,
             num_prefill_checkpoint_blocks=1,
             allow_speculative_checkpoints=True,
         )
         == 3648
+
+
+def test_dflash_does_not_back_off_last_cache_position() -> None:
+    """DFlash/DSpark never write target blocks, so the split must not back
+    off the last prefix-cache position by a mamba block.
+
+    Regression for #53477: the old `use_eagle` back-off made prompts shorter
+    than two mamba blocks skip the final block-aligned chunk, so the mamba
+    recurrent state was never materialized at a block boundary and the next
+    turn's prefix-cache lookup recomputed the whole context.
+    """
+    (request,) = create_requests(1, num_tokens=PROMPT_LEN, block_size=ATTN_BLOCK_SIZE)
+    assert (
+        _split(request, PROMPT_LEN, drop_last_prefix_cache_block=False)
+        == MAMBA_BLOCK_SIZE
+    )
+    assert (
+        _split(request, PROMPT_LEN, drop_last_prefix_cache_block=True)
+        == PROMPT_LEN
     )
 
 
@@ -367,14 +391,14 @@ def test_poisoning_is_block_size_independent(
 @pytest.mark.parametrize("partial_hit", [False, True])
 @pytest.mark.parametrize("resume_at", [331, 1599, 1601, 2531, 3011])
 @pytest.mark.parametrize(
-    ("num_prefill_checkpoint_blocks", "use_eagle"),
+    ("num_prefill_checkpoint_blocks", "drop_last_prefix_cache_block"),
     [(0, True), (1, False)],
 )
 def test_unaligned_resume_never_runs_past_its_block(
     partial_hit: bool,
     resume_at: int,
     num_prefill_checkpoint_blocks: int,
-    use_eagle: bool,
+    drop_last_prefix_cache_block: bool,
 ) -> None:
     """A prefill resuming mid-block must re-align before crossing a boundary.
 
@@ -392,7 +416,7 @@ def test_unaligned_resume_never_runs_past_its_block(
         num_new = _split(
             request,
             prompt_len - pos,
-            use_eagle=use_eagle,
+            drop_last_prefix_cache_block=drop_last_prefix_cache_block,
             partial_hit=partial_hit,
             num_prefill_checkpoint_blocks=num_prefill_checkpoint_blocks,
         )

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3835,6 +3835,7 @@ def test_mamba_align_eagle_schedules_encoder_at_boundary():
     )
     scheduler.need_mamba_block_aligned_split = True
     scheduler.use_eagle = True
+    scheduler.drop_last_prefix_cache_block = True
     scheduler.num_prefill_lookahead = 1
     scheduler.max_num_encoder_input_tokens = 2048
     scheduler.encoder_cache_manager = EncoderCacheManager(cache_size=2048)

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -36,7 +36,11 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
     is_store_reachable_swa_chunk,
 )
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
-from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock
+from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
+    KVCacheBlock,
+    make_block_hash_with_group_id,
+)
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
@@ -184,6 +188,64 @@ def test_partial_lookup_returns_exact_boundary_and_group_load_keys():
     assert dst_spec.group_sizes == [2, 1]
     assert dst_spec.block_indices == [0, 1]
     assert req_status.partial_tail_boundary is None
+
+
+def test_recurrent_group_unhashed_block_does_not_truncate_load_boundary():
+    """A recurrent group may hold unhashed blocks inside the computed prefix.
+
+    A recurrent (Mamba / GDN) group has no per-token KV: it carries a fixed-size
+    state, so most positions point at the null sentinel and the one real block
+    holding the state is legitimately not full-and-cached. Sliding-window groups
+    are similar -- neither is required to retain the whole prefix, so a non-null,
+    unhashed block can sit *below* the locally-computed mark. Scanning the
+    block list from index 0 treated such a block as the start of the freshly
+    allocated region, dragging the load boundary below that mark -- which loads the
+    wrong keys into the wrong destination blocks, and asserts on the way.
+
+    Geometry: tokens_per_block = tokens_per_chunk = 16, blocks_per_chunk = 1.
+    16 tokens are already computed (block 0) and 16 are loaded (block 1), so the
+    fresh region must start at index 1. The Mamba group's block 0 is non-null and
+    unhashed and must be ignored rather than taken as the boundary.
+    """
+    scheduler = _make_partial_tail_scheduler()
+
+    request = MagicMock()
+    request.request_id = "req"
+    request.kv_transfer_params = None
+    request.num_prompt_tokens = 64
+    request.num_tokens = 64
+    request.block_hashes = [BlockHash(f"b{i}".encode()) for i in range(16)]
+    request.all_token_ids = list(range(64))
+    request.lora_request = None
+    request.is_finished.return_value = False
+    scheduler.on_new_request(request)
+
+    req_status = scheduler._req_status["req"]
+    req_status.num_locally_computed_tokens = 16
+    req_status.update_offload_keys()
+
+    full_blocks = [KVCacheBlock(31), KVCacheBlock(32)]
+    mamba_blocks = [KVCacheBlock(41), KVCacheBlock(42)]
+    full_blocks[0].set_block_hash(
+        make_block_hash_with_group_id(BlockHash(b"h0"), 0), 16
+    )
+    # Both Mamba blocks are non-null and unhashed -- the shape a recurrent group
+    # produces for a prefix it does not retain.
+    for b in mamba_blocks:
+        assert b.block_hash is None and not b.is_null
+
+    scheduler.update_state_after_alloc(
+        request,
+        KVCacheBlocks((full_blocks, mamba_blocks)),
+        num_external_tokens=16,
+    )
+
+    [load_job] = scheduler._current_batch_load_jobs.values()
+    loaded = list(load_job.dst_spec.block_ids)
+    # The fresh region starts at index 1, so the sparse group's block 0 (id 41) is
+    # not a load destination. Before the fix the boundary collapsed to 0.
+    assert 41 not in loaded
+    assert 42 in loaded
 
 
 def test_partial_lookup_requires_every_cache_group():

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -113,8 +113,8 @@ def test_partial_tail_store_uses_attention_and_recurrent_cow_sources():
     req_status = scheduler._req_status["req"]
     req_status.group_states[0].block_ids[:] = [11, 12]
     req_status.group_states[1].block_ids[:] = [0, 21]
-    scheduler.manager.prepare_store.side_effect = (
-        lambda keys, req_context: generate_store_output(keys)
+    scheduler.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
     )
 
     output = SimpleNamespace(partial_tail_offloads={"req": [(1, 99, 28)]})

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -44,7 +44,9 @@ from vllm.v1.core.kv_cache_utils import (
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
+    KVCacheConfig,
     KVCacheGroupSpec,
+    MambaSpec,
     SlidingWindowSpec,
 )
 from vllm.v1.kv_offload.base import (
@@ -2760,8 +2762,9 @@ class TestEagle:
 
         Groups: 0=non-eagle full-attn, 1=eagle full-attn.
         Group 0 has only 1 hit (out of 3 keys) → max_hit tightens to 4.
-        This clears eagle_verified. Group 1 runs with max_hit=4 → only 1
-        key queried, 1 hit, pop to 0 → returns 0.
+        This clears eagle_verified. Group 1 runs with max_hit=4 → widened
+        query of 2 keys, 2 hits, pop to 1 → the confirmed boundary holds
+        at 4 tokens.
         """
         block_size = 4
         groups = [
@@ -2806,9 +2809,12 @@ class TestEagle:
             offload_keys_per_group=[[10, 11, 12], [1, 2, 3]],
         )
         # Group 0 (non-eagle FA): prefix finds 1 hit → max_hit=4, num_hit=4
-        # Group 1 (eagle FA): max_hit=4 → num_blocks=1, keys=[1].
-        #   Finds 1 hit, pop to 0 → new_num_hit = 0 < block_size → return 0
-        assert sched._lookup(req_status) == 0
+        # Group 1 (eagle FA): max_hit=4, widened query → keys=[1, 2].
+        #   Finds 2 hits, pop to 1 → boundary stays at 4 tokens. Before the
+        #   #52735 fix the query was not widened for full-attention groups,
+        #   so the pop landed on the only queried chunk and zeroed the
+        #   whole request.
+        assert sched._lookup(req_status) == 4
 
     def test_eagle_verified_survives_eagle_tighten(self, request_runner):
         """Eagle group tightening does NOT clear eagle_verified.
@@ -2924,10 +2930,12 @@ class TestEagle:
         runner.manager.prepare_store.side_effect = lambda keys, req_context: (
             generate_store_output(keys)
         )
-        # 4 decoded tokens fill block 3 entirely with decode tokens (one
-        # extra token so the block is stored under async scheduling too).
+        # 4 decoded tokens fill block 3; the extra decode steps let its store
+        # job complete within this run under both scheduling modes. The
+        # eagle group holds back its volatile trailing block (1, 3) while the
+        # request is still decoding, while the normal group stores (0, 3).
         runner.run(
-            decoded_tokens=[1, 1, 1, 1, 1, EOS_TOKEN_ID],
+            decoded_tokens=[1, 1, 1, 1, 1, 1, 1],
             expected_stored=(
                 (0, 0),
                 (0, 1),
@@ -2937,6 +2945,13 @@ class TestEagle:
                 (1, 1),
                 (1, 2),
             ),
+        )
+        # Once the request finishes, no spec rejection can rewrite the tail,
+        # so the exclusion is lifted (issue #52735): the held-back (1, 3) and
+        # the just-completed block 4 are stored for both groups.
+        runner.run(
+            decoded_tokens=[EOS_TOKEN_ID],
+            expected_stored=((0, 4), (1, 3), (1, 4)),
         )
 
     @pytest.mark.parametrize("async_scheduling", [True, False])
@@ -2979,10 +2994,16 @@ class TestEagle:
         runner.manager.prepare_store.side_effect = lambda keys, req_context: (
             generate_store_output(keys)
         )
-        # 4 decoded tokens fill block 3 entirely with decode tokens.
+        # 4 decoded tokens fill block 3 entirely with decode tokens. The
+        # eagle group holds back its volatile trailing block while decoding.
         runner.run(
-            decoded_tokens=[1, 1, 1, 1, EOS_TOKEN_ID],
+            decoded_tokens=[1, 1, 1, 1],
             expected_stored=((0, 0), (0, 1), (0, 2)),
+        )
+        # Finish lifts the exclusion; the tail block is stored (issue #52735).
+        runner.run(
+            decoded_tokens=[EOS_TOKEN_ID],
+            expected_stored=((0, 3),),
         )
 
     @pytest.mark.parametrize("async_scheduling", [True, False])
@@ -3425,3 +3446,226 @@ def test_chunked_local_attention_reports_its_chunk_window():
     assert get_sliding_window_size_in_chunks(spec, tokens_per_chunk=1024) == 8
     # Partial chunks round up, so the reachable tail is never understated.
     assert get_sliding_window_size_in_chunks(spec, tokens_per_chunk=3000) == 3
+
+
+def _shared_kv_mtp_config():
+    """Speculative config for a shared-group MTP model: eagle-family method
+    whose drafter layer merges into a target KV-cache group, so no group
+    self-identifies as a drafter group (issue #52735)."""
+    spec = MagicMock(name="shared_kv_mtp_spec")
+    spec.use_eagle.return_value = True
+    spec.use_multi_module_mtp.return_value = False
+    spec.num_speculative_tokens_per_batch_size = None
+    spec.max_num_new_slots_for_drafting = 0
+    spec.num_speculative_tokens = 1
+    return spec
+
+
+class TestSharedGroupMTPOffload:
+    """Regression tests for issue #52735: OffloadingConnector must keep
+    serving when speculative decoding is enabled but no KV-cache group is
+    annotated as a drafter group (shared-group MTP models)."""
+
+    def test_no_annotation_marks_no_groups(self, request_runner):
+        """Spec decode on + zero annotated groups must NOT mark every group
+        as a drafter group; the full store->load roundtrip must match the
+        non-speculative behavior of test_two_groups_full_and_sliding_window."""
+        block_size = 4
+        kv_cache_groups = [
+            KVCacheGroupSpec(
+                ["layer0"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["layer1"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=8,
+                ),
+            ),
+        ]
+        runner = request_runner(
+            block_size=block_size,
+            num_gpu_blocks=100,
+            async_scheduling=True,
+            kv_cache_groups=kv_cache_groups,
+            speculative_config=_shared_kv_mtp_config(),
+        )
+        kv_group_configs = runner.connector_scheduler.config.kv_group_configs
+        assert [c.is_eagle_group for c in kv_group_configs] == [False, False]
+
+        runner.new_request(token_ids=[0] * block_size * 3)
+        runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+            generate_store_output(keys)
+        )
+        runner.run(decoded_tokens=[0])
+        runner.run(
+            decoded_tokens=[0] * (block_size * 3 + 2),
+            expected_stored=(0, 1, 2, 3, 4, 5),
+        )
+        runner.run(decoded_tokens=[EOS_TOKEN_ID], expected_stored=(6,))
+
+        runner.scheduler.reset_prefix_cache()
+
+        runner.new_request(token_ids=[0] * (block_size * 3 + 1))
+        runner.manager.lookup.return_value = LookupResult.HIT
+        runner.run(
+            decoded_tokens=[EOS_TOKEN_ID],
+            expected_loaded=((0, 0), (0, 1), (0, 2), (1, 1), (1, 2)),
+        )
+
+
+class TestMambaHybridOffloadServing:
+    """Store->finish->lookup flows on a full-attention + mamba-align hybrid,
+    with a manager that only HITs keys that were actually stored. Guards the
+    two collapse routes of issue #52735."""
+
+    BLOCK = 4
+    MAMBA_BLOCK = 16
+    PROMPT_TOKENS = 28  # 7 hash blocks; 1 full mamba chunk
+
+    def _make_scheduler(self, speculative_config, mamba_eagle=False):
+        vllm_config = _make_vllm_config(
+            extra_config={"self_describing_kv_events": True}
+        )
+        vllm_config.cache_config.block_size = self.BLOCK
+        vllm_config.cache_config.prefix_match_unit = self.BLOCK
+        vllm_config.speculative_config = speculative_config
+        vllm_config.kv_events_config = KVEventsConfig(
+            enable_kv_cache_events=True, publisher="null"
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=64,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["full_layer"],
+                    FullAttentionSpec(
+                        block_size=self.BLOCK,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                    ),
+                    is_eagle_group=mamba_eagle,
+                ),
+                KVCacheGroupSpec(
+                    ["mamba_layer"],
+                    MambaSpec(
+                        block_size=self.MAMBA_BLOCK,
+                        shapes=((1, 1),),
+                        dtypes=(torch.float32,),
+                        mamba_cache_mode="align",
+                    ),
+                ),
+            ],
+        )
+        spec = MockOffloadingSpec(build_offloading_config(vllm_config, kv_cache_config))
+        return OffloadingConnectorScheduler(spec, vllm_config, kv_cache_config)
+
+    def _roundtrip_served_tokens(self, scheduler) -> int:
+        """Request A: prompt-only store, finish; request A2: served tokens."""
+        stored: set = set()
+        scheduler.manager.lookup.side_effect = lambda key, ctx: (
+            LookupResult.HIT if key in stored else LookupResult.MISS
+        )
+        scheduler.manager.prepare_store.side_effect = lambda keys, ctx: (
+            generate_store_output(list(keys))
+        )
+
+        def complete_all_jobs():
+            job_ids = list(scheduler._jobs.keys())
+            for jid in job_ids:
+                stored.update(scheduler._jobs[jid].keys)
+            if job_ids:
+                scheduler.update_connector_output(
+                    KVConnectorOutput(
+                        kv_connector_worker_meta=OffloadingWorkerMetadata(
+                            completed_jobs={jid: 1 for jid in job_ids}
+                        )
+                    )
+                )
+
+        def make_request(req_id):
+            request = MagicMock()
+            request.request_id = req_id
+            request.kv_transfer_params = None
+            request.num_prompt_tokens = self.PROMPT_TOKENS
+            request.num_tokens = self.PROMPT_TOKENS
+            request.num_computed_tokens = 0
+            request.block_hashes = [
+                BlockHash(f"h{i}".encode())
+                for i in range(self.PROMPT_TOKENS // self.BLOCK)
+            ]
+            request.all_token_ids = list(range(self.PROMPT_TOKENS))
+            request.lora_request = None
+            request.is_finished.return_value = False
+            request.status = None
+            scheduler.on_new_request(request)
+            return request
+
+        req = make_request("A")
+        req_status = scheduler._req_status["A"]
+        req_status.num_locally_computed_tokens = 0
+        req_status.update_offload_keys()
+        assert scheduler._lookup(req_status) == 0  # cold
+
+        n_full = self.PROMPT_TOKENS // self.BLOCK
+        n_mamba = self.PROMPT_TOKENS // self.MAMBA_BLOCK
+        req_status.group_states[0].block_ids[:] = list(range(1, n_full + 1))
+        req_status.group_states[1].block_ids[:] = list(range(101, 101 + n_mamba + 1))
+
+        out = SimpleNamespace(
+            num_scheduled_tokens={"A": self.PROMPT_TOKENS},
+            finished_req_ids=set(),
+        )
+        scheduler._build_store_jobs(out)
+        complete_all_jobs()
+
+        req.num_computed_tokens = self.PROMPT_TOKENS
+        req.num_tokens = self.PROMPT_TOKENS + 1
+        req.is_finished.return_value = True
+        req_status.update_offload_keys()
+        scheduler.request_finished(req)
+        out2 = SimpleNamespace(num_scheduled_tokens={}, finished_req_ids={"A"})
+        scheduler._build_store_jobs(out2)
+        complete_all_jobs()
+
+        make_request("A2")
+        rs2 = scheduler._req_status["A2"]
+        rs2.num_locally_computed_tokens = 0
+        rs2.update_offload_keys()
+        served = scheduler._lookup(rs2)
+        return served if served is not None else 0
+
+    def test_shared_group_mtp_serves_like_non_speculative(self):
+        """Route 1 of #52735: with spec decode on and no drafter annotation,
+        serving must equal the non-speculative baseline (was 0 before the
+        fix: the all-groups fallback marked the mamba group as a drafter and
+        the volatile-tail pop consumed its only servable chunk)."""
+        baseline = self._roundtrip_served_tokens(self._make_scheduler(None))
+        assert baseline == 16
+        served = self._roundtrip_served_tokens(
+            self._make_scheduler(_shared_kv_mtp_config())
+        )
+        assert served == baseline
+
+    def test_annotated_eagle_group_does_not_starve_coarse_sibling(self):
+        """Route 2 of #52735 (F1): a genuinely annotated eagle full-attention
+        group must not drag the confirmed boundary below a coarser sibling's
+        chunk granularity. The widened query makes the volatile-tail pop
+        land on an extra queried chunk, holding the boundary at 16 tokens
+        (was 0 before the fix: 4 hits -> pop -> 12 tokens < mamba chunk)."""
+        scheduler = self._make_scheduler(None, mamba_eagle=True)
+        assert [c.is_eagle_group for c in scheduler.config.kv_group_configs] == [
+            True,
+            False,
+        ]
+        assert self._roundtrip_served_tokens(scheduler) == 16

--- a/tests/v1/kv_connector/unit/offloading_connector/utils.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/utils.py
@@ -180,6 +180,7 @@ class RequestRunner:
         kv_cache_groups: list[KVCacheGroupSpec] | None = None,
         extra_config_overrides: dict[str, Any] | None = None,
         worker_count: int = 1,
+        speculative_config: Any | None = None,
     ):
         assert blocks_per_chunk == 1 or kv_cache_groups is None, (
             "blocks_per_chunk > 1 requires all groups to have the same "
@@ -200,6 +201,8 @@ class RequestRunner:
         )
         vllm_config.scheduler_config.async_scheduling = async_scheduling
         vllm_config.parallel_config.world_size = worker_count
+        if speculative_config is not None:
+            vllm_config.speculative_config = speculative_config
 
         extra_config: dict[str, Any] = {
             "spec_name": "MockOffloadingSpec",
@@ -676,6 +679,7 @@ def request_runner():
         kv_cache_groups=None,
         extra_config_overrides=None,
         worker_count=1,
+        speculative_config=None,
     ):
         runner = RequestRunner(
             block_size=block_size,
@@ -685,6 +689,7 @@ def request_runner():
             kv_cache_groups=kv_cache_groups,
             extra_config_overrides=extra_config_overrides,
             worker_count=worker_count,
+            speculative_config=speculative_config,
         )
         runners.append(runner)
         return runner

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -45,6 +45,7 @@ CacheDType = Literal[
     "fp8_e5m2",
     "fp8_inc",
     "fp8_ds_mla",
+    "nvfp4_ds_mla",
     "turboquant_k8v4",
     "turboquant_4bit_nc",
     "turboquant_k3v4_nc",
@@ -125,6 +126,7 @@ class CacheConfig:
     to fp8.
     "nvfp4_4over6" uses the NVFP4 layout and selects between max/6 and max/4
     scales per 16 values by minimizing squared reconstruction error.
+    "nvfp4_ds_mla" uses the model-specific packed sparse-MLA record.
     """
     is_attention_free: bool = False
     """Whether the model is attention-free. This is primarily set in

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1877,6 +1877,12 @@ class SpeculativeConfig:
         # TODO(ben): Refactor this so the naming is clearer
         return self.method in ("eagle", "eagle3", "mtp", "dflash", "dspark")
 
+    def use_eagle_preserves_target_kv_cache(self) -> bool:
+        # Only eagle-family drafters share (and pollute via lookahead KV
+        # write) the target's full-attention KV cache groups; DFlash/DSpark
+        # draft from their own KV cache and never write target blocks.
+        return self.method in ("eagle", "eagle3", "mtp")
+
     def use_dflash(self) -> bool:
         return self.method == "dflash"
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2678,6 +2678,7 @@ class VllmConfig:
             return self
         if (
             self.cache_config.cache_dtype.startswith("nvfp4")
+            and self.cache_config.cache_dtype != "nvfp4_ds_mla"
             and self.model_config.use_mla
         ):
             raise ValueError(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -1024,18 +1024,30 @@ class OffloadingConnectorScheduler:
             num_gpu_blocks = cdiv(num_cached_tokens, tokens_per_block)
 
             assert len(group_blocks) >= num_gpu_blocks
-            num_locally_computed_gpu_blocks = num_gpu_blocks
-            # Skip null placeholder blocks (used for sliding window or mamba padding).
-            for i, block in enumerate(group_blocks[:num_gpu_blocks]):
+            # ``load_start_gpu_block_idx``: the index in ``group_blocks`` where the
+            # load region begins -- a slice bound, not a count of computed blocks.
+            # Scan from the computed boundary, not 0: ``num_locally_computed_tokens``
+            # is block-aligned by the caller, so lower blocks are computed by
+            # definition, and a recurrent (Mamba / GDN) group legitimately holds a
+            # non-null *unhashed* block there -- a fixed-size state, not per-token
+            # KV. Taking that as the start drags the boundary below the computed
+            # mark and trips the assert. Skip nulls: block 0 is the shared sentinel
+            # and must never be a load destination.
+            first_fresh_gpu_block_idx = cdiv(
+                num_locally_computed_tokens, tokens_per_block
+            )
+            load_start_gpu_block_idx = num_gpu_blocks
+            for i in range(first_fresh_gpu_block_idx, num_gpu_blocks):
+                block = group_blocks[i]
                 if not block.is_null and block.block_hash is None:
-                    num_locally_computed_gpu_blocks = i
+                    load_start_gpu_block_idx = i
                     break
 
             assert (
                 num_locally_computed_tokens
-                <= num_locally_computed_gpu_blocks * tokens_per_block
+                <= load_start_gpu_block_idx * tokens_per_block
             )
-            num_pending_gpu_blocks = num_gpu_blocks - num_locally_computed_gpu_blocks
+            num_pending_gpu_blocks = num_gpu_blocks - load_start_gpu_block_idx
 
             if group_config.sliding_window_size_in_chunks is not None:
                 assert (
@@ -1048,7 +1060,7 @@ class OffloadingConnectorScheduler:
             num_chunks = cdiv(num_cached_tokens, tokens_per_chunk)
             if num_pending_gpu_blocks:
                 start_chunk_idx = (
-                    num_locally_computed_gpu_blocks // self.config.blocks_per_chunk
+                    load_start_gpu_block_idx // self.config.blocks_per_chunk
                 )
                 end_chunk_idx = num_chunks - (partial_tail_boundary is not None)
                 assert len(offload_keys) >= end_chunk_idx
@@ -1062,12 +1074,10 @@ class OffloadingConnectorScheduler:
 
             dst_block_ids.extend(
                 block.block_id
-                for block in group_blocks[
-                    num_locally_computed_gpu_blocks:num_gpu_blocks
-                ]
+                for block in group_blocks[load_start_gpu_block_idx:num_gpu_blocks]
             )
             group_sizes.append(num_pending_gpu_blocks)
-            block_indices.append(num_locally_computed_gpu_blocks)
+            block_indices.append(load_start_gpu_block_idx)
 
             # Skip prefix-hit chunks for block-level policy; for
             # request-level, next_stored_chunk_idx stays at 0 so all

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -225,7 +225,7 @@ class SchedulerOffloadConfig(NamedTuple):
 
         use_eagle = (
             vllm_config.speculative_config is not None
-            and vllm_config.speculative_config.use_eagle()
+            and vllm_config.speculative_config.use_eagle_preserves_target_kv_cache()
         )
         if use_eagle and not eagle_groups:
             eagle_groups = set(range(len(kv_cache_config.kv_cache_groups)))

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -228,7 +228,21 @@ class SchedulerOffloadConfig(NamedTuple):
             and vllm_config.speculative_config.use_eagle_preserves_target_kv_cache()
         )
         if use_eagle and not eagle_groups:
-            eagle_groups = set(range(len(kv_cache_config.kv_cache_groups)))
+            # No group is annotated as holding drafter layers. This happens
+            # for shared-group MTP models (e.g. Qwen3.5-style), whose drafter
+            # is a regular decoder layer merged into the target's
+            # full-attention group, and for separate-draft models that miss
+            # annotation. Treating every group as a drafter group here makes
+            # the volatile-tail pop apply to ALL groups, which can zero the
+            # whole request's offload hit whenever any group's servable
+            # window is a single chunk (issue #52735). Drafter KV served one
+            # chunk stale can only lower speculative acceptance rates — the
+            # target model verifies every draft — so fail toward serving.
+            logger.info_once(
+                "KV offloading: speculative decoding is enabled but no "
+                "KV-cache group is annotated as a drafter group; treating "
+                "all groups as non-draft for offloading."
+            )
 
         if eagle_groups:
             logger.info(
@@ -392,15 +406,18 @@ class RequestOffloadState:
         accepted position may be rewritten after spec-token rejection. During
         prefill the trailing chunk is stable (the draft input for a chunk's
         last position is the next prompt token), so it is stored immediately.
-        The exclusion must be applied consistently everywhere
-        ``next_stored_chunk_idx`` is derived: otherwise the trailing chunk of
-        each step is skipped on collection but jumped over by
-        ``next_stored_chunk_idx``, so it is never re-considered and a
-        permanent hole breaks prefix-reuse lookup.
+        Once the request has finished, no further spec-token rejection can
+        rewrite the tail, so the exclusion is lifted and the final chunk
+        becomes storable (issue #52735). The exclusion must be applied
+        consistently everywhere ``next_stored_chunk_idx`` is derived:
+        otherwise the trailing chunk of each step is skipped on collection but
+        jumped over by ``next_stored_chunk_idx``, so it is never re-considered
+        and a permanent hole breaks prefix-reuse lookup. ``is_finished`` is
+        monotonic, so the finish-time calls all see the lifted exclusion.
         """
         num_chunks = num_offloadable_tokens // group_config.tokens_per_chunk
         is_decoding = num_offloadable_tokens > self.req.num_prompt_tokens
-        if group_config.is_eagle_group and is_decoding:
+        if group_config.is_eagle_group and is_decoding and not self.req.is_finished():
             num_chunks = max(0, num_chunks - 1)
         num_allocated_chunks = (
             len(group_state.block_ids) // self.config.blocks_per_chunk
@@ -757,9 +774,13 @@ class OffloadingConnectorScheduler:
                 )
 
                 # For eagle groups, query one extra chunk that will be popped.
-                # We only need to increase the query size for sliding window groups.
+                # Widening applies to every group type: without it, the pop
+                # below shrinks max_hit_size_tokens past what was queried,
+                # which can push the confirmed boundary under a coarser
+                # sibling group's chunk granularity and zero the whole
+                # request's hit (issue #52735).
                 query_max = max_hit_size_tokens
-                if is_eagle_unverified and sliding_window_size_in_chunks is not None:
+                if is_eagle_unverified:
                     query_max = min(
                         max_hit_size_tokens + tokens_per_chunk,
                         len(offload_keys) * tokens_per_chunk,

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -368,6 +368,26 @@ def _canonicalize_sparse_mla_kv_cache_dtype(
     return kv_cache_dtype
 
 
+_PACKED_SPARSE_MLA_CACHE_DTYPES = frozenset({"fp8_ds_mla", "nvfp4_ds_mla"})
+
+
+def _is_packed_sparse_mla_cache_dtype(kv_cache_dtype: CacheDType) -> bool:
+    """Return whether an MLA cache uses an opaque packed-byte record."""
+    return kv_cache_dtype in _PACKED_SPARSE_MLA_CACHE_DTYPES
+
+
+def _maybe_view_mla_cache_as_fp8(
+    kv_cache: torch.Tensor,
+    kv_cache_dtype: CacheDType,
+) -> torch.Tensor:
+    """View ordinary FP8 caches as FP8 while preserving packed byte records."""
+    if is_quantized_kv_cache(kv_cache_dtype) and not (
+        _is_packed_sparse_mla_cache_dtype(kv_cache_dtype)
+    ):
+        return kv_cache.view(current_platform.fp8_dtype())
+    return kv_cache
+
+
 def _get_kv_b_proj_input_dtype(
     kv_b_proj: ColumnParallelLinear, use_fp8_prefill: bool
 ) -> torch.dtype | None:
@@ -615,7 +635,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             query_dtype = (
                 current_platform.fp8_dtype()
                 if is_quantized_kv_cache(self.kv_cache_dtype)
-                and self.kv_cache_dtype != "fp8_ds_mla"
+                and not _is_packed_sparse_mla_cache_dtype(self.kv_cache_dtype)
                 and self.impl.supports_quant_query_input
                 else dtype
             )
@@ -832,8 +852,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         k_c_normed = k_c_normed[:num_actual_toks, ...]
         k_pe = k_pe[:num_actual_toks, ...]
 
-        if fp8_attention and self.kv_cache_dtype != "fp8_ds_mla":
-            kv_cache = kv_cache.view(current_platform.fp8_dtype())
+        kv_cache = _maybe_view_mla_cache_as_fp8(kv_cache, self.kv_cache_dtype)
 
         assert (
             attn_metadata.num_decodes is not None
@@ -2211,7 +2230,9 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
             self.determine_chunked_prefill_workspace_size(vllm_config)
         )
 
-        use_packed_fp8_cache = vllm_config.cache_config.cache_dtype == "fp8_ds_mla"
+        use_packed_sparse_mla_cache = _is_packed_sparse_mla_cache_dtype(
+            vllm_config.cache_config.cache_dtype
+        )
         self.dcp_manager: MLADCPManager | None = None
         if self.dcp_world_size > 1:
             # Note(hc): The local kvcache is incomplete when DCP is triggered,
@@ -2225,9 +2246,11 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                     + self.chunked_prefill_workspace_size // self.dcp_world_size,
                     self.mla_dims.kv_lora_rank + self.mla_dims.qk_rope_head_dim,
                 ),
-                dtype=torch.bfloat16
-                if use_packed_fp8_cache
-                else self.model_config.dtype,
+                dtype=(
+                    torch.bfloat16
+                    if use_packed_sparse_mla_cache
+                    else self.model_config.dtype
+                ),
                 device=device,
             )
             self.dcp_manager = getattr(attention_layer, "dcp_manager", None)
@@ -2242,7 +2265,9 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                     self.chunked_prefill_workspace_size,
                     self.mla_dims.kv_lora_rank + self.mla_dims.qk_rope_head_dim,
                 ),
-                dtype=torch.bfloat16 if use_packed_fp8_cache else self.q_data_type,
+                dtype=(
+                    torch.bfloat16 if use_packed_sparse_mla_cache else self.q_data_type
+                ),
                 device=device,
             )
 

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -353,7 +353,17 @@ def _select_mqa_query(
     num_mqa_tokens: int,
     full_ckv_dcp: bool,
 ) -> tuple[torch.Tensor, bool]:
-    """Select local or replicated query geometry for MLA decode/prefill."""
+    """Select local or replicated query geometry for MLA decode/prefill.
+
+    Args:
+        q: Query tensor in the local DCP geometry.
+        q_dcp_replicated: Optional query tensor replicated across DCP ranks.
+        num_mqa_tokens: Number of active query tokens.
+        full_ckv_dcp: Whether the backend gathers the complete CKV cache.
+
+    Returns:
+        The selected query rows and whether replicated geometry was selected.
+    """
     if q_dcp_replicated is not None and not full_ckv_dcp:
         return q_dcp_replicated[:num_mqa_tokens], True
     return q[:num_mqa_tokens], False
@@ -385,15 +395,44 @@ _PACKED_SPARSE_MLA_CACHE_DTYPES = frozenset({"fp8_ds_mla", "nvfp4_ds_mla"})
 
 
 def _is_packed_sparse_mla_cache_dtype(kv_cache_dtype: CacheDType) -> bool:
-    """Return whether an MLA cache uses an opaque packed-byte record."""
+    """Return whether an MLA cache uses an opaque packed-byte record.
+
+    Args:
+        kv_cache_dtype: Resolved cache dtype name.
+
+    Returns:
+        Whether the dtype represents a packed sparse MLA record.
+    """
     return kv_cache_dtype in _PACKED_SPARSE_MLA_CACHE_DTYPES
+
+
+def _uses_packed_sparse_mla_workspace(kv_cache_spec: AttentionSpec) -> bool:
+    """Determine workspace layout from the resolved layer cache spec.
+
+    Args:
+        kv_cache_spec: Cache specification for the builder's layer group.
+
+    Returns:
+        Whether the layer group uses packed sparse MLA records.
+    """
+    cache_dtype = getattr(kv_cache_spec, "cache_dtype_str", None)
+    return cache_dtype is not None and _is_packed_sparse_mla_cache_dtype(cache_dtype)
 
 
 def _maybe_view_mla_cache_as_fp8(
     kv_cache: torch.Tensor,
     kv_cache_dtype: CacheDType,
 ) -> torch.Tensor:
-    """View ordinary FP8 caches as FP8 while preserving packed byte records."""
+    """View ordinary FP8 caches as FP8 while preserving packed byte records.
+
+    Args:
+        kv_cache: Cache tensor supplied by the allocator.
+        kv_cache_dtype: Resolved cache dtype name for the layer.
+
+    Returns:
+        An FP8 view for ordinary quantized caches, or the original tensor for
+        packed sparse MLA and unquantized caches.
+    """
     if is_quantized_kv_cache(kv_cache_dtype) and not (
         _is_packed_sparse_mla_cache_dtype(kv_cache_dtype)
     ):
@@ -2250,8 +2289,8 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
             self.determine_chunked_prefill_workspace_size(vllm_config)
         )
 
-        use_packed_sparse_mla_cache = _is_packed_sparse_mla_cache_dtype(
-            vllm_config.cache_config.cache_dtype
+        use_packed_sparse_mla_cache = _uses_packed_sparse_mla_workspace(
+            self.kv_cache_spec
         )
         self.dcp_manager: MLADCPManager | None = None
         if self.dcp_world_size > 1:

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -312,7 +312,11 @@ class DeepseekV32Attention(MLAAttention):
 
         fp8_attention = is_quantized_kv_cache(self.kv_cache_dtype)
         self._fp8_query = fp8_attention and self.impl.supports_quant_query_input
-        self._fp8_kv_needs_view = fp8_attention and self.kv_cache_dtype != "fp8_ds_mla"
+        self._native_packed_kv_update = self.kv_cache_dtype == "nvfp4_ds_mla"
+        self._fp8_kv_needs_view = fp8_attention and self.kv_cache_dtype not in (
+            "fp8_ds_mla",
+            "nvfp4_ds_mla",
+        )
 
         self._index_rope_interleave = getattr(config, "indexer_rope_interleave", False)
 
@@ -421,12 +425,18 @@ class DeepseekV32Attention(MLAAttention):
             mla_k_scale = None
             indexer_k_cache = None
             mla_slot = None
+        elif self._native_packed_kv_update:
+            # Keep the fused indexer-cache write, but let the sparse backend
+            # own the model-specific packed MLA record update below.
+            mla_kv_cache = None
+            mla_k_scale = None
         else:
             mla_kv_cache = self.kv_cache
             mla_k_scale = self._k_scale
 
-        kv_c_out = torch.empty_like(kv_c) if self.use_pcp else None
-        k_pe_out = torch.empty_like(k_pe) if self.use_pcp else None
+        separate_kv_update = self.use_pcp or self._native_packed_kv_update
+        kv_c_out = torch.empty_like(kv_c) if separate_kv_update else None
+        k_pe_out = torch.empty_like(k_pe) if separate_kv_update else None
         q_c = fused_norm_rope(
             positions,
             q_c,
@@ -540,17 +550,23 @@ class DeepseekV32Attention(MLAAttention):
             return
         attn_metadata = cast("MLACommonMetadata", attn_metadata)
 
-        if self.use_pcp:
+        if self.use_pcp or self._native_packed_kv_update:
             assert kv_c is not None and k_pe is not None
-            kv_for_cache, kpe_for_cache, cache_slot_mapping = (
-                maybe_gather_mla_latent_cache_inputs(
-                    kv_c,
-                    k_pe.unsqueeze(1),
-                    layer_slot_mapping,
-                    attn_metadata.num_decode_tokens,
-                    True,
+            if self.use_pcp:
+                kv_for_cache, kpe_for_cache, cache_slot_mapping = (
+                    maybe_gather_mla_latent_cache_inputs(
+                        kv_c,
+                        k_pe.unsqueeze(1),
+                        layer_slot_mapping,
+                        attn_metadata.num_decode_tokens,
+                        True,
+                    )
                 )
-            )
+            else:
+                kv_for_cache = kv_c
+                kpe_for_cache = k_pe.unsqueeze(1)
+                cache_slot_mapping = layer_slot_mapping
+            assert cache_slot_mapping is not None
             self.impl.do_kv_cache_update(  # type: ignore[attr-defined]
                 kv_for_cache,
                 kpe_for_cache,

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -175,10 +175,18 @@ def _select_sparse_components(
     ):
         from vllm.models.deepseek_v32.b12x import B12xDeepseekV32Indexer
         from vllm.v1.attention.backends.mla.b12x_mla_sparse import (
+            B12xGLMDSAMLASparseBackend,
             B12xMLASparseBackend,
         )
 
-        return B12xDeepseekV32Indexer, B12xMLASparseBackend
+        model_config = getattr(vllm_config, "model_config", None)
+        hf_config = getattr(model_config, "hf_text_config", None)
+        backend_cls = (
+            B12xGLMDSAMLASparseBackend
+            if getattr(hf_config, "model_type", None) == "glm_moe_dsa"
+            else B12xMLASparseBackend
+        )
+        return B12xDeepseekV32Indexer, backend_cls
     return indexer_cls, attn_backend
 
 

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -46,7 +46,6 @@ _SELECTION_WIDTH = 2051
 _INDEX_CACHE_WIDTH = 132
 _INDEX_PAGE_SIZE = 64
 _INDEX_PAGE_BYTES = _INDEX_PAGE_SIZE * _INDEX_CACHE_WIDTH
-_MLA_RECORD_BYTES = 528
 
 
 class Glm5NextPooledIndexer(nn.Module):
@@ -267,22 +266,25 @@ class Glm5NextPooledIndexer(nn.Module):
         if (
             main_cache.ndim != 3
             or main_cache.dtype != torch.uint8
-            or int(main_cache.shape[-1]) != _MLA_RECORD_BYTES
+            or int(main_cache.shape[-1]) <= 0
         ):
-            raise ValueError("GLM MLA cache must be uint8 [pages, block, 528]")
-        pages, block_size, _ = map(int, main_cache.shape)
+            raise ValueError("GLM MLA cache must be uint8 [pages, block, record_bytes]")
+        pages, block_size, record_bytes = map(int, main_cache.shape)
         if pages <= 0 or block_size % (_POOL_SIZE * _INDEX_PAGE_SIZE):
             raise ValueError(
                 "GLM MLA pages must contain a whole number of 64-pool C4 pages"
             )
-        if tuple(map(int, main_cache.stride()[1:])) != (_MLA_RECORD_BYTES, 1):
+        if tuple(map(int, main_cache.stride()[1:])) != (record_bytes, 1):
             raise ValueError("GLM MLA cache records must be contiguous within a page")
 
         subpages_per_parent = block_size // (_POOL_SIZE * _INDEX_PAGE_SIZE)
         parent_stride_bytes = int(main_cache.stride(0))
-        semantic_page_bytes = block_size * _MLA_RECORD_BYTES
+        semantic_page_bytes = block_size * record_bytes
+        index_tail_offset_bytes = (
+            (semantic_page_bytes + _INDEX_PAGE_BYTES - 1) // _INDEX_PAGE_BYTES
+        ) * _INDEX_PAGE_BYTES
         index_tail_bytes = subpages_per_parent * _INDEX_PAGE_BYTES
-        if parent_stride_bytes < semantic_page_bytes + index_tail_bytes:
+        if parent_stride_bytes < index_tail_offset_bytes + index_tail_bytes:
             raise ValueError("GLM MLA cache page does not contain its FP8 index tail")
         if parent_stride_bytes % _INDEX_PAGE_BYTES:
             raise ValueError(
@@ -295,7 +297,7 @@ class Glm5NextPooledIndexer(nn.Module):
                 "GLM virtual C4 page IDs exceed the int32 page-table range"
             )
 
-        tail_offset = int(main_cache.storage_offset()) + semantic_page_bytes
+        tail_offset = int(main_cache.storage_offset()) + index_tail_offset_bytes
         tail_end = (
             tail_offset + max_virtual_page * _INDEX_PAGE_BYTES + _INDEX_PAGE_BYTES
         )

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -383,7 +383,17 @@ class Glm5NextPooledIndexer(nn.Module):
         num_prefills: int,
         num_decode_tokens: int,
     ) -> tuple[torch.Tensor, torch.Tensor] | None:
-        """Return the direct physical selection produced for pure decode."""
+        """Return the direct physical selection produced for pure decode.
+
+        Args:
+            num_tokens: Number of active token rows.
+            num_prefills: Number of prefill requests.
+            num_decode_tokens: Number of decode token rows.
+
+        Returns:
+            Physical selected slots and active counts, or ``None`` when direct
+            selection is unavailable for the current batch geometry.
+        """
         if (
             not self._emit_physical_selection
             or self.dcp_world_size != 1

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -261,7 +261,14 @@ class Glm5NextPooledIndexer(nn.Module):
 
     @staticmethod
     def _active_index_page_count(seq_len: int) -> int:
-        """Return FP8 C4 pages that can contain completed visible pools."""
+        """Return FP8 C4 pages that can contain completed visible pools.
+
+        Args:
+            seq_len: Visible sequence length in tokens.
+
+        Returns:
+            Number of index pages that may contain completed pools.
+        """
         completed_pools = seq_len // _POOL_SIZE
         return max(1, math.ceil(completed_pools / _INDEX_PAGE_SIZE))
 

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -815,23 +815,30 @@ class Platform:
                     "Glm5NextForConditionalGeneration."
                 )
             if split_target_block_size.lower() == "auto":
-                retention_interval = cache_config.prefix_cache_retention_interval
+                geometry_interval = cache_config.prefix_cache_retention_interval
+                if geometry_interval is None:
+                    scheduler_config = vllm_config.scheduler_config
+                    geometry_interval = scheduler_config.max_num_scheduled_tokens
+                    if geometry_interval is None:
+                        geometry_interval = scheduler_config.max_num_batched_tokens
                 dcp_world_size = parallel_config.decode_context_parallel_size
                 if (
-                    retention_interval is None
-                    or retention_interval <= 0
-                    or retention_interval % dcp_world_size != 0
+                    geometry_interval is None
+                    or geometry_interval <= 0
+                    or geometry_interval % dcp_world_size != 0
                 ):
                     raise ValueError(
                         "Automatic GLM-5.3 split-cache geometry requires a "
-                        "positive prefix_cache_retention_interval divisible by "
-                        "decode_context_parallel_size."
+                        "positive prefix_cache_retention_interval or scheduler "
+                        "token budget divisible by decode_context_parallel_size."
                     )
                 # A DCP-sharded target block covers block_size * DCP global
-                # tokens. Fill one retention interval with exactly one target
-                # block per rank so packed NVFP4 pages use the shared pool
-                # efficiently and connector stores land on whole pages.
-                target_block_size = retention_interval // dcp_world_size
+                # tokens. Fill one retention interval, or one scheduler token
+                # budget when no external-cache retention policy is active,
+                # with exactly one target block per rank. This makes packed
+                # NVFP4 pages use the shared pool efficiently while connector
+                # stores still land on whole pages when retention is enabled.
+                target_block_size = geometry_interval // dcp_world_size
             else:
                 target_block_size = int(split_target_block_size)
 

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -814,22 +814,41 @@ class Platform:
                     "VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE is supported only for "
                     "Glm5NextForConditionalGeneration."
                 )
-            target_block_size = int(split_target_block_size)
-            split_mamba_block_size = int(
-                os.getenv(
-                    "VLLM_GLM53_SPLIT_MAMBA_BLOCK_SIZE",
-                    split_target_block_size,
-                )
+            if split_target_block_size.lower() == "auto":
+                retention_interval = cache_config.prefix_cache_retention_interval
+                dcp_world_size = parallel_config.decode_context_parallel_size
+                if (
+                    retention_interval is None
+                    or retention_interval <= 0
+                    or retention_interval % dcp_world_size != 0
+                ):
+                    raise ValueError(
+                        "Automatic GLM-5.3 split-cache geometry requires a "
+                        "positive prefix_cache_retention_interval divisible by "
+                        "decode_context_parallel_size."
+                    )
+                # A DCP-sharded target block covers block_size * DCP global
+                # tokens. Fill one retention interval with exactly one target
+                # block per rank so packed NVFP4 pages use the shared pool
+                # efficiently and connector stores land on whole pages.
+                target_block_size = retention_interval // dcp_world_size
+            else:
+                target_block_size = int(split_target_block_size)
+
+            split_mamba_block_size = os.getenv(
+                "VLLM_GLM53_SPLIT_MAMBA_BLOCK_SIZE", "auto"
+            )
+            mamba_block_size = (
+                target_block_size
+                if split_mamba_block_size.lower() == "auto"
+                else int(split_mamba_block_size)
             )
             if target_block_size <= 0 or target_block_size % 64 != 0:
                 raise ValueError(
                     "VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE must be a positive "
-                    "multiple of 64."
+                    "multiple of 64 after automatic resolution."
                 )
-            if (
-                split_mamba_block_size <= 0
-                or split_mamba_block_size % target_block_size != 0
-            ):
+            if mamba_block_size <= 0 or mamba_block_size % target_block_size != 0:
                 raise ValueError(
                     "VLLM_GLM53_SPLIT_MAMBA_BLOCK_SIZE must be a positive "
                     "multiple of VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE."
@@ -844,13 +863,13 @@ class Platform:
             # physical pages. Their token block sizes remain scheduler-visible,
             # so the recurrent block must be a multiple of the target block.
             cache_config.block_size = target_block_size
-            cache_config.mamba_block_size = split_mamba_block_size
+            cache_config.mamba_block_size = mamba_block_size
             cache_config.mamba_page_size_padded = None
             logger.warning(
                 "Using split GLM-5.3 cache pages: target block size %d tokens, "
                 "recurrent-state block size %d tokens.",
                 target_block_size,
-                split_mamba_block_size,
+                mamba_block_size,
             )
             return
 

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -6,6 +6,7 @@ import functools
 import os
 import platform
 import sys
+from dataclasses import replace
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -934,7 +935,16 @@ class Platform:
             cache_config.mamba_block_size = cache_config.block_size
 
         # Pad mamba page size to exactly match attention page size
-        attn_page_size = cache_config.block_size * attn_page_size_1_token
+        if model_config.use_mla and cache_config.cache_dtype == "nvfp4_ds_mla":
+            materialized_mla_spec = replace(
+                mla_spec, block_size=cache_config.block_size
+            )
+            with set_current_vllm_config(vllm_config):
+                attn_page_size = backend_cls.customize_spec(
+                    materialized_mla_spec
+                ).page_size_bytes
+        else:
+            attn_page_size = cache_config.block_size * attn_page_size_1_token
         assert attn_page_size >= mamba_page_size
 
         if attn_page_size == mamba_page_size:

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -816,7 +816,11 @@ class Platform:
                 )
             if split_target_block_size.lower() == "auto":
                 geometry_interval = cache_config.prefix_cache_retention_interval
-                if geometry_interval is None:
+                # ``0`` is a valid semantic-only retention policy, but it does
+                # not provide a periodic geometry interval. In that mode (and
+                # when retention is unset), derive the block from the worker's
+                # scheduler budget instead.
+                if geometry_interval is None or geometry_interval == 0:
                     scheduler_config = vllm_config.scheduler_config
                     geometry_interval = scheduler_config.max_num_scheduled_tokens
                     if geometry_interval is None:

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -800,13 +800,29 @@ class Platform:
 
         # Compute attention page size for 1 token
         if model_config.use_mla:
-            attn_page_size_1_token = MLAAttentionSpec(
+            mla_spec = MLAAttentionSpec(
                 block_size=1,
                 num_kv_heads=model_config.get_num_kv_heads(parallel_config),
                 head_size=model_config.get_head_size(),
                 dtype=kv_cache_dtype,
+                cache_dtype_str=cache_config.cache_dtype,
                 kv_quant_mode=kv_quant_mode,
-            ).page_size_bytes
+            )
+            # Most MLA cache formats are at least as large as the dense
+            # latent proxy above, so the materialized specs can safely pad
+            # Mamba up later. GLM5Next's packed NVFP4 record is smaller. Use
+            # the backend-published record width here so the manager chooses
+            # a large enough attention block before it fixes the Mamba page.
+            if cache_config.cache_dtype == "nvfp4_ds_mla":
+                with set_current_vllm_config(vllm_config):
+                    customized_mla_spec = backend_cls.customize_spec(mla_spec)
+                assert isinstance(customized_mla_spec, MLAAttentionSpec)
+                mla_spec = customized_mla_spec
+            # Hybrid sizing needs the unaligned per-token row. Page alignment
+            # is applied after the manager block size is known.
+            attn_page_size_1_token = (
+                mla_spec.state_content_size_bytes + mla_spec.page_tail_bytes_per_token
+            )
         elif cache_config.cache_dtype.startswith("turboquant_"):
             # TQ has a packed K|V layout; the standard FullAttentionSpec
             # formula over-sizes it and trips unify_kv_cache_spec_page_size

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -45,6 +45,7 @@ STR_DTYPE_TO_TORCH_DTYPE = {
     "fp8_per_token_head": torch.uint8,
     "fp8_inc": torch.float8_e4m3fn,
     "fp8_ds_mla": torch.uint8,
+    "nvfp4_ds_mla": torch.uint8,
     "turboquant_k8v4": torch.uint8,
     "turboquant_4bit_nc": torch.uint8,
     "turboquant_k3v4_nc": torch.uint8,

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -1154,6 +1154,12 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         if not module.is_supported():
             raise RuntimeError("B12X sparse MLA is not supported on this device.")
         required_symbols = ["Caps", "plan", "run_decode", "run_extend"]
+        if self._is_glm_next:
+            required_symbols.append(
+                "concat_and_cache_glm_next_mla_nvfp4"
+                if uses_nvfp4_cache
+                else "concat_and_cache_glm_next_mla_fp8"
+            )
         if self._uses_glm_dsa_nvfp4_cache:
             required_symbols.append("concat_and_cache_nvfp4_mla_fp8_rope")
         for name in required_symbols:
@@ -1165,7 +1171,11 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         self._concat_and_cache_glm_next_mla = None
         if self._is_glm_next:
             self._model_type = int(module.ModelType.GLM_NEXT)
-            self._concat_and_cache_glm_next_mla = module.concat_and_cache_glm_next_mla
+            self._concat_and_cache_glm_next_mla = (
+                module.concat_and_cache_glm_next_mla_nvfp4
+                if self._uses_nvfp4_cache
+                else module.concat_and_cache_glm_next_mla_fp8
+            )
         elif self._uses_glm_dsa_nvfp4_cache:
             self._model_type = int(module.ModelType.GLM_NSA)
             self._concat_and_cache_nvfp4_mla_fp8_rope = (
@@ -1245,6 +1255,11 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
             )
             if self._model_type is not None:
                 caps_kwargs["model_type"] = self._model_type
+            if self._uses_nvfp4_cache:
+                caps_kwargs.update(
+                    _nvfp4_run_options(is_glm_next=self._is_glm_next)
+                )
+            caps_kwargs["cache_record_bytes"] = self._cache_record_bytes
             return self._module.plan(self._module.Caps(**caps_kwargs))
 
         decode_plan = make_plan("decode")
@@ -1702,20 +1717,16 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
             selected_indices=selected_indices,
             cache_seqlens_int32=cache_seq_lens,
             nsa_cache_seqlens_int32=active_counts,
+            kv_cache=kv_cache_for_run,
         )
         run = self._run_decode if plan is self._decode_plan else self._run_extend
         run_kwargs = dict(
             binding=binding,
-            kv_cache=kv_cache_for_run,
             sm_scale=self.scale,
             v_head_dim=self.kv_lora_rank,
             return_lse=self.need_to_return_lse_for_decode,
             lse_scale="natural",
         )
-        if self._model_type is not None:
-            run_kwargs["model_type"] = self._model_type
-        if self._uses_nvfp4_cache:
-            run_kwargs.update(_nvfp4_run_options(is_glm_next=self._is_glm_next))
         result = run(**run_kwargs)
         if self.need_to_return_lse_for_decode:
             output, lse = result

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -262,7 +262,17 @@ def _global_causal_lens_for_ckv_gather(
     req_id_per_token: torch.Tensor,
     num_actual_tokens: int,
 ) -> torch.Tensor:
-    """Return each query token's causal length in the gathered global cache."""
+    """Compute each query token's causal length in the gathered global cache.
+
+    Args:
+        global_seq_lens: Global cache sequence length for each request.
+        query_start_loc: Start offset of each request's query chunk.
+        req_id_per_token: Request identifier for each query token.
+        num_actual_tokens: Number of active query tokens.
+
+    Returns:
+        Causal cache length for each active query token.
+    """
     num_reqs = global_seq_lens.shape[0]
     qsl = query_start_loc[: num_reqs + 1].to(torch.int32)
     req_ids = req_id_per_token[:num_actual_tokens].to(torch.int64)

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -151,12 +151,13 @@ def _is_glm_next_ckv_source_layout(
     kv_cache: torch.Tensor,
     *,
     page_size: int,
+    record_bytes: int,
 ) -> bool:
     return (
         kv_cache.dtype == torch.uint8
         and kv_cache.ndim == 3
-        and tuple(kv_cache.shape[1:]) == (page_size, _GLM_NEXT_CACHE_RECORD_BYTES)
-        and kv_cache.stride(1) == _GLM_NEXT_CACHE_RECORD_BYTES
+        and tuple(kv_cache.shape[1:]) == (page_size, record_bytes)
+        and kv_cache.stride(1) == record_bytes
         and kv_cache.stride(2) == 1
     )
 
@@ -1217,13 +1218,13 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         )
         ckv_specs = (
             (
-                (self._ckv_local_capacity, _GLM_NEXT_CACHE_RECORD_BYTES),
+                (self._ckv_local_capacity, self._cache_record_bytes),
                 torch.uint8,
             ),
             (
                 (
                     self.dcp_world_size * self._ckv_local_capacity,
-                    _GLM_NEXT_CACHE_RECORD_BYTES,
+                    self._cache_record_bytes,
                 ),
                 torch.uint8,
             ),
@@ -1378,19 +1379,22 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         if not self.uses_full_ckv_dcp(attn_metadata, attn_metadata.num_actual_tokens):
             raise RuntimeError("full CKV gather called for an ineligible batch")
         if not _is_glm_next_ckv_source_layout(
-            kv_cache, page_size=self._kernel_page_size
+            kv_cache,
+            page_size=self._kernel_page_size,
+            record_bytes=self._cache_record_bytes,
         ):
             raise ValueError(
-                "GLM5Next CKV gather requires native 528-byte records; "
+                "GLM5Next CKV gather requires native "
+                f"{self._cache_record_bytes}-byte records; "
                 f"got shape={tuple(kv_cache.shape)}, stride={kv_cache.stride()}"
             )
         expected_local_shape = (
             self._ckv_local_capacity,
-            _GLM_NEXT_CACHE_RECORD_BYTES,
+            self._cache_record_bytes,
         )
         expected_gathered_shape = (
             self.dcp_world_size * self._ckv_local_capacity,
-            _GLM_NEXT_CACHE_RECORD_BYTES,
+            self._cache_record_bytes,
         )
         if tuple(local_buffer.shape) != expected_local_shape:
             raise RuntimeError("CKV local workspace has an invalid shape")
@@ -1416,7 +1420,7 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
             gathered_buffer[: self.dcp_world_size * padded_tokens].view(-1),
         )
         return gathered_buffer.view(
-            -1, self._kernel_page_size, _GLM_NEXT_CACHE_RECORD_BYTES
+            -1, self._kernel_page_size, self._cache_record_bytes
         )
 
     def forward_mqa(

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -461,11 +461,8 @@ class B12xMLASparseBackend(AttentionBackend):
 
     @classmethod
     def supported_kv_cache_layouts(cls) -> tuple[KVCacheLayout, ...]:
-        # Sparse index caches share manager blocks with their MLA layer. Keep
-        # the layer dimension inside the manager's block so block copies and
-        # swaps carry both cache regions together. DeepSeek-V4's index backend
-        # already imposes the same constraint, so this preserves its layout.
-        return (KVCacheLayout.BLHNC,)
+        # The DSA kernels consume one layer-compact, token-major cache view.
+        return (KVCacheLayout.LBNHC,)
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
@@ -530,6 +527,13 @@ class B12xMLASparseBackend(AttentionBackend):
 
 
 class B12xGLM5NextMLASparseBackend(B12xMLASparseBackend):
+    @classmethod
+    def supported_kv_cache_layouts(cls) -> tuple[KVCacheLayout, ...]:
+        # GLM-Next's pooled index tail shares manager blocks with its MLA
+        # latent page. Keep the layer dimension inside the manager block so
+        # copies and swaps carry both cache regions together.
+        return (KVCacheLayout.BLHNC,)
+
     @staticmethod
     def get_builder_cls() -> type["B12xGLM5NextMLASparseMetadataBuilder"]:
         return B12xGLM5NextMLASparseMetadataBuilder

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -48,7 +48,9 @@ if TYPE_CHECKING:
 
 _GLM_NEXT_MODEL_TYPES = frozenset(("glm5_next", "glm5_next_text"))
 _GLM_NEXT_CACHE_RECORD_BYTES = 528
+_GLM_NEXT_NVFP4_CACHE_RECORD_BYTES = 304
 _GLM_NEXT_INDEX_TAIL_BYTES_PER_TOKEN = 132 // 4
+_GLM_NEXT_INDEX_PAGE_BYTES = 64 * 132
 
 
 def _is_glm_next_config(hf_config: object | None) -> bool:
@@ -146,6 +148,7 @@ class B12xMLASparseBackend(AttentionBackend):
         "fp8",
         "fp8_e4m3",
         "fp8_ds_mla",
+        "nvfp4_ds_mla",
     ]
 
     @staticmethod
@@ -178,9 +181,15 @@ class B12xMLASparseBackend(AttentionBackend):
                 "B12X GLM5Next sparse MLA requires head_size=512, got "
                 f"{spec.head_size}."
             )
+        record_bytes = (
+            _GLM_NEXT_NVFP4_CACHE_RECORD_BYTES
+            if spec.cache_dtype_str == "nvfp4_ds_mla"
+            else _GLM_NEXT_CACHE_RECORD_BYTES
+        )
         return replace(
             spec,
-            state_content_bytes=_GLM_NEXT_CACHE_RECORD_BYTES,
+            state_content_bytes=record_bytes,
+            alignment=_GLM_NEXT_INDEX_PAGE_BYTES,
             page_tail_bytes_per_token=_GLM_NEXT_INDEX_TAIL_BYTES_PER_TOKEN,
             model_version="glm5_next",
         )
@@ -244,6 +253,8 @@ class B12xMLASparseBackend(AttentionBackend):
                 if dcp_error := _glm_next_dcp_error(vllm_config):
                     return dcp_error
                 return None
+            if kv_cache_dtype == "nvfp4_ds_mla":
+                return "B12X nvfp4_ds_mla is supported only for GLM5Next"
             if head_size != 576:
                 return "B12X sparse MLA requires head_size=576"
             if int(getattr(hf_config, "kv_lora_rank", 0)) != 512:
@@ -657,11 +668,21 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
                 raise ValueError("B12X sparse MLA requires head_size=576.")
         if self.topk_indices_buffer is None:
             raise ValueError("B12X sparse MLA requires a top-k index buffer.")
-        if kv_cache_dtype != "fp8_ds_mla":
+        uses_nvfp4_cache = kv_cache_dtype == "nvfp4_ds_mla"
+        if kv_cache_dtype != "fp8_ds_mla" and not (
+            self._is_glm_next and uses_nvfp4_cache
+        ):
             raise ValueError(
-                "B12X sparse MLA requires the packed fp8_ds_mla KV cache; "
+                "B12X sparse MLA requires a packed fp8_ds_mla or "
+                "nvfp4_ds_mla KV cache; "
                 f"got kv_cache_dtype={kv_cache_dtype!r}."
             )
+        self._uses_nvfp4_cache = uses_nvfp4_cache
+        self._cache_record_bytes = (
+            _GLM_NEXT_NVFP4_CACHE_RECORD_BYTES
+            if self._uses_nvfp4_cache
+            else _GLM_NEXT_CACHE_RECORD_BYTES
+        )
 
         module = get_b12x_sparse_mla()
         if module is None:
@@ -789,10 +810,13 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
 
     def bind_kv_cache(self, kv_cache: torch.Tensor) -> None:
         if self._is_glm_next:
-            if kv_cache.ndim != 3 or int(kv_cache.shape[-1]) != 528:
+            if (
+                kv_cache.ndim != 3
+                or int(kv_cache.shape[-1]) != self._cache_record_bytes
+            ):
                 raise ValueError(
                     "B12X GLM5Next cache must have shape "
-                    "[pages, page_size, 528], got "
+                    f"[pages, page_size, {self._cache_record_bytes}], got "
                     f"shape={tuple(kv_cache.shape)}, stride={kv_cache.stride()}, "
                     f"dtype={kv_cache.dtype}"
                 )
@@ -931,6 +955,12 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         )
         if self._model_type is not None:
             run_kwargs["model_type"] = self._model_type
+        if self._uses_nvfp4_cache:
+            run_kwargs.update(
+                scale_format=2,
+                fp8_rope=False,
+                latent_scale_per_token=True,
+            )
         result = run(**run_kwargs)
         if self.need_to_return_lse_for_decode:
             output, lse = result

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -51,16 +51,22 @@ if TYPE_CHECKING:
 
 
 _GLM_NEXT_MODEL_TYPES = frozenset(("glm5_next", "glm5_next_text"))
+_GLM_DSA_MODEL_TYPES = frozenset(("glm_moe_dsa",))
 _GLM_NEXT_CACHE_RECORD_BYTES = 528
 _GLM_NEXT_NVFP4_CACHE_RECORD_BYTES = 304
 _GLM_NEXT_INDEX_TAIL_BYTES_PER_TOKEN = 132 // 4
 _GLM_NEXT_INDEX_PAGE_BYTES = 64 * 132
+_GLM_DSA_NVFP4_CACHE_RECORD_BYTES = 368
 
 logger = init_logger(__name__)
 
 
 def _is_glm_next_config(hf_config: object | None) -> bool:
     return getattr(hf_config, "model_type", None) in _GLM_NEXT_MODEL_TYPES
+
+
+def _is_glm_dsa_config(hf_config: object | None) -> bool:
+    return getattr(hf_config, "model_type", None) in _GLM_DSA_MODEL_TYPES
 
 
 def _current_hf_text_config() -> object | None:
@@ -75,6 +81,25 @@ def _is_glm_next_spec(spec: AttentionSpec) -> bool:
         return True
     hf_config = _current_hf_text_config()
     return hf_config is not None and _is_glm_next_config(hf_config)
+
+
+def _is_glm_dsa_spec(spec: AttentionSpec) -> bool:
+    if isinstance(spec, MLAAttentionSpec) and spec.model_version == "glm_moe_dsa":
+        return True
+    hf_config = _current_hf_text_config()
+    return hf_config is not None and _is_glm_dsa_config(hf_config)
+
+
+def _nvfp4_run_options(*, is_glm_next: bool) -> dict[str, bool | int]:
+    if is_glm_next:
+        # GLM5Next has no RoPE payload and stores one latent scale per token.
+        return {
+            "scale_format": 2,
+            "fp8_rope": False,
+            "latent_scale_per_token": True,
+        }
+    # GLM-5.2/5.3 DSA stores its 64-dimensional RoPE tail as E4M3.
+    return {"scale_format": 2, "fp8_rope": True}
 
 
 def _glm_next_recipe_error(hf_config: object) -> str | None:
@@ -434,12 +459,27 @@ class B12xMLASparseBackend(AttentionBackend):
 
     @classmethod
     def customize_spec(cls, spec: AttentionSpec) -> AttentionSpec:
-        if not _is_glm_next_spec(spec):
+        is_glm_next = _is_glm_next_spec(spec)
+        is_glm_dsa_nvfp4 = isinstance(spec, MLAAttentionSpec) and (
+            spec.cache_dtype_str == "nvfp4_ds_mla" and _is_glm_dsa_spec(spec)
+        )
+        if not is_glm_next and not is_glm_dsa_nvfp4:
             return spec
         if not isinstance(spec, MLAAttentionSpec):
             raise TypeError(
-                "B12X GLM5Next sparse MLA requires an MLAAttentionSpec, got "
+                "B12X GLM sparse MLA requires an MLAAttentionSpec, got "
                 f"{type(spec).__name__}."
+            )
+        if is_glm_dsa_nvfp4:
+            if spec.head_size != 576:
+                raise ValueError(
+                    "B12X GLM DSA NVFP4 sparse MLA requires head_size=576, got "
+                    f"{spec.head_size}."
+                )
+            return replace(
+                spec,
+                state_content_bytes=_GLM_DSA_NVFP4_CACHE_RECORD_BYTES,
+                model_version="glm_moe_dsa",
             )
         if spec.head_size != 512:
             raise ValueError(
@@ -515,8 +555,11 @@ class B12xMLASparseBackend(AttentionBackend):
                 if dcp_error := _glm_next_dcp_error(vllm_config):
                     return dcp_error
                 return None
-            if kv_cache_dtype == "nvfp4_ds_mla":
-                return "B12X nvfp4_ds_mla is supported only for GLM5Next"
+            if kv_cache_dtype == "nvfp4_ds_mla" and not _is_glm_dsa_config(hf_config):
+                return (
+                    "B12X nvfp4_ds_mla requires GLM5Next or the "
+                    "GLM-5.2/5.3 DSA architecture"
+                )
             if head_size != 576:
                 return "B12X sparse MLA requires head_size=576"
             if int(getattr(hf_config, "kv_lora_rank", 0)) != 512:
@@ -524,6 +567,17 @@ class B12xMLASparseBackend(AttentionBackend):
             if int(getattr(hf_config, "qk_rope_head_dim", 0)) != 64:
                 return "B12X sparse MLA requires qk_rope_head_dim=64"
         return None
+
+
+class B12xGLMDSAMLASparseBackend(B12xMLASparseBackend):
+    @classmethod
+    def customize_spec(cls, spec: AttentionSpec) -> AttentionSpec:
+        if not isinstance(spec, MLAAttentionSpec):
+            raise TypeError(
+                "B12X GLM DSA sparse MLA requires an MLAAttentionSpec, got "
+                f"{type(spec).__name__}."
+            )
+        return super().customize_spec(replace(spec, model_version="glm_moe_dsa"))
 
 
 class B12xGLM5NextMLASparseBackend(B12xMLASparseBackend):
@@ -1038,6 +1092,7 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         vllm_config = get_current_vllm_config()
         hf_config = vllm_config.model_config.hf_text_config
         self._is_glm_next = _is_glm_next_config(hf_config)
+        self._is_glm_dsa = _is_glm_dsa_config(hf_config)
         self.supports_mtp_with_cp_non_trivial_interleave_size = self._is_glm_next
         if self._is_glm_next:
             if recipe_error := _glm_next_recipe_error(hf_config):
@@ -1056,35 +1111,51 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         if self.topk_indices_buffer is None:
             raise ValueError("B12X sparse MLA requires a top-k index buffer.")
         uses_nvfp4_cache = kv_cache_dtype == "nvfp4_ds_mla"
-        if kv_cache_dtype != "fp8_ds_mla" and not (
-            self._is_glm_next and uses_nvfp4_cache
+        self._uses_glm_dsa_nvfp4_cache = self._is_glm_dsa and uses_nvfp4_cache
+        if uses_nvfp4_cache and not (
+            self._is_glm_next or self._uses_glm_dsa_nvfp4_cache
         ):
+            raise ValueError(
+                "B12X nvfp4_ds_mla requires GLM5Next or the "
+                "GLM-5.2/5.3 DSA architecture."
+            )
+        if kv_cache_dtype not in ("fp8_ds_mla", "nvfp4_ds_mla"):
             raise ValueError(
                 "B12X sparse MLA requires a packed fp8_ds_mla or "
                 "nvfp4_ds_mla KV cache; "
                 f"got kv_cache_dtype={kv_cache_dtype!r}."
             )
         self._uses_nvfp4_cache = uses_nvfp4_cache
-        self._cache_record_bytes = (
-            _GLM_NEXT_NVFP4_CACHE_RECORD_BYTES
-            if self._uses_nvfp4_cache
-            else _GLM_NEXT_CACHE_RECORD_BYTES
-        )
+        if self._is_glm_next and self._uses_nvfp4_cache:
+            self._cache_record_bytes = _GLM_NEXT_NVFP4_CACHE_RECORD_BYTES
+        elif self._uses_glm_dsa_nvfp4_cache:
+            self._cache_record_bytes = _GLM_DSA_NVFP4_CACHE_RECORD_BYTES
+        else:
+            self._cache_record_bytes = _GLM_NEXT_CACHE_RECORD_BYTES
 
         module = get_b12x_sparse_mla()
         if module is None:
             raise RuntimeError("B12X sparse MLA requires `pip install vllm[b12x]`.")
         if not module.is_supported():
             raise RuntimeError("B12X sparse MLA is not supported on this device.")
-        for name in ("Caps", "plan", "run_decode", "run_extend"):
+        required_symbols = ["Caps", "plan", "run_decode", "run_extend"]
+        if self._uses_glm_dsa_nvfp4_cache:
+            required_symbols.append("concat_and_cache_nvfp4_mla_fp8_rope")
+        for name in required_symbols:
             getattr(module, name)
         self._run_decode = module.run_decode
         self._run_extend = module.run_extend
         self._model_type: int | None = None
+        self._concat_and_cache_nvfp4_mla_fp8_rope = None
         self._concat_and_cache_glm_next_mla = None
         if self._is_glm_next:
             self._model_type = int(module.ModelType.GLM_NEXT)
             self._concat_and_cache_glm_next_mla = module.concat_and_cache_glm_next_mla
+        elif self._uses_glm_dsa_nvfp4_cache:
+            self._model_type = int(module.ModelType.GLM_NSA)
+            self._concat_and_cache_nvfp4_mla_fp8_rope = (
+                module.concat_and_cache_nvfp4_mla_fp8_rope
+            )
 
         scheduler_config = vllm_config.scheduler_config
         max_tokens = int(scheduler_config.max_num_batched_tokens)
@@ -1295,6 +1366,17 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         self._kernel_page_size_finalized = True
 
     def bind_kv_cache(self, kv_cache: torch.Tensor) -> None:
+        if getattr(self, "_uses_glm_dsa_nvfp4_cache", False) and (
+            kv_cache.ndim != 3
+            or int(kv_cache.shape[-1]) != _GLM_DSA_NVFP4_CACHE_RECORD_BYTES
+            or kv_cache.dtype != torch.uint8
+        ):
+            raise ValueError(
+                "B12X GLM DSA NVFP4 cache must have shape "
+                f"[pages, page_size, {_GLM_DSA_NVFP4_CACHE_RECORD_BYTES}] "
+                "uint8, got "
+                f"shape={tuple(kv_cache.shape)}, dtype={kv_cache.dtype}."
+            )
         if self._is_glm_next:
             if (
                 kv_cache.ndim != 3
@@ -1330,6 +1412,18 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         kv_cache_dtype: str,
         k_scale: torch.Tensor,
     ) -> None:
+        if getattr(self, "_uses_glm_dsa_nvfp4_cache", False):
+            if kv_cache.numel() == 0:
+                return
+            assert self._concat_and_cache_nvfp4_mla_fp8_rope is not None
+            self._concat_and_cache_nvfp4_mla_fp8_rope(
+                kv_c_normed,
+                k_pe.squeeze(1),
+                kv_cache,
+                slot_mapping.flatten(),
+                k_scale,
+            )
+            return
         if not self._is_glm_next:
             return super().do_kv_cache_update(
                 kv_c_normed,
@@ -1592,11 +1686,7 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         if self._model_type is not None:
             run_kwargs["model_type"] = self._model_type
         if self._uses_nvfp4_cache:
-            run_kwargs.update(
-                scale_format=2,
-                fp8_rope=False,
-                latent_scale_per_token=True,
-            )
+            run_kwargs.update(_nvfp4_run_options(is_glm_next=self._is_glm_next))
         result = run(**run_kwargs)
         if self.need_to_return_lse_for_decode:
             output, lse = result

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -206,6 +206,21 @@ class ScheduledEncoderInputStats:
 
 
 @dataclass
+class KVConnectorBlockState:
+    """Authoritative scheduler-side KV source state for external stores.
+
+    ``block_ids`` is a full per-group snapshot for every request scheduled in
+    this step. ``boundary_state_offloads`` identifies the exact recurrent
+    state block at each durable token boundary; connectors must not reconstruct
+    these sources from allocation deltas because align-mode Mamba tables are
+    sparse and mutable.
+    """
+
+    block_ids: dict[str, tuple[list[int], ...]]
+    boundary_state_offloads: dict[str, list[tuple[int, int, int]]]
+
+
+@dataclass
 class SchedulerOutput:
     # list of the requests that are scheduled for the first time.
     # We cache the request's data in each worker process, so that we don't
@@ -279,6 +294,11 @@ class SchedulerOutput:
     # the durable boundary block of a producer's last-prompt-boundary partial
     # tail (mamba "align" CoW target). None unless partial hash hits are active.
     partial_tail_offloads: dict[str, list[tuple[int, int, int]]] | None = None
+
+    # Authoritative source tables and recurrent boundary blocks for external
+    # KV stores. This is scheduler-only metadata consumed while connector
+    # metadata is built; workers use the resulting opaque connector metadata.
+    kv_connector_block_state: KVConnectorBlockState | None = None
 
     # Dynamic speculative decoding: optimal K chosen by scheduler.
     # Number of spec tokens to schedule for the next step.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -257,6 +257,7 @@ class Scheduler(SchedulerInterface):
         )
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False
+        self.drop_last_prefix_cache_block = False
         self.num_spec_tokens = vllm_config.num_speculative_tokens
         self.num_lookahead_tokens = vllm_config.num_lookahead_tokens
         # Positions past the computed tokens that the drafter reads mid-prefill.
@@ -291,6 +292,9 @@ class Scheduler(SchedulerInterface):
                     num_spec_tokens_by_batch_size=self.dynamic_sd_lookup,
                 )
             self.use_eagle = speculative_config.use_eagle()
+            self.drop_last_prefix_cache_block = (
+                speculative_config.use_eagle_preserves_target_kv_cache()
+            )
             if self.use_eagle:
                 self.num_prefill_lookahead = (
                     self.num_spec_tokens
@@ -307,7 +311,7 @@ class Scheduler(SchedulerInterface):
             max_model_len=self.max_model_len,
             max_in_flight_tokens=vllm_config.max_in_flight_tokens,
             enable_caching=self.cache_config.enable_prefix_caching,
-            use_eagle=self.use_eagle,
+            use_eagle=self.drop_last_prefix_cache_block,
             num_prefill_lookahead=self.num_prefill_lookahead,
             log_stats=self.log_stats,
             enable_kv_cache_events=self.enable_kv_cache_events,
@@ -443,11 +447,13 @@ class Scheduler(SchedulerInterface):
             return num_new_tokens
 
         block_size = self.cache_config.block_size
-        # The last block-aligned position whose state can be cached. With
-        # Eagle, FullAttn prunes the last matching block, so back off one
-        # block to avoid a Mamba cache miss.
+        # The last block-aligned position whose state can be cached.
+        # Eagle-family drafters pollute the target's last matching
+        # full-attention block with their lookahead KV write, so back off one
+        # block to avoid a Mamba cache miss. DFlash/DSpark draft from their own
+        # KV cache and never write target blocks.
         last_cache_position = request.num_tokens - request.num_tokens % block_size
-        if self.use_eagle:
+        if self.drop_last_prefix_cache_block:
             last_cache_position = max(last_cache_position - block_size, 0)
 
         end = start + num_new_tokens

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -42,6 +42,7 @@ from vllm.v1.core.sched.interface import PauseState, SchedulerInterface
 from vllm.v1.core.sched.output import (
     CachedRequestData,
     GrammarOutput,
+    KVConnectorBlockState,
     NewRequestData,
     ScheduledEncoderInputStats,
     SchedulerOutput,
@@ -71,6 +72,55 @@ from vllm.v1.structured_output import StructuredOutputGrammar, StructuredOutputM
 from vllm.v1.utils import record_function_or_nullcontext
 
 logger = init_logger(__name__)
+
+
+def _build_kv_connector_block_state(
+    kv_cache_config: KVCacheConfig,
+    kv_cache_manager: KVCacheManager,
+    request_ids: Iterable[str],
+    partial_tail_offloads: dict[str, list[tuple[int, int, int]]] | None,
+    retention_interval: int | None,
+) -> KVConnectorBlockState:
+    """Snapshot exact source blocks for connector stores in this step."""
+    current_block_ids = {
+        req_id: kv_cache_manager.get_block_ids(req_id) for req_id in request_ids
+    }
+    boundary_state_offloads = {
+        req_id: list(entries)
+        for req_id, entries in (partial_tail_offloads or {}).items()
+    }
+    if retention_interval is not None and retention_interval > 0:
+        for group_id, group in enumerate(kv_cache_config.kv_cache_groups):
+            spec = group.kv_cache_spec
+            if not isinstance(spec, MambaSpec):
+                continue
+            if retention_interval % spec.block_size != 0:
+                raise ValueError(
+                    "prefix_cache_retention_interval must be divisible by "
+                    f"Mamba block size: {retention_interval=} {spec.block_size=}"
+                )
+            blocks_per_boundary = retention_interval // spec.block_size
+            for req_id, grouped_ids in current_block_ids.items():
+                if group_id >= len(grouped_ids):
+                    continue
+                entries = boundary_state_offloads.setdefault(req_id, [])
+                existing = {
+                    (entry_group, boundary_tokens)
+                    for entry_group, _, boundary_tokens in entries
+                }
+                for block_index in range(
+                    blocks_per_boundary - 1,
+                    len(grouped_ids[group_id]),
+                    blocks_per_boundary,
+                ):
+                    block_id = grouped_ids[group_id][block_index]
+                    boundary_tokens = (block_index + 1) * spec.block_size
+                    if block_id > 0 and (group_id, boundary_tokens) not in existing:
+                        entries.append((group_id, block_id, boundary_tokens))
+    return KVConnectorBlockState(
+        block_ids=current_block_ids,
+        boundary_state_offloads=boundary_state_offloads,
+    )
 
 
 class Scheduler(SchedulerInterface):
@@ -1283,6 +1333,7 @@ class Scheduler(SchedulerInterface):
         # pin); the manager drops stale entries when the request's blocks are
         # popped for free.
         pending_partial_tail_offloads = None
+        kv_connector_block_state = None
         if (
             self.connector is not None
             and self.vllm_config.kv_transfer_config is not None
@@ -1290,6 +1341,13 @@ class Scheduler(SchedulerInterface):
         ):
             pending_partial_tail_offloads = (
                 self.kv_cache_manager.take_partial_tail_offloads() or None
+            )
+            kv_connector_block_state = _build_kv_connector_block_state(
+                self.kv_cache_config,
+                self.kv_cache_manager,
+                num_scheduled_tokens,
+                pending_partial_tail_offloads,
+                self.cache_config.prefix_cache_retention_interval,
             )
 
         kv_cache_block_copies, cow_retained_blocks = (
@@ -1343,6 +1401,7 @@ class Scheduler(SchedulerInterface):
             new_block_ids_to_zero=self._get_new_block_ids_to_zero(),
             kv_cache_block_copies=pending_kv_cache_block_copies,
             partial_tail_offloads=pending_partial_tail_offloads,
+            kv_connector_block_state=kv_connector_block_state,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
             ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -921,10 +921,12 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         assert pcp_world_size == 1 or kv_cache_spec.dcp_replicated, (
             "PCP only supports sliding-window KV when it is replicated."
         )
-        # Fine-grained partial hits are not supported for sliding window now
-        assert alignment_tokens % kv_cache_spec.block_size == 0, (
-            "SlidingWindowManager does not support fine-grained (partial) cache hits"
-        )
+        # Fine-grained partial hits are not supported for sliding window now.
+        # Fall back to block-aligned hits instead of crashing the engine when
+        # the coordinator alignment is finer than this group's block size
+        # (e.g. a hybrid mamba target with a finer `prefix_match_unit`).
+        if alignment_tokens % kv_cache_spec.block_size != 0:
+            alignment_tokens = kv_cache_spec.block_size
         block_hashes = resolve_block_hashes(
             block_hashes,
             block_pool.hash_block_size,


### PR DESCRIPTION
## Purpose

Provide one conflict-resolved Jovian Judgement integration head for the
GLM-5.3-Flash cache-complete r16 build. This is the release-integration view of
the component work, not a replacement for its focused review units.

## Included work

- #549: B12X `nvfp4_ds_mla` routing, packed cache ABI, page sizing, and DCP
  record handling for GLM-5.3-Flash.
- #575: automatic split target/recurrent page geometry for DCP1/2/4/8.
- #574: scheduler-authoritative exact recurrent sources for LMCache stores.
- Native vLLM APC/DRAM-offload correctness fixes:
  - `f63961c105`: do not truncate at an unhashed recurrent block;
  - `7ae4b8987c`: preserve safe hybrid/SWA cache-hit alignment;
  - `a2e92b9482`: retain DFlash/DSpark's final eligible prefix block;
  - `728b32ca2f`: preserve shared-group MTP/EAGLE offload hits.

The overlapping #549/#575 test changes are resolved in this branch. During
composition, a dropped closing assertion delimiter in the replayed native
prefix test was also restored before publication.

## Why this is not duplicate work

#549, #575, and #574 remain the focused review units. Their independently
mergeable heads overlap in `test_b12x_sparse_mla_api.py`, and the four native
prefix fixes are also required by the qualified image. This PR provides the
deterministic, buildable aggregate that an image-integration bot can consume
without inventing a conflict resolution or omitting an unpublished r15-only
equivalent.

## Dependencies and preflight

- B12X #266 at `c0f7f6ccd7ff664df1192ae9f68e1d3bf244ecc8`.
- LMCache exact integration head
  `0b8eedb6c9c268c62234eff54229f239123678f0`; the focused local review delta is
  LMCache #35 at `2579f617a27382e6210632a6698f314986ad3419`.
- Preserve upstream LMCache background L1 expansion. Do not add the private
  on-demand allocator experiments.
- An r16 base should retain its existing DFlash/DCP execution stack. In
  particular, verify the equivalents of vLLM #513 and #560 if those modes are
  exposed by the image.

## Validation

- All 21 changed Python files pass Ruff and Ruff format checks.
- Python compilation and `git diff --check` pass.
- vLLM auto-geometry suite: 8 passed, including DCP8 -> 512-token pages.
- Exact r15 image smoke: vLLM/B12X/LMCache imports, cache ABIs, launcher matrix,
  CUDA cuMem interposer, and upstream allocator policy passed.
- TP4 cold/APC/L1/restart-L2 content checks passed for DCP1, DCP2, and DCP4
  with both `fp8_ds_mla` and `nvfp4_ds_mla`.
- DCP4 NVFP4 passed five repeated APC-reset/L1 restores.
- TP8 is source-audited but not physically executed because an eight-GPU host
  was unavailable.

## AI assistance

OpenAI Codex assisted with source audit, conflict resolution, regression
construction, and integration validation. The submitter reviewed the resulting
source and evidence.
