### PR TITLE
fix(spec-decode): separate DFlash target and query input budgets

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1366,6 +1366,38 @@ def test_dspark_uses_separate_draft_input_budget(
     assert scheduler.schedule().num_scheduled_tokens == expected
 
 
+@pytest.mark.parametrize(
+    ("num_requests", "num_tokens", "expected"),
+    [
+        (2, 10, {"0": 10, "1": 10}),
+        (3, 1, {"0": 1, "1": 1}),
+    ],
+)
+def test_dflash_uses_separate_query_input_budget(
+    tmp_path, monkeypatch, num_requests, num_tokens, expected
+):
+    """DFlash target and query forwards share their input buffer sequentially."""
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "0")
+    (tmp_path / "config.json").write_text(
+        '{"architectures": ["OPTForCausalLM"], "model_type": "opt"}'
+    )
+    scheduler = create_scheduler(
+        model=str(tmp_path),
+        max_num_seqs=16,
+        max_num_batched_tokens=20,
+        num_speculative_tokens=7,
+        skip_tokenizer_init=True,
+    )
+    speculative_config = scheduler.vllm_config.speculative_config
+    assert speculative_config is not None
+    speculative_config.method = "dflash"
+
+    for request in create_requests(num_requests=num_requests, num_tokens=num_tokens):
+        scheduler.add_request(request)
+
+    assert scheduler.schedule().num_scheduled_tokens == expected
+
+
 # Note - these test cases mirror some of those in test_rejection_sampler.py
 @pytest.mark.parametrize(
     "spec_tokens,output_tokens,expected,expected_per_req",

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1334,6 +1334,38 @@ def test_draft_slots_budgeted_per_scheduled_request(tmp_path, monkeypatch):
     assert scheduler.schedule().num_scheduled_tokens == {"0": 10, "1": 4}
 
 
+@pytest.mark.parametrize(
+    ("num_requests", "num_tokens", "expected"),
+    [
+        (2, 8, {"0": 8, "1": 8}),
+        (5, 1, {"0": 1, "1": 1, "2": 1, "3": 1}),
+    ],
+)
+def test_dspark_uses_separate_draft_input_budget(
+    tmp_path, monkeypatch, num_requests, num_tokens, expected
+):
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "0")
+    (tmp_path / "config.json").write_text(
+        '{"architectures": ["OPTForCausalLM"], "model_type": "opt"}'
+    )
+    scheduler = create_scheduler(
+        model=str(tmp_path),
+        max_num_seqs=16,
+        max_num_batched_tokens=16,
+        num_speculative_tokens=4,
+        parallel_drafting=True,
+        skip_tokenizer_init=True,
+    )
+    speculative_config = scheduler.vllm_config.speculative_config
+    assert speculative_config is not None
+    speculative_config.method = "dspark"
+
+    for request in create_requests(num_requests=num_requests, num_tokens=num_tokens):
+        scheduler.add_request(request)
+
+    assert scheduler.schedule().num_scheduled_tokens == expected
+
+
 # Note - these test cases mirror some of those in test_rejection_sampler.py
 @pytest.mark.parametrize(
     "spec_tokens,output_tokens,expected,expected_per_req",

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -566,12 +566,15 @@ class Scheduler(SchedulerInterface):
         num_scheduled_tokens: dict[str, int] = {}
         token_budget = self.max_num_scheduled_tokens
         spec = self.vllm_config.speculative_config
-        dspark_draft_tokens = (
-            spec.num_speculative_tokens if spec is not None and spec.use_dspark() else 0
-        )
+        separate_draft_input_tokens = 0
+        if spec is not None:
+            if spec.use_dflash():
+                separate_draft_input_tokens = 1 + spec.num_speculative_tokens
+            elif spec.use_dspark():
+                separate_draft_input_tokens = spec.num_speculative_tokens
         draft_slots = (
             spec.max_num_new_slots_for_drafting
-            if spec is not None and not spec.use_dspark()
+            if spec is not None and separate_draft_input_tokens == 0
             else 0
         )
         input_budget = self.scheduler_config.max_num_batched_tokens
@@ -610,7 +613,10 @@ class Scheduler(SchedulerInterface):
         req_index = 0
         while req_index < len(self.running) and token_budget > 0:
             request = self.running[req_index]
-            if input_budget <= draft_slots or draft_input_budget < dspark_draft_tokens:
+            if (
+                input_budget <= draft_slots
+                or draft_input_budget < separate_draft_input_tokens
+            ):
                 break
 
             if (
@@ -747,7 +753,7 @@ class Scheduler(SchedulerInterface):
                             restored = num_scheduled_tokens.pop(preempted_req_id)
                             token_budget += restored
                             input_budget += restored + draft_slots
-                            draft_input_budget += dspark_draft_tokens
+                            draft_input_budget += separate_draft_input_tokens
                             req_to_new_blocks.pop(preempted_req_id)
                             scheduled_spec_decode_tokens.pop(preempted_req_id, None)
                             preempted_encoder_inputs = scheduled_encoder_inputs.pop(
@@ -786,7 +792,7 @@ class Scheduler(SchedulerInterface):
             num_scheduled_tokens[request_id] = num_new_tokens
             token_budget -= num_new_tokens
             input_budget -= num_new_tokens + draft_slots
-            draft_input_budget -= dspark_draft_tokens
+            draft_input_budget -= separate_draft_input_tokens
             req_index += 1
 
             # Speculative decode related.
@@ -839,7 +845,7 @@ class Scheduler(SchedulerInterface):
             while (self.waiting or self.skipped_waiting) and token_budget > 0:
                 if (
                     input_budget <= draft_slots
-                    or draft_input_budget < dspark_draft_tokens
+                    or draft_input_budget < separate_draft_input_tokens
                 ):
                     break
                 # Paused streaming sessions (WAITING_FOR_STREAMING_REQ) are not
@@ -1227,7 +1233,7 @@ class Scheduler(SchedulerInterface):
                 num_scheduled_tokens[request_id] = num_new_tokens
                 token_budget -= num_new_tokens
                 input_budget -= num_new_tokens + draft_slots
-                draft_input_budget -= dspark_draft_tokens
+                draft_input_budget -= separate_draft_input_tokens
                 request.status = RequestStatus.RUNNING
                 request.num_computed_tokens = num_computed_tokens
                 if pad_spec_decode:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -566,8 +566,16 @@ class Scheduler(SchedulerInterface):
         num_scheduled_tokens: dict[str, int] = {}
         token_budget = self.max_num_scheduled_tokens
         spec = self.vllm_config.speculative_config
-        draft_slots = spec.max_num_new_slots_for_drafting if spec is not None else 0
+        dspark_draft_tokens = (
+            spec.num_speculative_tokens if spec is not None and spec.use_dspark() else 0
+        )
+        draft_slots = (
+            spec.max_num_new_slots_for_drafting
+            if spec is not None and not spec.use_dspark()
+            else 0
+        )
         input_budget = self.scheduler_config.max_num_batched_tokens
+        draft_input_budget = input_budget
         if self._pause_state == PauseState.PAUSED_ALL:
             # Do not schedule any requests when paused.
             token_budget = 0
@@ -602,7 +610,7 @@ class Scheduler(SchedulerInterface):
         req_index = 0
         while req_index < len(self.running) and token_budget > 0:
             request = self.running[req_index]
-            if input_budget <= draft_slots:
+            if input_budget <= draft_slots or draft_input_budget < dspark_draft_tokens:
                 break
 
             if (
@@ -739,6 +747,7 @@ class Scheduler(SchedulerInterface):
                             restored = num_scheduled_tokens.pop(preempted_req_id)
                             token_budget += restored
                             input_budget += restored + draft_slots
+                            draft_input_budget += dspark_draft_tokens
                             req_to_new_blocks.pop(preempted_req_id)
                             scheduled_spec_decode_tokens.pop(preempted_req_id, None)
                             preempted_encoder_inputs = scheduled_encoder_inputs.pop(
@@ -777,6 +786,7 @@ class Scheduler(SchedulerInterface):
             num_scheduled_tokens[request_id] = num_new_tokens
             token_budget -= num_new_tokens
             input_budget -= num_new_tokens + draft_slots
+            draft_input_budget -= dspark_draft_tokens
             req_index += 1
 
             # Speculative decode related.
@@ -827,7 +837,10 @@ class Scheduler(SchedulerInterface):
             step_skipped_waiting = create_request_queue(self.policy)
 
             while (self.waiting or self.skipped_waiting) and token_budget > 0:
-                if input_budget <= draft_slots:
+                if (
+                    input_budget <= draft_slots
+                    or draft_input_budget < dspark_draft_tokens
+                ):
                     break
                 # Paused streaming sessions (WAITING_FOR_STREAMING_REQ) are not
                 # in `running` but still hold a model-runner request slot.
@@ -1214,6 +1227,7 @@ class Scheduler(SchedulerInterface):
                 num_scheduled_tokens[request_id] = num_new_tokens
                 token_budget -= num_new_tokens
                 input_budget -= num_new_tokens + draft_slots
+                draft_input_budget -= dspark_draft_tokens
                 request.status = RequestStatus.RUNNING
                 request.num_computed_tokens = num_computed_tokens
                 if pad_spec_decode:
@@ -1254,6 +1268,7 @@ class Scheduler(SchedulerInterface):
 
         assert token_budget >= 0
         assert input_budget >= 0
+        assert draft_input_budget >= 0
         assert len(self.running) <= self.max_num_running_reqs
         # Since some requests in the RUNNING queue may not be scheduled in
         # this step, the total number of scheduled requests can be smaller than


### PR DESCRIPTION
## Purpose

DFlash executes its target forward and its `K + 1` parallel-query forward
sequentially in the same model-runner input buffer. The scheduler previously
reserved both peaks additively, so DFlash K7 reduced an 8,192-token target
prefill step even though the query forward used the buffer only after target
execution completed.

This change tracks a separate parallel-draft input budget. Target scheduling
can use the full configured token budget, while request admission remains
bounded so all DFlash query rows fit. DSpark retains the same independent-budget
contract with `K` query rows per request.

## Attribution and duplicate analysis

The first commit is the unmodified logical change from
vllm-project/vllm#52996 and retains `guptaishaan` as author. The second commit
extends that accounting to DFlash and retains Martin Vit as author.

vllm-project/vllm#52996 covers DSpark but not DFlash. vllm-project/vllm#41971
allocates DFlash lookahead KV slots during first prefill; it does not separate
model-runner input-buffer peaks. local-inference-lab/vllm#519 and #520 change
DFlash cache geometry, not scheduler input accounting. Searches of both the
upstream and local repositories found no open DFlash input-budget PR.

## Correctness contract

- Ordinary speculative methods retain the additive per-request reservation.
- DSpark uses `K` rows from its separate query budget.
- DFlash uses `K + 1` rows from its separate query budget.
- Preemption restores both target and parallel-query budgets.
- The final scheduler assertions require both budgets to remain nonnegative.

## Validation

Directly on this two-commit pull-request head:

```text
pytest -q tests/v1/core/test_scheduler.py \
  -k "draft_slots_budgeted or dspark_uses_separate or dflash_uses_separate"
5 passed
```

The complete scheduler file produced `154 passed, 1 failed`. The single failure
is `test_abort_request_when_structured_output_fsm_cannot_advance`, which fails
identically on the unmodified `dev/jovian-judgement` base because its manually
constructed `Scheduler` lacks `acceptance_length_controller`; it is unrelated
to input-budget accounting. The composed GLM integration tree, whose fixture
already initializes that field, passed all 165 scheduler tests.

TP4/DCP1 GLM-5.3-Flash DFlash2 K7 serving on four stock-clock RTX PRO 6000
Blackwell Workstation Edition GPUs completed a cold 32k prefill at 15,019
prompt tok/s. The run used 2,048-token target/recurrent pages, an 8,192-token
scheduler budget, B12X attention/MoE/linear backends, 16 NCCL channels, and a
2 MiB NCCL buffer.

AI assistance was used to inspect execution contracts, prepare the DFlash
extension, run tests, and draft this description. The submitter reviewed the
changed files and validation results.
