### PR TITLE
fix(memory): profile GLM DCP attention before KV cache sizing

### DIFF
--- a/tests/v1/worker/test_cp_utils.py
+++ b/tests/v1/worker/test_cp_utils.py
@@ -10,6 +10,27 @@ from vllm.v1.attention.backends.utils import get_dcp_local_seq_lens
 from vllm.v1.worker.cp_utils import should_skip_dcp_context_attention
 
 
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({}, 0),
+        ({"single_request_prefill": True}, 16),
+        ({"create_mixed_batch": True}, 16),
+    ],
+)
+def test_dcp_dummy_context_covers_single_request_prefill(kwargs, expected):
+    arguments = {
+        "dcp_world_size": 4,
+        "cp_kv_cache_interleave_size": 4,
+        "has_kv_cache_config": True,
+        "create_mixed_batch": False,
+        "is_graph_capturing": False,
+        "uniform_decode": False,
+    }
+    arguments.update(kwargs)
+    assert cp_utils.get_dcp_dummy_context_len(**arguments) == expected
+
+
 def test_skip_gate_only_for_zero_context():
     assert should_skip_dcp_context_attention(torch.zeros(3, dtype=torch.int32))
     assert not should_skip_dcp_context_attention(

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import gc
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -1752,6 +1753,74 @@ def test_mamba_cache_raises_when_max_num_seqs_exceeds_blocks():
 
         with pytest.raises(ValueError, match="max_num_seqs"):
             runner.initialize_kv_cache(kv_cache_config)
+
+
+@pytest.mark.parametrize("dummy_run_fails", [False, True])
+def test_glm_dcp_attention_profile_uses_single_request_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+    dummy_run_fails: bool,
+):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.model_config = SimpleNamespace(
+        architecture="Glm5NextForConditionalGeneration"
+    )
+    runner.dcp_world_size = 4
+    runner.vllm_config = object()
+    runner.max_num_tokens = 4096
+    events: list[object] = []
+
+    runner._init_minimal_kv_cache_for_profiling = lambda: events.append("init-kv")
+
+    def dummy_run(*args, **kwargs):
+        events.append(("dummy-run", args, kwargs))
+        if dummy_run_fails:
+            raise RuntimeError("expected DCP profile failure")
+        return torch.empty(1), torch.empty(1)
+
+    runner._dummy_run = dummy_run
+    runner._sync_device = lambda: events.append("sync")
+    runner._cleanup_profiling_kv_cache = lambda: events.append("cleanup")
+
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "set_current_vllm_config",
+        lambda _: nullcontext(),
+    )
+
+    if dummy_run_fails:
+        with pytest.raises(RuntimeError, match="expected DCP profile failure"):
+            runner.profile_glm_dcp_attention()
+    else:
+        runner.profile_glm_dcp_attention()
+
+    assert events[0] == "init-kv"
+    assert events[1] == (
+        "dummy-run",
+        (4096,),
+        {
+            "force_attention": True,
+            "skip_eplb": True,
+            "is_profile": True,
+            "single_request_prefill": True,
+        },
+    )
+    assert events[-1] == "cleanup"
+    if not dummy_run_fails:
+        assert events[-2] == "sync"
+
+
+def test_glm_dcp_attention_profile_skips_non_glm_and_dcp1():
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.model_config = SimpleNamespace(architecture="OtherArchitecture")
+    runner.dcp_world_size = 4
+    runner._init_minimal_kv_cache_for_profiling = Mock()
+    runner.profile_glm_dcp_attention()
+    runner._init_minimal_kv_cache_for_profiling.assert_not_called()
+
+    runner.model_config.architecture = "Glm5NextForConditionalGeneration"
+    runner.dcp_world_size = 1
+    runner.profile_glm_dcp_attention()
+    runner._init_minimal_kv_cache_for_profiling.assert_not_called()
 
 
 class TestInitFp8KvScalesHybridModels:

--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -116,3 +116,88 @@ def test_append_block_ids_rejects_write_past_row_capacity():
         )
 
     assert block_tables.num_blocks.np[0, 1] == 3
