### PR TITLE
feat(glm5next): tensor-parallel head padding for TP3 (GLM-5.3-Flash on three GPUs)

### DIFF
--- a/tests/models/glm5next/test_glm53_tp_pad.py
+++ b/tests/models/glm5next/test_glm53_tp_pad.py
@@ -1,0 +1,59 @@
+# No-GPU unit test for the TP3 padding overlay: run inside the R17 image with the overlays mounted,
+#   VLLM_GLM53_TP_HEAD_PAD=72,66 TP=3, model dir at /model.
+import torch, vllm.distributed as dist
+dist.get_tensor_model_parallel_world_size = lambda: 3  # no process group in this test
+from vllm.transformers_utils.configs.glm5_next import Glm5NextConfig
+from vllm.transformers_utils.configs.glm53_tp_pad import pad_head_weights, routed_expert_intermediate, shared_expert_intermediate, vocab_padding_size
+c = Glm5NextConfig.from_pretrained("/model"); t = c.text_config
+assert (t.num_attention_heads, t.linear_num_heads, t.linear_attn_config["num_heads"], t.num_attention_heads_ckpt, t.linear_num_heads_ckpt) == (72, 66, 66, 64, 64)
+t2 = type(t)(**t.to_dict()); assert (t2.num_attention_heads, t2.num_attention_heads_ckpt) == (72, 64), "re-instantiation not idempotent"
+assert routed_expert_intermediate(t, 3) == 2304 and routed_expert_intermediate(t, 3, mtp=True) == 2304 and routed_expert_intermediate(t, 4) == 2048 and routed_expert_intermediate(t, 2) == 2048 and routed_expert_intermediate(t, 8) == 2048
+assert shared_expert_intermediate(t, 3) == 2112 and shared_expert_intermediate(t, 4) == 2048 and vocab_padding_size() == 192
+P = "layers.%d.%s"  # prefix-relative names, as AutoWeightsLoader passes them to Glm5NextModel.load_weights
+bf = torch.bfloat16
+cases = {
+ P % (0, "self_attn.q_proj.weight"): ((8192, 4096), (8448, 4096)),
+ P % (0, "self_attn.b_proj.weight"): ((64, 4096), (66, 4096)),
+ P % (0, "self_attn.forget_gate.A_log"): ((64,), (66,)),
+ P % (0, "self_attn.dt_bias"): ((8192,), (8448,)),
+ P % (0, "self_attn.k_conv1d.weight"): ((8192, 1, 4), (8448, 1, 4)),
+ P % (0, "self_attn.f_b_proj.weight"): ((8192, 128), (8448, 128)),
+ P % (0, "self_attn.g_b_proj.weight"): ((8192, 128), (8448, 128)),
+ P % (0, "self_attn.o_proj.weight"): ((4096, 8192), (4096, 8448)),
+ P % (0, "self_attn.f_a_proj.weight"): ((128, 4096), (128, 4096)),
+ P % (0, "mlp.gate_proj.weight"): ((12288, 4096), (12288, 4096)),
+ P % (3, "self_attn.q_b_proj.weight"): ((16384, 1536), (18432, 1536)),
+ P % (3, "self_attn.kv_b_proj.weight"): ((32768, 512), (36864, 512)),
+ P % (3, "self_attn.o_proj.weight"): ((4096, 16384), (4096, 18432)),
+ P % (3, "self_attn.indexer.wq_b.weight"): ((4096, 1536), (4096, 1536)),
+ P % (3, "mlp.shared_experts.gate_proj.weight"): ((2048, 4096), (2112, 4096)),
+ P % (3, "mlp.shared_experts.up_proj.weight"): ((2048, 4096), (2112, 4096)),
+ P % (3, "mlp.shared_experts.down_proj.weight"): ((4096, 2048), (4096, 2112)),
+ P % (45, "self_attn.kv_b_proj.weight"): ((32768, 512), (36864, 512)),
+ P % (45, "mlp.shared_experts.down_proj.weight"): ((4096, 2048), (4096, 2112)),
+ P % (3, "mlp.experts.0.gate_proj.weight"): ((2048, 2048), (2304, 2048)),
+ P % (3, "mlp.experts.0.up_proj.weight_scale"): ((2048, 256), (2304, 256)),
+ P % (3, "mlp.experts.7.down_proj.weight"): ((4096, 1024), (4096, 1152)),
+ P % (3, "mlp.experts.7.down_proj.weight_scale"): ((4096, 128), (4096, 144)),
+ P % (3, "mlp.experts.7.down_proj.weight_scale_2"): ((), ()),
+ P % (45, "mlp.experts.0.gate_proj.weight"): ((2048, 4096), (2304, 4096)),
+ P % (45, "mlp.experts.0.gate_proj.weight_scale"): ((2048, 128), (2304, 128)),
+ P % (45, "mlp.experts.0.down_proj.weight"): ((4096, 2048), (4096, 2304)),
+ P % (45, "mlp.experts.0.down_proj.weight_scale"): ((4096, 64), (4096, 72)),
+ "model.layers.45.self_attn.o_proj.weight": ((4096, 16384), (4096, 18432)),
+ "lm_head.weight": ((154880, 4096), (154880, 4096)),
+}
+def dt(n):
+    if "A_log" in n or "dt_bias" in n or n.endswith("_scale_2"): return torch.float32
+    if ".experts." in n and ".shared" not in n:
+        mtp = "layers.45." in n
+        if n.endswith("weight_scale"): return torch.uint8 if mtp else torch.float8_e4m3fn
+        return torch.float8_e4m3fn if mtp else torch.uint8
+    return bf
+ws = [(n, torch.ones(s, dtype=dt(n))) for n, (s, _) in cases.items()]
+out = dict(pad_head_weights(ws, t))
+for n, (_, want) in cases.items():
+    got = tuple(out[n].shape); assert got == want, (n, got, want)
+    if got != cases[n][0]:  # padded region must be zero, original region intact
+        assert float(out[n].float().sum()) == float(torch.ones(cases[n][0]).sum()), n
+print("PAD TEST OK:", len(cases), "tensors")

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -95,6 +95,12 @@ from .multimodal import (
     Glm5NextVisionTransformer,
 )
 from .pooled_indexer import Glm5NextPooledIndexer
