### PR TITLE
feat(scheduler): bound mixed prefill work under active decode

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -6280,6 +6280,43 @@ def test_mixed_prefill_budget_reserves_waiter_then_rotates_running(
     ]
 
 
+def test_partial_prefill_limit_keeps_excess_waiter_queued(lp11_model_path):
+    scheduler, (p0, p1) = _prepare_lp11_prefills(
+        lp11_model_path,
+        num_prefills=2,
+        mixed_prefill_budget=4608,
+    )
+    scheduler.max_num_partial_prefills = 2
+    assert len(scheduler._inflight_prefills) == 2
+    (waiter,) = create_requests(
+        num_requests=1,
+        num_tokens=12000,
+        req_ids=["waiter"],
+    )
+    scheduler.add_request(waiter)
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens == {
+        "decode": 1,
+        p0.request_id: 2304,
+        p1.request_id: 2304,
+    }
+    assert waiter not in scheduler.running
+    assert waiter in scheduler.waiting
+    assert len(scheduler._inflight_prefills) == 2
+
+
+def test_max_num_partial_prefills_validation():
+    with pytest.raises(ValueError, match="max_num_partial_prefills"):
+        SchedulerConfig(
+            max_model_len=32768,
+            is_encoder_decoder=False,
+            max_num_seqs=2,
+            max_num_partial_prefills=3,
+        )
+
+
 def test_mixed_prefill_budget_does_not_limit_prefill_only_step(lp11_model_path):
     scheduler = create_scheduler(
         model=lp11_model_path,

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -6206,9 +6206,7 @@ def _empty_output_for_schedule(output: SchedulerOutput) -> ModelRunnerOutput:
     return ModelRunnerOutput(
         req_ids=req_ids,
         req_id_to_index={req_id: index for index, req_id in enumerate(req_ids)},
-        sampled_token_ids=[
-            [0] if req_id == "decode" else [] for req_id in req_ids
-        ],
+        sampled_token_ids=[[0] if req_id == "decode" else [] for req_id in req_ids],
         logprobs=None,
         prompt_logprobs_dict={},
         pooler_output=[],
@@ -6391,9 +6389,7 @@ def test_mixed_prefill_budget_selects_2304_token_running_quanta():
 
     scheduler._prefill_budget_quantum = 1
     scheduler._prefill_budget_rotation = 0
-    assert Scheduler._select_running_prefill_limits(
-        scheduler, request_ids, 8192
-    ) == {
+    assert Scheduler._select_running_prefill_limits(scheduler, request_ids, 8192) == {
         "p0": 2731,
         "p1": 2731,
         "p2": 2730,
@@ -6437,10 +6433,16 @@ def test_decode_burst_controller_balances_prefill_and_decode(lp11_model_path):
     prefill_ids = {request.request_id for request in prefills}
 
     outputs = []
+    interval_stats = []
     for _ in range(5):
         output = scheduler.schedule()
         outputs.append(output)
-        scheduler.update_from_output(output, _empty_output_for_schedule(output))
+        engine_outputs = scheduler.update_from_output(
+            output, _empty_output_for_schedule(output)
+        )
+        stats = next(iter(engine_outputs.values())).scheduler_stats
+        assert stats is not None
+        interval_stats.append(stats)
 
     prefill_tokens = [
         sum(
@@ -6457,13 +6459,27 @@ def test_decode_burst_controller_balances_prefill_and_decode(lp11_model_path):
 
     waiter.arrival_time = time.time() - 30.001
     fairness_output = scheduler.schedule()
-    assert sum(
-        count
-        for request_id, count in fairness_output.num_scheduled_tokens.items()
-        if request_id in prefill_ids
-    ) == 2304
+    assert (
+        sum(
+            count
+            for request_id, count in fairness_output.num_scheduled_tokens.items()
+            if request_id in prefill_ids
+        )
+        == 2304
+    )
 
-    stats = scheduler.drain_decode_prefill_stats()
+    final_stats = scheduler.drain_decode_prefill_stats()
+    stats = {
+        "scheduled_prefill_tokens": sum(
+            row.scheduled_prefill_tokens for row in interval_stats
+        )
+        + final_stats["scheduled_prefill_tokens"],
+        "active_partial_prefills": final_stats["active_partial_prefills"],
+        "decode_only_steps": sum(row.decode_only_steps for row in interval_stats)
+        + final_stats["decode_only_steps"],
+        "fairness_bypasses": sum(row.fairness_bypasses for row in interval_stats)
+        + final_stats["fairness_bypasses"],
+    }
     assert stats == {
         "scheduled_prefill_tokens": 4608,
         "active_partial_prefills": 2,

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -6169,7 +6169,8 @@ def test_encoder_input_skipped_when_connector_already_has_the_item(ec_role: str)
 @pytest.fixture
 def lp11_model_path(tmp_path):
     (tmp_path / "config.json").write_text(
-        '{"architectures": ["OPTForCausalLM"], "model_type": "opt"}'
+        '{"architectures": ["OPTForCausalLM"], "model_type": "opt", '
+        '"max_position_embeddings": 32768}'
     )
     return str(tmp_path)
 
@@ -6213,31 +6214,70 @@ def _empty_output_for_schedule(output: SchedulerOutput) -> ModelRunnerOutput:
     )
 
 
-def test_mixed_prefill_budget_is_shared_across_waiting_requests(lp11_model_path):
+def _prepare_lp11_prefills(
+    lp11_model_path,
+    num_prefills: int,
+    mixed_prefill_budget: int,
+):
     scheduler = create_scheduler(
         model=lp11_model_path,
         skip_tokenizer_init=True,
         device="cpu",
-        max_num_seqs=8,
-        max_num_batched_tokens=64,
-        max_model_len=256,
-        max_num_prefill_tokens_per_step=16,
+        max_num_seqs=4,
+        max_num_batched_tokens=8192,
+        max_model_len=32768,
+        long_prefill_token_threshold=2304,
+        max_num_prefill_tokens_per_step=0,
     )
     _establish_decode_request(scheduler)
 
     prefills = create_requests(
-        num_requests=4,
-        num_tokens=160,
-        req_ids=["p0", "p1", "p2", "p3"],
+        num_requests=num_prefills,
+        num_tokens=12000,
+        req_ids=[f"p{index}" for index in range(num_prefills)],
     )
     for request in prefills:
         scheduler.add_request(request)
 
     output = scheduler.schedule()
+    scheduler.update_from_output(output, _empty_output_for_schedule(output))
+    assert all(request in scheduler.running for request in prefills)
 
-    assert "decode" in output.num_scheduled_tokens
-    assert [output.num_scheduled_tokens[r.request_id] for r in prefills] == [4] * 4
-    assert sum(output.num_scheduled_tokens[r.request_id] for r in prefills) == 16
+    scheduler.max_num_prefill_tokens_per_step = mixed_prefill_budget
+    scheduler._prefill_budget_quantum = 2304
+    scheduler._prefill_budget_rotation = 0
+    return scheduler, prefills
+
+
+def test_mixed_prefill_budget_reserves_waiter_then_rotates_running(
+    lp11_model_path,
+):
+    scheduler, (p0, p1) = _prepare_lp11_prefills(
+        lp11_model_path,
+        num_prefills=2,
+        mixed_prefill_budget=4608,
+    )
+    (waiter,) = create_requests(
+        num_requests=1,
+        num_tokens=12000,
+        req_ids=["waiter"],
+    )
+    scheduler.add_request(waiter)
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens == {
+        "decode": 1,
+        p0.request_id: 2304,
+        waiter.request_id: 2304,
+    }
+    assert p1.request_id not in output.num_scheduled_tokens
+    assert [request.request_id for request in scheduler.running] == [
+        "decode",
+        "p0",
+        "p1",
+        "waiter",
+    ]
 
 
 def test_mixed_prefill_budget_does_not_limit_prefill_only_step(lp11_model_path):
@@ -6245,92 +6285,42 @@ def test_mixed_prefill_budget_does_not_limit_prefill_only_step(lp11_model_path):
         model=lp11_model_path,
         skip_tokenizer_init=True,
         device="cpu",
-        max_num_batched_tokens=64,
-        max_model_len=256,
-        max_num_prefill_tokens_per_step=16,
+        max_num_batched_tokens=8192,
+        max_model_len=32768,
+        max_num_prefill_tokens_per_step=2304,
     )
     (request,) = create_requests(
         num_requests=1,
-        num_tokens=64,
+        num_tokens=8192,
         req_ids=["prefill"],
     )
     scheduler.add_request(request)
 
     output = scheduler.schedule()
 
-    assert output.num_scheduled_tokens[request.request_id] == 64
+    assert output.num_scheduled_tokens[request.request_id] == 8192
 
 
-def test_mixed_prefill_budget_reserves_a_waiting_slot(lp11_model_path):
-    scheduler = create_scheduler(
-        model=lp11_model_path,
-        skip_tokenizer_init=True,
-        device="cpu",
-        max_num_seqs=4,
-        max_num_batched_tokens=64,
-        max_model_len=256,
-        max_num_prefill_tokens_per_step=16,
-    )
-    _establish_decode_request(scheduler)
-    p0, p1 = create_requests(
-        num_requests=2,
-        num_tokens=160,
-        req_ids=["p0", "p1"],
-    )
-    scheduler.add_request(p0)
-    scheduler.add_request(p1)
-    output = scheduler.schedule()
-    scheduler.update_from_output(output, _empty_output_for_schedule(output))
-    assert p0 in scheduler.running and p1 in scheduler.running
-
-    (p2,) = create_requests(
-        num_requests=1,
-        num_tokens=160,
-        req_ids=["p2"],
-    )
-    scheduler.add_request(p2)
-    output = scheduler.schedule()
-
-    assert "decode" in output.num_scheduled_tokens
-    assert all(
-        req_id in output.num_scheduled_tokens for req_id in ("p0", "p1", "p2")
-    )
-    assert (
-        sum(
-            output.num_scheduled_tokens[req_id] for req_id in ("p0", "p1", "p2")
-        )
-        <= 16
+def test_mixed_prefill_budget_rotates_one_quantum_after_slots_fill(
+    lp11_model_path,
+):
+    scheduler, prefills = _prepare_lp11_prefills(
+        lp11_model_path,
+        num_prefills=3,
+        mixed_prefill_budget=2304,
     )
 
-
-def test_mixed_prefill_budget_rotates_extra_tokens_without_reordering(lp11_model_path):
-    scheduler = create_scheduler(
-        model=lp11_model_path,
-        skip_tokenizer_init=True,
-        device="cpu",
-        max_num_seqs=4,
-        max_num_batched_tokens=64,
-        max_model_len=256,
-        max_num_prefill_tokens_per_step=16,
-    )
-    _establish_decode_request(scheduler)
-    prefills = create_requests(
-        num_requests=3,
-        num_tokens=160,
-        req_ids=["p0", "p1", "p2"],
-    )
-    for request in prefills:
-        scheduler.add_request(request)
-
-    largest_share_ids = []
+    selected_ids = []
     for _ in range(3):
         output = scheduler.schedule()
-        shares = {
-            request.request_id: output.num_scheduled_tokens[request.request_id]
+        selected = [
+            request.request_id
             for request in prefills
-        }
-        assert sorted(shares.values()) == [5, 5, 6]
-        largest_share_ids.append(max(shares, key=shares.get))
+            if request.request_id in output.num_scheduled_tokens
+        ]
+        assert len(selected) == 1
+        assert output.num_scheduled_tokens[selected[0]] == 2304
+        selected_ids.extend(selected)
         assert [request.request_id for request in scheduler.running] == [
             "decode",
             "p0",
@@ -6339,35 +6329,34 @@ def test_mixed_prefill_budget_rotates_extra_tokens_without_reordering(lp11_model
         ]
         scheduler.update_from_output(output, _empty_output_for_schedule(output))
 
-    assert largest_share_ids == ["p0", "p1", "p2"]
+    assert selected_ids == ["p0", "p1", "p2"]
 
 
-def test_mixed_prefill_budget_distributes_mamba_aligned_candidate_values():
+def test_mixed_prefill_budget_selects_2304_token_running_quanta():
     scheduler = Mock(
-        need_mamba_block_aligned_split=True,
-        mamba_block_size=256,
+        _prefill_budget_quantum=2304,
         _prefill_budget_rotation=0,
     )
+    request_ids = ["p0", "p1", "p2"]
 
-    small = Scheduler._distribute_prefill_token_budget(scheduler, 2304, 7)
-    assert sum(small) == 2304
-    assert sorted(small) == [256, 256, 256, 256, 256, 512, 512]
-    assert small[:2] == [512, 512]
+    assert Scheduler._select_running_prefill_limits(scheduler, request_ids, 1) == {
+        "p0": 2304
+    }
+    assert Scheduler._select_running_prefill_limits(scheduler, request_ids, 2) == {
+        "p1": 2304,
+        "p2": 2304,
+    }
+    assert Scheduler._select_running_prefill_limits(scheduler, request_ids, 1) == {
+        "p0": 2304
+    }
 
-    large = Scheduler._distribute_prefill_token_budget(scheduler, 4608, 7)
-    assert sum(large) == 4608
-    assert sorted(large) == [512, 512, 512, 768, 768, 768, 768]
-    assert large[2:6] == [768, 768, 768, 768]
 
-    assert all(tokens % 256 == 0 for tokens in small + large)
-
-
-@pytest.mark.parametrize("value", [-1, 65])
+@pytest.mark.parametrize("value", [-1, 8193])
 def test_max_num_prefill_tokens_per_step_validation(value: int):
     with pytest.raises(ValueError):
         SchedulerConfig(
-            max_model_len=256,
+            max_model_len=32768,
             is_encoder_decoder=False,
-            max_num_batched_tokens=64,
+            max_num_batched_tokens=8192,
             max_num_prefill_tokens_per_step=value,
         )

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -6164,3 +6164,210 @@ def test_encoder_input_skipped_when_connector_already_has_the_item(ec_role: str)
 
     assert output.num_scheduled_tokens[req_id] > 0
     assert not output.scheduled_encoder_inputs.get(req_id)
+
+
+@pytest.fixture
+def lp11_model_path(tmp_path):
+    (tmp_path / "config.json").write_text(
+        '{"architectures": ["OPTForCausalLM"], "model_type": "opt"}'
+    )
+    return str(tmp_path)
+
+
+def _establish_decode_request(scheduler, req_id: str = "decode"):
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=8,
+        max_tokens=200,
+        req_ids=[req_id],
+    )
+    scheduler.add_request(request)
+    output = scheduler.schedule()
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=[req_id],
+            req_id_to_index={req_id: 0},
+            sampled_token_ids=[[0]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+    assert request in scheduler.running
+    assert not request.is_prefill_chunk
+    return request
+
+
+def _empty_output_for_schedule(output: SchedulerOutput) -> ModelRunnerOutput:
+    req_ids = list(output.num_scheduled_tokens)
+    return ModelRunnerOutput(
+        req_ids=req_ids,
+        req_id_to_index={req_id: index for index, req_id in enumerate(req_ids)},
+        sampled_token_ids=[
+            [0] if req_id == "decode" else [] for req_id in req_ids
+        ],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+
+def test_mixed_prefill_budget_is_shared_across_waiting_requests(lp11_model_path):
+    scheduler = create_scheduler(
+        model=lp11_model_path,
+        skip_tokenizer_init=True,
+        device="cpu",
+        max_num_seqs=8,
+        max_num_batched_tokens=64,
+        max_model_len=256,
+        max_num_prefill_tokens_per_step=16,
+    )
+    _establish_decode_request(scheduler)
+
+    prefills = create_requests(
+        num_requests=4,
+        num_tokens=160,
+        req_ids=["p0", "p1", "p2", "p3"],
+    )
+    for request in prefills:
+        scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert "decode" in output.num_scheduled_tokens
+    assert [output.num_scheduled_tokens[r.request_id] for r in prefills] == [4] * 4
+    assert sum(output.num_scheduled_tokens[r.request_id] for r in prefills) == 16
+
+
+def test_mixed_prefill_budget_does_not_limit_prefill_only_step(lp11_model_path):
+    scheduler = create_scheduler(
+        model=lp11_model_path,
+        skip_tokenizer_init=True,
+        device="cpu",
+        max_num_batched_tokens=64,
+        max_model_len=256,
+        max_num_prefill_tokens_per_step=16,
+    )
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=64,
+        req_ids=["prefill"],
+    )
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens[request.request_id] == 64
+
+
+def test_mixed_prefill_budget_reserves_a_waiting_slot(lp11_model_path):
+    scheduler = create_scheduler(
+        model=lp11_model_path,
+        skip_tokenizer_init=True,
+        device="cpu",
+        max_num_seqs=4,
+        max_num_batched_tokens=64,
+        max_model_len=256,
+        max_num_prefill_tokens_per_step=16,
+    )
+    _establish_decode_request(scheduler)
+    p0, p1 = create_requests(
+        num_requests=2,
+        num_tokens=160,
+        req_ids=["p0", "p1"],
+    )
+    scheduler.add_request(p0)
+    scheduler.add_request(p1)
+    output = scheduler.schedule()
+    scheduler.update_from_output(output, _empty_output_for_schedule(output))
+    assert p0 in scheduler.running and p1 in scheduler.running
+
+    (p2,) = create_requests(
+        num_requests=1,
+        num_tokens=160,
+        req_ids=["p2"],
+    )
+    scheduler.add_request(p2)
+    output = scheduler.schedule()
+
+    assert "decode" in output.num_scheduled_tokens
+    assert all(
+        req_id in output.num_scheduled_tokens for req_id in ("p0", "p1", "p2")
+    )
+    assert (
+        sum(
+            output.num_scheduled_tokens[req_id] for req_id in ("p0", "p1", "p2")
+        )
+        <= 16
+    )
+
+
+def test_mixed_prefill_budget_rotates_extra_tokens_without_reordering(lp11_model_path):
+    scheduler = create_scheduler(
+        model=lp11_model_path,
+        skip_tokenizer_init=True,
+        device="cpu",
+        max_num_seqs=4,
+        max_num_batched_tokens=64,
+        max_model_len=256,
+        max_num_prefill_tokens_per_step=16,
+    )
+    _establish_decode_request(scheduler)
+    prefills = create_requests(
+        num_requests=3,
+        num_tokens=160,
+        req_ids=["p0", "p1", "p2"],
+    )
+    for request in prefills:
+        scheduler.add_request(request)
+
+    largest_share_ids = []
+    for _ in range(3):
+        output = scheduler.schedule()
+        shares = {
+            request.request_id: output.num_scheduled_tokens[request.request_id]
+            for request in prefills
+        }
+        assert sorted(shares.values()) == [5, 5, 6]
+        largest_share_ids.append(max(shares, key=shares.get))
+        assert [request.request_id for request in scheduler.running] == [
+            "decode",
+            "p0",
+            "p1",
+            "p2",
+        ]
+        scheduler.update_from_output(output, _empty_output_for_schedule(output))
+
+    assert largest_share_ids == ["p0", "p1", "p2"]
+
+
+def test_mixed_prefill_budget_distributes_mamba_aligned_candidate_values():
+    scheduler = Mock(
+        need_mamba_block_aligned_split=True,
+        mamba_block_size=256,
+        _prefill_budget_rotation=0,
+    )
+
+    small = Scheduler._distribute_prefill_token_budget(scheduler, 2304, 7)
+    assert sum(small) == 2304
+    assert sorted(small) == [256, 256, 256, 256, 256, 512, 512]
+    assert small[:2] == [512, 512]
+
+    large = Scheduler._distribute_prefill_token_budget(scheduler, 4608, 7)
+    assert sum(large) == 4608
+    assert sorted(large) == [512, 512, 512, 768, 768, 768, 768]
+    assert large[2:6] == [768, 768, 768, 768]
+
+    assert all(tokens % 256 == 0 for tokens in small + large)
+
+
+@pytest.mark.parametrize("value", [-1, 65])
+def test_max_num_prefill_tokens_per_step_validation(value: int):
+    with pytest.raises(ValueError):
+        SchedulerConfig(
+            max_model_len=256,
+            is_encoder_decoder=False,
+            max_num_batched_tokens=64,
+            max_num_prefill_tokens_per_step=value,
+        )

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -6168,7 +6168,7 @@ def test_encoder_input_skipped_when_connector_already_has_the_item(ec_role: str)
 
 
 @pytest.fixture
-def lp11_model_path(tmp_path):
+def long_context_opt_model_path(tmp_path):
     (tmp_path / "config.json").write_text(
         '{"architectures": ["OPTForCausalLM"], "model_type": "opt", '
         '"max_position_embeddings": 32768}'
@@ -6213,13 +6213,13 @@ def _empty_output_for_schedule(output: SchedulerOutput) -> ModelRunnerOutput:
     )
 
 
-def _prepare_lp11_prefills(
-    lp11_model_path,
+def _prepare_mixed_prefill_scheduler(
+    long_context_opt_model_path,
     num_prefills: int,
     mixed_prefill_budget: int,
 ):
     scheduler = create_scheduler(
-        model=lp11_model_path,
+        model=long_context_opt_model_path,
         skip_tokenizer_init=True,
         device="cpu",
         max_num_seqs=4,
@@ -6249,10 +6249,10 @@ def _prepare_lp11_prefills(
 
 
 def test_mixed_prefill_budget_reserves_waiter_then_rotates_running(
-    lp11_model_path,
+    long_context_opt_model_path,
 ):
-    scheduler, (p0, p1) = _prepare_lp11_prefills(
-        lp11_model_path,
+    scheduler, (p0, p1) = _prepare_mixed_prefill_scheduler(
+        long_context_opt_model_path,
         num_prefills=2,
         mixed_prefill_budget=4608,
     )
@@ -6279,9 +6279,11 @@ def test_mixed_prefill_budget_reserves_waiter_then_rotates_running(
     ]
 
 
-def test_partial_prefill_limit_keeps_excess_waiter_queued(lp11_model_path):
-    scheduler, (p0, p1) = _prepare_lp11_prefills(
-        lp11_model_path,
+def test_partial_prefill_limit_keeps_excess_waiter_queued(
+    long_context_opt_model_path,
+):
+    scheduler, (p0, p1) = _prepare_mixed_prefill_scheduler(
+        long_context_opt_model_path,
         num_prefills=2,
         mixed_prefill_budget=4608,
     )
@@ -6316,9 +6318,11 @@ def test_max_num_partial_prefills_validation():
         )
 
 
-def test_mixed_prefill_budget_does_not_limit_prefill_only_step(lp11_model_path):
+def test_mixed_prefill_budget_does_not_limit_prefill_only_step(
+    long_context_opt_model_path,
+):
     scheduler = create_scheduler(
-        model=lp11_model_path,
+        model=long_context_opt_model_path,
         skip_tokenizer_init=True,
         device="cpu",
         max_num_batched_tokens=8192,
@@ -6339,10 +6343,10 @@ def test_mixed_prefill_budget_does_not_limit_prefill_only_step(lp11_model_path):
 
 
 def test_mixed_prefill_budget_rotates_one_quantum_after_slots_fill(
-    lp11_model_path,
+    long_context_opt_model_path,
 ):
-    scheduler, prefills = _prepare_lp11_prefills(
-        lp11_model_path,
+    scheduler, prefills = _prepare_mixed_prefill_scheduler(
+        long_context_opt_model_path,
         num_prefills=3,
         mixed_prefill_budget=2304,
     )
@@ -6416,9 +6420,11 @@ def test_decode_burst_requires_mixed_prefill_budget():
         )
 
 
-def test_decode_burst_controller_balances_prefill_and_decode(lp11_model_path):
-    scheduler, prefills = _prepare_lp11_prefills(
-        lp11_model_path, num_prefills=2, mixed_prefill_budget=2304
+def test_decode_burst_controller_balances_prefill_and_decode(
+    long_context_opt_model_path,
+):
+    scheduler, prefills = _prepare_mixed_prefill_scheduler(
+        long_context_opt_model_path, num_prefills=2, mixed_prefill_budget=2304
     )
     scheduler.max_num_partial_prefills = 2
     scheduler.decode_prefill_min_decode_steps = 4

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -6350,6 +6350,16 @@ def test_mixed_prefill_budget_selects_2304_token_running_quanta():
         "p0": 2304
     }
 
+    scheduler._prefill_budget_quantum = 1
+    scheduler._prefill_budget_rotation = 0
+    assert Scheduler._select_running_prefill_limits(
+        scheduler, request_ids, 8192
+    ) == {
+        "p0": 2731,
+        "p1": 2731,
+        "p2": 2730,
+    }
+
 
 @pytest.mark.parametrize("value", [-1, 8193])
 def test_max_num_prefill_tokens_per_step_validation(value: int):

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import dataclasses
+import time
 from concurrent.futures import Future
 from unittest.mock import Mock
 
@@ -6326,6 +6327,7 @@ def test_mixed_prefill_budget_does_not_limit_prefill_only_step(lp11_model_path):
         max_model_len=32768,
         max_num_prefill_tokens_per_step=2304,
     )
+    scheduler.decode_prefill_min_decode_steps = 4
     (request,) = create_requests(
         num_requests=1,
         num_tokens=8192,
@@ -6407,3 +6409,64 @@ def test_max_num_prefill_tokens_per_step_validation(value: int):
             max_num_batched_tokens=8192,
             max_num_prefill_tokens_per_step=value,
         )
+
+
+def test_decode_burst_requires_mixed_prefill_budget():
+    with pytest.raises(ValueError, match="max_num_prefill_tokens_per_step"):
+        SchedulerConfig(
+            max_model_len=32768,
+            is_encoder_decoder=False,
+            decode_prefill_min_decode_steps=4,
+        )
+
+
+def test_decode_burst_controller_balances_prefill_and_decode(lp11_model_path):
+    scheduler, prefills = _prepare_lp11_prefills(
+        lp11_model_path, num_prefills=2, mixed_prefill_budget=2304
+    )
+    scheduler.max_num_partial_prefills = 2
+    scheduler.decode_prefill_min_decode_steps = 4
+    scheduler.decode_prefill_max_wait_ms = 30_000
+    scheduler.drain_decode_prefill_stats()
+    (waiter,) = create_requests(
+        num_requests=1,
+        num_tokens=12000,
+        req_ids=["waiter"],
+    )
+    scheduler.add_request(waiter)
+    prefill_ids = {request.request_id for request in prefills}
+
+    outputs = []
+    for _ in range(5):
+        output = scheduler.schedule()
+        outputs.append(output)
+        scheduler.update_from_output(output, _empty_output_for_schedule(output))
+
+    prefill_tokens = [
+        sum(
+            count
+            for request_id, count in output.num_scheduled_tokens.items()
+            if request_id in prefill_ids
+        )
+        for output in outputs
+    ]
+    assert prefill_tokens[:4] == [0, 0, 0, 0]
+    assert prefill_tokens[4] == 2304
+    assert all(output.num_scheduled_tokens["decode"] > 0 for output in outputs)
+    assert waiter in scheduler.waiting
+
+    waiter.arrival_time = time.time() - 30.001
+    fairness_output = scheduler.schedule()
+    assert sum(
+        count
+        for request_id, count in fairness_output.num_scheduled_tokens.items()
+        if request_id in prefill_ids
+    ) == 2304
+
+    stats = scheduler.drain_decode_prefill_stats()
+    assert stats == {
+        "scheduled_prefill_tokens": 4608,
+        "active_partial_prefills": 2,
+        "decode_only_steps": 4,
+        "fairness_bypasses": 1,
+    }

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -7,6 +7,7 @@ import vllm.envs as envs
 from tests.v1.kv_connector.unit.utils import MockKVConfig
 from vllm.config import (
     CacheConfig,
+    DeviceConfig,
     ECTransferConfig,
     KVTransferConfig,
     ModelConfig,
@@ -55,6 +56,8 @@ def create_scheduler(
     enable_chunked_prefill: bool = True,
     enable_prefix_caching: bool = False,
     long_prefill_token_threshold: int = 0,
+    max_num_prefill_tokens_per_step: int = 0,
+    device: str = "auto",
     disable_chunked_mm_input: bool = False,
     use_kv_connector: None | bool | str | MockKVConfig = None,
     kv_role: str = "kv_both",
@@ -106,6 +109,7 @@ def create_scheduler(
         max_num_batched_tokens=max_num_batched_tokens,
         max_model_len=max_model_len,
         long_prefill_token_threshold=long_prefill_token_threshold,
+        max_num_prefill_tokens_per_step=max_num_prefill_tokens_per_step,
         disable_chunked_mm_input=disable_chunked_mm_input,
         enable_chunked_prefill=enable_chunked_prefill,
         async_scheduling=async_scheduling,
@@ -182,6 +186,7 @@ def create_scheduler(
     )
 
     vllm_config = VllmConfig(
+        device_config=DeviceConfig(device=device),
         scheduler_config=scheduler_config,
         model_config=model_config,
         cache_config=cache_config,

--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -34,6 +34,10 @@ def test_scheduler_iteration_details_serialization():
         scheduler_stats=SchedulerStats(
             kv_cache_usage=0.5,
             iteration_details=iteration_details,
+            scheduled_prefill_tokens=2304,
+            active_partial_prefills=2,
+            decode_only_steps=4,
+            fairness_bypasses=1,
         )
     )
 
@@ -43,6 +47,10 @@ def test_scheduler_iteration_details_serialization():
     assert decoded.scheduler_stats is not None
     assert decoded.scheduler_stats.kv_cache_usage == 0.5
     assert decoded.scheduler_stats.iteration_details == iteration_details
+    assert decoded.scheduler_stats.scheduled_prefill_tokens == 2304
+    assert decoded.scheduler_stats.active_partial_prefills == 2
+    assert decoded.scheduler_stats.decode_only_steps == 4
+    assert decoded.scheduler_stats.fairness_bypasses == 1
 
 
 def test_compute_iteration_details_includes_encoder_stats():

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -159,6 +159,20 @@ class SchedulerConfig:
     current step may still be admitted when the limit is full.
     """
 
+    decode_prefill_min_decode_steps: int = Field(default=0, ge=0)
+    """Minimum decode-only steps between mixed-prefill steps.
+
+    Zero disables decode-burst scheduling. This applies only while decode is
+    eligible. Prefill-only steps continue to use max_num_batched_tokens.
+    """
+
+    decode_prefill_max_wait_ms: int = Field(default=0, ge=0)
+    """Maximum waiter age before bypassing a decode burst, in milliseconds.
+
+    Zero disables the fairness deadline. The deadline has an effect only when
+    decode-burst scheduling is enabled.
+    """
+
     async_scheduling: bool | None = None
     """If set to False, disable async scheduling. Async scheduling helps to
     avoid gaps in GPU utilization, leading to better latency and throughput.
@@ -308,6 +322,15 @@ class SchedulerConfig:
                 "max_num_partial_prefills "
                 f"({self.max_num_partial_prefills}) cannot be greater than "
                 f"max_num_seqs ({self.max_num_seqs})."
+            )
+
+        if (
+            self.decode_prefill_min_decode_steps > 0
+            and self.max_num_prefill_tokens_per_step == 0
+        ):
+            raise ValueError(
+                "decode_prefill_min_decode_steps requires "
+                "max_num_prefill_tokens_per_step to be greater than zero."
             )
 
         return self

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -144,6 +144,14 @@ class SchedulerConfig:
     """Schedule prefill work once every N engine steps while decode requests
     are running. Data-parallel engines align the cadence across DP ranks."""
 
+    max_num_prefill_tokens_per_step: int = Field(default=0, ge=0)
+    """Maximum local prefill tokens scheduled in a step with eligible decode.
+
+    The budget is shared across running prefill chunks and waiting admissions.
+    Zero disables the separate mixed-step budget. Prefill-only steps continue
+    to use max_num_batched_tokens.
+    """
+
     async_scheduling: bool | None = None
     """If set to False, disable async scheduling. Async scheduling helps to
     avoid gaps in GPU utilization, leading to better latency and throughput.
@@ -279,6 +287,13 @@ class SchedulerConfig:
                 "long_prefill_token_threshold "
                 f"({self.long_prefill_token_threshold}) cannot be greater "
                 f"than the max_model_len ({max_model_len})."
+            )
+
+        if self.max_num_prefill_tokens_per_step > self.max_num_batched_tokens:
+            raise ValueError(
+                "max_num_prefill_tokens_per_step "
+                f"({self.max_num_prefill_tokens_per_step}) cannot be greater "
+                f"than max_num_batched_tokens ({self.max_num_batched_tokens})."
             )
 
         return self

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -152,6 +152,13 @@ class SchedulerConfig:
     to use max_num_batched_tokens.
     """
 
+    max_num_partial_prefills: int = Field(default=0, ge=0)
+    """Maximum requests allowed to remain partially prefilling.
+
+    Zero disables the separate limit. A request that can finish prefill in the
+    current step may still be admitted when the limit is full.
+    """
+
     async_scheduling: bool | None = None
     """If set to False, disable async scheduling. Async scheduling helps to
     avoid gaps in GPU utilization, leading to better latency and throughput.
@@ -294,6 +301,13 @@ class SchedulerConfig:
                 "max_num_prefill_tokens_per_step "
                 f"({self.max_num_prefill_tokens_per_step}) cannot be greater "
                 f"than max_num_batched_tokens ({self.max_num_batched_tokens})."
+            )
+
+        if self.max_num_partial_prefills > self.max_num_seqs:
+            raise ValueError(
+                "max_num_partial_prefills "
+                f"({self.max_num_partial_prefills}) cannot be greater than "
+                f"max_num_seqs ({self.max_num_seqs})."
             )
 
         return self

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -637,6 +637,7 @@ class EngineArgs:
     max_num_prefill_tokens_per_step: int = (
         SchedulerConfig.max_num_prefill_tokens_per_step
     )
+    max_num_partial_prefills: int = SchedulerConfig.max_num_partial_prefills
 
     watermark: float = SchedulerConfig.watermark
 
@@ -1594,6 +1595,10 @@ class EngineArgs:
             **scheduler_kwargs["max_num_prefill_tokens_per_step"],
         )
         scheduler_group.add_argument(
+            "--max-num-partial-prefills",
+            **scheduler_kwargs["max_num_partial_prefills"],
+        )
+        scheduler_group.add_argument(
             "--disable-hybrid-kv-cache-manager",
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"],
         )
@@ -2377,6 +2382,7 @@ class EngineArgs:
             max_num_prefill_tokens_per_step=(
                 self.max_num_prefill_tokens_per_step
             ),
+            max_num_partial_prefills=self.max_num_partial_prefills,
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -638,6 +638,10 @@ class EngineArgs:
         SchedulerConfig.max_num_prefill_tokens_per_step
     )
     max_num_partial_prefills: int = SchedulerConfig.max_num_partial_prefills
+    decode_prefill_min_decode_steps: int = (
+        SchedulerConfig.decode_prefill_min_decode_steps
+    )
+    decode_prefill_max_wait_ms: int = SchedulerConfig.decode_prefill_max_wait_ms
 
     watermark: float = SchedulerConfig.watermark
 
@@ -1599,6 +1603,14 @@ class EngineArgs:
             **scheduler_kwargs["max_num_partial_prefills"],
         )
         scheduler_group.add_argument(
+            "--decode-prefill-min-decode-steps",
+            **scheduler_kwargs["decode_prefill_min_decode_steps"],
+        )
+        scheduler_group.add_argument(
+            "--decode-prefill-max-wait-ms",
+            **scheduler_kwargs["decode_prefill_max_wait_ms"],
+        )
+        scheduler_group.add_argument(
             "--disable-hybrid-kv-cache-manager",
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"],
         )
@@ -2383,6 +2395,10 @@ class EngineArgs:
                 self.max_num_prefill_tokens_per_step
             ),
             max_num_partial_prefills=self.max_num_partial_prefills,
+            decode_prefill_min_decode_steps=(
+                self.decode_prefill_min_decode_steps
+            ),
+            decode_prefill_max_wait_ms=self.decode_prefill_max_wait_ms,
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2391,13 +2391,9 @@ class EngineArgs:
             scheduler_reserve_full_isl=self.scheduler_reserve_full_isl,
             watermark=self.watermark,
             prefill_schedule_interval=self.prefill_schedule_interval,
-            max_num_prefill_tokens_per_step=(
-                self.max_num_prefill_tokens_per_step
-            ),
+            max_num_prefill_tokens_per_step=(self.max_num_prefill_tokens_per_step),
             max_num_partial_prefills=self.max_num_partial_prefills,
-            decode_prefill_min_decode_steps=(
-                self.decode_prefill_min_decode_steps
-            ),
+            decode_prefill_min_decode_steps=(self.decode_prefill_min_decode_steps),
             decode_prefill_max_wait_ms=self.decode_prefill_max_wait_ms,
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -634,6 +634,9 @@ class EngineArgs:
 
     scheduler_reserve_full_isl: bool = SchedulerConfig.scheduler_reserve_full_isl
     prefill_schedule_interval: int = SchedulerConfig.prefill_schedule_interval
+    max_num_prefill_tokens_per_step: int = (
+        SchedulerConfig.max_num_prefill_tokens_per_step
+    )
 
     watermark: float = SchedulerConfig.watermark
 
@@ -1587,6 +1590,10 @@ class EngineArgs:
             **scheduler_kwargs["prefill_schedule_interval"],
         )
         scheduler_group.add_argument(
+            "--max-num-prefill-tokens-per-step",
+            **scheduler_kwargs["max_num_prefill_tokens_per_step"],
+        )
+        scheduler_group.add_argument(
             "--disable-hybrid-kv-cache-manager",
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"],
         )
@@ -2367,6 +2374,9 @@ class EngineArgs:
             scheduler_reserve_full_isl=self.scheduler_reserve_full_isl,
             watermark=self.watermark,
             prefill_schedule_interval=self.prefill_schedule_interval,
+            max_num_prefill_tokens_per_step=(
+                self.max_num_prefill_tokens_per_step
+            ),
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -338,6 +338,16 @@ class Scheduler(SchedulerInterface):
         self.max_num_partial_prefills = (
             self.scheduler_config.max_num_partial_prefills
         )
+        self.decode_prefill_min_decode_steps = (
+            self.scheduler_config.decode_prefill_min_decode_steps
+        )
+        self.decode_prefill_max_wait_ms = (
+            self.scheduler_config.decode_prefill_max_wait_ms
+        )
+        self._decode_prefill_steps_since_prefill = 0
+        self._decode_prefill_scheduled_prefill_tokens = 0
+        self._decode_prefill_decode_only_steps = 0
+        self._decode_prefill_fairness_bypasses = 0
         self._prefill_budget_rotation = 0
         self.scheduler_reserve_full_isl = (
             self.scheduler_config.scheduler_reserve_full_isl
@@ -598,6 +608,50 @@ class Scheduler(SchedulerInterface):
             self._prefill_budget_rotation = (start + 1) % len(request_ids)
         return limits
 
+    @staticmethod
+    def _request_has_pending_prefill(request: Request) -> bool:
+        return request.is_prefill_chunk or (
+            request.status in (RequestStatus.WAITING, RequestStatus.PREEMPTED)
+            and request.num_computed_tokens < request.num_tokens - 1
+        )
+
+    def _has_pending_prefill(self) -> bool:
+        return any(
+            self._request_has_pending_prefill(request)
+            for request in (*self.running, *self.waiting, *self.skipped_waiting)
+        )
+
+    def _oldest_prefill_waiter_age_ms(self, now: float) -> float:
+        arrival_times = (
+            request.arrival_time
+            for request in (*self.waiting, *self.skipped_waiting)
+            if self._request_has_pending_prefill(request)
+        )
+        oldest_arrival = min(arrival_times, default=now)
+        return max((now - oldest_arrival) * 1000, 0.0)
+
+    @property
+    def decode_prefill_active_partial_prefills(self) -> int:
+        return len(self._inflight_prefills)
+
+    def drain_decode_prefill_stats(self) -> dict[str, int]:
+        """Return and reset decode-prefill interval counters.
+
+        The active-partial-prefill value is a gauge and is not reset.
+        """
+        stats = {
+            "scheduled_prefill_tokens": (
+                self._decode_prefill_scheduled_prefill_tokens
+            ),
+            "active_partial_prefills": self.decode_prefill_active_partial_prefills,
+            "decode_only_steps": self._decode_prefill_decode_only_steps,
+            "fairness_bypasses": self._decode_prefill_fairness_bypasses,
+        }
+        self._decode_prefill_scheduled_prefill_tokens = 0
+        self._decode_prefill_decode_only_steps = 0
+        self._decode_prefill_fairness_bypasses = 0
+        return stats
+
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         self.current_step += 1
         # NOTE(woosuk) on the scheduling algorithm:
@@ -633,6 +687,7 @@ class Scheduler(SchedulerInterface):
         scheduled_spec_decode_tokens: dict[str, list[int]] = {}
         # Whether the running batch contains any prefill requests.
         prefill_scheduled = False
+        all_scheduled_prefill_req_ids: set[str] = set()
 
         # For logging.
         scheduled_timestamp = time.monotonic()
@@ -648,9 +703,26 @@ class Scheduler(SchedulerInterface):
             and self.current_step >= request.next_decode_eligible_step
             for request in self.running
         )
-        defer_prefills = (
+        legacy_defer_prefills = (
             throttle_prefills and not self.prefill_capacity_bound
         ) and has_eligible_decode
+        has_pending_prefill = self._has_pending_prefill()
+        decode_prefill_enabled = self.decode_prefill_min_decode_steps > 0
+        fairness_due = (
+            decode_prefill_enabled
+            and self.decode_prefill_max_wait_ms > 0
+            and self._oldest_prefill_waiter_age_ms(time.time())
+            >= self.decode_prefill_max_wait_ms
+        )
+        decode_burst_defer_prefills = (
+            decode_prefill_enabled
+            and has_eligible_decode
+            and has_pending_prefill
+            and self._decode_prefill_steps_since_prefill
+            < self.decode_prefill_min_decode_steps
+            and not fairness_due
+        )
+        defer_prefills = legacy_defer_prefills or decode_burst_defer_prefills
 
         prefill_budget_remaining: int | None = None
         running_prefill_limits: dict[str, int] = {}
@@ -863,6 +935,9 @@ class Scheduler(SchedulerInterface):
                                 scheduled_prefill_req_ids.remove(
                                     preempted_req_id
                                 )
+                            all_scheduled_prefill_req_ids.discard(
+                                preempted_req_id
+                            )
                             req_to_new_blocks.pop(preempted_req_id)
                             scheduled_spec_decode_tokens.pop(preempted_req_id, None)
                             preempted_encoder_inputs = scheduled_encoder_inputs.pop(
@@ -899,6 +974,8 @@ class Scheduler(SchedulerInterface):
             request_id = request.request_id
             req_to_new_blocks[request_id] = new_blocks
             num_scheduled_tokens[request_id] = num_new_tokens
+            if request.is_prefill_chunk:
+                all_scheduled_prefill_req_ids.add(request_id)
             token_budget -= num_new_tokens
             input_budget -= num_new_tokens + draft_slots
             if running_prefill_limit is not None:
@@ -1375,6 +1452,8 @@ class Scheduler(SchedulerInterface):
                     request_id
                 )
                 num_scheduled_tokens[request_id] = num_new_tokens
+                if has_local_prefill and num_new_tokens > 0:
+                    all_scheduled_prefill_req_ids.add(request_id)
                 token_budget -= num_new_tokens
                 input_budget -= num_new_tokens + draft_slots
                 if waiting_prefill_limit is not None:
@@ -1556,6 +1635,29 @@ class Scheduler(SchedulerInterface):
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
             ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
         )
+
+        scheduled_prefill_tokens = sum(
+            num_scheduled_tokens[request_id]
+            for request_id in all_scheduled_prefill_req_ids
+        )
+        self._decode_prefill_scheduled_prefill_tokens += scheduled_prefill_tokens
+        scheduled_decode_tokens = (
+            total_num_scheduled_tokens - scheduled_prefill_tokens
+        )
+        if decode_prefill_enabled:
+            if scheduled_prefill_tokens > 0:
+                self._decode_prefill_steps_since_prefill = 0
+                if fairness_due:
+                    self._decode_prefill_fairness_bypasses += 1
+            elif (
+                has_eligible_decode
+                and has_pending_prefill
+                and scheduled_decode_tokens > 0
+            ):
+                self._decode_prefill_steps_since_prefill += 1
+                self._decode_prefill_decode_only_steps += 1
+            elif not has_eligible_decode:
+                self._decode_prefill_steps_since_prefill = 0
 
         # NOTE(Kuntai): this function is designed for multiple purposes:
         # 1. Plan the KV cache store

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1626,7 +1626,7 @@ class Scheduler(SchedulerInterface):
             num_scheduled_tokens[request_id]
             for request_id in all_scheduled_prefill_req_ids
         )
-        self._decode_prefill_scheduled_prefill_tokens += scheduled_prefill_tokens
+        self._decode_prefill_scheduled_prefill_tokens += mixed_prefill_tokens_scheduled
         scheduled_decode_tokens = total_num_scheduled_tokens - scheduled_prefill_tokens
         if decode_prefill_enabled:
             if scheduled_prefill_tokens > 0:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -348,6 +348,25 @@ class Scheduler(SchedulerInterface):
         self.need_mamba_block_aligned_split = (
             self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
         )
+        mamba_block_sizes = [
+            group.kv_cache_spec.block_size
+            for group in kv_cache_config.kv_cache_groups
+            if isinstance(group.kv_cache_spec, MambaSpec)
+        ]
+        self.mamba_block_size = math.lcm(*mamba_block_sizes)
+        self._prefill_budget_quantum = (
+            self.mamba_block_size if self.need_mamba_block_aligned_split else 1
+        )
+        if (
+            self.need_mamba_block_aligned_split
+            and self.max_num_prefill_tokens_per_step
+            and self.max_num_prefill_tokens_per_step % self._prefill_budget_quantum
+            != 0
+        ):
+            raise ValueError(
+                "max_num_prefill_tokens_per_step must be a multiple of "
+                f"the Mamba block size ({self._prefill_budget_quantum})"
+            )
         glm5_next_mtp_has_independent_draft_state = (
             speculative_config is not None
             and speculative_config.method == "mtp"
@@ -548,40 +567,24 @@ class Scheduler(SchedulerInterface):
             num_new_tokens -= self.num_prefill_lookahead - remaining
         return max(num_new_tokens, 0)
 
-    def _distribute_prefill_token_budget(
+    def _select_running_prefill_limits(
         self,
-        budget: int,
-        num_candidates: int,
-    ) -> list[int]:
-        if budget <= 0 or num_candidates <= 0:
-            return []
+        request_ids: list[str],
+        num_quanta: int,
+    ) -> dict[str, int]:
+        if num_quanta <= 0 or not request_ids:
+            return {}
 
-        alignment = (
-            self.mamba_block_size if self.need_mamba_block_aligned_split else 1
-        )
-        budget_units = budget // alignment
-        base_units, extra_units = divmod(budget_units, num_candidates)
-        limits = [base_units * alignment for _ in range(num_candidates)]
-
-        if base_units == 0:
-            # Keep the earliest candidates eligible when the budget cannot
-            # cover every candidate. This retains FCFS admission order.
-            extra_indices = range(extra_units)
-        else:
-            # Rotate only the ownership of remainder units. Request and queue
-            # order stay unchanged, while equal-priority prefills take turns
-            # receiving the larger chunk.
-            start = self._prefill_budget_rotation % num_candidates
-            extra_indices = (
-                (start + offset) % num_candidates for offset in range(extra_units)
+        start = self._prefill_budget_rotation % len(request_ids)
+        limits: dict[str, int] = {}
+        for offset in range(num_quanta):
+            request_id = request_ids[(start + offset) % len(request_ids)]
+            limits[request_id] = (
+                limits.get(request_id, 0) + self._prefill_budget_quantum
             )
-            if extra_units:
-                self._prefill_budget_rotation = (
-                    start + extra_units
-                ) % num_candidates
-
-        for index in extra_indices:
-            limits[index] += alignment
+        self._prefill_budget_rotation = (
+            start + num_quanta
+        ) % len(request_ids)
         return limits
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
@@ -654,6 +657,9 @@ class Scheduler(SchedulerInterface):
                 token_budget,
                 input_budget,
             )
+            mixed_prefill_quanta = (
+                mixed_prefill_budget // self._prefill_budget_quantum
+            )
             running_prefill_ids = [
                 request.request_id
                 for request in self.running
@@ -662,23 +668,21 @@ class Scheduler(SchedulerInterface):
             ]
             num_running = len(self.running) + self.num_waiting_for_streaming_input
             free_sequence_slots = max(self.max_num_running_reqs - num_running, 0)
-            waiting_slots = min(
-                free_sequence_slots,
-                len(self.waiting) + len(self.skipped_waiting),
+            reserve_waiting_quantum = int(
+                mixed_prefill_quanta > 0
+                and free_sequence_slots > 0
+                and bool(self.waiting or self.skipped_waiting)
             )
-            limits = self._distribute_prefill_token_budget(
-                mixed_prefill_budget,
-                len(running_prefill_ids) + waiting_slots,
+            waiting_prefill_limits = (
+                [self._prefill_budget_quantum] if reserve_waiting_quantum else []
             )
-            running_prefill_limits = dict(
-                zip(
-                    running_prefill_ids,
-                    limits[: len(running_prefill_ids)],
-                    strict=True,
-                )
+            running_prefill_limits = self._select_running_prefill_limits(
+                running_prefill_ids,
+                mixed_prefill_quanta - reserve_waiting_quantum,
             )
-            waiting_prefill_limits = limits[len(running_prefill_ids) :]
-            prefill_budget_remaining = sum(limits)
+            prefill_budget_remaining = sum(running_prefill_limits.values()) + sum(
+                waiting_prefill_limits
+            )
 
         # First, schedule the RUNNING requests.
         req_index = 0

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -576,15 +576,23 @@ class Scheduler(SchedulerInterface):
             return {}
 
         start = self._prefill_budget_rotation % len(request_ids)
-        limits: dict[str, int] = {}
-        for offset in range(num_quanta):
+        base_quanta, remainder = divmod(num_quanta, len(request_ids))
+        limits = {
+            request_id: base_quanta * self._prefill_budget_quantum
+            for request_id in request_ids
+            if base_quanta > 0
+        }
+        for offset in range(remainder):
             request_id = request_ids[(start + offset) % len(request_ids)]
             limits[request_id] = (
                 limits.get(request_id, 0) + self._prefill_budget_quantum
             )
-        self._prefill_budget_rotation = (
-            start + num_quanta
-        ) % len(request_ids)
+        if remainder:
+            self._prefill_budget_rotation = (
+                start + remainder
+            ) % len(request_ids)
+        elif base_quanta:
+            self._prefill_budget_rotation = (start + 1) % len(request_ids)
         return limits
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -335,6 +335,9 @@ class Scheduler(SchedulerInterface):
         self.max_num_prefill_tokens_per_step = (
             self.scheduler_config.max_num_prefill_tokens_per_step
         )
+        self.max_num_partial_prefills = (
+            self.scheduler_config.max_num_partial_prefills
+        )
         self._prefill_budget_rotation = 0
         self.scheduler_reserve_full_isl = (
             self.scheduler_config.scheduler_reserve_full_isl
@@ -676,9 +679,14 @@ class Scheduler(SchedulerInterface):
             ]
             num_running = len(self.running) + self.num_waiting_for_streaming_input
             free_sequence_slots = max(self.max_num_running_reqs - num_running, 0)
+            partial_prefill_slot_available = (
+                self.max_num_partial_prefills == 0
+                or len(self._inflight_prefills) < self.max_num_partial_prefills
+            )
             reserve_waiting_quantum = int(
                 mixed_prefill_quanta > 0
                 and free_sequence_slots > 0
+                and partial_prefill_slot_available
                 and bool(self.waiting or self.skipped_waiting)
             )
             waiting_prefill_limits = (
@@ -1227,6 +1235,17 @@ class Scheduler(SchedulerInterface):
                     if num_new_tokens == 0:
                         # The request cannot be scheduled.
                         break
+
+                will_remain_partial = (
+                    has_local_prefill
+                    and num_computed_tokens + num_new_tokens < request.num_tokens
+                )
+                if (
+                    will_remain_partial
+                    and self.max_num_partial_prefills > 0
+                    and len(self._inflight_prefills) >= self.max_num_partial_prefills
+                ):
+                    break
 
                 # During async KV load, no forward pass is run yet.
                 # Allocate speculative lookahead slots later to avoid

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
+import math
 import time
 from collections import defaultdict, deque
 from collections.abc import Iterable
@@ -335,9 +336,7 @@ class Scheduler(SchedulerInterface):
         self.max_num_prefill_tokens_per_step = (
             self.scheduler_config.max_num_prefill_tokens_per_step
         )
-        self.max_num_partial_prefills = (
-            self.scheduler_config.max_num_partial_prefills
-        )
+        self.max_num_partial_prefills = self.scheduler_config.max_num_partial_prefills
         self.decode_prefill_min_decode_steps = (
             self.scheduler_config.decode_prefill_min_decode_steps
         )
@@ -373,8 +372,7 @@ class Scheduler(SchedulerInterface):
         if (
             self.need_mamba_block_aligned_split
             and self.max_num_prefill_tokens_per_step
-            and self.max_num_prefill_tokens_per_step % self._prefill_budget_quantum
-            != 0
+            and self.max_num_prefill_tokens_per_step % self._prefill_budget_quantum != 0
         ):
             raise ValueError(
                 "max_num_prefill_tokens_per_step must be a multiple of "
@@ -601,9 +599,7 @@ class Scheduler(SchedulerInterface):
                 limits.get(request_id, 0) + self._prefill_budget_quantum
             )
         if remainder:
-            self._prefill_budget_rotation = (
-                start + remainder
-            ) % len(request_ids)
+            self._prefill_budget_rotation = (start + remainder) % len(request_ids)
         elif base_quanta:
             self._prefill_budget_rotation = (start + 1) % len(request_ids)
         return limits
@@ -640,9 +636,7 @@ class Scheduler(SchedulerInterface):
         The active-partial-prefill value is a gauge and is not reset.
         """
         stats = {
-            "scheduled_prefill_tokens": (
-                self._decode_prefill_scheduled_prefill_tokens
-            ),
+            "scheduled_prefill_tokens": (self._decode_prefill_scheduled_prefill_tokens),
             "active_partial_prefills": self.decode_prefill_active_partial_prefills,
             "decode_only_steps": self._decode_prefill_decode_only_steps,
             "fairness_bypasses": self._decode_prefill_fairness_bypasses,
@@ -740,9 +734,7 @@ class Scheduler(SchedulerInterface):
                 token_budget,
                 input_budget,
             )
-            mixed_prefill_quanta = (
-                mixed_prefill_budget // self._prefill_budget_quantum
-            )
+            mixed_prefill_quanta = mixed_prefill_budget // self._prefill_budget_quantum
             running_prefill_ids = [
                 request.request_id
                 for request in self.running
@@ -827,6 +819,7 @@ class Scheduler(SchedulerInterface):
                 num_new_tokens, token_budget, input_budget - draft_slots
             )
             if running_prefill_limit is not None:
+                assert prefill_budget_remaining is not None
                 num_new_tokens = min(
                     num_new_tokens,
                     running_prefill_limit,
@@ -932,12 +925,8 @@ class Scheduler(SchedulerInterface):
                                 assert prefill_budget_remaining is not None
                                 prefill_budget_remaining += restored
                                 mixed_prefill_tokens_scheduled -= restored
-                                scheduled_prefill_req_ids.remove(
-                                    preempted_req_id
-                                )
-                            all_scheduled_prefill_req_ids.discard(
-                                preempted_req_id
-                            )
+                                scheduled_prefill_req_ids.remove(preempted_req_id)
+                            all_scheduled_prefill_req_ids.discard(preempted_req_id)
                             req_to_new_blocks.pop(preempted_req_id)
                             scheduled_spec_decode_tokens.pop(preempted_req_id, None)
                             preempted_encoder_inputs = scheduled_encoder_inputs.pop(
@@ -1200,8 +1189,7 @@ class Scheduler(SchedulerInterface):
                 pad_spec_decode = False
                 waiting_prefill_limit = None
                 has_local_prefill = (
-                    not load_kv_async
-                    and num_computed_tokens < request.num_tokens - 1
+                    not load_kv_async and num_computed_tokens < request.num_tokens - 1
                 )
 
                 if load_kv_async:
@@ -1216,8 +1204,7 @@ class Scheduler(SchedulerInterface):
                     request_token_budget = min(token_budget, input_budget - draft_slots)
                     if has_local_prefill and prefill_budget_remaining is not None:
                         if (
-                            waiting_prefill_limit_index
-                            >= len(waiting_prefill_limits)
+                            waiting_prefill_limit_index >= len(waiting_prefill_limits)
                             or prefill_budget_remaining <= 0
                         ):
                             break
@@ -1502,8 +1489,7 @@ class Scheduler(SchedulerInterface):
         if prefill_budget_remaining is not None:
             assert prefill_budget_remaining >= 0
             assert (
-                mixed_prefill_tokens_scheduled
-                <= self.max_num_prefill_tokens_per_step
+                mixed_prefill_tokens_scheduled <= self.max_num_prefill_tokens_per_step
             )
 
         assert token_budget >= 0
@@ -1641,9 +1627,7 @@ class Scheduler(SchedulerInterface):
             for request_id in all_scheduled_prefill_req_ids
         )
         self._decode_prefill_scheduled_prefill_tokens += scheduled_prefill_tokens
-        scheduled_decode_tokens = (
-            total_num_scheduled_tokens - scheduled_prefill_tokens
-        )
+        scheduled_decode_tokens = total_num_scheduled_tokens - scheduled_prefill_tokens
         if decode_prefill_enabled:
             if scheduled_prefill_tokens > 0:
                 self._decode_prefill_steps_since_prefill = 0
@@ -3039,11 +3023,16 @@ class Scheduler(SchedulerInterface):
         connector_stats_payload = (
             kv_connector_stats.data if kv_connector_stats else None
         )
+        decode_prefill_stats = self.drain_decode_prefill_stats()
         return SchedulerStats(
             num_running_reqs=len(self.running),
             num_waiting_reqs=len(self.waiting),
             num_skipped_waiting_reqs=len(self.skipped_waiting),
             kv_cache_usage=self.kv_cache_manager.usage,
+            scheduled_prefill_tokens=decode_prefill_stats["scheduled_prefill_tokens"],
+            active_partial_prefills=decode_prefill_stats["active_partial_prefills"],
+            decode_only_steps=decode_prefill_stats["decode_only_steps"],
+            fairness_bypasses=decode_prefill_stats["fairness_bypasses"],
             prefix_cache_stats=prefix_cache_stats,
             connector_prefix_cache_stats=connector_prefix_cache_stats,
             kv_cache_eviction_events=eviction_events,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -332,6 +332,10 @@ class Scheduler(SchedulerInterface):
         # prefill batch fully drained the waiting queue. Prefill throttling
         # is disabled in this case.
         self.prefill_capacity_bound = False
+        self.max_num_prefill_tokens_per_step = (
+            self.scheduler_config.max_num_prefill_tokens_per_step
+        )
+        self._prefill_budget_rotation = 0
         self.scheduler_reserve_full_isl = (
             self.scheduler_config.scheduler_reserve_full_isl
         )
@@ -544,6 +548,42 @@ class Scheduler(SchedulerInterface):
             num_new_tokens -= self.num_prefill_lookahead - remaining
         return max(num_new_tokens, 0)
 
+    def _distribute_prefill_token_budget(
+        self,
+        budget: int,
+        num_candidates: int,
+    ) -> list[int]:
+        if budget <= 0 or num_candidates <= 0:
+            return []
+
+        alignment = (
+            self.mamba_block_size if self.need_mamba_block_aligned_split else 1
+        )
+        budget_units = budget // alignment
+        base_units, extra_units = divmod(budget_units, num_candidates)
+        limits = [base_units * alignment for _ in range(num_candidates)]
+
+        if base_units == 0:
+            # Keep the earliest candidates eligible when the budget cannot
+            # cover every candidate. This retains FCFS admission order.
+            extra_indices = range(extra_units)
+        else:
+            # Rotate only the ownership of remainder units. Request and queue
+            # order stay unchanged, while equal-priority prefills take turns
+            # receiving the larger chunk.
+            start = self._prefill_budget_rotation % num_candidates
+            extra_indices = (
+                (start + offset) % num_candidates for offset in range(extra_units)
+            )
+            if extra_units:
+                self._prefill_budget_rotation = (
+                    start + extra_units
+                ) % num_candidates
+
+        for index in extra_indices:
+            limits[index] += alignment
+        return limits
+
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         self.current_step += 1
         # NOTE(woosuk) on the scheduling algorithm:
@@ -598,6 +638,48 @@ class Scheduler(SchedulerInterface):
             throttle_prefills and not self.prefill_capacity_bound
         ) and has_eligible_decode
 
+        prefill_budget_remaining: int | None = None
+        running_prefill_limits: dict[str, int] = {}
+        waiting_prefill_limits: list[int] = []
+        waiting_prefill_limit_index = 0
+        scheduled_prefill_req_ids: set[str] = set()
+        mixed_prefill_tokens_scheduled = 0
+        if (
+            self.max_num_prefill_tokens_per_step > 0
+            and has_eligible_decode
+            and not defer_prefills
+        ):
+            mixed_prefill_budget = min(
+                self.max_num_prefill_tokens_per_step,
+                token_budget,
+                input_budget,
+            )
+            running_prefill_ids = [
+                request.request_id
+                for request in self.running
+                if request.is_prefill_chunk
+                and self.current_step >= request.next_decode_eligible_step
+            ]
+            num_running = len(self.running) + self.num_waiting_for_streaming_input
+            free_sequence_slots = max(self.max_num_running_reqs - num_running, 0)
+            waiting_slots = min(
+                free_sequence_slots,
+                len(self.waiting) + len(self.skipped_waiting),
+            )
+            limits = self._distribute_prefill_token_budget(
+                mixed_prefill_budget,
+                len(running_prefill_ids) + waiting_slots,
+            )
+            running_prefill_limits = dict(
+                zip(
+                    running_prefill_ids,
+                    limits[: len(running_prefill_ids)],
+                    strict=True,
+                )
+            )
+            waiting_prefill_limits = limits[len(running_prefill_ids) :]
+            prefill_budget_remaining = sum(limits)
+
         # First, schedule the RUNNING requests.
         req_index = 0
         while req_index < len(self.running) and token_budget > 0:
@@ -633,6 +715,15 @@ class Scheduler(SchedulerInterface):
                 req_index += 1
                 continue
 
+            running_prefill_limit = None
+            if request.is_prefill_chunk and prefill_budget_remaining is not None:
+                running_prefill_limit = running_prefill_limits.get(
+                    request.request_id, 0
+                )
+                if running_prefill_limit <= 0 or prefill_budget_remaining <= 0:
+                    req_index += 1
+                    continue
+
             num_new_tokens = (
                 request.num_tokens_with_spec
                 + request.num_output_placeholders
@@ -643,6 +734,12 @@ class Scheduler(SchedulerInterface):
             num_new_tokens = min(
                 num_new_tokens, token_budget, input_budget - draft_slots
             )
+            if running_prefill_limit is not None:
+                num_new_tokens = min(
+                    num_new_tokens,
+                    running_prefill_limit,
+                    prefill_budget_remaining,
+                )
 
             # Make sure the input position does not exceed the max model len.
             # This is necessary when using spec decoding.
@@ -739,6 +836,13 @@ class Scheduler(SchedulerInterface):
                             restored = num_scheduled_tokens.pop(preempted_req_id)
                             token_budget += restored
                             input_budget += restored + draft_slots
+                            if preempted_req_id in scheduled_prefill_req_ids:
+                                assert prefill_budget_remaining is not None
+                                prefill_budget_remaining += restored
+                                mixed_prefill_tokens_scheduled -= restored
+                                scheduled_prefill_req_ids.remove(
+                                    preempted_req_id
+                                )
                             req_to_new_blocks.pop(preempted_req_id)
                             scheduled_spec_decode_tokens.pop(preempted_req_id, None)
                             preempted_encoder_inputs = scheduled_encoder_inputs.pop(
@@ -777,6 +881,11 @@ class Scheduler(SchedulerInterface):
             num_scheduled_tokens[request_id] = num_new_tokens
             token_budget -= num_new_tokens
             input_budget -= num_new_tokens + draft_slots
+            if running_prefill_limit is not None:
+                assert prefill_budget_remaining is not None
+                prefill_budget_remaining -= num_new_tokens
+                mixed_prefill_tokens_scheduled += num_new_tokens
+                scheduled_prefill_req_ids.add(request_id)
             req_index += 1
 
             # Speculative decode related.
@@ -992,17 +1101,40 @@ class Scheduler(SchedulerInterface):
                 external_load_encoder_input = []
                 new_encoder_compute_budget = encoder_compute_budget
                 pad_spec_decode = False
+                waiting_prefill_limit = None
+                has_local_prefill = (
+                    not load_kv_async
+                    and num_computed_tokens < request.num_tokens - 1
+                )
 
                 if load_kv_async:
                     # KVTransfer: loading remote KV, do not allocate for new work.
                     assert num_external_computed_tokens > 0
                     num_new_tokens = 0
-                elif defer_prefills and num_computed_tokens < request.num_tokens - 1:
+                elif defer_prefills and has_local_prefill:
                     # DP prefill balancing: defer this step's local prefill
                     # compute to a cadence-aligned step.
                     break
                 else:
                     request_token_budget = min(token_budget, input_budget - draft_slots)
+                    if has_local_prefill and prefill_budget_remaining is not None:
+                        if (
+                            waiting_prefill_limit_index
+                            >= len(waiting_prefill_limits)
+                            or prefill_budget_remaining <= 0
+                        ):
+                            break
+                        waiting_prefill_limit = waiting_prefill_limits[
+                            waiting_prefill_limit_index
+                        ]
+                        waiting_prefill_limit_index += 1
+                        if waiting_prefill_limit <= 0:
+                            break
+                        request_token_budget = min(
+                            request_token_budget,
+                            waiting_prefill_limit,
+                            prefill_budget_remaining,
+                        )
                     # Number of tokens to be scheduled.
                     # We use `request.num_tokens` instead of
                     # `request.num_prompt_tokens` to consider the resumed
@@ -1214,6 +1346,11 @@ class Scheduler(SchedulerInterface):
                 num_scheduled_tokens[request_id] = num_new_tokens
                 token_budget -= num_new_tokens
                 input_budget -= num_new_tokens + draft_slots
+                if waiting_prefill_limit is not None:
+                    assert prefill_budget_remaining is not None
+                    prefill_budget_remaining -= num_new_tokens
+                    mixed_prefill_tokens_scheduled += num_new_tokens
+                    scheduled_prefill_req_ids.add(request_id)
                 request.status = RequestStatus.RUNNING
                 request.num_computed_tokens = num_computed_tokens
                 if pad_spec_decode:
@@ -1251,6 +1388,13 @@ class Scheduler(SchedulerInterface):
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
         assert total_num_scheduled_tokens <= self.max_num_scheduled_tokens
+
+        if prefill_budget_remaining is not None:
+            assert prefill_budget_remaining >= 0
+            assert (
+                mixed_prefill_tokens_scheduled
+                <= self.max_num_prefill_tokens_per_step
+            )
 
         assert token_budget >= 0
         assert input_budget >= 0

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -568,6 +568,44 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             gauge_kv_cache_usage, per_engine_labelvalues
         )
 
+        counter_decode_prefill_scheduled_tokens = self._counter_cls(
+            name="vllm:decode_prefill_scheduled_tokens",
+            documentation=(
+                "Prefill tokens scheduled while decode-burst control is enabled."
+            ),
+            labelnames=labelnames,
+        )
+        self.counter_decode_prefill_scheduled_tokens = create_metric_per_engine(
+            counter_decode_prefill_scheduled_tokens, per_engine_labelvalues
+        )
+        gauge_decode_prefill_active_partial_prefills = self._gauge_cls(
+            name="vllm:decode_prefill_active_partial_prefills",
+            documentation="Active requests that remain partially prefilling.",
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_decode_prefill_active_partial_prefills = create_metric_per_engine(
+            gauge_decode_prefill_active_partial_prefills, per_engine_labelvalues
+        )
+        counter_decode_prefill_decode_only_steps = self._counter_cls(
+            name="vllm:decode_prefill_decode_only_steps",
+            documentation=(
+                "Scheduler steps where decode-burst control deferred prefill."
+            ),
+            labelnames=labelnames,
+        )
+        self.counter_decode_prefill_decode_only_steps = create_metric_per_engine(
+            counter_decode_prefill_decode_only_steps, per_engine_labelvalues
+        )
+        counter_decode_prefill_fairness_bypasses = self._counter_cls(
+            name="vllm:decode_prefill_fairness_bypasses",
+            documentation="Prefill releases caused by the oldest-waiter deadline.",
+            labelnames=labelnames,
+        )
+        self.counter_decode_prefill_fairness_bypasses = create_metric_per_engine(
+            counter_decode_prefill_fairness_bypasses, per_engine_labelvalues
+        )
+
         if envs.VLLM_COMPUTE_NANS_IN_LOGITS:
             counter_corrupted_requests = self._counter_cls(
                 name="vllm:corrupted_requests",
@@ -1121,6 +1159,18 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 scheduler_stats.num_skipped_waiting_reqs
             )
             self.gauge_kv_cache_usage[engine_idx].set(scheduler_stats.kv_cache_usage)
+            self.counter_decode_prefill_scheduled_tokens[engine_idx].inc(
+                scheduler_stats.scheduled_prefill_tokens
+            )
+            self.gauge_decode_prefill_active_partial_prefills[engine_idx].set(
+                scheduler_stats.active_partial_prefills
+            )
+            self.counter_decode_prefill_decode_only_steps[engine_idx].inc(
+                scheduler_stats.decode_only_steps
+            )
+            self.counter_decode_prefill_fairness_bypasses[engine_idx].inc(
+                scheduler_stats.fairness_bypasses
+            )
 
             self.counter_prefix_cache_queries[engine_idx].inc(
                 scheduler_stats.prefix_cache_stats.queries

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -198,6 +198,11 @@ class SchedulerStats:
     kv_cache_usage: float = 0.0
     iteration_details: SchedulerIterationDetails | None = None
 
+    scheduled_prefill_tokens: int = 0
+    active_partial_prefills: int = 0
+    decode_only_steps: int = 0
+    fairness_bypasses: int = 0
+
     prefix_cache_stats: PrefixCacheStats = field(default_factory=PrefixCacheStats)
     connector_prefix_cache_stats: PrefixCacheStats | None = None
 


### PR DESCRIPTION
## Purpose

Protect active decode from long-prefill pressure while preserving bounded
progress for waiting prompts. The controls are optional and apply only when a
scheduler step has eligible decode work.

## Behavior

The scheduler exposes four zero-default controls:

- `--max-num-prefill-tokens-per-step` caps local prefill tokens in a step that
  also has eligible decode work. Prefill-only steps retain the complete
  `--max-num-batched-tokens` budget.
- `--max-num-partial-prefills` limits requests that may remain partially
  prefilling. A request that completes prefill in the step may still be
  admitted.
- `--decode-prefill-min-decode-steps` requires a number of decode-only steps
  between mixed-prefill releases. It requires a nonzero mixed-prefill token
  budget.
- `--decode-prefill-max-wait-ms` lets the oldest waiting prefill bypass the
  decode-only interval after its deadline.

Mixed-prefill work is divided into rotating quanta so running prompts make
round-robin progress. Mamba `align` mode uses the least common multiple of its
cache block sizes as the quantum; other models use one-token quanta. One quantum
is reserved for a waiting request when a sequence slot and partial-prefill slot
are available.

Prometheus exports the governed token count, active partial-prefill count,
decode-only step count, and fairness-deadline bypass count. The token counter
excludes prefill-only work that is not governed by the mixed-step budget.

## Compatibility

All four controls default to zero, so scheduling policy remains unchanged
unless an operator enables them. The active-partial-prefill gauge is observable
without enabling the policy. Mamba `align` configurations reject a nonzero
mixed-prefill budget that is not a multiple of the derived cache quantum.

The PR does not change prefix-cache retention, external KV connectors, DCP
collectives, attention backends, sampling, or model outputs.

## Validation

The following tests ran against the source tree with a Python 3.12, PyTorch
2.10 test environment:

```text
tests/v1/core/test_scheduler.py
  -k 'mixed_prefill or decode_burst or partial_prefill'
  8 passed, 153 deselected

tests/v1/metrics/test_stats.py
  12 passed
```

Repository pre-commit hooks passed Ruff, formatting, mypy, typos, SPDX,
configuration-default validation, forbidden-import checks, and CUDA API guards.
`git diff --check` passed.

GPU throughput and high-concurrency service quality are not claimed by this PR;
the scheduler policy requires workload-specific values and an A/B qualification
before deployment.

## Related changes

- #556 corrects local Mamba prefix-state retention for EAGLE/MTP replay.
- #560 handles empty DCP ranks and sparse MLA query gathering.
- #589 defines GLM-5.3 DFlash cache semantics and cache geometry.
- This PR replaces only the scheduler-policy and scheduler-metrics scope of
  #583. Hybrid prefix-cache diagnostics from #583 are excluded because their
  implementation performs an additional per-group cache lookup on the
  admission path.

All commits retain `logprobz` as the author. OpenAI Codex assisted with the
scope split, validation, and documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable mixed prefill/decode scheduling to balance prompt processing with token generation.
  * Added controls for prefill token budgets, partial-prefill limits, decode bursts, and maximum prefill wait time.
  * Added fairness safeguards to reduce request starvation and support round-robin prefill processing.
  * Added scheduler metrics for prefill activity, partial prefills, decode-only steps, and fairness bypasses.
  * Added command-line options for configuring the new scheduling behavior.

* **Bug Fixes**
  * Added validation to reject incompatible or out-of-range scheduling configurations.

* **Tests**
  * Added coverage for budgeting, fairness, validation, starvation prevention, and metric serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->