+
+
+@pytest.mark.parametrize("dummy_run_fails", [False, True])
+def test_glm_dcp_attention_profile_uses_single_request_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+    dummy_run_fails: bool,
+):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.model_config = SimpleNamespace(
+        architecture="Glm5NextForConditionalGeneration"
+    )
+    runner.dcp_size = 4
+    runner.cp_interleave = 4
+    runner.max_num_tokens = 4096
+    events: list[object] = []
+
+    monkeypatch.setattr(
+        model_runner_module,
+        "_init_minimal_kv_cache_for_profiling",
+        lambda _: events.append("init-kv"),
+    )
+    monkeypatch.setattr(
+        model_runner_module,
+        "_teardown_profiling_state",
+        lambda _: events.append("cleanup"),
+    )
+
+    def dummy_run(*args, **kwargs):
+        events.append(("dummy-run", args, kwargs))
+        if dummy_run_fails:
+            raise RuntimeError("expected DCP profile failure")
+        return torch.empty(1), torch.empty(1)
+
+    runner._dummy_run = dummy_run
+    monkeypatch.setattr(torch.accelerator, "synchronize", lambda: events.append("sync"))
+
+    if dummy_run_fails:
+        with pytest.raises(RuntimeError, match="expected DCP profile failure"):
+            runner.profile_glm_dcp_attention()
+    else:
+        runner.profile_glm_dcp_attention()
+
+    assert events[0] == "init-kv"
+    assert events[1] == (
+        "dummy-run",
+        (4096,),
+        {
+            "context_len": 16,
+            "skip_eplb": True,
+            "is_profile": True,
+            "single_request_prefill": True,
+        },
+    )
+    assert events[-1] == "cleanup"
+    if not dummy_run_fails:
+        assert events[-2] == "sync"
+
+
+@pytest.mark.parametrize(
+    ("architecture", "dcp_size"),
+    [("OtherArchitecture", 4), ("Glm5NextForConditionalGeneration", 1)],
+)
+def test_glm_dcp_attention_profile_skips_irrelevant_configurations(
+    monkeypatch: pytest.MonkeyPatch,
+    architecture: str,
+    dcp_size: int,
+):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.model_config = SimpleNamespace(architecture=architecture)
+    runner.dcp_size = dcp_size
+    initialized = False
+
+    def record_initialization(_):
+        nonlocal initialized
+        initialized = True
+
+    monkeypatch.setattr(
+        model_runner_module,
+        "_init_minimal_kv_cache_for_profiling",
+        record_initialization,
+    )
+
+    runner.profile_glm_dcp_attention()
+
+    assert not initialized

--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -167,6 +167,7 @@ def test_glm_dcp_attention_profile_uses_single_request_and_cleans_up(
             "skip_eplb": True,
             "is_profile": True,
             "single_request_prefill": True,
+            "profile_all_kv_cache_groups": True,
         },
     )
     assert events[-1] == "cleanup"

--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -80,14 +80,27 @@ def test_startup_plan_apply_gate(plan_env):
     assert explicit.cache_config.kv_cache_memory_bytes == 7 * GiB_bytes
 
 
-def test_b12x_warmup_precedes_cudagraph_memory_profile(monkeypatch):
+@pytest.mark.parametrize(
+    "final_free_memory,expected_available_memory",
+    [(80, 80), (75, 75)],
+)
+def test_b12x_warmup_precedes_cudagraph_memory_profile(
+    monkeypatch,
+    final_free_memory,
+    expected_available_memory,
+):
     """B12X launch modules must be resolved before descriptor capture begins."""
