### PR TITLE
fix(kv-cache): balance GLM split groups by memory cost

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2434,6 +2434,41 @@ def test_glm5next_fp8_keeps_lower_group_count(
     assert [len(group.layer_names) for group in groups] == [12, 11, 11, 12]
 
 
+def test_glm5next_weighted_groups_replace_over_limit_baseline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE", "2048")
+    all_specs = _glm5next_split_specs("nvfp4_ds_mla")
+    specs = {
+        name: spec
+        for name, spec in all_specs.items()
+        if name == "model.target.0"
+        or name in {f"model.recurrent.{index}" for index in range(8)}
+    }
+
+    groups = kv_cache_utils._get_weighted_shared_pool_kv_cache_groups(
+        _glm5next_split_config(), specs
+    )
+
+    assert len(groups) <= kv_cache_utils._MAX_WEIGHTED_SHARED_POOL_GROUPS
+    assert {name for group in groups for name in group.layer_names} == set(specs)
+
+
+def test_glm5next_weighted_groups_reject_more_than_eight_buckets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        kv_cache_utils,
+        "_get_kv_cache_layer_buckets",
+        lambda _: [[f"layer.{index}"] for index in range(9)],
+    )
+
+    with pytest.raises(ValueError, match="9 incompatible layer buckets"):
+        kv_cache_utils._get_weighted_shared_pool_kv_cache_groups(
+            _glm5next_split_config(), {}
+        )
+
+
 def test_glm5next_nvfp4_auto_geometry_capacity() -> None:
     """DCP4 4K retention geometry recovers the expected 12.67M capacity."""
     target = MLAAttentionSpec(

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2337,7 +2337,7 @@ def test_glm5next_split_cache_preserves_physical_pages(
 
     monkeypatch.setenv("VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE", "512")
     groups = get_kv_cache_groups(
-        _grouping_config(),
+        _glm5next_split_config(),
         {"model.target": target, "model.recurrent": recurrent},
     )
 
@@ -2360,6 +2360,122 @@ def test_glm5next_split_cache_preserves_physical_pages(
     assert kv_cache_utils._get_kv_cache_bytes_per_block(groups) == (
         expected_pool_stride
     )
+
+
+def _glm5next_split_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        speculative_config=None,
+        model_config=SimpleNamespace(max_model_len=202_752),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=4),
+        cache_config=SimpleNamespace(mamba_cache_mode="align"),
+    )
+
+
+def _glm5next_split_specs(cache_dtype: str) -> dict[str, KVCacheSpec]:
+    target = MLAAttentionSpec(
+        block_size=2048,
+        num_kv_heads=1,
+        head_size=512 if cache_dtype == "nvfp4_ds_mla" else 528,
+        dtype=torch.uint8,
+        cache_dtype_str=cache_dtype,
+        state_content_bytes=304 if cache_dtype == "nvfp4_ds_mla" else None,
+        model_version="glm5_next",
+        page_tail_bytes_per_token=33,
+        alignment=64 * 132,
+    )
+    recurrent = MambaSpec(
+        block_size=2048,
+        shapes=((1_122_304,),),
+        dtypes=(torch.uint8,),
+        mamba_cache_mode="align",
+        num_speculative_blocks=3,
+        num_prefill_checkpoint_blocks=1,
+    )
+    return {
+        **{f"model.recurrent.{i}": recurrent for i in range(34)},
+        **{f"model.target.{i}": target for i in range(12)},
+    }
+
+
+def test_glm5next_nvfp4_weights_split_cache_groups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE", "2048")
+    specs = _glm5next_split_specs("nvfp4_ds_mla")
+    groups = get_kv_cache_groups(_glm5next_split_config(), specs)
+
+    recurrent_groups = [
+        group for group in groups if isinstance(group.kv_cache_spec, MambaSpec)
+    ]
+    target_groups = [
+        group for group in groups if isinstance(group.kv_cache_spec, MLAAttentionSpec)
+    ]
+    assert [len(group.layer_names) for group in recurrent_groups] == [7, 7, 7, 7, 6]
+    assert [len(group.layer_names) for group in target_groups] == [12]
+    assert {name for group in groups for name in group.layer_names} == set(specs)
+    assert kv_cache_utils._get_kv_cache_bytes_per_block(groups) == 8_312_832
+    assert (
+        kv_cache_utils._get_kv_cache_group_allocation_cost(
+            _glm5next_split_config(), groups
+        )
+        == 457_205_760
+    )
+
+
+def test_glm5next_fp8_keeps_lower_group_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE", "2048")
+    specs = _glm5next_split_specs("fp8_ds_mla")
+    groups = get_kv_cache_groups(_glm5next_split_config(), specs)
+
+    assert len(groups) == 4
+    assert [len(group.layer_names) for group in groups] == [12, 11, 11, 12]
+
+
+def test_glm5next_nvfp4_auto_geometry_capacity() -> None:
+    """DCP4 4K retention geometry recovers the expected 12.67M capacity."""
+    target = MLAAttentionSpec(
+        block_size=1024,
+        num_kv_heads=1,
+        head_size=512,
+        dtype=torch.uint8,
+        cache_dtype_str="nvfp4_ds_mla",
+        state_content_bytes=304,
+        model_version="glm5_next",
+        page_tail_bytes_per_token=33,
+        alignment=64 * 132,
+    )
+    recurrent = MambaSpec(
+        block_size=1024,
+        shapes=((1_085_440,),),
+        dtypes=(torch.uint8,),
+        mamba_cache_mode="align",
+        num_prefill_checkpoint_blocks=1,
+    )
+    groups = [
+        KVCacheGroupSpec([f"recurrent.{i}.{j}" for j in range(width)], recurrent)
+        for i, width in enumerate((9, 9, 8, 8))
+    ]
+    groups.append(KVCacheGroupSpec([f"target.{i}" for i in range(11)], target))
+    config = KVCacheConfig(
+        num_blocks=3873,
+        kv_cache_tensors=[],
+        kv_cache_groups=groups,
+        prefix_cache_retention_interval=4096,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(max_model_len=202_752),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=4),
+        cache_config=SimpleNamespace(mamba_cache_mode="align"),
+    )
+
+    capacity, concurrency = get_kv_cache_capacity(vllm_config, config)
+
+    assert target.page_size_bytes == 346_368
+    assert capacity == 12_665_459
+    assert concurrency == pytest.approx(62.46774193548387)
 
 
 def new_indexer_mla_spec(block_size=16):

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -4,6 +4,7 @@
 
 import copy
 import hashlib
