### PR TITLE
distributed: RoCEnante shim for b12x one-shot RoCE collectives on multi-node DGX Spark

### DIFF
--- a/tests/v1/worker/test_b12x_roce_health.py
+++ b/tests/v1/worker/test_b12x_roce_health.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Placement of the RoCEnante fail-stop health check in the GPU worker.
+
+The four-node adapter tests in b12x establish the GPU behaviour; this test
+pins where the worker runs the check relative to the step's device-to-host
+completion: immediately for a synchronous output (or ``None``), and only after
+``get_output()`` for an asynchronous output.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import vllm.v1.worker.gpu_worker as gpu_worker_module
+from vllm.v1.outputs import AsyncModelRunnerOutput, ModelRunnerOutput
+from vllm.v1.worker.gpu_worker import Worker, _B12xRoceCheckedAsyncOutput
+
+
+class _AsyncOutput(AsyncModelRunnerOutput):
+    def __init__(self, result: ModelRunnerOutput, trace: list[str]) -> None:
+        self._result = result
+        self._trace = trace
+
+    def get_output(self) -> ModelRunnerOutput:
+        self._trace.append("get_output")
+        return self._result
+
+
+def _worker_with_communicator(monkeypatch, comm) -> Worker:
+    worker = Worker.__new__(Worker)  # no GPU, no init: only the helpers are used
+    group = SimpleNamespace(device_communicator=SimpleNamespace(b12x_ar_comm=comm))
+    monkeypatch.setattr(gpu_worker_module, "get_tp_group", lambda: group)
+    return worker
+
+
+def _sync_output() -> ModelRunnerOutput:
+    return ModelRunnerOutput(
+        req_ids=["r0"],
+        req_id_to_index={"r0": 0},
+        sampled_token_ids=[[1]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+
+def test_sync_output_is_checked_immediately(monkeypatch):
+    comm = Mock()
+    worker = _worker_with_communicator(monkeypatch, comm)
+    output = _sync_output()
+    assert worker._b12x_roce_guarded(output) is output
+    comm.check_health.assert_called_once_with()
+
+
+def test_none_output_is_checked_and_passed_through(monkeypatch):
+    comm = Mock()
+    worker = _worker_with_communicator(monkeypatch, comm)
+    assert worker._b12x_roce_guarded(None) is None
+    comm.check_health.assert_called_once_with()
+
+
+def test_async_output_is_checked_after_completion(monkeypatch):
+    trace: list[str] = []
+    comm = Mock()
+    comm.check_health.side_effect = lambda: trace.append("check")
+    worker = _worker_with_communicator(monkeypatch, comm)
+    result = _sync_output()
+    wrapped = worker._b12x_roce_guarded(_AsyncOutput(result, trace))
+    assert isinstance(wrapped, _B12xRoceCheckedAsyncOutput)
+    assert isinstance(wrapped, AsyncModelRunnerOutput)
+    assert trace == []  # nothing checked before the copy to host completes
+    assert wrapped.get_output() is result
+    assert trace == ["get_output", "check"]
+
+
+def test_failure_propagates_from_sync_and_async(monkeypatch):
+    comm = Mock()
+    comm.check_health.side_effect = RuntimeError("poisoned")
+    worker = _worker_with_communicator(monkeypatch, comm)
+    with pytest.raises(RuntimeError, match="poisoned"):
+        worker._b12x_roce_guarded(_sync_output())
+    wrapped = worker._b12x_roce_guarded(_AsyncOutput(_sync_output(), []))
+    with pytest.raises(RuntimeError, match="poisoned"):
+        wrapped.get_output()
+
+
+def test_no_roce_communicator_means_no_wrapping(monkeypatch):
+    for comm in (None, SimpleNamespace()):  # no adapter, or one without a check
+        worker = _worker_with_communicator(monkeypatch, comm)
+        output = _sync_output()
+        assert worker._b12x_roce_guarded(output) is output
+        async_output = _AsyncOutput(output, [])
+        assert worker._b12x_roce_guarded(async_output) is async_output

--- a/vllm/distributed/device_communicators/b12x_roce_all_reduce.py
+++ b/vllm/distributed/device_communicators/b12x_roce_all_reduce.py
@@ -6,6 +6,23 @@ Thin shim: capability voting, construction, and size gating live here; the
 protocol lives in ``b12x.comm.roce``.  Enabled with
 ``VLLM_ENABLE_ROCE_ALLREDUCE=1`` for tensor-parallel groups whose ranks span
 nodes; single-node groups keep their existing backends.
+
+Contract with the runtime (``b12x.comm.roce.API_VERSION`` ==
+``REQUIRED_B12X_ROCE_API_VERSION``):
+
+- Every rank parses the size limits and checks the API version before the
+  vote; the parsed limits are exchanged and must be identical, and the
+  runtime itself refuses ranks whose ABI, HCA count, slot geometry, spin
+  limit or launch geometry differ.  Any rank that cannot take part disables
+  the backend on every rank, at initialization only.
+- Dispatch is rank-invariant: eligibility depends on dtype, shape, contiguity
+  and size, never on pointer values, so all ranks route the same collective.
+- Failures are fail-stop, never a fallback: a wait that times out freezes the
+  runtime, later launches do nothing, and ``check_health`` (called by the
+  worker after each step's host synchronization) raises so the step's output
+  never leaves the worker.  Peers starve on the stalled rank and raise too.
+- The runtime orders collectives across streams with an event and requires a
+  single stream inside a CUDA graph capture, which is how vLLM captures.
 """
 
 from __future__ import annotations
@@ -24,6 +41,9 @@ from vllm.distributed.parallel_state import in_the_same_node_as
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+
+REQUIRED_B12X_ROCE_API_VERSION = 1
 
 
 class B12xRoceAllReduce:
@@ -55,21 +75,19 @@ class B12xRoceAllReduce:
             return
 
         # Vote before the collective constructor so a rank that cannot take
-        # part fails every rank cleanly instead of leaving peers in a gather.
-        reason = self._local_capability()
-        if not self._all_ranks_succeeded(reason):
-            if reason is not None:
-                logger.warning(
-                    "RoCEnante unavailable on rank %d: %s", self.rank, reason
-                )
-            else:
-                logger.warning("RoCEnante unavailable on another rank.")
+        # part (missing package, wrong API version, unsupported device, or an
+        # unparsable limit) disables the backend on every rank instead of
+        # leaving peers in the runtime's setup exchange.  The parsed limits
+        # travel with the vote and must be identical everywhere.
+        reason, limits = self._local_capability()
+        verdict = self._exchange_vote(reason, limits)
+        if verdict is not None:
+            logger.warning("RoCEnante disabled on every rank: %s", verdict)
             return
+        max_size, max_gather = limits
 
         from b12x.comm import roce
 
-        max_size = _parse_byte_size(envs.VLLM_ROCE_ALLREDUCE_MAX_SIZE)
-        max_gather = _parse_byte_size(envs.VLLM_ROCE_ALLGATHER_MAX_SIZE)
         try:
             # Exchange setup over the CPU (gloo) group: using the torch NCCL
             # group would create a torch NCCL communicator that vLLM otherwise
@@ -94,19 +112,54 @@ class B12xRoceAllReduce:
                 max_gather,
             )
 
-    def _local_capability(self) -> str | None:
+    def _local_capability(self) -> tuple[str | None, tuple[int, int] | None]:
+        """(reason this rank cannot take part, parsed (max_size, max_gather))."""
         try:
             from b12x.comm import roce
         except ModuleNotFoundError:
-            return "b12x.comm.roce is not installed"
+            return "b12x.comm.roce is not installed", None
+        api = getattr(roce, "API_VERSION", None)
+        if api != REQUIRED_B12X_ROCE_API_VERSION:
+            needed = REQUIRED_B12X_ROCE_API_VERSION
+            return f"b12x.comm.roce API version {api}, adapter needs {needed}", None
         if not roce.is_supported(self.device):
-            return "needs an integrated GPU with an active RDMA device"
+            return "needs an integrated GPU with an active RDMA device", None
+        try:
+            limits = (
+                _parse_byte_size(envs.VLLM_ROCE_ALLREDUCE_MAX_SIZE),
+                _parse_byte_size(envs.VLLM_ROCE_ALLGATHER_MAX_SIZE),
+            )
+        except Exception as exc:  # noqa: BLE001 - reported through the vote
+            return f"invalid RoCEnante size limit: {exc}", None
+        return None, limits
+
+    def _exchange_vote(
+        self, reason: str | None, limits: tuple[int, int] | None
+    ) -> str | None:
+        """Gather every rank's reason and limits; None when all can proceed."""
+        votes: list[tuple[str | None, tuple[int, int] | None]] = [
+            (None, None)
+        ] * self.world_size
+        dist.all_gather_object(votes, (reason, limits), group=self.group)
+        failures = [f"rank {i}: {r}" for i, (r, _) in enumerate(votes) if r]
+        if failures:
+            return "; ".join(failures)
+        reference = votes[0][1]
+        differing = [
+            f"rank {i}: {lim}" for i, (_, lim) in enumerate(votes) if lim != reference
+        ]
+        if differing:
+            return (
+                f"size limits differ across ranks (rank 0: {reference}; "
+                + "; ".join(differing)
+                + ")"
+            )
         return None
 
-    def _all_ranks_succeeded(self, reason: str | None) -> bool:
-        failed = torch.tensor([int(reason is not None)], dtype=torch.int32)
-        dist.all_reduce(failed, op=dist.ReduceOp.MAX, group=self.group)
-        return int(failed.item()) == 0
+    def check_health(self) -> None:
+        """Raise if a RoCEnante wait timed out or the proxy died (fail-stop)."""
+        if not self.disabled and self._runtime is not None:
+            self._runtime.check_health()
 
     def should_custom_ar(self, inp: torch.Tensor) -> bool:
         return not self.disabled and self._runtime.should_allreduce(inp)
@@ -153,7 +206,9 @@ class B12xRoceAllReduce:
         if self.disabled:
             yield
             return
-        # Compile before capture; the runtime refuses to compile inside a graph.
+        # Compile and allocate scratch before capture; the runtime refuses both
+        # inside a graph.  vLLM's gather shards have 16-byte rows (direct
+        # layout), so the padded-gather scratch is not requested here.
         self._runtime.prepare((torch.bfloat16, torch.float16, torch.float32))
         with self._runtime.capture(stream=stream):
             yield

--- a/vllm/distributed/device_communicators/b12x_roce_all_reduce.py
+++ b/vllm/distributed/device_communicators/b12x_roce_all_reduce.py
@@ -113,11 +113,16 @@ class B12xRoceAllReduce:
             )
 
     def _local_capability(self) -> tuple[str | None, tuple[int, int] | None]:
-        """(reason this rank cannot take part, parsed (max_size, max_gather))."""
+        """Evaluate this rank's ability to take part, without any collective.
+
+        Returns:
+            A pair of the reason this rank cannot take part (None when it can)
+            and the parsed ``(max_size, max_gather)`` limits (None on failure).
+        """
         try:
             from b12x.comm import roce
-        except ModuleNotFoundError:
-            return "b12x.comm.roce is not installed", None
+        except ImportError as exc:  # missing package or a broken native build
+            return f"b12x.comm.roce is not importable: {exc}", None
         api = getattr(roce, "API_VERSION", None)
         if api != REQUIRED_B12X_ROCE_API_VERSION:
             needed = REQUIRED_B12X_ROCE_API_VERSION
@@ -136,7 +141,16 @@ class B12xRoceAllReduce:
     def _exchange_vote(
         self, reason: str | None, limits: tuple[int, int] | None
     ) -> str | None:
-        """Gather every rank's reason and limits; None when all can proceed."""
+        """Gather every rank's capability result over the CPU group.
+
+        Args:
+            reason: This rank's reason for not taking part, or None.
+            limits: This rank's parsed ``(max_size, max_gather)``, or None.
+
+        Returns:
+            None when every rank can proceed with identical limits, else the
+            text naming the ranks that cannot or whose limits differ.
+        """
         votes: list[tuple[str | None, tuple[int, int] | None]] = [
             (None, None)
         ] * self.world_size
@@ -157,7 +171,11 @@ class B12xRoceAllReduce:
         return None
 
     def check_health(self) -> None:
-        """Raise if a RoCEnante wait timed out or the proxy died (fail-stop)."""
+        """Fail-stop check of the runtime.
+
+        Raises:
+            RuntimeError: When a RoCEnante wait timed out or its proxy died.
+        """
         if not self.disabled and self._runtime is not None:
             self._runtime.check_health()
 

--- a/vllm/distributed/device_communicators/b12x_roce_all_reduce.py
+++ b/vllm/distributed/device_communicators/b12x_roce_all_reduce.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""RoCEnante: adapter for the b12x one-shot RoCE collectives (multi-node DGX Spark TP).
+
+Thin shim: capability voting, construction, and size gating live here; the
+protocol lives in ``b12x.comm.roce``.  Enabled with
+``VLLM_ENABLE_ROCE_ALLREDUCE=1`` for tensor-parallel groups whose ranks span
+nodes; single-node groups keep their existing backends.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+import vllm.envs as envs
+from vllm.distributed.device_communicators.b12x_pcie_all_reduce import (
+    _parse_byte_size,
+)
+from vllm.distributed.parallel_state import in_the_same_node_as
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class B12xRoceAllReduce:
+    """Route eligible tensor-parallel all-reduces to ``b12x.comm.roce``."""
+
+    backend_name = "B12X_ROCENANTE"
+
+    def __init__(
+        self,
+        group: ProcessGroup,
+        device_group: ProcessGroup | None,
+        device: torch.device,
+    ) -> None:
+        self.disabled = True
+        self.group = group
+        self.device_group = device_group
+        self.device = device
+        self.rank = dist.get_rank(group=group)
+        self.world_size = dist.get_world_size(group=group)
+        self._runtime = None
+        self._announced = False
+        self._announced_gather = False
+
+        if device_group is None:
+            logger.warning("RoCEnante requires a CUDA process group.")
+            return
+        if all(in_the_same_node_as(group, source_rank=0)):
+            logger.info("RoCEnante skipped: group is single-node.")
+            return
+
+        # Vote before the collective constructor so a rank that cannot take
+        # part fails every rank cleanly instead of leaving peers in a gather.
+        reason = self._local_capability()
+        if not self._all_ranks_succeeded(reason):
+            if reason is not None:
+                logger.warning(
+                    "RoCEnante unavailable on rank %d: %s", self.rank, reason
+                )
+            else:
+                logger.warning("RoCEnante unavailable on another rank.")
+            return
+
+        from b12x.comm import roce
+
+        max_size = _parse_byte_size(envs.VLLM_ROCE_ALLREDUCE_MAX_SIZE)
+        max_gather = _parse_byte_size(envs.VLLM_ROCE_ALLGATHER_MAX_SIZE)
+        try:
+            # Exchange setup over the CPU (gloo) group: using the torch NCCL
+            # group would create a torch NCCL communicator that vLLM otherwise
+            # never needs, costing ~3.4 GB of unified memory per rank on Spark.
+            self._runtime = roce.AllReduce.from_exchange_group(
+                exchange_group=group,
+                device=device,
+                max_size=max_size,
+                max_gather_bytes=max_gather,
+            )
+        except Exception as exc:  # noqa: BLE001 - the runtime already coordinated ranks
+            logger.warning("RoCEnante initialization failed: %s", exc)
+            return
+        self.disabled = False
+        if self.rank == 0:
+            logger.info(
+                "Using RoCEnante (b12x one-shot RoCE collectives): world=%d, hcas=%s, "
+                "all-reduce max=%d bytes, all-gather shard max=%d bytes.",
+                self.world_size,
+                ",".join(self._runtime.hca_names),
+                max_size,
+                max_gather,
+            )
+
+    def _local_capability(self) -> str | None:
+        try:
+            from b12x.comm import roce
+        except ModuleNotFoundError:
+            return "b12x.comm.roce is not installed"
+        if not roce.is_supported(self.device):
+            return "needs an integrated GPU with an active RDMA device"
+        return None
+
+    def _all_ranks_succeeded(self, reason: str | None) -> bool:
+        failed = torch.tensor([int(reason is not None)], dtype=torch.int32)
+        dist.all_reduce(failed, op=dist.ReduceOp.MAX, group=self.group)
+        return int(failed.item()) == 0
+
+    def should_custom_ar(self, inp: torch.Tensor) -> bool:
+        return not self.disabled and self._runtime.should_allreduce(inp)
+
+    def custom_all_reduce(self, inp: torch.Tensor) -> torch.Tensor | None:
+        if not self.should_custom_ar(inp):
+            return None
+        if not self._announced:
+            self._announced = True
+            # One confirmation line, rank 0 only; workers keep it at debug.
+            log = logger.info if self.rank == 0 else logger.debug
+            log(
+                "RoCEnante all-reduce is live: first routed all-reduce is %d bytes "
+                "(%s); NCCL remains the fallback above %s.",
+                inp.numel() * inp.element_size(),
+                str(inp.dtype).replace("torch.", ""),
+                envs.VLLM_ROCE_ALLREDUCE_MAX_SIZE,
+            )
+        return self._runtime.all_reduce(inp)
+
+    def should_all_gather(self, inp: torch.Tensor, dim: int) -> bool:
+        return not self.disabled and self._runtime.should_all_gather(inp, dim)
+
+    def all_gather(self, inp: torch.Tensor, dim: int) -> torch.Tensor:
+        """Concatenate along ``dim`` (0 or last) directly in the output layout."""
+
+        if not self._announced_gather:
+            self._announced_gather = True
+            log = logger.info if self.rank == 0 else logger.debug
+            log(
+                "RoCEnante all-gather is live: first routed shard is %s %s "
+                "along dim %d.",
+                tuple(inp.shape),
+                str(inp.dtype).replace("torch.", ""),
+                dim,
+            )
+        return self._runtime.all_gather(inp, dim=dim)
+
+    def supports_fused_add_rms_norm(self) -> bool:
+        return False
+
+    @contextmanager
+    def capture(self, stream: torch.cuda.Stream | None = None):
+        if self.disabled:
+            yield
+            return
+        # Compile before capture; the runtime refuses to compile inside a graph.
+        self._runtime.prepare((torch.bfloat16, torch.float16, torch.float32))
+        with self._runtime.capture(stream=stream):
+            yield
+
+    def close(self) -> None:
+        if self._runtime is not None:
+            self._runtime.close()
+            self._runtime = None
+        self.disabled = True

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -54,6 +54,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
             use_flashinfer_allreduce = False
             use_aiter_allreduce = False
             use_b12x_allreduce = False
+            use_roce_allreduce = False
         else:
             from vllm.distributed.parallel_state import _ENABLE_CUSTOM_ALL_REDUCE
 
@@ -71,7 +72,10 @@ class CudaCommunicator(DeviceCommunicatorBase):
                 and envs.VLLM_ENABLE_PCIE_ALLREDUCE
                 and envs.VLLM_PCIE_ALLREDUCE_BACKEND == "b12x"
             )
-            if use_b12x_allreduce:
+            use_roce_allreduce = (
+                use_custom_allreduce and envs.VLLM_ENABLE_ROCE_ALLREDUCE
+            )
+            if use_b12x_allreduce or use_roce_allreduce:
                 use_flashinfer_allreduce = False
 
         self.use_custom_allreduce = use_custom_allreduce
@@ -79,6 +83,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
         self.use_flashinfer_allreduce = use_flashinfer_allreduce
         self.use_aiter_allreduce = use_aiter_allreduce
         self.use_b12x_allreduce = use_b12x_allreduce
+        self.use_roce_allreduce = use_roce_allreduce
 
         # lazy import to avoid documentation build error
         from vllm.distributed.device_communicators.custom_all_reduce import (
@@ -113,6 +118,16 @@ class CudaCommunicator(DeviceCommunicatorBase):
             from .b12x_pcie_all_reduce import B12xPcieAllReduce
 
             self.b12x_ar_comm = B12xPcieAllReduce(
+                group=self.cpu_group,
+                device_group=self.device_group,
+                device=self.device,
+            )
+        elif self.use_roce_allreduce and self.world_size > 1:
+            # RoCEnante: multi-node DGX Spark one-shot RDMA collectives
+            # from b12x.comm.roce.
+            from .b12x_roce_all_reduce import B12xRoceAllReduce
+
+            self.b12x_ar_comm = B12xRoceAllReduce(
                 group=self.cpu_group,
                 device_group=self.device_group,
                 device=self.device,
@@ -245,6 +260,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
         """
         all_potential_ar_backends = [
             "B12X_PCIE",
+            "B12X_ROCENANTE",
             "FLASHINFER",
             "NCCL_SYMM_MEM",
             "QUICK_REDUCE",
@@ -255,7 +271,9 @@ class CudaCommunicator(DeviceCommunicatorBase):
         ]
         enabled_ar_backends: list[str] = []
         if self.b12x_ar_comm is not None and not self.b12x_ar_comm.disabled:
-            enabled_ar_backends.append("B12X_PCIE")
+            enabled_ar_backends.append(
+                getattr(self.b12x_ar_comm, "backend_name", "B12X_PCIE")
+            )
         if self.fi_ar_comm is not None and not self.fi_ar_comm.disabled:
             enabled_ar_backends.append("FLASHINFER")
         # Mirror the static preconditions of `should_nccl_symm_mem_allreduce`:
@@ -402,6 +420,16 @@ class CudaCommunicator(DeviceCommunicatorBase):
         # gather-before-GEMM uses dim=0 with tp-aligned (uniform) shards.
         if dim < 0:
             dim += input_.dim()
+        # RoCEnante all-gather (writes the concatenated
+        # layout directly, so no reshape/copy follows).
+        b12x_ar_comm = self.b12x_ar_comm
+        if (
+            b12x_ar_comm is not None
+            and not b12x_ar_comm.disabled
+            and getattr(b12x_ar_comm, "should_all_gather", None) is not None
+            and b12x_ar_comm.should_all_gather(input_, dim)
+        ):
+            return b12x_ar_comm.all_gather(input_, dim)
         if dim == 0 and should_nccl_symm_mem_ag_rs():
             return self._all_gather_symm_mem(input_.contiguous())
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -225,6 +225,9 @@ if TYPE_CHECKING:
     VLLM_ENABLE_PCIE_ALLREDUCE: bool = False
     VLLM_PCIE_ALLREDUCE_BACKEND: Literal["b12x"] = "b12x"
     VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE: str = "84KB"
+    VLLM_ENABLE_ROCE_ALLREDUCE: bool = False
+    VLLM_ROCE_ALLREDUCE_MAX_SIZE: str = "2MB"
+    VLLM_ROCE_ALLGATHER_MAX_SIZE: str = "16MB"
     VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE: str = "84KB"
     VLLM_PCIE_DMA_MIN_BYTES: str = "6MB"
     VLLM_PCIE_DMA_FP8: str | None = None
@@ -1902,6 +1905,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
         "VLLM_PCIE_ALLREDUCE_BACKEND", "b12x", ["b12x"]
     ),
     # Maximum input sizes dispatched to the low-latency one-shot kernels.
+    # Enable the b12x one-shot RoCE all-reduce for multi-node TP (DGX Spark).
+    "VLLM_ENABLE_ROCE_ALLREDUCE": lambda: bool(
+        int(os.getenv("VLLM_ENABLE_ROCE_ALLREDUCE", "0"))
+    ),
+    "VLLM_ROCE_ALLREDUCE_MAX_SIZE": lambda: os.getenv(
+        "VLLM_ROCE_ALLREDUCE_MAX_SIZE", "2MB"
+    ),
+    # Largest per-rank shard routed to the RoCE all-gather
+    # (e.g. logits [rows, vocab/tp]).
+    "VLLM_ROCE_ALLGATHER_MAX_SIZE": lambda: os.getenv(
+        "VLLM_ROCE_ALLGATHER_MAX_SIZE", "16MB"
+    ),
     "VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE": lambda: os.getenv(
         "VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE", "84KB"
     ),

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -141,6 +141,30 @@ class AsyncIntermediateTensors(IntermediateTensors):
         return object.__getattribute__(self, name)
 
 
+
+class _B12xRoceCheckedAsyncOutput(AsyncModelRunnerOutput):
+    """An asynchronous output whose completion is followed by the RoCEnante check."""
+
+    def __init__(
+        self, inner: AsyncModelRunnerOutput, check: Callable[[], None]
+    ) -> None:
+        self._inner = inner
+        self._check = check
+
+    def get_output(self) -> ModelRunnerOutput:
+        """Wait for the wrapped output, then run the fail-stop check.
+
+        Returns:
+            The completed ModelRunnerOutput.
+
+        Raises:
+            RuntimeError: When a RoCEnante wait timed out or its proxy died.
+        """
+        output = self._inner.get_output()
+        self._check()
+        return output
+
+
 class Worker(WorkerBase):
     def __init__(
         self,
@@ -1066,26 +1090,49 @@ class Worker(WorkerBase):
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput:
-        output = self.model_runner.sample_tokens(grammar_output)
-        self._check_b12x_roce_health()
-        return output
+        return self._b12x_roce_guarded(
+            self.model_runner.sample_tokens(grammar_output)
+        )
 
-    def _check_b12x_roce_health(self) -> None:
-        """Fail-stop check for RoCEnante collectives, after the step's host sync.
+    def _b12x_roce_health_check(self) -> Callable[[], None] | None:
+        """The RoCEnante health check of the TP communicator, if one is active.
 
-        A RoCEnante wait that timed out records itself and freezes the runtime;
-        the sampled tokens are on the host here, so every collective of the step
-        has completed and raising now keeps the step's output from leaving the
-        worker.  Every rank reaches the same state on its own (a stalled rank
-        starves its peers' waits), so the raise is coordinated without a
-        supervisor.  With async scheduling the copy to host is deferred and the
-        check lands one step late.  Two pinned-memory reads; no synchronization.
+        Returns:
+            The check callable, or None when RoCEnante is not in use.
         """
         communicator = get_tp_group().device_communicator
         comm = getattr(communicator, "b12x_ar_comm", None)
-        check = getattr(comm, "check_health", None)
-        if check is not None:
-            check()
+        return getattr(comm, "check_health", None)
+
+    def _b12x_roce_guarded(self, output):
+        """Fail-stop RoCEnante check once the step's output is on the host.
+
+        A RoCEnante wait that timed out records itself and freezes the runtime.
+        A synchronous output already holds the sampled tokens on the host, so
+        every collective of the step has completed and the check runs now; an
+        asynchronous output is wrapped so the check runs right after its
+        ``get_output()`` completes the copy.  Either way a failed collective's
+        output never leaves the worker.  Every rank reaches the same state on
+        its own (a stalled rank starves its peers' waits), so the raise is
+        coordinated without a supervisor.  Two pinned-memory reads; no added
+        synchronization.
+
+        Args:
+            output: The model runner's output for this step, possibly None.
+
+        Returns:
+            The same output, or a wrapper for an asynchronous output.
+
+        Raises:
+            RuntimeError: When a RoCEnante wait timed out or its proxy died.
+        """
+        check = self._b12x_roce_health_check()
+        if check is None:
+            return output
+        if isinstance(output, AsyncModelRunnerOutput):
+            return _B12xRoceCheckedAsyncOutput(output, check)
+        check()
+        return output
 
     @torch.inference_mode()
     @with_gpu_sync_check
@@ -1161,8 +1208,7 @@ class Worker(WorkerBase):
             if isinstance(
                 output, ModelRunnerOutput | AsyncModelRunnerOutput | NoneType
             ):
-                self._check_b12x_roce_health()
-                return output
+                return self._b12x_roce_guarded(output)
 
         assert isinstance(output, IntermediateTensors)
         parallel_config = self.vllm_config.parallel_config

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1066,7 +1066,26 @@ class Worker(WorkerBase):
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput:
-        return self.model_runner.sample_tokens(grammar_output)
+        output = self.model_runner.sample_tokens(grammar_output)
+        self._check_b12x_roce_health()
+        return output
+
+    def _check_b12x_roce_health(self) -> None:
+        """Fail-stop check for RoCEnante collectives, after the step's host sync.
+
+        A RoCEnante wait that timed out records itself and freezes the runtime;
+        the sampled tokens are on the host here, so every collective of the step
+        has completed and raising now keeps the step's output from leaving the
+        worker.  Every rank reaches the same state on its own (a stalled rank
+        starves its peers' waits), so the raise is coordinated without a
+        supervisor.  With async scheduling the copy to host is deferred and the
+        check lands one step late.  Two pinned-memory reads; no synchronization.
+        """
+        communicator = get_tp_group().device_communicator
+        comm = getattr(communicator, "b12x_ar_comm", None)
+        check = getattr(comm, "check_health", None)
+        if check is not None:
+            check()
 
     @torch.inference_mode()
     @with_gpu_sync_check
@@ -1142,6 +1161,7 @@ class Worker(WorkerBase):
             if isinstance(
                 output, ModelRunnerOutput | AsyncModelRunnerOutput | NoneType
             ):
+                self._check_b12x_roce_health()
                 return output
 
         assert isinstance(output, IntermediateTensors)


### PR DESCRIPTION
## TL;DR

Thin shim that routes tensor-parallel all-reduces and all-gathers to **RoCEnante** (`b12x.comm.roce`, local-inference-lab/b12x#295) on multi-node DGX Spark. With it enabled, the GLM-5.3-Flash TP4 decode step runs with **zero NCCL kernels**; measured with nothing else changed: decode per-step latency down 5–19% across a 15-cell concurrency × context matrix, c=16 throughput +15–23%, coding-peak c=1 +12.7%, prefill unchanged. Four files, ~300 lines, off by default. Pinned to `b12x.comm.roce.API_VERSION == 1` (b12x#295 at `00280f2` or later).

Depends on the b12x package from local-inference-lab/b12x#295 being present in the image; without it (or on a single-node group, or a non-integrated GPU) the adapter logs once and every collective stays on its current backend.

## What changed

- `vllm/distributed/device_communicators/b12x_roce_all_reduce.py` (new): `B12xRoceAllReduce`, mirroring `B12xPcieAllReduce`. Votes capability across ranks over the CPU group before the collective constructor (so a rank that cannot participate fails every rank cleanly instead of leaving peers in a gather), constructs the runtime, gates by size/dtype/layout, and exposes `should_custom_ar`/`custom_all_reduce` and `should_all_gather`/`all_gather`. First routed all-reduce and all-gather each log one line on rank 0. `supports_fused_add_rms_norm()` is `False`, so the all-reduce+RMSNorm fusion pass ignores it.
- `vllm/distributed/device_communicators/cuda_communicator.py`: constructs the adapter into the existing `b12x_ar_comm` slot when `VLLM_ENABLE_ROCE_ALLREDUCE` is set (so the all-reduce dispatch, graph-capture context, backend listing and `close` paths need no changes); one hook at the top of `all_gather` for eligible dim-0 / last-dim gathers, which the runtime writes directly in the concatenated layout so the reshape/copy after `pynccl.all_gather` is skipped; `B12X_ROCENANTE` in the potential-backend list.
- `vllm/envs.py`: `VLLM_ENABLE_ROCE_ALLREDUCE` (0), `VLLM_ROCE_ALLREDUCE_MAX_SIZE` (2MB, covers the 192-token max capture batch), `VLLM_ROCE_ALLGATHER_MAX_SIZE` (16MB per-rank shard).
- `vllm/v1/worker/gpu_worker.py` (`aef3576`, `5272694`): the fail-stop check runs after `sample_tokens` and before returning `execute_model` output; an `AsyncModelRunnerOutput` is wrapped so the check follows its `get_output()`. `tests/v1/worker/test_b12x_roce_health.py` (`a7935eb`) pins that placement for synchronous, `None` and asynchronous outputs without a GPU. That point is after the step's own device-to-host copy of the sampled tokens, so every collective of the step has completed; a RoCEnante wait that timed out has frozen the runtime by then and the raise keeps the step's output from leaving the worker. Two pinned-memory reads, no added synchronization. With async scheduling the copy is deferred and the check lands one step late.

Contract with the runtime (`aef3576`): every rank parses both size limits and checks `API_VERSION` **before** the capability vote, the parsed limits travel with the vote over the gloo group and must be identical, so an invalid or inconsistent environment disables the backend on every rank instead of stranding peers in the runtime's setup exchange (the runtime additionally refuses ranks whose proxy ABI, HCA count, slot geometry, spin limit or launch geometry differ). Dispatch is rank-invariant (the runtime decides from dtype, shape, contiguity and size, never pointer values). Failures are fail-stop, never a fallback: peers of a stalled rank starve on their next wait and raise on their own, so the worker group converges without a supervisor.

Setup exchange uses the gloo group on purpose: exchanging over the torch NCCL device group makes torch build its own NCCL communicator, which costs ~3.4 GB of unified memory per rank on Spark and pushed the tightest rank under its earlyoom line.

## Evidence (four DGX Spark, GLM-5.3-Flash NVFP4 + DFlash2 MTP5, TP4)

Serving A/B with `llm-decode-bench` (30 s sustained-decode cells, exact token targeting, coding-prompt peak test), only difference the shim:

| Cell | NCCL tok/s | RoCEnante tok/s | Δ | Step latency NCCL → RoCEnante |
|---|---|---|---|---|
| c1 @ 0k / 16k / 32k | 42.9 / 38.6 / 40.3 | 37.9 / 40.8 / 41.8 | −12 / +6 / +4% | 64–66 → 59–60 ms |
| c4 @ 0k / 16k / 32k | 99.8 / 86.3 / 89.3 | 98.2 / 103.2 / 102.7 | −2 / +20 / +15% | 110 → 99 ms |
| c8 @ 0k / 16k / 32k | 128.6 / 118.7 / 118.0 | 146.1 / 130.3 / 116.7 | +14 / +10 / −1% | 162 → 148 ms |
| c16 @ 0k / 16k / 32k | 174.4 / 166.7 / 159.6 | 213.9 / 192.0 / 190.4 | +23 / +15 / +19% | 246 → 204 ms |
| coding peak c1 (median of 5) | 69.8 | 78.7 | +12.7% | |
| cold prefill 8k / 32k / 128k | 2612 / 2761 / 2699 | 2613 / 2781 / 2717 | ~0 | unchanged |

Per-step latency is the direct signal and is lower in every cell (~100 all-reduces per step, ~30–40 us saved each); gains grow with concurrency because the all-reduce share of the step grows with batch size; c=1 throughput on padding text swings ±10% run to run with speculative acceptance (later runs of the same c1@0k cell against the same NCCL 42.9 measured 41.8, 45.7 and 47.7 tok/s, −3% to +11%), so the coding peak is the c=1 number to read; prefill's 64 MB all-reduces are above the cap and stay on NCCL by design.

Decode-step profile (8 iterations, CUDA graphs) after routing the all-gather: 0 NCCL kernels, 102 RoCEnante all-reduces, 3 RoCEnante all-gathers per step. The full breakdown is in the b12x PR; communication is now ~6% of the step.

Tried and not adopted alongside this (recorded so nobody repeats them): `--async-scheduling` (no gain; the step is GPU-bound at 97% busy), and enabling `GateLinear`'s cuteDSL router path on SM121 (engages and is correct, but 15 us vs 9 us for cuBLAS on GB10).

## Serving A/B on the final heads (2026-09-03)

Same four nodes, one image (`roce10`, built from this branch at `aef3576` and b12x#295 at `00280f2`), RoCEnante toggled by `VLLM_ENABLE_ROCE_ALLREDUCE` alone, arms run back to back. Full receipt with commands, revisions, GPU UUIDs, startup backend lines, sanity output and per-request raw samples: `docs/evidence/rocenante/serving-ab-final-20260903/` in b12x#295.

| Cell | NCCL tok/s | RoCEnante tok/s | Δ | Step latency NCCL → RoCEnante |
|---|---|---|---|---|
| c1 @ 0k / 16k / 32k | 39.4 / 39.1 / 36.5 | 40.8 / 37.0 / 40.8 | +4 / −6 / +12% | 65–66 → 62–64 ms |
| c2 @ 0k / 16k / 32k | 58.4 / 53.7 / 55.9 | 61.9 / 54.4 / 59.4 | +6 / +1 / +6% | 88–89 → 86–89 ms |
| c4 @ 0k / 16k / 32k | 92.1 / 89.6 / 80.4 | 108.9 / 94.8 / 97.9 | +18 / +6 / +22% | 107–113 → 99–105 ms |
| c8 @ 0k / 16k / 32k | 120.9 / 114.2 / 122.2 | 126.3 / 130.7 / 131.3 | +5 / +14 / +8% | 160–166 → 148–160 ms |
| c16 @ 0k / 16k / 32k | 163.7 / 159.2 / 152.2 | 215.2 / 193.9 / 191.6 | +32 / +22 / +26% | 246–259 → 194–212 ms |
| coding peak c1 (median of 5) | 72.1 | 70.5 | −2% (noise) | |
| cold prefill 8k / 32k / 128k | 2599 / 2758 / 2702 | 2601 / 2763 / 2701 | ~0 | unchanged |

Compared with the 2026-09-02 A/B above: the matrix and step-latency picture is the same or better, the coding-peak gain did not reproduce (both arms 70–72 tok/s this time), and the per-step health check, alignment staging and stream events added in this round cost nothing measurable.

## Status for the maintainer

- Head `a7935eb`; base `dev/jovian-judgement`. Requires the b12x package to export `b12x.comm.roce.API_VERSION == 1` (b12x#295 at `00280f2` or later); the adapter disables itself on every rank otherwise.
- External review (two rounds) closed with no outstanding technical blocker; merge is the maintainer's call after b12x#295.
- Qualified performance pair: b12x `00280f2` + this branch at `aef3576` (the receipt in b12x#295, `docs/evidence/rocenante/serving-ab-final-20260903/`). `5272694` and `a7935eb` change only the async wrapper and tests; treat them as functionally equivalent but not independently benchmark-qualified unless rerun.
- Follow-up, not a gate: a hard process-kill / QP-error fault-injection test on the b12x side.

## Notes

- The `ep:0` group still lists `PYNCCL` only: the communicator enables custom backends only for `tp` groups. It carries no decode traffic with EP size 1; enabling EP would need that gate widened and an all-to-all runtime.
- Deployed via an overlay image on the test cluster (`VLLM_ENABLE_ROCE_ALLREDUCE=1` in the compose override); temperature-0 sanity outputs unchanged.

https://claude.ai/code/session_018UfbfZM16WWuuLNt5JMDGc