-    events = []
+    events: list[object] = []
+
+    def profile_cudagraph_memory():
+        events.append("profile_cudagraph_memory")
+        return 0
 
     model_runner = SimpleNamespace(
         model_memory_usage=0,
         profile_run=lambda: events.append("profile_run"),
-        profile_cudagraph_memory=lambda: events.append("profile_cudagraph_memory") or 0,
+        profile_glm_dcp_attention=lambda: events.append("profile_glm_dcp_attention"),
+        profile_cudagraph_memory=profile_cudagraph_memory,
     )
     profile_result = SimpleNamespace(
         total_consumed=10,
@@ -108,6 +121,7 @@ def test_b12x_warmup_precedes_cudagraph_memory_profile(monkeypatch):
         model_runner=model_runner,
         init_snapshot=SimpleNamespace(free_memory=100, total_memory=100),
         requested_memory=90,
+        device="cuda:0",
         model_config=SimpleNamespace(multimodal_config=None),
         parallel_config=SimpleNamespace(),
         vllm_config=SimpleNamespace(
@@ -120,6 +134,11 @@ def test_b12x_warmup_precedes_cudagraph_memory_profile(monkeypatch):
 
     monkeypatch.setattr(gpu_worker, "maybe_apply_startup_plan", lambda worker: None)
     monkeypatch.setattr(gpu_worker, "memory_profiling", fake_memory_profiling)
+    monkeypatch.setattr(
+        gpu_worker,
+        "MemorySnapshot",
+        lambda **_kwargs: SimpleNamespace(free_memory=final_free_memory),
+    )
     monkeypatch.setattr(
         gpu_worker,
         "current_platform",
@@ -140,7 +159,8 @@ def test_b12x_warmup_precedes_cudagraph_memory_profile(monkeypatch):
 
     assert events == [
         "profile_run",
+        "profile_glm_dcp_attention",
         ("b12x_warmup", (8, 4)),
         "profile_cudagraph_memory",
     ]
-    assert available == 80
+    assert available == expected_available_memory

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -88,11 +88,16 @@ def get_dcp_dummy_context_len(
     create_mixed_batch: bool,
     is_graph_capturing: bool,
     uniform_decode: bool,
+    single_request_prefill: bool = False,
 ) -> int:
     if (
         dcp_world_size <= 1
         or not has_kv_cache_config
-        or not (create_mixed_batch or (is_graph_capturing and uniform_decode))
+        or not (
+            create_mixed_batch
+            or (is_graph_capturing and uniform_decode)
+            or single_request_prefill
+        )
     ):
         return 0
     return dcp_world_size * cp_kv_cache_interleave_size

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -700,6 +700,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         skip_eplb: bool = False,
         is_profile: bool = False,
         single_request_prefill: bool = False,
+        profile_all_kv_cache_groups: bool = False,
         **kwargs,
     ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
         if skip_attn and not is_profile:
@@ -758,6 +759,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 skip_attn_for_dummy_run=skip_attn,
                 is_profile=is_profile,
                 context_len=context_len,
+                profile_all_kv_cache_groups=profile_all_kv_cache_groups,
             )
         self.kv_connector.set_disabled(False)
 
@@ -905,6 +907,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 skip_eplb=True,
                 is_profile=True,
                 single_request_prefill=True,
+                profile_all_kv_cache_groups=True,
             )
             torch.accelerator.synchronize()
         finally:
@@ -1541,6 +1544,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         skip_attn_for_dummy_run: bool = False,
         is_profile: bool = False,
         context_len: int = 0,
+        profile_all_kv_cache_groups: bool = False,
     ) -> ModelRunnerOutput | IntermediateTensors | None:
         if not dummy_run:
             # Update the request states.
@@ -1661,7 +1665,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             )
             assert block_tables is not None
             attn_groups = self.attn_groups
