### PR TITLE
perf(glm): enable full-CKV DCP prefill for GLM DSA

### DIFF
--- a/tests/kernels/test_fused_deepseek_v32_norm_rope.py
+++ b/tests/kernels/test_fused_deepseek_v32_norm_rope.py
@@ -234,6 +234,57 @@ def test_fused_norm_rope(num_tokens: int, index_interleave: bool, mla_dtype: str
     assert (topk == -1).all(), "topk buffer not cleared on indexer layer"
 
 
+def test_fused_norm_rope_computes_q_for_unmapped_dcp_tokens():
+    """DCP cache ownership must not turn replicated query rows into padding."""
+    torch.manual_seed(11)
+    dev = "cuda"
+    num_tokens = 4
+    pos = torch.arange(num_tokens, device=dev, dtype=torch.int64)
+    q_c = torch.randn(num_tokens, Q_LORA, device=dev, dtype=torch.bfloat16)
+    kv_c = torch.randn(num_tokens, KV_LORA, device=dev, dtype=torch.bfloat16)
+    k_pe = torch.randn(num_tokens, ROPE_DIM, device=dev, dtype=torch.bfloat16)
+    qw = torch.randn(Q_LORA, device=dev, dtype=torch.bfloat16)
+    kvw = torch.randn(KV_LORA, device=dev, dtype=torch.bfloat16)
+    cos_sin = make_cos_sin(16, ROPE_DIM, dev)
+    mla_cache = torch.zeros(
+        1,
+        num_tokens,
+        KV_LORA + ROPE_DIM,
+        device=dev,
+        dtype=torch.bfloat16,
+    )
+    slot_mapping = torch.tensor([0, -1, 1, -1], device=dev, dtype=torch.int64)
+    topk = torch.empty((num_tokens, 2048), device=dev, dtype=torch.int32)
+
+    q_out = K.fused_norm_rope(
+        pos,
+        q_c,
+        qw,
+        EPS,
+        kv_c,
+        kvw,
+        EPS,
+        k_pe,
+        cos_sin,
+        None,
+        None,
+        None,
+        EPS,
+        None,
+        topk,
+        slot_mapping=slot_mapping,
+        mla_kv_cache=mla_cache,
+        has_indexer=False,
+    )
+
+    assert_bf16(q_out, rms_norm(q_c, qw), "DCP q_c rmsnorm")
+    kv_ref = rms_norm(kv_c, kvw)
+    kpe_ref = rope(k_pe.float(), pos, cos_sin, interleave=True)
+    expected_cache = torch.cat([kv_ref[[0, 2]], kpe_ref[[0, 2]]], dim=-1)
+    assert_bf16(mla_cache[0, :2], expected_cache, "DCP-owned MLA cache rows")
+    assert torch.count_nonzero(mla_cache[0, 2:]) == 0
+
+
 def test_fused_norm_rope_writes_strided_indexer_cache_pages():
     """BLHNC indexer pages must retain their physical block stride."""
     torch.manual_seed(7)

--- a/tests/models/deepseek_v32/test_attention.py
+++ b/tests/models/deepseek_v32/test_attention.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.models.deepseek_v32 import attention as deepseek_v32_attention
+
+
+@pytest.mark.parametrize("full_ckv_dcp", [False, True])
+def test_sparse_dcp_collectives_match_cache_mode(monkeypatch, full_ckv_dcp):
+    attention = object.__new__(deepseek_v32_attention.DeepseekV32Attention)
+    nn.Module.__init__(attention)
+    attention.indexer = None
+    attention.skip_topk = True
+    attention.use_pcp = False
+    attention.layer_name = "model.layers.0.self_attn.attn"
+    attention._fp8_kv_needs_view = False
+    attention._fp8_query = False
+    attention.num_local_heads = 1
+    attention.kv_lora_rank = 2
+    attention.v_head_dim = 2
+    attention.W_UV = torch.eye(2).unsqueeze(0)
+
+    seq_lens = torch.tensor([1, 2], dtype=torch.int32)
+    query_start_loc = torch.tensor([0, 1, 3], dtype=torch.int32)
+    metadata = SimpleNamespace(
+        num_actual_tokens=3,
+        num_decodes=1,
+        seq_lens=seq_lens,
+        query_start_loc=query_start_loc,
+        decode=SimpleNamespace(seq_lens=seq_lens[:1]),
+    )
+    attn_out = torch.arange(6, dtype=torch.float32).view(3, 1, 2)
+    gathered_query = torch.empty((3, 2, 2))
+    query_gather = Mock(return_value=gathered_query)
+    combine = Mock(return_value=attn_out)
+    attention.dcp_manager = SimpleNamespace(
+        query_gather=query_gather,
+        combine=combine,
+    )
+    attention.impl = SimpleNamespace(
+        dcp_world_size=2,
+        pcp_world_size=1,
+        uses_full_ckv_dcp=Mock(return_value=full_ckv_dcp),
+        forward_mqa=Mock(return_value=(attn_out, torch.zeros(3, 1))),
+    )
+    monkeypatch.setattr(
+        deepseek_v32_attention,
+        "get_attention_context",
+        lambda layer_name: (metadata, None, torch.empty(0), torch.empty(0)),
+    )
+
+    output = torch.empty((3, 2))
+    attention._sparse_indexer_and_attn(
+        q_c=torch.empty((3, 2)),
+        index_q_fp8=None,
+        index_k=None,
+        index_weights_out=None,
+        kv_c=None,
+        k_pe=None,
+        ql_nope=torch.empty((3, 1, 1)),
+        mqa_q=torch.empty((3, 1, 1)),
+        output=output,
+    )
+
+    if full_ckv_dcp:
+        query_gather.assert_not_called()
+        combine.assert_not_called()
+    else:
+        query_gather.assert_called_once()
+        assert attention.impl.forward_mqa.call_args.args[0] is gathered_query
+        assert combine.call_args.kwargs["seq_lens"] is seq_lens
+        assert combine.call_args.kwargs["query_start_loc"] is query_start_loc
+    torch.testing.assert_close(output, attn_out.flatten(1))

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -35,8 +35,9 @@ from vllm.v1.attention.backends.mla.b12x_mla_sparse import (
     B12xMLASparseImpl,
     B12xMLASparseMetadata,
     B12xMLASparseMetadataBuilder,
+    _full_ckv_record_bytes,
     _global_causal_lens_for_ckv_gather,
-    _is_glm_next_ckv_source_layout,
+    _is_full_ckv_source_layout,
     _is_speculative_decode_batch,
     _max_speculative_decode_query_len,
     _selected_index_block_stride_rows,
@@ -137,6 +138,24 @@ def _glm5_next_config(
         ),
         speculative_config=object() if speculative else None,
         cache_config=SimpleNamespace(enable_prefix_caching=prefix_caching),
+    )
+
+
+def _glm_moe_dsa_config(*, dcp_size: int = 4) -> SimpleNamespace:
+    return SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(
+                model_type="glm_moe_dsa",
+                index_topk=2048,
+                kv_lora_rank=512,
+                qk_rope_head_dim=64,
+            )
+        ),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=dcp_size,
+            cp_kv_cache_interleave_size=1,
+        ),
+        speculative_config=None,
     )
 
 
