### PR TITLE
Fix Qwen3.8 PLE state corruption under piecewise CUDA graphs

### DIFF
--- a/tests/models/test_qwen3_8_flash_next_model.py
+++ b/tests/models/test_qwen3_8_flash_next_model.py
@@ -120,6 +120,30 @@ def test_explicit_ple_table_memory_overrides_env_alias(monkeypatch) -> None:
     )
 
 
+def test_ple_registers_request_dependent_piecewise_splitting_ops_once() -> None:
+    compilation_config = SimpleNamespace(
+        static_forward_context={},
+        splitting_ops=[],
+    )
+
+    ple_layer_module._register_ple_compilation_context(
+        compilation_config,
+        "model.layers.1.ple",
+        nn.Identity(),
+    )
+    ple_layer_module._register_ple_compilation_context(
+        compilation_config,
+        "model.layers.5.ple",
+        nn.Identity(),
+    )
+
+    assert compilation_config.splitting_ops == list(ple_layer_module._PLE_SPLITTING_OPS)
+    assert set(compilation_config.static_forward_context) == {
+        "model.layers.1.ple",
+        "model.layers.5.ple",
+    }
+
+
 def test_gated_residual_uses_canonical_combine_ops(monkeypatch) -> None:
     combined = torch.full((2, 8), 3.0, dtype=torch.bfloat16)
     normalized = torch.full((2, 8), 5.0, dtype=torch.bfloat16)

--- a/vllm/models/qwen3_8_flash_next/ple_layer.py
+++ b/vllm/models/qwen3_8_flash_next/ple_layer.py
@@ -42,6 +42,36 @@ from .config import Qwen3_8FlashNextTextConfig
 
 logger = init_logger(__name__)
 
+_PLE_SPLITTING_OPS = (
+    "vllm::qwen3_8_flash_next_ple_embedding",
+    "vllm::qwen3_8_flash_next_ple",
+)
+
+
+def _register_ple_compilation_context(
+    compilation_config: Any,
+    layer_name: str,
+    layer: nn.Module,
+) -> None:
+    """Keep request-dependent PLE transactions outside piecewise graphs.
+
+    Piecewise graph dispatch is keyed by padded token count, while PLE hashing
+    and recurrent-state routing also depend on the live request count and query
+    boundaries.  Both custom operators must therefore execute as partition
+    boundaries so a graph compiled for one request layout cannot replay stale
+    PLE metadata for another layout.
+    """
+    static_context = compilation_config.static_forward_context
+    if layer_name in static_context:
+        raise ValueError(f"duplicate layer name: {layer_name}")
+    static_context[layer_name] = layer
+
+    splitting_ops = compilation_config.splitting_ops
+    if splitting_ops is not None:
+        for op_name in _PLE_SPLITTING_OPS:
+            if op_name not in splitting_ops:
+                splitting_ops.append(op_name)
+
 
 def _b12x_module(name: str) -> Any:
     api = {
@@ -747,9 +777,7 @@ class Qwen3_8FlashNextPLELayer(nn.Module, MambaBase):
         self.kv_cache = (torch.tensor([]),)
 
         compilation_config = get_current_vllm_config().compilation_config
-        if prefix in compilation_config.static_forward_context:
-            raise ValueError(f"duplicate layer name: {prefix}")
-        compilation_config.static_forward_context[prefix] = self
+        _register_ple_compilation_context(compilation_config, prefix, self)
 
     def _make_plan(self, max_state_slots: int):
         api = _b12x_module("ple")


### PR DESCRIPTION
## Problem

The `qwen3_8_flash_next` PLE embedding and recurrent-update custom operators consume live request counts, query boundaries, cache slots, and recurrent state. Neither operator was registered as a compilation splitting operation. Piecewise graph selection is based on padded token count, so a graph captured for one request layout could replay stale PLE metadata for a later request with the same padded shape.

With TP2, MTP3, and `FULL_AND_PIECEWISE` CUDA graphs, a fresh request was correct but the next fresh request could enter a repeated-token loop. Instrumentation localized the first invalid state transition to PLE: a 64-token prefill replayed metadata captured for 32 decode rows, including invalid query boundaries. Eager and piecewise-only execution remained correct.

## Implementation

Register these operators in `CompilationConfig.splitting_ops` when a Qwen3.8 PLE layer initializes:

- `vllm::qwen3_8_flash_next_ple_embedding`
- `vllm::qwen3_8_flash_next_ple`

Registration is idempotent across the model's PLE layers. The operators become piecewise graph boundaries and therefore receive the live request metadata for every invocation. Full CUDA graph capture remains enabled around the partitioned execution.

The official upstream Qwen3.8 implementation has the equivalent constraint: vLLM PR [#53896](https://github.com/vllm-project/vllm/pull/53896) lists its PLE n-gram and short-convolution operators as splitting operations.

## Compatibility

No command-line option or environment variable changes. PLE cache ownership, B12X plans, caller-owned scratch, eager execution, and piecewise-only execution are unchanged.

## Validation

Configuration:

- RTX PRO 6000 Blackwell, TP2
- Qwen3.8-Flash-Next-NVFP4 revision `b797d2e1160b9596b2570e56c1d3590faa09d4ed`
- MTP with three speculative tokens
- B12X GDN decode, MoE, linear, and PCIe all-reduce backends
- BF16 KV cache
- `FULL_AND_PIECEWISE` CUDA graphs

Results:

- The original unpatched sequence failed on its second fresh request with repeated output.
- The patched sequence remained coherent across two 32,760-token prefills and subsequent request-slot reuse.
- Twelve additional sequential factual requests passed 12/12 after the long-prefill sequence.
- PLE metadata for fresh 64-token prefills was `[0, 64]`; speculative target steps used `[0, 4]`; no invalid PLE state or non-finite recurrent cache was observed.
- Compilation produced 51 graph entries and 19 artifacts instead of 49 entries and 17 artifacts, accounting for the two required partition boundaries.
- `ruff check`, `ruff format --check`, repository pre-commit hooks, `git diff --check`, and the focused registration assertion passed.