+from vllm.transformers_utils.configs.glm53_tp_pad import (
+    pad_head_weights,
+    routed_expert_intermediate,
+    shared_expert_intermediate,
+    vocab_padding_size,
+)
 
 logger = init_logger(__name__)
 
@@ -202,6 +208,7 @@ class Glm5NextMoE(nn.Module):
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
         apply_routed_scale_to_output: bool = False,
+        is_mtp_layer: bool = False,
     ):
         super().__init__()
         self.tp_size = get_tensor_model_parallel_world_size()
@@ -255,7 +262,8 @@ class Glm5NextMoE(nn.Module):
         if config.n_shared_experts is None:
             self.shared_experts = None
         else:
-            intermediate_size = config.moe_intermediate_size * config.n_shared_experts
+            # TP3: 2048 does not split three ways; pad to a multiple of 64 x TP (see glm53_tp_pad).
+            intermediate_size = shared_expert_intermediate(config, self.tp_size)
 
             self.shared_experts = Glm5NextMLP(
                 hidden_size=config.hidden_size,
@@ -273,7 +281,8 @@ class Glm5NextMoE(nn.Module):
             num_experts=config.n_routed_experts,
             top_k=config.num_experts_per_token,
             hidden_size=config.hidden_size,
-            intermediate_size=config.moe_intermediate_size,
+            # TP3: pad 2048 -> 2064 (688 per rank, the b12x corpus/profile case) for target layers, 2304 (768) for the MTP layer.
+            intermediate_size=routed_expert_intermediate(config, self.tp_size, mtp=is_mtp_layer),
             renormalize=config.moe_renormalize,
             quant_config=quant_config,
             use_grouped_topk=True,
@@ -402,6 +411,7 @@ class Glm5NextDecoderLayer(nn.Module):
                 parallel_config=parallel_config,
                 quant_config=quant_config,
                 prefix=f"{prefix}.mlp",
+                is_mtp_layer=is_mtp_layer,
             )
         else:
             self.mlp = Glm5NextMLP(
@@ -723,6 +733,7 @@ class Glm5NextModel(nn.Module, EagleModelMixin):
             self.embed_tokens = VocabParallelEmbedding(
                 config.vocab_size,
                 config.hidden_size,
+                padding_size=vocab_padding_size(),
                 prefix=f"{prefix}.embed_tokens",
             )
         else:
@@ -867,6 +878,9 @@ class Glm5NextModel(nn.Module, EagleModelMixin):
         return hidden_states
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # TP head padding (VLLM_GLM53_TP_HEAD_PAD): zero-pad head-sharded
+        # attention tensors to the padded head counts before sharding.
+        weights = pad_head_weights(weights, self.config)
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             (".gate_up_proj", ".gate_proj", 0),
@@ -1064,6 +1078,7 @@ class Glm5NextForCausalLM(
                 self.config.vocab_size,
                 self.config.hidden_size,
                 quant_config=quant_config,
+                padding_size=vocab_padding_size(),
                 prefix=maybe_prefix(prefix, "lm_head"),
             )
         else:

--- a/vllm/models/glm5next/nvidia/mtp.py
+++ b/vllm/models/glm5next/nvidia/mtp.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers.fused_moe import (
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
     VocabParallelEmbedding,
 )
 from vllm.model_executor.model_loader.weight_utils import (
@@ -25,6 +26,10 @@ from vllm.model_executor.models.utils import WeightsMapper, maybe_prefix
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
+from vllm.transformers_utils.configs.glm53_tp_pad import (
+    pad_head_weights,
+    vocab_padding_size,
+)
 from .model import (
     GLM5NEXT_PACKED_MODULES_MAPPING,
     Glm5NextDecoderLayer,
@@ -34,6 +39,21 @@ from .model import (
     get_spec_layer_idx_from_weight_name,
 )
 from .pooled_indexer import Glm5NextPooledIndexer
+
+
+class _TpPaddedSharedHead(SharedHead):
+    """SharedHead whose lm_head pads the vocab to lcm(64, TP) (TP3: 154,880 -> 155,136)."""
+
+    def __init__(self, config, prefix: str, quant_config=None) -> None:
+        nn.Module.__init__(self)
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            padding_size=vocab_padding_size(),
+            prefix=maybe_prefix(prefix, "head"),
+        )
 
 
 class Glm5NextMultiTokenPredictorLayer(nn.Module):
@@ -63,7 +83,7 @@ class Glm5NextMultiTokenPredictorLayer(nn.Module):
             dtype=torch.int32,
             device=current_platform.device_type,
         )
-        self.shared_head = SharedHead(
+        self.shared_head = _TpPaddedSharedHead(
             config=config, prefix=prefix, quant_config=quant_config
         )
         # MTP layers sit past the base model's hidden layers; parse the index
@@ -128,6 +148,7 @@ class Glm5NextMultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            padding_size=vocab_padding_size(),
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
         # Plain list for the per-propose lookup: ModuleDict[str(...)] builds a
@@ -341,6 +362,8 @@ class Glm5NextMTP(nn.Module, DeepseekV2MixtureOfExperts):
         return name
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # TP head padding (VLLM_GLM53_TP_HEAD_PAD), see model.py.
+        weights = pad_head_weights(weights, self.config)
         stacked_params_mapping = [
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),

--- a/vllm/transformers_utils/configs/glm53_tp_pad.py
+++ b/vllm/transformers_utils/configs/glm53_tp_pad.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tensor-parallel head padding for GLM-5.3-Flash (TP3, TP6, ...).
+
+GLM-5.3-Flash has 64 MLA heads, 64 KDA heads and a 2048-wide MoE intermediate.
+Tensor-parallel sizes that do not divide 64 (TP3) are made to work by padding
+the head axes with inert zero heads at load time:
+
+* MLA: ``num_attention_heads`` 64 -> ``mla_heads`` (72 = 24 per rank on TP3;
+  the B12X sparse-MLA decode kernel runs its native H8 grid when the local
+  head count is a multiple of 8).  ``q_b_proj`` / ``kv_b_proj`` rows and
+  ``o_proj`` columns are zero for the padded heads, so they attend uniformly
+  over zero values and contribute nothing.
+* KDA: ``linear_num_heads`` 64 -> ``kda_heads`` (66 = 22 per rank on TP3).
+  ``q/k/v_proj``, ``b_proj``, ``f_b_proj``, ``g_b_proj``, the three conv1d
+  banks, ``A_log`` and ``dt_bias`` are zero-padded and ``o_proj`` columns are
+  zero; with q = k = v = 0 the recurrent state of a padded head stays zero.
+* The routed experts are not split (run with ``--enable-expert-parallel``:
+  288 experts / 3 ranks).  The shared expert (12288) and dense MLPs divide.
+* Vocabulary: ``padding_size`` becomes lcm(64, TP) so the padded vocab
+  divides across ranks (154,880 -> 155,136 on TP3).
+
+Enable with ``VLLM_GLM53_TP_HEAD_PAD=<mla_heads>,<kda_heads>`` (``72,66`` on
+TP3) or ``VLLM_GLM53_TP_HEAD_PAD=auto`` together with the launcher's ``TP``.
+Only BF16/FP16/FP32 attention tensors are padded; quantized attention
+checkpoints (Spark MXFP8) raise.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+
+_ENV = "VLLM_GLM53_TP_HEAD_PAD"
+# AutoWeightsLoader hands submodules prefix-relative names ("layers.0.self_attn..."), so no leading dot.
+_LAYER_RE = re.compile(r"(?:^|\.)layers\.(\d+)\.")
+_MTP_SELF_ATTN = ".self_attn."
+
+
+def _round_up(value: int, multiple: int) -> int:
+    return -(-value // multiple) * multiple
+
+
+def requested_head_counts(ckpt_mla_heads: int, ckpt_kda_heads: int) -> tuple[int, int] | None:
+    """Return (mla_heads, kda_heads) after padding, or None when disabled."""
+    spec = os.getenv(_ENV, "").strip()
+    if not spec:
+        return None
+    if spec.lower() == "auto":
+        tp = int(os.getenv("TP", "0") or 0)
+        if tp <= 1:
+            return None
+        # MLA: local head count a multiple of 8 (B12X H8 decode grid).
+        mla = _round_up(ckpt_mla_heads, 8 * tp)
+        kda = _round_up(ckpt_kda_heads, tp)
+        return mla, kda
+    parts = [int(p) for p in spec.split(",")]
+    if len(parts) != 2:
+        raise ValueError(f"{_ENV} must be 'auto' or '<mla_heads>,<kda_heads>', got {spec!r}")
+    mla, kda = parts
+    if mla < ckpt_mla_heads or kda < ckpt_kda_heads:
+        raise ValueError(f"{_ENV}={spec} pads below the checkpoint head counts ({ckpt_mla_heads}, {ckpt_kda_heads})")
+    return mla, kda
+
+
+def apply_config_padding(cfg: Any) -> None:
+    """Pad the head counts on a Glm5Next text config in place (idempotent)."""
+    ckpt_mla = int(getattr(cfg, "num_attention_heads_ckpt", None) or cfg.num_attention_heads)
+    ckpt_kda = int(getattr(cfg, "linear_num_heads_ckpt", None) or cfg.linear_num_heads)
+    counts = requested_head_counts(ckpt_mla, ckpt_kda)
+    if counts is None:
+        return
+    mla, kda = counts
+    cfg.num_attention_heads_ckpt = ckpt_mla
+    cfg.linear_num_heads_ckpt = ckpt_kda
+    cfg.num_attention_heads = mla
+    cfg.num_key_value_heads = mla
+    cfg.linear_num_heads = kda
+    lac = getattr(cfg, "linear_attn_config", None)
+    if isinstance(lac, dict):
+        cfg.linear_attn_config = {**lac, "num_heads": kda}
+
+
+def shared_expert_intermediate(config: Any, tp_size: int | None = None) -> int:
+    """Shared-expert MLP width padded to a multiple of 64 x TP (2048 -> 2112 on TP3).
+
+    The padded channels have zero gate/up rows and zero down columns, so
+    silu(0) * 0 contributes nothing; the math is exact.  No-op for TP 1/2/4/8.
+    """
+    if tp_size is None:
+        from vllm.distributed import get_tensor_model_parallel_world_size
+
+        tp_size = get_tensor_model_parallel_world_size()
+    base = int(config.moe_intermediate_size) * int(config.n_shared_experts or 1)
+    return _round_up(base, 64 * int(tp_size))
+
+
+def routed_expert_intermediate(config: Any, tp_size: int | None = None, *, mtp: bool = False) -> int:
+    """Routed-expert intermediate padded so it shards across TP.
+
+    Multiple of 128 x TP (2048 -> 2304 on TP3 = 768 per rank, 6 x 128 tiles).
+    No-op for TP 1/2/4/8.  Padded gate/up rows and down
+    columns are zero (zero codes and zero block scales), so the math is exact.
+    """
+    if tp_size is None:
+        from vllm.distributed import get_tensor_model_parallel_world_size
+
+        tp_size = get_tensor_model_parallel_world_size()
+    # 128 x TP for every layer: the 16-aligned 688 shard is rounded to 704 by the runtime and
+    # benches 20 % slower at C4+ than 768 (both on heuristic configs); the profile sweep targets 768.
+    del mtp
+    align = 128 * int(tp_size)
+    return _round_up(int(config.moe_intermediate_size), align)
+
+
+def _pad_expert_tensor(t: torch.Tensor, leaf: str, extra: int, base_intermediate: int) -> torch.Tensor:
+    """Zero-pad one routed-expert tensor along its intermediate axis.
+
+    ``extra`` counts logical (unpacked) intermediate elements.  Layouts in the
+    GLM-5.3-Flash checkpoints:
+      NVFP4 (target): gate/up ``weight`` u8 [I, H/2], ``weight_scale`` fp8 [I, H/16];
+                      down ``weight`` u8 [H, I/2], ``weight_scale`` fp8 [H, I/16]
+      MXFP8 (MTP):    gate/up ``weight`` fp8 [I, H], ``weight_scale`` u8 [I, H/32];
+                      down ``weight`` fp8 [H, I], ``weight_scale`` u8 [H, I/32]
+    Scalars (``input_scale``, ``weight_scale_2``) pass through.  Zero codes and
+    zero block scales make the padded channels contribute exactly nothing.
+    """
+    proj, _, kind = leaf.partition(".")
+    if kind not in ("weight", "weight_scale") or t.dim() != 2:
+        return t
+    if proj in ("gate_proj", "up_proj"):
+        return _pad_any(t, 0, extra)
+    if proj != "down_proj":
+        return t
+    if kind == "weight":
+        packed = 2 if t.dtype == torch.uint8 else 1  # fp4 pairs per byte vs fp8/bf16
+        return _pad_any(t, 1, extra // packed)
+    group = base_intermediate // int(t.shape[1])  # 16 (NVFP4) or 32 (MXFP8)
+    return _pad_any(t, 1, extra // group)
+
+
+def _pad_any(t: torch.Tensor, dim: int, extra: int) -> torch.Tensor:
+    if extra <= 0:
+        return t
+    shape = list(t.shape)
+    shape[dim] = extra
+    return torch.cat([t, torch.zeros(shape, dtype=t.dtype, device=t.device)], dim=dim)
+
+
+def vocab_padding_size(default: int = 64) -> int:
+    """Vocab padding that keeps the padded vocab divisible by the TP size."""
+    from vllm.distributed import get_tensor_model_parallel_world_size
+
+    tp = get_tensor_model_parallel_world_size()
+    return math.lcm(default, tp)
+
+
+def _pad_dim(t: torch.Tensor, dim: int, extra: int) -> torch.Tensor:
+    if extra <= 0:
+        return t
+    if t.dtype not in (torch.bfloat16, torch.float16, torch.float32):
+        raise NotImplementedError(
+            f"TP head padding supports BF16/FP16/FP32 attention tensors only, got {t.dtype} "
+            "(quantized attention checkpoints are not supported)"
+        )
+    shape = list(t.shape)
+    shape[dim] = extra
+    pad = torch.zeros(shape, dtype=t.dtype, device=t.device)
+    return torch.cat([t, pad], dim=dim)
+
+
+def pad_head_weights(weights: Iterable[tuple], config: Any) -> Iterable[tuple]:
+    """Wrap a checkpoint weight iterator, padding head-sharded tensors."""
+    ckpt_mla = getattr(config, "num_attention_heads_ckpt", None)
+    ckpt_kda = getattr(config, "linear_num_heads_ckpt", None)
+    if ckpt_mla is None and ckpt_kda is None:
+        yield from weights
+        return
+    mla_extra = int(config.num_attention_heads) - int(ckpt_mla or config.num_attention_heads)
+    kda_extra = int(config.linear_num_heads) - int(ckpt_kda or config.linear_num_heads)
+    qk_dim = int(config.qk_nope_head_dim) + int(config.qk_rope_head_dim)
+    kv_b_dim = int(config.qk_nope_head_dim) + int(config.v_head_dim)
+    v_dim = int(config.v_head_dim)
+    kda_hd = int(config.linear_head_dim)
+
+    def is_kda(layer_idx: int) -> bool:
+        return bool(config.is_kda_layer(layer_idx))
+
+    shared_extra = 0
+    if os.getenv(_ENV, "").strip():
+        from vllm.distributed import get_tensor_model_parallel_world_size
+
+        base = int(config.moe_intermediate_size) * int(config.n_shared_experts or 1)
+        shared_extra = shared_expert_intermediate(config, get_tensor_model_parallel_world_size()) - base
+
+    routed_extra = routed_extra_mtp = 0
+    if os.getenv(_ENV, "").strip():
+        from vllm.distributed import get_tensor_model_parallel_world_size
+
+        tp = get_tensor_model_parallel_world_size()
+        base_inter = int(config.moe_intermediate_size)
+        routed_extra = routed_expert_intermediate(config, tp) - base_inter
+        routed_extra_mtp = routed_expert_intermediate(config, tp, mtp=True) - base_inter
+    num_target_layers = int(config.num_hidden_layers)
+
+    for item in weights:
+        name, w = item[0], item[1]
+        if (routed_extra or routed_extra_mtp) and ".mlp.experts." in name and ".shared_experts." not in name:
+            leaf = name.rsplit(".mlp.experts.", 1)[1].split(".", 1)[1]  # "<proj>.<kind>"
+            lm = _LAYER_RE.search(name)
+            is_mtp = lm is not None and int(lm.group(1)) >= num_target_layers
+            extra = routed_extra_mtp if is_mtp else routed_extra
+            w = _pad_expert_tensor(w, leaf, extra, int(config.moe_intermediate_size))
+            yield (name, w, *item[2:])
+            continue
+        if shared_extra and ".mlp.shared_experts." in name:
+            leaf = name.rsplit(".mlp.shared_experts.", 1)[1]
+            if leaf in ("gate_proj.weight", "up_proj.weight"):
+                w = _pad_dim(w, 0, shared_extra)
+            elif leaf == "down_proj.weight":
+                w = _pad_dim(w, 1, shared_extra)
+            elif "weight_scale" in leaf:
+                raise NotImplementedError("TP padding does not support quantized shared experts")
+            yield (name, w, *item[2:])
+            continue
+        m = _LAYER_RE.search(name)
+        if m is None or _MTP_SELF_ATTN not in name:
+            yield item
+            continue
+        layer_idx = int(m.group(1))
+        suffix = name.split(_MTP_SELF_ATTN, 1)[1]
+        suffix = suffix.replace("forget_gate.", "")
+        if is_kda(layer_idx):
+            if kda_extra:
+                if suffix in ("q_proj.weight", "k_proj.weight", "v_proj.weight", "f_b_proj.weight", "g_b_proj.weight", "dt_bias", "q_conv1d.weight", "k_conv1d.weight", "v_conv1d.weight"):
+                    w = _pad_dim(w, 0, kda_extra * kda_hd)
+                elif suffix in ("b_proj.weight", "A_log"):
+                    if w.dim() == 4:  # legacy (1, 1, H, 1) A_log
+                        w = w.reshape(w.shape[2])
+                    w = _pad_dim(w, 0, kda_extra)
+                elif suffix == "conv1d.weight":  # fused q/k/v banks
+                    rows = w.shape[0] // 3
+                    w = torch.cat([_pad_dim(w.narrow(0, i * rows, rows), 0, kda_extra * kda_hd) for i in range(3)], dim=0)
+                elif suffix == "o_proj.weight":
+                    w = _pad_dim(w, 1, kda_extra * kda_hd)
+        elif mla_extra:
+            if suffix == "q_b_proj.weight":
+                w = _pad_dim(w, 0, mla_extra * qk_dim)
+            elif suffix == "kv_b_proj.weight":
+                w = _pad_dim(w, 0, mla_extra * kv_b_dim)
+            elif suffix == "o_proj.weight":
+                w = _pad_dim(w, 1, mla_extra * v_dim)
+            elif suffix in ("q_b_proj.weight_scale", "q_b_proj.weight_scale_inv", "o_proj.weight_scale", "o_proj.weight_scale_inv", "kv_b_proj.weight_scale", "kv_b_proj.weight_scale_inv"):
+                raise NotImplementedError("TP head padding does not support quantized MLA projections")
+        yield (name, w, *item[2:])

--- a/vllm/transformers_utils/configs/glm5_next.py
+++ b/vllm/transformers_utils/configs/glm5_next.py
@@ -205,6 +205,12 @@ class Glm5NextTextConfig(PretrainedConfig):
             tie_word_embeddings=tie_word_embeddings,
             **kwargs,
         )
+        # TP head padding (VLLM_GLM53_TP_HEAD_PAD): pad the MLA/KDA head counts
+        # so tensor-parallel sizes that do not divide 64 (TP3) shard evenly.
+        # The checkpoint counts are kept as *_ckpt for the weight loader.
+        from vllm.transformers_utils.configs.glm53_tp_pad import apply_config_padding
+
+        apply_config_padding(self)
 
     @property
     def is_mla(self):


### PR DESCRIPTION
## Summary

Tensor-parallel head padding so GLM-5.3-Flash serves on three GPUs (TP3). The model has 64 MLA heads, 64 KDA heads, a 2048-wide routed-expert intermediate, a 2048-wide shared expert and a 154,880 vocab; none divide by 3.

With `VLLM_GLM53_TP_HEAD_PAD=<mla_heads>,<kda_heads>` (or `auto` with the launcher's `TP`):
- the text config pads the head counts (72 / 66 on TP3; the checkpoint counts are kept as `num_attention_heads_ckpt` / `linear_num_heads_ckpt`),
- the checkpoint iterator zero-pads the head-sharded tensors (MLA `q_b_proj`, `kv_b_proj`, `o_proj`; KDA `q/k/v_proj`, `b_proj`, `f_b_proj`, `g_b_proj`, `A_log`, `dt_bias`, the conv1d banks, `o_proj`), the routed experts to 128 x TP in their packed NVFP4/MXFP8 layouts (768 per rank on TP3), the shared expert to 64 x TP, and the vocab to lcm(64, TP) on `VocabParallelEmbedding`, `ParallelLMHead` and the MTP `SharedHead`.

Padded heads are inert: zero `kv_b_proj` rows make W_UK = W_UV = 0 and `o_proj` columns are zero; padded KDA heads have q = k = v = 0 so their state stays zero. Zero fp4/fp8 codes with zero block scales contribute nothing to the experts.

Everything is a no-op unless the env var is set, and the rounding helpers return values 2048 / 154,880 already satisfy at TP 1/2/4/8.

## Test plan

Three RTX PRO 6000 Blackwell, `jovian-judgement-community-20260902-r17` + this change, TP3/DCP1, MTP3 (marlin / probabilistic / standard), 2048-token split pages, b12x NVFP4 MoE on plain TP3, world-size-3 PCIe one-shot/DMA all-reduce (b12x PR) and a regenerated b12x profile for the TP3 shapes:

| | C1 | C4 | C8 | C12 | C24 | C32 |
|---|---|---|---|---|---|---|
| TP3 tok/s @ target steps/s | 187 @ 76.6 | 437 @ 177 | 638 @ 258 | 796 @ 318 | 1091 @ 445 | 1258 @ 504 |
| TP4 reference (same image family) | 263 @ 107.7 | 604 @ 238 | 873 @ 348 | 1013 @ 411 | 1433 @ 578 | 1616 @ 645 |
| ratio (steps/s) | 71 % | 74 % | 74 % | 77 % | 77 % | 78 % |

Prefill 8.2k / 9.1k / 9.0k / 8.8k tok/s at 8k / 32k / 64k / 128k (TP4: ~11.5k). 1M context: 10 GiB KV per card = 1,145,519 tokens, a 904,457-token prompt answered correctly. Greedy probes (arithmetic, 700-token continuation, code, 55k-token needle) coherent; unit test `tests/models/glm5next/test_glm53_tp_pad.py` covers config idempotence and 30 tensor shapes/zero content.

TP4 no-regression (same TP4 config with these files present, env unset): KV pool identical (4,621,648 tokens); C1/C8 cells: C1 target steps/s over three 30 s cells, overlays present [98.8, 98.1, 97.7] vs plain [99.3, 98.7, 98.3]; C8 850.8 @ 345.1 vs 831.9 @ 339.2.

Scope: tested with MTP3 only. DFlash2 on TP3 is untested; the `DFlash2DraftModel` (32 query / 8 KV heads) needs its own padding hook.

Related: the world-size-3 collective tables and the TP3 policy corpus are in the b12x PR; the two-shot row padding for world size 3 is a follow-up on #580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tensor-parallel padding support for GLM-5.3-Next and GLM-5.3-Flash checkpoints.
  - Improved compatibility with tensor-parallel configurations where attention heads, expert dimensions, or vocabulary size do not divide evenly.
  - Added consistent padding for multi-token prediction embeddings, language-model heads, and attention weights.
  - Preserved checkpoint values while filling required padding with zeros.

- **Compatibility**
  - Attention-weight padding supports BF16, FP16, and FP32 checkpoints.
  - Quantized attention checkpoints remain unsupported for this padding path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->