### PR TITLE
perf(qwen3.8): trust scheduler-owned B12X metadata

### DIFF
--- a/tests/models/test_qwen3_8_flash_next_model.py
+++ b/tests/models/test_qwen3_8_flash_next_model.py
@@ -16,6 +16,9 @@ import vllm.models.qwen3_8_flash_next.hyperconnection as hyperconnection_module
 import vllm.models.qwen3_8_flash_next.model as model_module
 import vllm.models.qwen3_8_flash_next.ple_layer as ple_layer_module
 from vllm.config.compilation import CompilationMode
+from vllm.model_executor.layers.mamba.gdn import (
+    qwen_gdn_linear_attn as qwen_gdn_module,
+)
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
     QwenGatedDeltaNetAttention,
     _resolve_gdn_decode_kernel,
@@ -430,6 +433,49 @@ def test_b12x_gdn_bind_preserves_exact_aligned_page_stride(monkeypatch) -> None:
     assert layer.kv_cache == ()
     assert layer._b12x_plan is None
     assert layer._b12x_binding is None
+
+
+def test_b12x_gdn_plan_trusts_scheduler_metadata(monkeypatch) -> None:
+    captured_caps: dict[str, Any] = {}
+
+    class FakeApi:
+        @staticmethod
+        def Caps(**kwargs):
+            captured_caps.update(kwargs)
+            return kwargs
+
+        @staticmethod
+        def plan(caps):
+            return caps
+
+    layer = QwenGatedDeltaNetAttention.__new__(QwenGatedDeltaNetAttention)
+    nn.Module.__init__(layer)
+    layer._b12x_gdn_api = FakeApi()
+    layer._b12x_max_tokens = 16
+    layer._b12x_max_seqs = 4
+    layer._b12x_state_index_columns = 4
+    layer._b12x_local_key_heads = 4
+    layer._b12x_local_value_heads = 4
+    layer.head_k_dim = 128
+    layer.head_v_dim = 128
+    layer.model_config = SimpleNamespace(dtype=torch.bfloat16)
+    layer.norm = SimpleNamespace(activation="silu")
+
+    monkeypatch.setattr(
+        QwenGatedDeltaNetAttention,
+        "get_state_dtype",
+        lambda _: (torch.bfloat16, torch.float32),
+    )
+    monkeypatch.setattr(
+        qwen_gdn_module,
+        "current_platform",
+        SimpleNamespace(current_device=lambda: "cuda:0"),
+    )
+
+    plan = layer._make_b12x_gdn_plan(max_state_slots=32)
+
+    assert plan == captured_caps
+    assert captured_caps["qwen_metadata_validation"] == "trusted"
 
 
 def test_b12x_gdn_stages_speculative_rollback_metadata() -> None:

--- a/tests/models/test_qwen3_8_flash_next_qsa.py
+++ b/tests/models/test_qwen3_8_flash_next_qsa.py
@@ -298,6 +298,7 @@ def test_qsa_bind_uses_shared_workspace_with_smaller_profile_cache(
     assert caps.max_q_rows == owner.max_tokens
     assert caps.num_main_cache_pages == planned_pages
     assert caps.num_compressed_cache_pages == planned_pages
+    assert caps.metadata_validation == "trusted"
     assert owner._main_block_table.shape == (owner.max_seqs, planned_pages)
     assert bind_kwargs["main_k_cache"] is main_k_cache
     assert bind_kwargs["main_v_cache"] is main_v_cache

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -651,6 +651,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 state_dtype=self.get_state_dtype()[1],
                 gate_activation=self.norm.activation,
                 qk_l2norm=True,
+                qwen_metadata_validation="trusted",
             )
         )
 

--- a/vllm/models/qwen3_8_flash_next/nvidia/qsa.py
+++ b/vllm/models/qwen3_8_flash_next/nvidia/qsa.py
@@ -1076,6 +1076,7 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
                 rms_norm_eps=float(self.indexer.q_layernorm.variance_epsilon),
                 dtype=torch.bfloat16,
                 kv_dtype=self.kv_cache_kernel_dtype,
+                metadata_validation="trusted",
             )
         )
         (scratch,) = get_b12x_scratch_buffers(plan)


### PR DESCRIPTION
## Purpose

Status: **qualified** on NVIDIA RTX PRO 6000 Blackwell Workstation Edition.

The Qwen3.8 vLLM integration owns the cache tables, packed request boundaries,
accepted-token counts, and recurrent-state slot assignment passed to B12X. It
therefore selects the trusted metadata specializations provided by
local-inference-lab/b12x#298 for recurrent GDN decode and QSA.

B12X keeps transactional validation as its public default. Only the Qwen3.8
plans created by this integration opt into the trusted contract.

## Contract

The integration guarantees that active request rows have valid packed
boundaries, page tables reference allocated cache pages, recurrent-state slots
are in range, and no two active requests own the same state slot. Violating one
of these conditions while trusted mode is selected is unsupported.

## Performance evidence

The matched test used TP1 Qwen3.8-Flash-Next-NVFP4, MTP with three speculative
tokens, C1 greedy decode, 30-second samples, stock clocks, and the same physical
GPU 10.

| Mode | Target verifier steps/s |
|---|---:|
| Transactional validation, median of 2 | 61.491 |
| Trusted validation, median of 3 | 62.360 |

The verifier gain is **1.41%**. MTP output tok/s is not used for the comparison
because accepted length varied between samples.

A rank-0 Torch trace measured approximately 279.3 microseconds of GDN and QSA
validation per target step. The trusted path retains a 9.1-microsecond QSA
status initialization and removes approximately 270.2 microseconds per step.

## Validation

The two vLLM construction tests passed:

```text
pytest -q \
  tests/models/test_qwen3_8_flash_next_model.py::test_b12x_gdn_plan_trusts_scheduler_metadata \
  tests/models/test_qwen3_8_flash_next_qsa.py::test_qsa_bind_uses_shared_workspace_with_smaller_profile_cache
```

Repository pre-commit hooks, Ruff, formatting, mypy, SPDX validation, and
`git diff --check` pass.

The B12X implementation passed six SM120 tests covering transactional behavior,
trusted-mode parity, stale status, a production page-boundary rollback, CUDA
graph replay, and stable allocation.

A composed server captured full and piecewise CUDA graphs, completed a
six-sample 32,161-token prefill, and answered deterministic post-prefill checks
with `36`, `Paris`, `OK`, and `Jupiter`. Two warmed clean-source C1 samples on
GPU 12 measured 55.5 and 56.0 verifier steps/s, matching the preceding composed
implementation on that GPU at approximately 56.1 steps/s.

## Dependency and duplicate-work check

This pull request requires local-inference-lab/b12x#298. It has no dependency on
the FlashInfer GDN prefill selection change because it modifies only B12X plan
configuration.

No open local-inference-lab/vllm pull request matches the Qwen GDN and QSA
trusted-metadata integration.

AI assistance was used to inspect the trace, prepare the integration, and run
validation. The submitter reviewed the resulting diff and evidence.