+import itertools
 import math
 import os
 from collections import defaultdict
@@ -1129,8 +1130,56 @@ def is_kv_cache_type_attention_free(kv_cache_spec: dict[str, KVCacheSpec]) -> bo
     return not kv_cache_spec
 
 
+def _get_kv_cache_layer_buckets(
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> list[list[str]]:
+    # Group all layers by kv_cache_spec.
+    # E.g., 2 full attention layers and 3 sliding window attention layers,
+    # -> (full.0, full.1), (sw.0, sw.1, sw.2).
+    same_type_layers: dict[KVCacheSpec, list[str]] = defaultdict(list)
+    for layer_name, layer_spec in kv_cache_spec.items():
+        same_type_layers[layer_spec].append(layer_name)
+
+    # Attempt to further merge same-type layers based on whether their KV
+    # cache specs can be merged, to minimize the group count. This benefits
+    # situations where specs share a block layout and differ only in a
+    # property it can reconcile (e.g. full attention layers differing only in
+    # sliding window / attention chunk size).
+    layer_buckets: list[list[str]] = []
+    spec_buckets: list[list[KVCacheSpec]] = []
+    for layer_spec, layer_names in same_type_layers.items():
+        for names, specs in zip(layer_buckets, spec_buckets):
+            try:
+                # A raise means that the specs are incompatible.
+                type(specs[0]).merge([*specs, layer_spec])
+            except (AssertionError, ValueError):
+                continue
+            names.extend(layer_names)
+            specs.append(layer_spec)
+            break
+        else:
+            layer_buckets.append(list(layer_names))
+            spec_buckets.append([layer_spec])
+    return layer_buckets
+
+
+def _split_kv_cache_layer_buckets(
+    kv_cache_spec: dict[str, KVCacheSpec],
+    layer_buckets: list[list[str]],
+    group_counts: Sequence[int],
+) -> list[KVCacheGroupSpec]:
+    grouped_layers = [
+        layers[i::num_groups]
+        for layers, num_groups in zip(layer_buckets, group_counts)
+        for i in range(num_groups)
+    ]
+    return create_kv_cache_group_specs(kv_cache_spec, grouped_layers)
+
+
 def _get_kv_cache_groups_uniform_page_size(
     kv_cache_spec: dict[str, KVCacheSpec],
+    *,
+    log_padding: bool = True,
 ) -> list[KVCacheGroupSpec]:
     """
     Generates the KV cache groups for hybrid models with multiple
@@ -1194,33 +1243,7 @@ def _get_kv_cache_groups_uniform_page_size(
     Returns:
         The generated KVCacheGroupSpecs
     """
-    # Group all layers by kv_cache_spec.
-    # E.g., 2 full attention layers and 3 sliding window attention layers,
-    # -> (full.0, full.1), (sw.0, sw.1, sw.2).
-    same_type_layers: dict[KVCacheSpec, list[str]] = defaultdict(list)
-    for layer_name, layer_spec in kv_cache_spec.items():
-        same_type_layers[layer_spec].append(layer_name)
-
-    # Attempt to further merge same-type layers based on whether their KV
-    # cache specs can be merged, to minimize the group count. This benefits
-    # situations where specs share a block layout and differ only in a
-    # property it can reconcile (e.g. full attention layers differing only in
-    # sliding window / attention chunk size).
-    layer_buckets: list[list[str]] = []
-    spec_buckets: list[list[KVCacheSpec]] = []
-    for layer_spec, layer_names in same_type_layers.items():
-        for names, specs in zip(layer_buckets, spec_buckets):
-            try:
-                # A raise means that the specs are incompatible.
-                type(specs[0]).merge([*specs, layer_spec])
-            except (AssertionError, ValueError):
-                continue
-            names.extend(layer_names)
-            specs.append(layer_spec)
-            break
-        else:
-            layer_buckets.append(list(layer_names))
-            spec_buckets.append([layer_spec])
+    layer_buckets = _get_kv_cache_layer_buckets(kv_cache_spec)
 
     # Split each group into smaller groups, to make the number of layers in each
     # group identical. Add padding to the last group of each type if necessary.
@@ -1246,10 +1269,10 @@ def _get_kv_cache_groups_uniform_page_size(
         # layers while accommodating speculative decoding drafters that add
         # extra layers to one attention type.
         group_size = max_num_layers
-    grouped_layers = []
+    group_counts = []
     for layers in layer_buckets:
         num_padding_layers = group_size - len(layers) % group_size
-        if num_padding_layers != group_size:
+        if log_padding and num_padding_layers != group_size:
             logger.warning(
                 "Add %d padding layers, may waste at most %.2f%% KV cache memory",  # noqa
                 num_padding_layers,
@@ -1267,9 +1290,8 @@ def _get_kv_cache_groups_uniform_page_size(
         # the same and will cause memory waste.
         # To avoid this, we assign layers[i::num_groups] to the i-th group
         # instead of layers[i * group_size: (i + 1) * group_size]
-        for i in range(num_groups):
-            grouped_layers.append(layers[i::num_groups])
-    return create_kv_cache_group_specs(kv_cache_spec, grouped_layers)
+        group_counts.append(num_groups)
+    return _split_kv_cache_layer_buckets(kv_cache_spec, layer_buckets, group_counts)
 
 
 def _get_per_layer_spec(
@@ -1318,6 +1340,70 @@ def _get_kv_cache_bytes_per_block(
         glm_c4_index_page_bytes = 64 * 132
         bytes_per_block = round_up(bytes_per_block, glm_c4_index_page_bytes)
     return bytes_per_block
+
+
+# Groups add block-table rows and connector work. This is twice GLM-5.3's
+# baseline count, enough to balance its split pages without unbounded overhead.
+_MAX_WEIGHTED_SHARED_POOL_GROUPS = 8
+
+
+def _get_kv_cache_group_allocation_cost(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> int:
+    """Return shared-pool bytes needed by one maximum-length request."""
+    num_blocks_per_request = sum(
+        cdiv(
+            group.kv_cache_spec.max_memory_usage_bytes(vllm_config),
+            group.kv_cache_spec.page_size_bytes,
+        )
+        for group in kv_cache_groups
+    )
+    return _get_kv_cache_bytes_per_block(kv_cache_groups) * num_blocks_per_request
+
+
+def _get_weighted_shared_pool_kv_cache_groups(
+    vllm_config: VllmConfig,
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> list[KVCacheGroupSpec]:
+    """Balance split-page groups by their actual shared-pool memory cost."""
+    layer_buckets = _get_kv_cache_layer_buckets(kv_cache_spec)
+    baseline_groups = _get_kv_cache_groups_uniform_page_size(
+        kv_cache_spec, log_padding=False
+    )
+    baseline_cost = _get_kv_cache_group_allocation_cost(vllm_config, baseline_groups)
+    best_groups = baseline_groups
+    best_key = (baseline_cost, len(baseline_groups))
+
+    group_count_ranges = [
+        range(1, min(len(layers), _MAX_WEIGHTED_SHARED_POOL_GROUPS) + 1)
+        for layers in layer_buckets
+    ]
+    for group_counts in itertools.product(*group_count_ranges):
+        total_groups = sum(group_counts)
+        if total_groups > _MAX_WEIGHTED_SHARED_POOL_GROUPS:
+            continue
+        groups = _split_kv_cache_layer_buckets(
+            kv_cache_spec, layer_buckets, group_counts
+        )
+        cost = _get_kv_cache_group_allocation_cost(vllm_config, groups)
+        candidate_key = (cost, total_groups)
+        if candidate_key < best_key:
+            best_key = candidate_key
+            best_groups = groups
+
+    if best_groups is not baseline_groups:
+        logger.warning(
+            "Rebalanced split KV cache groups from layer counts %s to %s; "
+            "shared-pool max-request cost decreased from %d to %d bytes "
+            "(%.2f%%).",
+            [len(group.layer_names) for group in baseline_groups],
+            [len(group.layer_names) for group in best_groups],
+            baseline_cost,
+            best_key[0],
+            (baseline_cost - best_key[0]) / baseline_cost * 100,
+        )
+    return best_groups
 
 
 def validate_kv_cache_layout(
@@ -1943,7 +2029,7 @@ def get_kv_cache_groups(
         # Preserve the target MLA and recurrent-state physical page sizes.
         # The block-outermost layout packs each group's pages independently,
         # while the hybrid coordinator handles their token block sizes.
-        groups = _get_kv_cache_groups_uniform_page_size(filtered_spec)
+        groups = _get_weighted_shared_pool_kv_cache_groups(vllm_config, filtered_spec)
         logger.warning(
             "Keeping split GLM-5.3 cache groups with physical page sizes %s.",
             sorted(

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -4,7 +4,6 @@
 
 import copy
 import hashlib
-import itertools
 import math
 import os
 from collections import defaultdict
@@ -1347,6 +1346,43 @@ def _get_kv_cache_bytes_per_block(
 _MAX_WEIGHTED_SHARED_POOL_GROUPS = 8
 
 
+def _iter_bounded_group_counts(
+    group_count_ranges: Sequence[range],
+    max_total: int,
+) -> Iterator[tuple[int, ...]]:
+    """Yield group-count combinations whose sum does not exceed a limit.
+
+    Args:
+        group_count_ranges: Ascending positive group counts for each layer bucket.
+        max_total: Maximum sum permitted across one combination.
+
+    Yields:
+        A group-count tuple whose sum is at most ``max_total``.
+    """
+
+    def visit(
+        bucket_index: int,
+        running_total: int,
+        counts: tuple[int, ...],
+    ) -> Iterator[tuple[int, ...]]:
+        if bucket_index == len(group_count_ranges):
+            yield counts
+            return
+
+        remaining_buckets = len(group_count_ranges) - bucket_index - 1
+        for group_count in group_count_ranges[bucket_index]:
+            new_total = running_total + group_count
+            if new_total + remaining_buckets > max_total:
+                break
+            yield from visit(
+                bucket_index + 1,
+                new_total,
+                (*counts, group_count),
+            )
+
+    yield from visit(0, 0, ())
+
+
 def _get_kv_cache_group_allocation_cost(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
@@ -1368,30 +1404,43 @@ def _get_weighted_shared_pool_kv_cache_groups(
 ) -> list[KVCacheGroupSpec]:
     """Balance split-page groups by their actual shared-pool memory cost."""
     layer_buckets = _get_kv_cache_layer_buckets(kv_cache_spec)
+    if len(layer_buckets) > _MAX_WEIGHTED_SHARED_POOL_GROUPS:
+        raise ValueError(
+            "Cannot represent split KV cache within the group limit: "
+            f"{len(layer_buckets)} incompatible layer buckets require at least "
+            f"{len(layer_buckets)} groups, but the limit is "
+            f"{_MAX_WEIGHTED_SHARED_POOL_GROUPS}."
+        )
     baseline_groups = _get_kv_cache_groups_uniform_page_size(
         kv_cache_spec, log_padding=False
     )
     baseline_cost = _get_kv_cache_group_allocation_cost(vllm_config, baseline_groups)
-    best_groups = baseline_groups
-    best_key = (baseline_cost, len(baseline_groups))
+    baseline_within_limit = len(baseline_groups) <= _MAX_WEIGHTED_SHARED_POOL_GROUPS
+    best_groups = baseline_groups if baseline_within_limit else None
+    best_key = (baseline_cost, len(baseline_groups)) if baseline_within_limit else None
 
     group_count_ranges = [
         range(1, min(len(layers), _MAX_WEIGHTED_SHARED_POOL_GROUPS) + 1)
         for layers in layer_buckets
     ]
-    for group_counts in itertools.product(*group_count_ranges):
+    for group_counts in _iter_bounded_group_counts(
+        group_count_ranges, _MAX_WEIGHTED_SHARED_POOL_GROUPS
+    ):
         total_groups = sum(group_counts)
-        if total_groups > _MAX_WEIGHTED_SHARED_POOL_GROUPS:
-            continue
         groups = _split_kv_cache_layer_buckets(
             kv_cache_spec, layer_buckets, group_counts
         )
         cost = _get_kv_cache_group_allocation_cost(vllm_config, groups)
         candidate_key = (cost, total_groups)
-        if candidate_key < best_key:
+        if best_key is None or candidate_key < best_key:
             best_key = candidate_key
             best_groups = groups
 
+    if best_groups is None or best_key is None:
+        raise ValueError(
+            "No compatible split KV cache layout fits within the "
+            f"{_MAX_WEIGHTED_SHARED_POOL_GROUPS}-group limit."
+        )
     if best_groups is not baseline_groups:
         logger.warning(
             "Rebalanced split KV cache groups from layer counts %s to %s; "

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1132,6 +1132,14 @@ def is_kv_cache_type_attention_free(kv_cache_spec: dict[str, KVCacheSpec]) -> bo
 def _get_kv_cache_layer_buckets(
     kv_cache_spec: dict[str, KVCacheSpec],
 ) -> list[list[str]]:
+    """Group layers whose cache specifications can share one group.
+
+    Args:
+        kv_cache_spec: Cache specification keyed by layer name.
+
+    Returns:
+        Compatible layer-name buckets in input discovery order.
+    """
     # Group all layers by kv_cache_spec.
     # E.g., 2 full attention layers and 3 sliding window attention layers,
     # -> (full.0, full.1), (sw.0, sw.1, sw.2).
@@ -1167,6 +1175,16 @@ def _split_kv_cache_layer_buckets(
     layer_buckets: list[list[str]],
     group_counts: Sequence[int],
 ) -> list[KVCacheGroupSpec]:
+    """Split compatible layer buckets into round-robin cache groups.
+
+    Args:
+        kv_cache_spec: Cache specification keyed by layer name.
+        layer_buckets: Compatible layer-name buckets to split.
+        group_counts: Number of groups to create from each bucket.
+
+    Returns:
+        Cache-group specifications for the requested splits.
+    """
     grouped_layers = [
         layers[i::num_groups]
         for layers, num_groups in zip(layer_buckets, group_counts)
@@ -1387,7 +1405,15 @@ def _get_kv_cache_group_allocation_cost(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
 ) -> int:
-    """Return shared-pool bytes needed by one maximum-length request."""
+    """Calculate shared-pool bytes needed by a maximum-length request.
+
+    Args:
+        vllm_config: Serving configuration used to determine request capacity.
+        kv_cache_groups: Candidate cache groups sharing the physical pool.
+
+    Returns:
+        Required shared-pool bytes for one maximum-length request.
+    """
     num_blocks_per_request = sum(
         cdiv(
             group.kv_cache_spec.max_memory_usage_bytes(vllm_config),
@@ -1402,7 +1428,18 @@ def _get_weighted_shared_pool_kv_cache_groups(
     vllm_config: VllmConfig,
     kv_cache_spec: dict[str, KVCacheSpec],
 ) -> list[KVCacheGroupSpec]:
-    """Balance split-page groups by their actual shared-pool memory cost."""
+    """Balance split-page groups by their shared-pool memory cost.
+
+    Args:
+        vllm_config: Serving configuration used to evaluate candidate layouts.
+        kv_cache_spec: Cache specification keyed by layer name.
+
+    Returns:
+        Lowest-cost compatible layout within the cache-group limit.
+
+    Raises:
+        ValueError: If incompatible layer buckets cannot fit within the limit.
+    """
     layer_buckets = _get_kv_cache_layer_buckets(kv_cache_spec)
     if len(layer_buckets) > _MAX_WEIGHTED_SHARED_POOL_GROUPS:
         raise ValueError(


### PR DESCRIPTION
## Summary

- balance GLM-5.3 split KV-cache groups using their actual shared-pool memory cost
- keep the existing grouping as a fallback and use fewer groups as a deterministic tie-breaker
- cap the search at eight groups to bound block-table and connector overhead
- add focused FP8/NVFP4 layout and allocation-cost tests

Closes #602.

## Why

GLM-5.3-Flash has heterogeneous target-attention and recurrent-state page sizes. Equal layer-count grouping does not equalize memory cost, so the largest shared group can waste a substantial part of the GPU KV pool. On the qualified TP4/DCP4 NVFP4 layout, the selected grouping reduces maximum-request allocation cost from 606,008,832 to 385,676,544 bytes (36.36%) without changing physical pages or logical cache geometry.

This PR is complementary to #598: #598 profiles the available memory; this PR uses the resulting pool more efficiently.

## Validation

- Focused cache-layout unit tests for FP8 and NVFP4
- Every cache layer retained exactly once
- Deterministic group-count and allocation-cost assertions
- Runtime validation on TP4/DCP4 with FP8 and NVFP4
- Stable combined-candidate capacities across restart:
  - FP8: 16,050,206 tokens
  - NVFP4: 18,444,720 tokens
- Cold compute, LMCache L1 restore, and restart-surviving L2 restore correctness passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GLM-5.3 split-cache grouping across supported cache data types.
  * Improved memory-cost balancing for split-page cache groups.
  * Added support for accurate capacity and geometry handling in DCP4 4K retention scenarios.
  * Reduced unnecessary padding warnings during cache grouping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->