### PR TITLE
perf(qwen3.8): trust scheduler-owned PLE metadata

### DIFF
--- a/tests/models/test_qwen3_8_flash_next_model.py
+++ b/tests/models/test_qwen3_8_flash_next_model.py
@@ -120,6 +120,115 @@ def test_explicit_ple_table_memory_overrides_env_alias(monkeypatch) -> None:
     )
 
 
+def test_b12x_ple_embedding_trusts_scheduler_metadata(monkeypatch) -> None:
+    captured_caps: dict[str, Any] = {}
+
+    class FakePlan:
+        multipliers = torch.empty(0, dtype=torch.int64)
+        table_offsets = torch.empty(0, dtype=torch.int64)
+        prime_sizes = torch.empty(0, dtype=torch.int64)
+        output_shape = (8, 64)
+        output_dtype = torch.bfloat16
+
+        @staticmethod
+        def bind(**_kwargs):
+            return object()
+
+    class FakeApi:
+        @staticmethod
+        def Caps(**kwargs):
+            captured_caps.update(kwargs)
+            return kwargs
+
+        @staticmethod
+        def plan(_caps):
+            return FakePlan()
+
+    class FakeStorage(nn.Module):
+        mapped_host_nbytes = 0
+
+        def __init__(self, _plan) -> None:
+            super().__init__()
+            self.weight = nn.Parameter(torch.empty(0), requires_grad=False)
+            self.register_parameter("weight_scale", None)
+            self.register_parameter("weight_scale_2", None)
+
+    config = SimpleNamespace(
+        ngram_size=3,
+        heads_per_ngram=2,
+        eos_token_id=31,
+        split_ngram_parts=8,
+        ple_embedding_dtype="bfloat16",
+        vocab_size=32,
+        ngram_vocab_size_base=5,
+        make_ngram_vocab_size_divisible_by=8,
+    )
+    monkeypatch.setattr(ple_layer_module, "_b12x_module", lambda _name: FakeApi())
+    monkeypatch.setattr(ple_layer_module, "_NGramEmbeddingStorage", FakeStorage)
+    monkeypatch.setattr(
+        ple_layer_module, "get_b12x_scratch_buffers", lambda _plan: (torch.empty(1),)
+    )
+    monkeypatch.setattr(
+        ple_layer_module,
+        "current_platform",
+        SimpleNamespace(current_device=lambda: "cpu"),
+    )
+    monkeypatch.setattr(
+        ple_layer_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    monkeypatch.setattr(ple_layer_module, "get_tensor_model_parallel_rank", lambda: 0)
+
+    ple_layer_module.Qwen3_8FlashNextNGramEmbedding(
+        config,
+        embedding_dim=64,
+        ple_dense_layer_id=0,
+        max_total_tokens=8,
+        max_num_reqs=4,
+        owner_prefix="model.layers.1",
+        prefix="model.layers.1.ple_embedding",
+        dtype=torch.bfloat16,
+        table_memory="device",
+    )
+
+    assert captured_caps["metadata_validation"] == "trusted"
+
+
+def test_b12x_ple_state_plan_trusts_scheduler_metadata(monkeypatch) -> None:
+    captured_caps: dict[str, Any] = {}
+
+    class FakeApi:
+        @staticmethod
+        def Caps(**kwargs):
+            captured_caps.update(kwargs)
+            return kwargs
+
+        @staticmethod
+        def plan(caps):
+            return caps
+
+    layer = Qwen3_8FlashNextPLELayer.__new__(Qwen3_8FlashNextPLELayer)
+    nn.Module.__init__(layer)
+    layer.max_tokens = 16
+    layer.max_seqs = 4
+    layer.num_spec_tokens = 3
+    layer.hc_count = 4
+    layer.hidden_size = 64
+    layer.conv_kernel_size = 4
+    layer.short_conv_dilation = 3
+    layer.model_config = SimpleNamespace(dtype=torch.bfloat16)
+    monkeypatch.setattr(ple_layer_module, "_b12x_module", lambda _name: FakeApi())
+    monkeypatch.setattr(
+        ple_layer_module,
+        "current_platform",
+        SimpleNamespace(current_device=lambda: "cuda:0"),
+    )
+
+    plan = layer._make_plan(max_state_slots=32)
+
+    assert plan == captured_caps
+    assert captured_caps["metadata_validation"] == "trusted"
+
+
 def test_ple_registers_request_dependent_piecewise_splitting_ops_once() -> None:
     compilation_config = SimpleNamespace(
         static_forward_context={},

--- a/vllm/models/qwen3_8_flash_next/ple_layer.py
+++ b/vllm/models/qwen3_8_flash_next/ple_layer.py
@@ -244,6 +244,7 @@ class Qwen3_8FlashNextNGramEmbedding(nn.Module):
                 quant_mode=self._quant_mode,
                 table_memory=table_memory,
                 output_dtype=dtype,
+                metadata_validation="trusted",
             )
         )
         # The plan and checkpoint loader share these exact tensors.  Loading a