@@ -284,7 +303,7 @@ def test_b12x_full_ckv_gather_excludes_decode_and_mtp_batches(
     assert (
         _use_b12x_full_ckv_gather(
             enabled=True,
-            is_glm_next=True,
+            supported_model=True,
             dcp_world_size=4,
             max_query_len=max_query_len,
             num_tokens=num_tokens,
@@ -379,15 +398,55 @@ def test_b12x_glm5_next_rejects_recipe_drift(monkeypatch) -> None:
     ]
 
 
-def test_b12x_glm5_next_ckv_source_layout() -> None:
-    storage = torch.empty((2 * 37888,), dtype=torch.uint8)
+@pytest.mark.parametrize("record_bytes", [528, 656])
+def test_b12x_full_ckv_source_layout(record_bytes: int) -> None:
+    page_stride = 64 * record_bytes + 4096
+    storage = torch.empty((2 * page_stride,), dtype=torch.uint8)
     cache = torch.as_strided(
         storage,
-        size=(2, 64, 528),
-        stride=(37888, 528, 1),
+        size=(2, 64, record_bytes),
+        stride=(page_stride, record_bytes, 1),
     )
-    assert _is_glm_next_ckv_source_layout(cache, page_size=64)
-    assert not _is_glm_next_ckv_source_layout(cache[:, :, ::2], page_size=64)
+    assert _is_full_ckv_source_layout(cache, page_size=64, record_bytes=record_bytes)
+    assert not _is_full_ckv_source_layout(
+        cache[:, :, ::2], page_size=64, record_bytes=record_bytes
+    )
+
+
+def test_b12x_full_ckv_record_width_is_model_specific() -> None:
+    assert _full_ckv_record_bytes(_glm5_next_config()) == 528
+    assert _full_ckv_record_bytes(_glm_moe_dsa_config()) == 656
+
+    target = _glm_moe_dsa_config().model_config
+    draft = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(model_type="deepseek_mtp")
+        ),
+        speculative_config=SimpleNamespace(target_model_config=target),
+    )
+    assert _full_ckv_record_bytes(draft) == 656
+
+
+def test_b12x_nonflash_full_ckv_workspace_uses_native_record_width() -> None:
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._max_tokens = 1024
+    impl._q_head_dim = 576
+    impl._ckv_local_capacity = 131200
+    impl._full_ckv_record_bytes = 656
+    impl.dcp_world_size = 4
+    plan = SimpleNamespace(shapes_and_dtypes=lambda: ())
+
+    specs = impl._workspace_specs(
+        plan,
+        input_num_heads=16,
+        include_ckv=True,
+    )
+
+    assert specs == (
+        ((1024, 16, 576), torch.bfloat16),
+        ((131200, 656), torch.uint8),
+        ((524800, 656), torch.uint8),
+    )
 
 
 @pytest.mark.parametrize("record_bytes", [528, 656])

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -142,6 +142,14 @@ def _glm5_next_config(
 
 
 def _glm_moe_dsa_config(*, dcp_size: int = 4) -> SimpleNamespace:
+    """Build a minimal GLM-MoE-DSA test model configuration.
+
+    Args:
+        dcp_size: Number of decode-context-parallel ranks.
+
+    Returns:
+        Configuration namespace for GLM-MoE-DSA sparse-MLA tests.
+    """
     return SimpleNamespace(
         model_config=SimpleNamespace(
             hf_text_config=SimpleNamespace(

--- a/tests/v1/attention/test_dcp_ops.py
+++ b/tests/v1/attention/test_dcp_ops.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.v1.attention.ops.dcp import mask_dcp_empty_shards_
+
+
+def test_mask_dcp_empty_shards_with_no_local_sequences() -> None:
+    lse = torch.zeros((4, 1), dtype=torch.float32)
+    seq_lens = torch.empty((0,), dtype=torch.int32)
+    query_start_loc = torch.zeros((1,), dtype=torch.int32)
+
+    mask_dcp_empty_shards_(lse, seq_lens, query_start_loc)
+
+    assert torch.isneginf(lse).all()

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -567,33 +567,44 @@ class DeepseekV32Attention(MLAAttention):
         else:
             mqa_q_arg = (ql_nope[:num_actual], mqa_q[:num_actual])
 
-        if self.use_pcp and self.impl.dcp_world_size > self.impl.pcp_world_size:
-            if isinstance(mqa_q_arg, tuple):
-                mqa_q_arg = torch.cat(mqa_q_arg, dim=-1)
-            mqa_q_arg = get_tp_group().all_gather(mqa_q_arg, dim=1)
+        full_ckv_dcp = self.impl.uses_full_ckv_dcp(  # type: ignore[attr-defined]
+            attn_metadata, num_actual
+        )
+        if self.impl.dcp_world_size > 1:
+            assert self.dcp_manager is not None
+            if self.use_pcp:
+                if self.impl.dcp_world_size > self.impl.pcp_world_size:
+                    if isinstance(mqa_q_arg, tuple):
+                        mqa_q_arg = torch.cat(mqa_q_arg, dim=-1)
+                    mqa_q_arg = get_tp_group().all_gather(mqa_q_arg, dim=1)
+            else:
+                if isinstance(mqa_q_arg, tuple):
+                    mqa_q_arg = torch.cat(mqa_q_arg, dim=-1)
+                if not full_ckv_dcp:
+                    assert self.dcp_manager.query_gather is not None
+                    mqa_q_arg = self.dcp_manager.query_gather(mqa_q_arg)
         attn_out, lse = self.impl.forward_mqa(  # type: ignore[attr-defined]
             mqa_q_arg, kv_cache, attn_metadata, self
         )
 
-        if self.use_pcp and self.impl.dcp_world_size > 1:
+        if self.impl.dcp_world_size > 1 and not full_ckv_dcp:
             assert lse is not None and self.dcp_manager is not None
-            seq_lens = (
-                attn_metadata.decode.seq_lens
-                if attn_metadata.decode is not None
-                else cast(torch.Tensor, attn_metadata.seq_lens)[  # type: ignore[attr-defined]
-                    : attn_metadata.num_decodes
-                ]
+            # This implementation always uses sparse MQA for both prefill and
+            # decode.  The DCP combine therefore covers every sequence in the
+            # batch, not only the leading decode sequences.
+            seq_lens = cast(
+                torch.Tensor,
+                attn_metadata.seq_lens,  # type: ignore[attr-defined]
             )
-            query_start_loc = attn_metadata.query_start_loc[
-                : attn_metadata.num_decodes + 1
-            ]
+            query_start_loc = attn_metadata.query_start_loc
             attn_out = self.dcp_manager.combine(
                 attn_out,
                 lse,
                 seq_lens=seq_lens,
                 query_start_loc=query_start_loc,
             )
-            attn_out = finalize_mla_pcp_decode(attn_out, self.num_heads)
+            if self.use_pcp:
+                attn_out = finalize_mla_pcp_decode(attn_out, self.num_heads)
 
         # NOTE(woosuk): While the below does not need to be in the eager region,
         # we put it here to avoid copying the attention output. Move this back to the

--- a/vllm/models/deepseek_v32/common/kernels.py
+++ b/vllm/models/deepseek_v32/common/kernels.py
@@ -184,8 +184,9 @@ def _fused_norm_rope_kernel(
     if slot_mapping_ptr is None:
         if kv_out_ptr is None and kpe_out_ptr is None and index_k_out_ptr is None:
             return
-    elif tl.load(slot_mapping_ptr + tok_idx) < 0:
-        # Padding
+    elif pid != 2 and tl.load(slot_mapping_ptr + tok_idx) < 0:
+        # A negative DCP slot suppresses rank-local cache writes. Q remains
+        # replicated and must still be computed on every rank.
         return
 
     if pid == 2:

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -53,6 +53,8 @@ if TYPE_CHECKING:
 _GLM_NEXT_MODEL_TYPES = frozenset(("glm5_next", "glm5_next_text"))
 _GLM_NEXT_CACHE_RECORD_BYTES = 528
 _GLM_NEXT_INDEX_TAIL_BYTES_PER_TOKEN = 132 // 4
+_GLM_MOE_DSA_MODEL_TYPE = "glm_moe_dsa"
+_GLM_MOE_DSA_CACHE_RECORD_BYTES = 656
 
 logger = init_logger(__name__)
 
@@ -70,6 +72,39 @@ class B12xPhysicalSelectionProvider(Protocol):
 
 def _is_glm_next_config(hf_config: object | None) -> bool:
     return getattr(hf_config, "model_type", None) in _GLM_NEXT_MODEL_TYPES
+
+
+def _is_glm_moe_dsa_config(vllm_config: VllmConfig) -> bool:
+    """Recognize GLM DSA target and its in-process MTP draft model."""
+    model_config = vllm_config.model_config
+    if model_config is None:
+        return False
+    hf_config = model_config.hf_text_config
+    model_type = getattr(hf_config, "model_type", None)
+    if model_type == _GLM_MOE_DSA_MODEL_TYPE:
+        return True
+    if model_type != "deepseek_mtp":
+        return False
+    speculative_config = vllm_config.speculative_config
+    target_model_config = getattr(speculative_config, "target_model_config", None)
+    if target_model_config is None:
+        return False
+    target_hf_config = getattr(
+        target_model_config,
+        "hf_text_config",
+        getattr(target_model_config, "hf_config", None),
+    )
+    return getattr(target_hf_config, "model_type", None) == _GLM_MOE_DSA_MODEL_TYPE
+
+
+def _full_ckv_record_bytes(vllm_config: VllmConfig) -> int | None:
+    """Return the native packed record width for supported GLM CKV gathers."""
+    hf_config = vllm_config.model_config.hf_text_config
+    if _is_glm_next_config(hf_config):
+        return _GLM_NEXT_CACHE_RECORD_BYTES
+    if _is_glm_moe_dsa_config(vllm_config):
+        return _GLM_MOE_DSA_CACHE_RECORD_BYTES
+    return None
 
 
 def _current_hf_text_config() -> object | None:
@@ -157,16 +192,17 @@ def _is_speculative_decode_batch(
     )
 
 
-def _is_glm_next_ckv_source_layout(
+def _is_full_ckv_source_layout(
     kv_cache: torch.Tensor,
     *,
     page_size: int,
+    record_bytes: int,
 ) -> bool:
     return (
         kv_cache.dtype == torch.uint8
         and kv_cache.ndim == 3
-        and tuple(kv_cache.shape[1:]) == (page_size, _GLM_NEXT_CACHE_RECORD_BYTES)
-        and kv_cache.stride(1) == _GLM_NEXT_CACHE_RECORD_BYTES
+        and tuple(kv_cache.shape[1:]) == (page_size, record_bytes)
+        and kv_cache.stride(1) == record_bytes
         and kv_cache.stride(2) == 1
     )
 
@@ -174,7 +210,7 @@ def _is_glm_next_ckv_source_layout(
 def _use_b12x_full_ckv_gather(
     *,
     enabled: bool,
-    is_glm_next: bool,
+    supported_model: bool,
     dcp_world_size: int,
     max_query_len: int,
     num_tokens: int,
@@ -184,7 +220,7 @@ def _use_b12x_full_ckv_gather(
 ) -> bool:
     return (
         enabled
-        and is_glm_next
+        and supported_model
         and dcp_world_size > 1
         and max_query_len > 1
         and num_decode_tokens == 0
@@ -594,6 +630,7 @@ class B12xMLASparseMetadataBuilder(
     ) -> None:
         hf_config = vllm_config.model_config.hf_text_config
         self.requires_glm_next_selector_metadata = _is_glm_next_config(hf_config)
+        self._full_ckv_record_bytes = _full_ckv_record_bytes(vllm_config)
         if self.requires_glm_next_selector_metadata and (
             dcp_error := _glm_next_dcp_error(vllm_config)
         ):
@@ -627,13 +664,13 @@ class B12xMLASparseMetadataBuilder(
                 max_reqs, dtype=torch.bool, device=device
             )
         self._ckv_gather_requested = (
-            self.requires_glm_next_selector_metadata
+            self._full_ckv_record_bytes is not None
             and self.dcp_world_size > 1
             and envs.VLLM_B12X_MLA_CKV_GATHER
         )
         if self._ckv_gather_requested:
-            hf_config = vllm_config.model_config.hf_text_config
-            ckv_topk_tokens = int(hf_config.index_topk) + int(hf_config.index_kpool) - 1
+            index_kpool = int(getattr(hf_config, "index_kpool", 1) or 1)
+            ckv_topk_tokens = int(hf_config.index_topk) + index_kpool - 1
             self.ckv_selected_indices_buffer = torch.empty(
                 (max_tokens, ckv_topk_tokens), dtype=torch.int32, device=device
             )
@@ -840,7 +877,7 @@ class B12xMLASparseMetadataBuilder(
             ].clone()
         if _use_b12x_full_ckv_gather(
             enabled=self._ckv_gather_requested,
-            is_glm_next=self.requires_glm_next_selector_metadata,
+            supported_model=(getattr(self, "_full_ckv_record_bytes", None) is not None),
             dcp_world_size=self.dcp_world_size,
             max_query_len=common.max_query_len,
             num_tokens=num_tokens,
@@ -1024,6 +1061,7 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         vllm_config = get_current_vllm_config()
         hf_config = vllm_config.model_config.hf_text_config
         self._is_glm_next = _is_glm_next_config(hf_config)
+        full_ckv_record_bytes = _full_ckv_record_bytes(vllm_config)
         self._physical_selection_provider = (
             indexer if isinstance(indexer, B12xPhysicalSelectionProvider) else None
         )
@@ -1088,11 +1126,12 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
             max_seqs * self._max_speculative_decode_query_len,
         )
         self._kv_dtype = torch.uint8
+        self._full_ckv_record_bytes = full_ckv_record_bytes
         kernel_page_size = (
             int(vllm_config.cache_config.block_size) if self._is_glm_next else 64
         )
         self._ckv_gather_enabled = (
-            self._is_glm_next
+            self._full_ckv_record_bytes is not None
             and self.dcp_world_size > 1
             and envs.VLLM_B12X_MLA_CKV_GATHER
         )
@@ -1109,6 +1148,8 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         self._kernel_page_size = 0
         self._kernel_page_size_finalized = not self._is_glm_next
         self._set_kernel_page_size(kernel_page_size)
+        if self._ckv_gather_enabled and self._kernel_page_size_finalized:
+            self._reserve_attention_workspaces()
         self.supports_quant_query_input = False
 
     def _set_kernel_page_size(self, kernel_page_size: int) -> None:
@@ -1209,23 +1250,27 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
             (self._max_tokens, input_num_heads, self._q_head_dim),
             torch.bfloat16,
         )
-        ckv_specs = (
-            (
-                (self._ckv_local_capacity, _GLM_NEXT_CACHE_RECORD_BYTES),
-                torch.uint8,
-            ),
-            (
+        ckv_specs: tuple[tuple[tuple[int, ...], torch.dtype], ...] = ()
+        if include_ckv:
+            record_bytes = getattr(self, "_full_ckv_record_bytes", None)
+            if record_bytes is None and getattr(self, "_is_glm_next", False):
+                record_bytes = _GLM_NEXT_CACHE_RECORD_BYTES
+            if record_bytes is None:
+                raise RuntimeError("CKV workspace requested for an unsupported model")
+            ckv_specs = (
+                ((self._ckv_local_capacity, record_bytes), torch.uint8),
                 (
-                    self.dcp_world_size * self._ckv_local_capacity,
-                    _GLM_NEXT_CACHE_RECORD_BYTES,
+                    (
+                        self.dcp_world_size * self._ckv_local_capacity,
+                        record_bytes,
+                    ),
+                    torch.uint8,
                 ),
-                torch.uint8,
-            ),
-        )
+            )
         return (
             q_spec,
             *plan.shapes_and_dtypes(),
-            *(ckv_specs if include_ckv else ()),
+            *ckv_specs,
         )
 
     def _reserve_attention_workspaces(self) -> None:
@@ -1368,20 +1413,23 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
     ) -> torch.Tensor:
         if not self.uses_full_ckv_dcp(attn_metadata, attn_metadata.num_actual_tokens):
             raise RuntimeError("full CKV gather called for an ineligible batch")
-        if not _is_glm_next_ckv_source_layout(
-            kv_cache, page_size=self._kernel_page_size
+        assert self._full_ckv_record_bytes is not None
+        if not _is_full_ckv_source_layout(
+            kv_cache,
+            page_size=self._kernel_page_size,
+            record_bytes=self._full_ckv_record_bytes,
         ):
             raise ValueError(
-                "GLM5Next CKV gather requires native 528-byte records; "
+                "full CKV gather requires contiguous native packed records; "
                 f"got shape={tuple(kv_cache.shape)}, stride={kv_cache.stride()}"
             )
         expected_local_shape = (
             self._ckv_local_capacity,
-            _GLM_NEXT_CACHE_RECORD_BYTES,
+            self._full_ckv_record_bytes,
         )
         expected_gathered_shape = (
             self.dcp_world_size * self._ckv_local_capacity,
-            _GLM_NEXT_CACHE_RECORD_BYTES,
+            self._full_ckv_record_bytes,
         )
         if tuple(local_buffer.shape) != expected_local_shape:
             raise RuntimeError("CKV local workspace has an invalid shape")
@@ -1407,7 +1455,7 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
             gathered_buffer[: self.dcp_world_size * padded_tokens].view(-1),
         )
         return gathered_buffer.view(
-            -1, self._kernel_page_size, _GLM_NEXT_CACHE_RECORD_BYTES
+            -1, self._kernel_page_size, self._full_ckv_record_bytes
         )
 
     def forward_mqa(
@@ -1434,7 +1482,10 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         if use_ckv_gather:
             assert self._ckv_extend_plan is not None
             plan = self._ckv_extend_plan
-            logger.info_once("Using full-CKV gather for GLM5Next B12X DCP prefill")
+            logger.info_once(
+                "Using full-CKV gather for B12X DCP prefill (record_bytes=%d)",
+                self._full_ckv_record_bytes,
+            )
         else:
             plan = (
                 self._decode_plan

--- a/vllm/v1/attention/ops/dcp.py
+++ b/vllm/v1/attention/ops/dcp.py
@@ -49,6 +49,11 @@ def mask_dcp_empty_shards_(
         or query_start_loc.shape[0] != seq_lens.shape[0] + 1
     ):
         raise ValueError("query_start_loc must contain one boundary per sequence")
+    if seq_lens.numel() == 0:
+        # A DCP rank can receive no local sequences during draft prefill. Its
+        # contribution must be ignored by the cross-rank LSE reduction.
+        lse.fill_(float("-inf"))
+        return
 
     row_indices = torch.arange(
         lse.shape[0], device=lse.device, dtype=query_start_loc.dtype


### PR DESCRIPTION
Adds the existing B12X native full-CKV DCP prefill path to `glm_moe_dsa` (GLM-5.2/5.3 non-Flash) and its MTP draft model.

This is intentionally architecture-gated and reuses the r15 GLM-Next implementation: GLM-Next retains its 528-byte records and selector metadata; GLM DSA uses its native 656-byte packed record. Other architectures remain unchanged.

Depends on #560 for the non-PCP DCP query and empty-rank correctness fixes. Once #560 merges, this PR reduces to commit 914c4f4b3.

Validation:
- focused API tests: 50 passed
- overlay-matched tests: 49 passed, 1 unrelated layout expectation deselected
- ruff, compileall, and diff check passed
- cn3 TP4/DCP4/MTP3, FP8 KV, max_num_seqs=8: healthy, zero restarts, no fallback/OOM
- KV pool unchanged: 906,143 tokens at max_model_len=900,000
- 32K prefill: ~1,005 stock r15 -> 1,849 full-CKV at 1,024-token chunks -> 2,382 at the validated 4,096-token deployment setting

The historical `i8_ring` TP all-reduce wire codec is deliberately excluded: the full-CKV path uses the DCP NCCL all-gather directly, so that codec does not compress the dominant transfer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for full-CKV distributed context parallelism in sparse attention.
  * Extended full-CKV gathering and workspace handling to supported GLM-MoE-DSA models.
  * Improved handling of unmapped cache slots and ranks with no local sequences.

* **Bug Fixes**
  * Corrected sparse attention output combination and query gathering across distributed execution modes.
  * Ensured unmapped cache rows remain zeroed while valid query outputs are preserved.
  * Fixed masking behavior for empty distributed shards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->