### PR TITLE
fix(dcp): require peer access for direct A2A

### DIFF
--- a/tests/distributed/test_dcp_direct_a2a_lse_reduce.py
+++ b/tests/distributed/test_dcp_direct_a2a_lse_reduce.py
@@ -141,6 +141,70 @@ class _FakeProcessGroup:
 
 
 class TestDirectDCPGating:
+    def test_a2a_factory_falls_back_without_p2p(self, monkeypatch):
+        monkeypatch.delenv("VLLM_USE_DIRECT_DCP_A2A", raising=False)
+        monkeypatch.setattr(
+            dcp, "direct_cp_peer_access_enabled", lambda *args: False
+        )
+        dcp.get_direct_dcp_a2a_workspace.cache_clear()
+
+        assert (
+            dcp.get_direct_dcp_a2a_workspace(
+                _FakeGroupCoordinator(),
+                torch.device("cpu"),
+                16,
+                2,
+                32,
+                torch.bfloat16,
+                1,
+            )
+            is None
+        )
+
+    def test_auto_a2a_requires_all_pairs_p2p(self, monkeypatch):
+        monkeypatch.delenv("VLLM_USE_DIRECT_DCP_A2A", raising=False)
+        monkeypatch.setattr(cp_common, "direct_cp_enabled", lambda *args: True)
+        monkeypatch.setattr(cp_common, "_cuda_p2p_spans_group", lambda group: False)
+
+        assert not cp_common.direct_cp_peer_access_enabled(
+            _FakeGroupCoordinator(), torch.bfloat16, None
+        )
+
+    def test_forced_a2a_preserves_explicit_override(self, monkeypatch):
+        monkeypatch.setattr(
+            cp_common,
+            "_cuda_p2p_spans_group",
+            lambda group: pytest.fail("forced mode should bypass the automatic probe"),
+        )
+
+        assert cp_common.direct_cp_peer_access_enabled(
+            _FakeGroupCoordinator(), torch.bfloat16, True
+        )
+
+    @pytest.mark.parametrize("p2p_available", [False, True])
+    def test_p2p_probe_checks_both_directions(self, monkeypatch, p2p_available):
+        group = MagicMock(world_size=2, local_rank=2, cpu_group=object())
+        cp_common._cuda_p2p_spans_group.cache_clear()
+        monkeypatch.setattr(cp_common.current_platform, "is_cuda", lambda: True)
+
+        def gather_local_ranks(output, value, *, group):
+            assert value == 2
+            output[:] = [2, 3]
+
+        monkeypatch.setattr(
+            torch.distributed, "all_gather_object", gather_local_ranks
+        )
+        peer_checks = MagicMock(
+            side_effect=lambda src, dst: p2p_available or (src, dst) != (3, 2)
+        )
+        monkeypatch.setattr(cp_common, "gpu_p2p_access_check", peer_checks)
+
+        assert cp_common._cuda_p2p_spans_group(group) is p2p_available
+        if p2p_available:
+            assert peer_checks.call_count == 2
+        else:
+            assert peer_checks.call_args.args == (3, 2)
+
     def test_env_disabled_returns_none(self, monkeypatch):
         monkeypatch.setenv("VLLM_USE_DIRECT_DCP_A2A", "0")
         dcp.get_direct_dcp_a2a_workspace.cache_clear()

--- a/vllm/v1/attention/ops/cp_common.py
+++ b/vllm/v1/attention/ops/cp_common.py
@@ -9,6 +9,9 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
+from vllm.distributed.device_communicators.all_reduce_utils import (
+    gpu_p2p_access_check,
+)
 from vllm.distributed.parallel_state import in_the_same_node_as
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
@@ -57,6 +60,40 @@ def _symm_mem_spans_group(group: GroupCoordinator) -> bool:
     return spans
 
 
+@functools.cache
+def _cuda_p2p_spans_group(group: GroupCoordinator) -> bool:
+    """Return whether every rank can directly access every peer GPU."""
+    if not current_platform.is_cuda():
+        return False
+    if group.world_size <= 1:
+        return True
+
+    try:
+        local_ranks: list[int | None] = [None] * group.world_size
+        torch.distributed.all_gather_object(
+            local_ranks,
+            group.local_rank,
+            group=group.cpu_group,
+        )
+        if any(rank is None for rank in local_ranks):
+            return False
+        spans = all(
+            src == dst or gpu_p2p_access_check(src, dst)
+            for src in local_ranks
+            for dst in local_ranks
+            if src is not None and dst is not None
+        )
+    except Exception as error:
+        logger.debug("Direct CP CUDA P2P probe failed: %s", error)
+        return False
+    logger.debug_once(
+        "Direct CP CUDA P2P across %d ranks: %s",
+        group.world_size,
+        "available" if spans else "unavailable",
+    )
+    return spans
+
+
 def direct_cp_enabled(
     group: GroupCoordinator,
     dtype: torch.dtype,
@@ -74,6 +111,24 @@ def direct_cp_enabled(
             or _symm_mem_spans_group(group)
         )
     )