-            if dummy_run and is_profile:
+            if dummy_run and is_profile and not profile_all_kv_cache_groups:
                 # Mamba layers take a cheap warmup path with no metadata;
                 # attention metadata is still built so those kernels tune.
                 attn_groups = [

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -92,6 +92,8 @@ from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.cudagraph_utils import (
     BatchExecutionDescriptor,
     ModelCudaGraphManager,
+    _init_minimal_kv_cache_for_profiling,
+    _teardown_profiling_state,
     normalize_model_token_inputs,
 )
 from vllm.v1.worker.gpu.cudagraph_utils import (
@@ -697,6 +699,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         context_len: int = 0,
         skip_eplb: bool = False,
         is_profile: bool = False,
+        single_request_prefill: bool = False,
         **kwargs,
     ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
         if skip_attn and not is_profile:
@@ -705,8 +708,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             )
 
         # Create a dummy scheduler output.
-        num_reqs = min(num_tokens, self.max_num_reqs)
+        num_reqs = 1 if single_request_prefill else min(num_tokens, self.max_num_reqs)
         if uniform_decode:
+            assert not single_request_prefill
             # HACK(lucas): for now since the worker is shared between MRV1 and MRV2,
             # and for spec-decode with MTP we want to make sure the dummy runs use
             # 1+num_speculative_tokens we use max here, this will likely be eventually
@@ -875,6 +879,36 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         del hidden_states, sample_hidden_states
         self.reset_encoder_cache()
         gc.collect()
+
+    @torch.inference_mode()
+    def profile_glm_dcp_attention(self) -> None:
+        """Measure the GLM DCP query-gather peak before KV cache sizing.
+
+        The general activation profile deliberately skips attention and splits
+        its token budget across many requests. A GLM sparse-MLA prefill can put
+        the complete scheduler budget in one request, causing the DCP query
+        all-gather to require substantially more temporary memory. Bind a
+        minimal split cache, execute that shape, then release all temporary
+        cache and backend state before production cache allocation.
+        """
+        if (
+            self.model_config.architecture != "Glm5NextForConditionalGeneration"
+            or self.dcp_size <= 1
+        ):
+            return
+
+        _init_minimal_kv_cache_for_profiling(self)
+        try:
+            self._dummy_run(
+                self.max_num_tokens,
+                context_len=self.dcp_size * self.cp_interleave,
+                skip_eplb=True,
+                is_profile=True,
+                single_request_prefill=True,
+            )
+            torch.accelerator.synchronize()
+        finally:
+            _teardown_profiling_state(self)
 
     def post_kv_cache_wake_up(self) -> None:
         self.block_tables.init_block_table_layout_tensors()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5955,6 +5955,7 @@ class GPUModelRunner(
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         randomize_inputs: bool = False,
+        single_request_prefill: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Run a dummy forward pass to warm up/profile run or capture the
@@ -5982,6 +5983,10 @@ class GPUModelRunner(
             profile_seq_lens: If provided, use this value for seq_lens instead
                 of max_query_len. Used to profile attention workspace that
                 scales with context length.
+            single_request_prefill: If True, place the complete token budget in
+                one prefill request. This exposes attention and collective
+                workspace peaks that are hidden when the ordinary profile
+                distributes the same token budget across many requests.
         """
         mm_config = self.vllm_config.model_config.multimodal_config
         if mm_config and mm_config.mm_encoder_only:
@@ -6014,7 +6019,13 @@ class GPUModelRunner(
         # has num_tokens in total.
         assert num_tokens <= self.max_num_tokens
         max_num_reqs = self.scheduler_config.max_num_seqs
-        if create_mixed_batch:
+        if single_request_prefill:
+            assert not create_mixed_batch
+            assert not uniform_decode
+            num_reqs = 1
+            num_scheduled_tokens_list = [num_tokens]
+            max_query_len = num_tokens
+        elif create_mixed_batch:
             assert not uniform_decode
             # Create mixed batch:
             # first half decode tokens, second half one prefill
@@ -6089,6 +6100,7 @@ class GPUModelRunner(
             create_mixed_batch,
             is_graph_capturing,
             uniform_decode,
+            single_request_prefill,
         )
         ubatch_slices, ubatch_slices_padded = maybe_create_ubatch_slices(
             should_ubatch,
@@ -6632,6 +6644,39 @@ class GPUModelRunner(
         del hidden_states, output
         self.encoder_cache.clear()
         gc.collect()
+
+    @torch.inference_mode()
+    def profile_glm_dcp_attention(self) -> None:
+        """Profile GLM split-cache DCP attention before KV cache sizing.
+
+        The generic activation profile omits attention metadata and spreads the
+        scheduler token budget across many requests. GLM sparse MLA can instead
+        receive one full prefill quantum and gather its query heads across the
+        decode-context-parallel group. A minimal temporary cache makes that
+        backend path reachable without reserving production KV storage.
+        """
+        if (
+            self.model_config.architecture != "Glm5NextForConditionalGeneration"
+            or self.dcp_world_size <= 1
+        ):
+            return
+
+        with set_current_vllm_config(self.vllm_config):
+            self._init_minimal_kv_cache_for_profiling()
+
+        model_output: tuple[torch.Tensor, torch.Tensor] | None = None
+        try:
+            model_output = self._dummy_run(
+                self.max_num_tokens,
+                force_attention=True,
+                skip_eplb=True,
+                is_profile=True,
+                single_request_prefill=True,
+            )
+            self._sync_device()
+        finally:
+            del model_output
+            self._cleanup_profiling_kv_cache()
 
     def _init_minimal_kv_cache_for_profiling(self) -> None:
         from vllm.v1.core.kv_cache_utils import (

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -524,6 +524,7 @@ class Worker(WorkerBase):
             weights_memory=int(self.model_runner.model_memory_usage),
         ) as profile_result:
             self.model_runner.profile_run()
+            self.model_runner.profile_glm_dcp_attention()
 
         # Profile CUDA graph memory if graphs will be captured.
         # ROCm is included: #44825 moved the profiler to
@@ -553,13 +554,23 @@ class Worker(WorkerBase):
             else 0
         )
 
-        self.total_consumed = profile_result.total_consumed
+        # Backend and CUDA-graph profiling can initialize communication pools,
+        # compiled modules, and other persistent device allocations after the
+        # main activation profile. Include their retained footprint before the
+        # remaining memory is assigned to production KV cache storage.
+        final_profile_snapshot = MemorySnapshot(device=self.device)
+        late_persistent_memory = max(
+            profile_result.after_profile.free_memory
+            - final_profile_snapshot.free_memory,
+            0,
+        )
+        self.total_consumed = profile_result.total_consumed + late_persistent_memory
         self.peak_activation_memory = (
             profile_result.transient_peak_headroom + cudagraph_memory_estimate_applied
         )
         self.cudagraph_memory_estimate = cudagraph_memory_estimate
 
-        free_gpu_memory = profile_result.after_profile.free_memory
+        free_gpu_memory = final_profile_snapshot.free_memory
         # NOTE(woosuk): Here we assume that the other processes using the same
         # GPU did not change their memory usage during the profiling.
         assert self.init_snapshot.free_memory >= free_gpu_memory, (
@@ -574,6 +585,7 @@ class Worker(WorkerBase):
         self.available_kv_cache_memory_bytes = (
             self.requested_memory
             - profile_result.non_kv_cache_memory
+            - late_persistent_memory
             - cudagraph_memory_estimate_applied
         )
 


### PR DESCRIPTION
## Resulting behavior

Automatic KV-cache sizing now accounts for the production GLM-5.3 DCP attention path and device allocations retained by backend and CUDA-graph initialization.

For GLM-5.3 with decode-context parallelism greater than one, each model runner binds a minimal hybrid KV cache and profiles one prefill request containing the configured scheduler token budget. The V2 runner retains every hybrid cache group for this dedicated probe while preserving the cheaper filtered metadata path for the general activation profile. Profiling-only cache and backend state is released before production KV allocation.

The worker takes a final device-memory snapshot after backend and CUDA-graph profiling. Persistent allocations created after the main activation profile are subtracted from the production KV-cache budget.

## Technical reason

The general many-request profile did not execute the production GLM sparse-MLA DCP query gather. With TP4/DCP4, `max_num_batched_tokens=4096`, and GPU memory utilization 0.93, the resulting KV pool left approximately 140 MiB free. A fresh 54K-token prefill then failed when each rank requested a 256 MiB query all-gather buffer.

## Compatibility

- GLM-5.3 DCP1 and non-GLM configurations skip the dedicated attention profile.
- The general V2 activation profile continues to omit recurrent cache groups.
- Both legacy and V2 model runners use the same single-request sizing contract.
- The change affects automatic KV-cache sizing; an explicit KV-cache byte limit remains authoritative.

## Validation

- 9 focused worker and runner tests passed on the branch.
- TP4/DCP4, FP8 MLA KV cache, `max_num_batched_tokens=4096`, GPU memory utilization 0.93: an exact 54,639-token cold request completed without OOM.
- FP8 and NVFP4 LMCache qualification completed exact cold, in-process L1 restore, and filesystem L2 restore requests with 53,248 externally restored prefix tokens.
- Commit hooks covering Ruff, formatting, MyPy, SPDX, configuration defaults, and repository policy passed.

The implementation retains D-Rock attribution in every source commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GPU memory profiling for GLM models using distributed context parallelism.
  * Improved single-request prefill handling during profiling.
* **Bug Fixes**
  * KV-cache memory availability now accounts for memory allocated after profiling.
  * Profiling cleanup is ensured even when a profiling run fails.
* **Tests**
  * Added coverage for GLM profiling, skipped profiling scenarios, dummy context sizing, and memory accounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->