@@ -794,6 +795,7 @@ class Qwen3_8FlashNextPLELayer(nn.Module, MambaBase):
                 kernel_size=self.conv_kernel_size,
                 dilation=self.short_conv_dilation,
                 dtype=self.model_config.dtype,
+                metadata_validation="trusted",
             )
         )
 


### PR DESCRIPTION
## Purpose

Select B12X trusted metadata plans for Qwen3.8 Flash Next PLE hashing,
embedding lookup, and recurrent-state execution. The vLLM scheduler stages
bounded packed requests and owns exclusive cache-slot assignment, satisfying
the B12X trusted metadata contract without repeating device-side validation in
every PLE transaction.

The required B12X API is provided by local-inference-lab/b12x#299.
General B12X callers retain transactional validation by default.

This does not duplicate vllm-project/vllm#55054. That pull request makes
Qwen4Exp short-convolution request-index transfers asynchronous in
`short_conv_attn.py`; this pull request selects a B12X plan contract for the
Qwen3.8 Flash Next model implementation in `ple_layer.py`.

AI assistance was used to implement and validate this change. The human
submitter reviewed the resulting behavior, tests, and serving evidence.

## Test Plan

- Verify both Qwen PLE plan constructors select the trusted contract.
- Run the complete Qwen3.8 Flash Next model test module.
- Run deterministic API smoke probes under full-and-piecewise CUDA graphs.
- Compare C1 verifier execution and 32K prefill on the same physical GPU.
- Capture a rank-0 Torch trace and verify that PLE validation/reset kernels are
  absent from target decode iterations.

## Test Result

```text
python -m pytest -q tests/models/test_qwen3_8_flash_next_model.py
11 passed
```

The serving comparison used `Qwen3.8-Flash-Next-NVFP4`, TP1, MTP3, FP8 KV
cache, B12X GDN decode, B12X NVFP4 MoE, full-and-piecewise CUDA graphs, 4,096
maximum batched tokens, stock GPU clocks, and the same physical NVIDIA RTX PRO
6000 Blackwell Workstation Edition.

| Measurement | Transactional PLE | Trusted PLE | Result |
| --- | ---: | ---: | ---: |
| C1 verifier steps/s, median | 62.36 (5 runs) | 63.87 (3 runs) | +2.43% |
| 32K prefill tok/s | 6,483 | 6,458 | -0.39% |

Each decode sample used a 10-second warmup followed by a 30-second measurement.
Verifier steps/s is reported because generated-text-dependent MTP acceptance
makes raw output tokens/s unsuitable for this kernel comparison.

A rank-0 Torch trace captured four target iterations. The transactional arm
executed eight metadata-validation kernels and eight error-reset kernels,
using 67.391 microseconds of CUDA kernel time. The trusted arm executed none of
those kernels and contained exactly 16 fewer CUDA kernel events.

Deterministic serving probes returned `36`, `Paris`, `OK`, and `Jupiter`, with
no repeated-token corruption.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose and B12X dependency are described.
- [x] Duplicate-work checks and the distinct upstream work are described.
- [x] Test commands and results are included.
- [x] Model-serving correctness and performance evidence are included.
- [x] No user-facing documentation update is required; this selects an
  internal model/backend contract.

</details>