+
+
+def direct_cp_peer_access_enabled(
+    group: GroupCoordinator,
+    dtype: torch.dtype,
+    use_direct: bool | None,
+    supported_dtypes: tuple[torch.dtype, ...] | None = None,
+) -> bool:
+    """Gate direct CP operations that dereference peer GPU pointers."""
+    if use_direct is not None:
+        return use_direct
+    enabled = direct_cp_enabled(group, dtype, None, supported_dtypes)
+    if enabled and not _cuda_p2p_spans_group(group):
+        logger.info_once(
+            "Direct CP peer access is unavailable; falling back to collectives."
+        )
+        return False
+    return enabled
 
 
 def direct_cp_multicast_enabled(

--- a/vllm/v1/attention/ops/cp_common.py
+++ b/vllm/v1/attention/ops/cp_common.py
@@ -62,7 +62,14 @@ def _symm_mem_spans_group(group: GroupCoordinator) -> bool:
 
 @functools.cache
 def _cuda_p2p_spans_group(group: GroupCoordinator) -> bool:
-    """Return whether every rank can directly access every peer GPU."""
+    """Check whether every rank can directly access every peer GPU.
+
+    Args:
+        group: Process group whose local CUDA devices should be checked.
+
+    Returns:
+        Whether all directed device pairs in the group support CUDA P2P access.
+    """
     if not current_platform.is_cuda():
         return False
     if group.world_size <= 1:
@@ -119,7 +126,17 @@ def direct_cp_peer_access_enabled(
     use_direct: bool | None,
     supported_dtypes: tuple[torch.dtype, ...] | None = None,
 ) -> bool:
-    """Gate direct CP operations that dereference peer GPU pointers."""
+    """Check eligibility for direct CP operations that access peer pointers.
+
+    Args:
+        group: Process group used by the direct CP operation.
+        dtype: Data type transferred by the operation.
+        use_direct: Explicit direct-path override, or ``None`` for auto selection.
+        supported_dtypes: Data types supported by the direct implementation.
+
+    Returns:
+        Whether the direct peer-access path should be used.
+    """
     if use_direct is not None:
         return use_direct
     enabled = direct_cp_enabled(group, dtype, None, supported_dtypes)

--- a/vllm/v1/attention/ops/dcp.py
+++ b/vllm/v1/attention/ops/dcp.py
@@ -18,8 +18,8 @@ from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.ops.cp_common import (
     DirectCPWorkspace,
-    direct_cp_enabled,
     direct_cp_multicast_enabled,
+    direct_cp_peer_access_enabled,
 )
 from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
@@ -907,7 +907,7 @@ def get_direct_dcp_a2a_workspace(
     dtype: torch.dtype,
     num_ubatches: int,
 ) -> DirectDCPA2AWorkspace | None:
-    if not direct_cp_enabled(
+    if not direct_cp_peer_access_enabled(
         group, dtype, envs.VLLM_USE_DIRECT_DCP_A2A, _A2A_SUPPORTED_DTYPES
     ):
         return None


### PR DESCRIPTION
## Summary

- require bidirectional CUDA P2P across every DCP rank before automatically selecting direct symmetric-memory A2A
- reuse the existing cross-process CUDA IPC transfer probe rather than trusting topology or the driver capability bit alone
- fall back to the existing collective A2A path when direct peer access is unavailable
- preserve the explicit `VLLM_USE_DIRECT_DCP_A2A=0/1` override behavior

## Why

Same-node placement does not guarantee CUDA peer access. `DirectDCPA2AWorkspace` publishes peer pointers and the direct kernel dereferences them, but the automatic gate previously accepted any same-node DCP group. On PCIe hosts with no GPU P2P, that can silently wedge the first request that executes the direct kernel. NCCL transport settings do not protect this path because the direct kernel bypasses NCCL.

## Validation

- focused `TestDirectDCPGating` subset in the Jovian r15 runtime: **17 passed**
- covers automatic fallback, explicit override preservation, DCP local-rank collection, and both directed P2P checks
- `compileall` and `git diff --check` pass

This is a standalone portability fix. It does not claim to resolve the separate field report where an HTTP request remains in API-side preprocessing and never reaches EngineCore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Direct distributed attention communication now automatically checks GPU peer-to-peer access before using direct transfers.
  - Systems without full peer access fall back to collective communication for improved compatibility.
  - Explicit configuration overrides remain supported.
  - Peer-access checks now validate connectivity in both directions and handle unsupported or failed capability probes safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->