### PR TITLE
feat(scheduler): allocate adaptive prefill compute share

### DIFF
--- a/tests/v1/core/test_compute_fairness.py
+++ b/tests/v1/core/test_compute_fairness.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections import deque
+
 import pytest
 
 from vllm.v1.core.sched.compute_fairness import PrefillComputeShareController
@@ -18,6 +20,7 @@ def _run_controller(
         service_class = controller.select(decode_runnable=True, prefill_runnable=True)
         assert service_class is not None
         elapsed = prefill_cost if service_class == "prefill" else decode_cost
+        controller.dispatch(service_class, contended=True)
         totals[service_class] += elapsed
         controller.record(service_class, elapsed, contended=True)
     return totals
@@ -57,6 +60,7 @@ def test_runtime_cost_change_changes_selected_cadence():
 def test_contention_transitions_reset_credit():
     controller = PrefillComputeShareController(0.5)
     controller.select(decode_runnable=True, prefill_runnable=True)
+    controller.dispatch("decode", contended=True)
     controller.record("decode", 1.0, contended=True)
     assert controller.decode_virtual_runtime > 0.0
 
@@ -88,6 +92,7 @@ def test_neither_class_starves_at_asymmetric_share():
 def test_outlier_lead_is_bounded_to_one_service_quantum():
     controller = PrefillComputeShareController(0.5)
     controller.select(decode_runnable=True, prefill_runnable=True)
+    controller.dispatch("prefill", contended=True)
     controller.record("prefill", 100.0, contended=True)
 
     normalized_quantum = 100.0 / controller.prefill_compute_share
@@ -99,3 +104,39 @@ def test_ties_favor_decode():
     controller = PrefillComputeShareController(0.5)
 
     assert controller.select(decode_runnable=True, prefill_runnable=True) == "decode"
+
+
+def test_two_deep_async_queue_converges_with_unequal_costs():
+    controller = PrefillComputeShareController(0.5)
+    pending: deque[str] = deque()
+    totals = {"decode": 0.0, "prefill": 0.0}
+
+    for _ in range(10_000):
+        while len(pending) < 2:
+            service_class = controller.select(
+                decode_runnable=True, prefill_runnable=True
+            )
+            assert service_class is not None
+            controller.dispatch(service_class, contended=True)
+            pending.append(service_class)
+
+        service_class = pending.popleft()
+        elapsed = 0.7 if service_class == "prefill" else 0.01
+        totals[service_class] += elapsed
+        controller.record(service_class, elapsed, contended=True)
+
+    prefill_fraction = totals["prefill"] / sum(totals.values())
+    assert prefill_fraction == pytest.approx(0.5, abs=0.01)
+
+
+def test_zero_elapsed_completion_releases_reservation():
+    controller = PrefillComputeShareController(0.5, last_decode_seconds=0.1)
+    service_class = controller.select(decode_runnable=True, prefill_runnable=True)
+    assert service_class == "decode"
+    controller.dispatch(service_class, contended=True)
+
+    assert controller.decode_reservations
+    controller.record(service_class, 0.0, contended=True)
+
+    assert not controller.decode_reservations
+    assert controller.decode_virtual_runtime == 0.0

--- a/tests/v1/core/test_compute_fairness.py
+++ b/tests/v1/core/test_compute_fairness.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.v1.core.sched.compute_fairness import PrefillComputeShareController
+
+
+def _run_controller(
+    controller: PrefillComputeShareController,
+    *,
+    decode_cost: float,
+    prefill_cost: float,
+    steps: int,
+) -> dict[str, float]:
+    totals = {"decode": 0.0, "prefill": 0.0}
+    for _ in range(steps):
+        service_class = controller.select(decode_runnable=True, prefill_runnable=True)
+        assert service_class is not None
+        elapsed = prefill_cost if service_class == "prefill" else decode_cost
+        totals[service_class] += elapsed
+        controller.record(service_class, elapsed, contended=True)
+    return totals
+
+
+@pytest.mark.parametrize(
+    ("decode_cost", "prefill_cost"), [(1.0, 1.0), (0.1, 1.0), (2.0, 0.25)]
+)
+def test_controller_converges_for_equal_and_unequal_costs(
+    decode_cost: float, prefill_cost: float
+):
+    controller = PrefillComputeShareController(0.5)
+
+    totals = _run_controller(
+        controller,
+        decode_cost=decode_cost,
+        prefill_cost=prefill_cost,
+        steps=1000,
+    )
+
+    prefill_fraction = totals["prefill"] / sum(totals.values())
+    assert prefill_fraction == pytest.approx(0.5, abs=0.01)
+
+
+def test_runtime_cost_change_changes_selected_cadence():
+    controller = PrefillComputeShareController(0.5)
+
+    first = _run_controller(controller, decode_cost=0.1, prefill_cost=1.0, steps=200)
+    first_prefill_steps = first["prefill"] / 1.0
+
+    second = _run_controller(controller, decode_cost=0.1, prefill_cost=0.2, steps=200)
+    second_prefill_steps = second["prefill"] / 0.2
+
+    assert second_prefill_steps > first_prefill_steps
+
+
+def test_contention_transitions_reset_credit():
+    controller = PrefillComputeShareController(0.5)
+    controller.select(decode_runnable=True, prefill_runnable=True)
+    controller.record("decode", 1.0, contended=True)
+    assert controller.decode_virtual_runtime > 0.0
+
+    assert controller.select(decode_runnable=True, prefill_runnable=False) == "decode"
+    assert controller.decode_virtual_runtime == 0.0
+    assert controller.prefill_virtual_runtime == 0.0
+    assert not controller.contention_active
+
+    assert controller.select(decode_runnable=True, prefill_runnable=True) == "decode"
+
+
+def test_single_runnable_class_receives_full_service():
+    controller = PrefillComputeShareController(0.5)
+
+    assert controller.select(decode_runnable=True, prefill_runnable=False) == "decode"
+    assert controller.select(decode_runnable=False, prefill_runnable=True) == "prefill"
+    assert controller.select(decode_runnable=False, prefill_runnable=False) is None
+
+
+def test_neither_class_starves_at_asymmetric_share():
+    controller = PrefillComputeShareController(0.9)
+    totals = _run_controller(controller, decode_cost=0.1, prefill_cost=1.0, steps=1000)
+
+    assert totals["decode"] > 0.0
+    assert totals["prefill"] > 0.0
+    assert totals["prefill"] / sum(totals.values()) == pytest.approx(0.9, abs=0.02)
+
+
+def test_outlier_lead_is_bounded_to_one_service_quantum():
+    controller = PrefillComputeShareController(0.5)
+    controller.select(decode_runnable=True, prefill_runnable=True)
+    controller.record("prefill", 100.0, contended=True)
+
+    normalized_quantum = 100.0 / controller.prefill_compute_share
+    lead = controller.prefill_virtual_runtime - controller.decode_virtual_runtime
+    assert 0.0 <= lead <= normalized_quantum
+
+
+def test_ties_favor_decode():
+    controller = PrefillComputeShareController(0.5)
+
+    assert controller.select(decode_runnable=True, prefill_runnable=True) == "decode"

--- a/tests/v1/core/test_compute_fairness.py
+++ b/tests/v1/core/test_compute_fairness.py
@@ -80,13 +80,16 @@ def test_single_runnable_class_receives_full_service():
     assert controller.select(decode_runnable=False, prefill_runnable=False) is None
 
 
-def test_neither_class_starves_at_asymmetric_share():
-    controller = PrefillComputeShareController(0.9)
+@pytest.mark.parametrize("prefill_share", [0.2, 0.8, 0.9])
+def test_neither_class_starves_at_asymmetric_share(prefill_share: float):
+    controller = PrefillComputeShareController(prefill_share)
     totals = _run_controller(controller, decode_cost=0.1, prefill_cost=1.0, steps=1000)
 
     assert totals["decode"] > 0.0
     assert totals["prefill"] > 0.0
-    assert totals["prefill"] / sum(totals.values()) == pytest.approx(0.9, abs=0.02)
+    assert totals["prefill"] / sum(totals.values()) == pytest.approx(
+        prefill_share, abs=0.02
+    )
 
 
 def test_outlier_lead_is_bounded_to_one_service_quantum():

--- a/tests/v1/core/test_prefill_compute_share_scheduler.py
+++ b/tests/v1/core/test_prefill_compute_share_scheduler.py
@@ -59,7 +59,7 @@ def _establish_decode(scheduler, req_id: str = "decode"):
     )
     scheduler.add_request(request)
     output = scheduler.schedule()
-    assert output.compute_service_class == "prefill"
+    assert output.compute_service_class is None
     assert not output.compute_contention
     _update(scheduler, output)
     assert not request.is_prefill_chunk
@@ -362,7 +362,10 @@ def test_partial_external_hit_is_prefill_compute(opt_model_path):
 
     output = scheduler.schedule()
 
-    assert output.compute_service_class == "prefill"
+    # The local remainder is prefill work, but there is no competing decode,
+    # so the controller does not install timing on this model step.
+    assert output.compute_service_class is None
+    assert not output.compute_contention
     assert output.num_scheduled_tokens[request.request_id] == 32
 
 

--- a/tests/v1/core/test_prefill_compute_share_scheduler.py
+++ b/tests/v1/core/test_prefill_compute_share_scheduler.py
@@ -1,0 +1,435 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.config import SchedulerConfig
+from vllm.engine.arg_utils import EngineArgs
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+from vllm.v1.outputs import ModelRunnerOutput
+
+from .utils import create_requests, create_scheduler, mock_kv
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.fixture
+def opt_model_path(tmp_path):
+    (tmp_path / "config.json").write_text(
+        '{"architectures":["OPTForCausalLM"],"model_type":"opt",'
+        '"max_position_embeddings":32768}'
+    )
+    return str(tmp_path)
+
+
+def _create_fair_scheduler(opt_model_path, **kwargs):
+    return create_scheduler(
+        model=opt_model_path,
+        skip_tokenizer_init=True,
+        prefill_compute_share=0.5,
+        device="cpu",
+        **kwargs,
+    )
+
+
+def _update(scheduler, output) -> None:
+    req_ids = list(output.num_scheduled_tokens)
+    sampled_token_ids = [
+        [] if scheduler.requests[req_id].is_prefill_chunk else [0] for req_id in req_ids
+    ]
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=req_ids,
+            req_id_to_index={req_id: index for index, req_id in enumerate(req_ids)},
+            sampled_token_ids=sampled_token_ids,
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+
+def _establish_decode(scheduler, req_id: str = "decode"):
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=4,
+        max_tokens=100,
+        req_ids=[req_id],
+    )
+    scheduler.add_request(request)
+    output = scheduler.schedule()
+    assert output.compute_service_class == "prefill"
+    assert not output.compute_contention
+    _update(scheduler, output)
+    assert not request.is_prefill_chunk
+    return request
+
+
+@pytest.mark.parametrize("share", [0.0, 1.0, -0.1, 1.1])
+def test_prefill_compute_share_rejects_invalid_values(share: float):
+    with pytest.raises(ValueError, match="prefill_compute_share"):
+        SchedulerConfig(
+            max_model_len=128,
+            is_encoder_decoder=False,
+            prefill_compute_share=share,
+        )
+
+
+def test_prefill_compute_share_cli_contract():
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+
+    namespace = parser.parse_args(["--prefill-compute-share", "0.65"])
+    engine_args = EngineArgs.from_cli_args(namespace)
+
+    assert engine_args.prefill_compute_share == pytest.approx(0.65)
+
+
+def test_prefill_compute_share_rejects_fixed_cadence():
+    with pytest.raises(ValueError, match="prefill_compute_share"):
+        SchedulerConfig(
+            max_model_len=128,
+            is_encoder_decoder=False,
+            prefill_compute_share=0.5,
+            prefill_schedule_interval=2,
+        )
+
+
+def test_prefill_compute_share_rejects_unsynchronized_dp(opt_model_path):
+    with pytest.raises(ValueError, match="synchronized service-class decision"):
+        _create_fair_scheduler(opt_model_path, data_parallel_size=2)
+
+
+def test_disabled_scheduler_emits_no_compute_policy(opt_model_path):
+    scheduler = create_scheduler(
+        model=opt_model_path,
+        skip_tokenizer_init=True,
+        device="cpu",
+    )
+    (request,) = create_requests(num_requests=1, req_ids=["legacy"])
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert scheduler.compute_share_controller is None
+    assert output.compute_service_class is None
+    assert not output.compute_contention
+
+
+def test_decode_tie_then_prefill_and_work_conserving_fallback(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_batched_tokens=16,
+        max_model_len=128,
+    )
+    _establish_decode(scheduler)
+    (prefill,) = create_requests(
+        num_requests=1,
+        num_tokens=4,
+        req_ids=["prefill"],
+    )
+    scheduler.add_request(prefill)
+
+    decode_output = scheduler.schedule()
+    assert decode_output.compute_service_class == "decode"
+    assert decode_output.compute_contention
+    assert set(decode_output.num_scheduled_tokens) == {"decode"}
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+
+    prefill_output = scheduler.schedule()
+    assert prefill_output.compute_service_class == "prefill"
+    assert prefill_output.compute_contention
+    assert "prefill" in prefill_output.num_scheduled_tokens
+    # The selected short prefill cannot fill the batch, so decode consumes the
+    # genuinely remaining capacity in the same model step.
+    assert "decode" in prefill_output.num_scheduled_tokens
+
+
+def test_prefill_fcfs_and_capacity_bound_does_not_bypass_share(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_seqs=4,
+        max_num_batched_tokens=8,
+        max_model_len=128,
+    )
+    _establish_decode(scheduler)
+    first, second = create_requests(
+        num_requests=2,
+        num_tokens=16,
+        req_ids=["first", "second"],
+    )
+    scheduler.add_request(first)
+    scheduler.add_request(second)
+
+    decode_output = scheduler.schedule()
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+
+    # The legacy cadence escape must have no effect in adaptive mode.
+    scheduler.prefill_capacity_bound = True
+    prefill_output = scheduler.schedule()
+    assert prefill_output.compute_service_class == "prefill"
+    assert prefill_output.num_scheduled_tokens == {"first": 8}
+    assert second in scheduler.waiting
+
+
+def test_running_prefills_retain_fcfs_order(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_seqs=4,
+        max_num_batched_tokens=16,
+        max_model_len=128,
+        long_prefill_token_threshold=8,
+    )
+    _establish_decode(scheduler)
+    first, second = create_requests(
+        num_requests=2,
+        num_tokens=32,
+        req_ids=["first", "second"],
+    )
+    scheduler.add_request(first)
+    scheduler.add_request(second)
+
+    decode_output = scheduler.schedule()
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+    first_prefill_output = scheduler.schedule()
+    assert list(first_prefill_output.num_scheduled_tokens) == ["first", "second"]
+    scheduler.record_compute_time("prefill", 0.01, contended=True)
+    _update(scheduler, first_prefill_output)
+
+    second_decode_output = scheduler.schedule()
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, second_decode_output)
+    second_prefill_output = scheduler.schedule()
+
+    assert list(second_prefill_output.num_scheduled_tokens) == ["first", "second"]
+
+
+def test_prefill_turn_falls_back_when_prefill_is_alignment_blocked(
+    opt_model_path, monkeypatch
+):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_batched_tokens=16,
+        max_model_len=128,
+    )
+    _establish_decode(scheduler)
+    (prefill,) = create_requests(
+        num_requests=1,
+        num_tokens=32,
+        req_ids=["blocked-prefill"],
+    )
+    scheduler.add_request(prefill)
+    decode_output = scheduler.schedule()
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+
+    scheduler.need_mamba_block_aligned_split = True
+
+    def block_prefill(request, num_new_tokens, *_args):
+        return 0 if request.request_id == prefill.request_id else num_new_tokens
+
+    monkeypatch.setattr(scheduler, "_mamba_block_aligned_split", block_prefill)
+    output = scheduler.schedule()
+
+    assert output.compute_service_class == "decode"
+    assert output.num_scheduled_tokens == {"decode": 1}
+
+
+def test_decode_turn_falls_back_when_decode_is_no_longer_runnable(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_batched_tokens=16,
+        max_model_len=128,
+    )
+    decode = _establish_decode(scheduler)
+    # Model the async guard that can make a coarsely eligible decode unable to
+    # consume another step after the class decision has already been made.
+    decode.num_output_placeholders = 1
+    decode.max_tokens = 0
+    decode.sampling_params.max_tokens = 0
+    (prefill,) = create_requests(
+        num_requests=1,
+        num_tokens=32,
+        req_ids=["fallback-prefill"],
+    )
+    scheduler.add_request(prefill)
+
+    output = scheduler.schedule()
+
+    assert output.compute_service_class == "prefill"
+    assert output.num_scheduled_tokens == {prefill.request_id: 16}
+
+
+def test_decode_turn_falls_back_to_running_prefill(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_batched_tokens=16,
+        max_model_len=128,
+        long_prefill_token_threshold=8,
+    )
+    decode = _establish_decode(scheduler)
+    (prefill,) = create_requests(
+        num_requests=1,
+        num_tokens=32,
+        req_ids=["running-prefill"],
+    )
+    scheduler.add_request(prefill)
+    decode_output = scheduler.schedule()
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+    prefill_output = scheduler.schedule()
+    scheduler.record_compute_time("prefill", 0.01, contended=True)
+    _update(scheduler, prefill_output)
+    assert prefill.is_prefill_chunk
+
+    decode.num_output_placeholders = 1
+    decode.max_tokens = 0
+    decode.sampling_params.max_tokens = 0
+    fallback_output = scheduler.schedule()
+
+    assert fallback_output.compute_service_class == "prefill"
+    assert fallback_output.num_scheduled_tokens == {prefill.request_id: 8}
+
+
+def test_full_apc_hit_is_decode_not_prefill(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        enable_prefix_caching=True,
+        block_size=16,
+        max_model_len=128,
+    )
+    warm, hit = create_requests(
+        num_requests=2,
+        num_tokens=33,
+        same_prompt=True,
+        max_tokens=1,
+        req_ids=["warm", "hit"],
+    )
+    scheduler.add_request(warm)
+    warm_output = scheduler.schedule()
+    _update(scheduler, warm_output)
+    assert warm.request_id in scheduler.finished_req_ids
+
+    _establish_decode(scheduler)
+    scheduler.add_request(hit)
+    hit_output = scheduler.schedule()
+    assert hit_output.compute_service_class == "decode"
+    assert hit_output.num_scheduled_tokens["hit"] == 1
+
+
+def test_async_external_load_does_not_consume_service_credit(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        enable_prefix_caching=True,
+        block_size=16,
+        max_model_len=128,
+        use_kv_connector=mock_kv(matched_tokens=32, is_async=True),
+    )
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=64,
+        req_ids=["restore"],
+    )
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+    assert output.total_num_scheduled_tokens == 0
+    assert output.compute_service_class is None
+    assert not output.compute_contention
+    controller = scheduler.compute_share_controller
+    assert controller is not None
+    assert controller.decode_virtual_runtime == 0.0
+    assert controller.prefill_virtual_runtime == 0.0
+
+
+def test_partial_external_hit_is_prefill_compute(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        enable_prefix_caching=True,
+        block_size=16,
+        max_model_len=128,
+        use_kv_connector=mock_kv(matched_tokens=32, is_async=False),
+    )
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=64,
+        req_ids=["partial-restore"],
+    )
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert output.compute_service_class == "prefill"
+    assert output.num_scheduled_tokens[request.request_id] == 32
+
+
+def test_only_contended_compute_is_exported_and_stats_drain(opt_model_path):
+    scheduler = _create_fair_scheduler(opt_model_path)
+
+    scheduler.record_compute_time("decode", 1.0, contended=False)
+    scheduler.record_compute_time("decode", 0.25, contended=True)
+    scheduler.record_compute_time("prefill", 0.75, contended=True)
+    stats = scheduler.make_stats()
+
+    assert stats is not None
+    assert stats.decode_compute_seconds == pytest.approx(0.25)
+    assert stats.prefill_compute_seconds == pytest.approx(0.75)
+    assert stats.prefill_compute_share == pytest.approx(0.5)
+
+    drained = scheduler.make_stats()
+    assert drained is not None
+    assert drained.decode_compute_seconds == 0.0
+    assert drained.prefill_compute_seconds == 0.0
+
+
+def test_speculative_decode_preserves_selected_prefill_quantum(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_batched_tokens=16,
+        max_model_len=128,
+        num_speculative_tokens=3,
+    )
+    _establish_decode(scheduler)
+    (prefill,) = create_requests(
+        num_requests=1,
+        num_tokens=32,
+        req_ids=["spec-prefill"],
+    )
+    scheduler.add_request(prefill)
+
+    decode_output = scheduler.schedule()
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+    prefill_output = scheduler.schedule()
+
+    assert prefill_output.compute_service_class == "prefill"
+    assert prefill_output.num_scheduled_tokens[prefill.request_id] == 16
+    assert "decode" not in prefill_output.num_scheduled_tokens
+
+
+def test_async_scheduler_preserves_compute_class_selection(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        async_scheduling=True,
+        max_num_batched_tokens=16,
+        max_model_len=128,
+    )
+    _establish_decode(scheduler)
+    (prefill,) = create_requests(
+        num_requests=1,
+        num_tokens=32,
+        req_ids=["async-prefill"],
+    )
+    scheduler.add_request(prefill)
+
+    decode_output = scheduler.schedule()
+    assert decode_output.compute_service_class == "decode"
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+    prefill_output = scheduler.schedule()
+
+    assert prefill_output.compute_service_class == "prefill"
+    assert prefill_output.num_scheduled_tokens[prefill.request_id] == 16

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3418,6 +3418,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.return_sampling_mask = False
     scheduler.recompute_kv_load_failures = False
     scheduler.defer_block_free = False
+    scheduler.acceptance_length_controller = None
     scheduler.make_stats = Mock(return_value=None)
     scheduler.max_model_len = 128
 

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -7,6 +7,7 @@ import vllm.envs as envs
 from tests.v1.kv_connector.unit.utils import MockKVConfig
 from vllm.config import (
     CacheConfig,
+    DeviceConfig,
     ECTransferConfig,
     KVTransferConfig,
     ModelConfig,
@@ -55,6 +56,8 @@ def create_scheduler(
     enable_chunked_prefill: bool = True,
     enable_prefix_caching: bool = False,
     long_prefill_token_threshold: int = 0,
+    prefill_compute_share: float | None = None,
+    device: str = "auto",
     disable_chunked_mm_input: bool = False,
     use_kv_connector: None | bool | str | MockKVConfig = None,
     kv_role: str = "kv_both",
@@ -106,6 +109,7 @@ def create_scheduler(
         max_num_batched_tokens=max_num_batched_tokens,
         max_model_len=max_model_len,
         long_prefill_token_threshold=long_prefill_token_threshold,
+        prefill_compute_share=prefill_compute_share,
         disable_chunked_mm_input=disable_chunked_mm_input,
         enable_chunked_prefill=enable_chunked_prefill,
         async_scheduling=async_scheduling,
@@ -182,6 +186,7 @@ def create_scheduler(
     )
 
     vllm_config = VllmConfig(
+        device_config=DeviceConfig(device=device),
         scheduler_config=scheduler_config,
         model_config=model_config,
         cache_config=cache_config,

--- a/tests/v1/engine/test_compute_fairness_feedback.py
+++ b/tests/v1/engine/test_compute_fairness_feedback.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from concurrent.futures import Future
+from unittest.mock import Mock, call, patch
+
+import pytest
+
+from vllm.v1.core.sched.compute_fairness import ComputeServiceClass
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.engine.core import EngineCore, _ModelExecutionTiming
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _scheduler_output(
+    service_class: ComputeServiceClass | None,
+    *,
+    contended: bool = False,
+) -> SchedulerOutput:
+    output = SchedulerOutput.make_empty()
+    output.compute_service_class = service_class
+    output.compute_contention = contended
+    return output
+
+
+def test_completion_callback_excludes_later_batch_queue_residency():
+    future: Future[None] = Future()
+    with patch("vllm.v1.engine.core.time.perf_counter", side_effect=[10.0, 10.25]):
+        timing = _ModelExecutionTiming()
+        timing.bind(future)
+        future.set_result(None)
+
+    # Reading much later must use the completion callback's timestamp.
+    assert timing.elapsed_seconds == pytest.approx(0.25)
+
+
+def test_disabled_output_does_not_install_execution_timing():
+    completed_future: Future[None] = Future()
+    completed_future.set_result(None)
+    engine = object.__new__(EngineCore)
+    engine.model_executor = Mock()
+    engine.model_executor.execute_model.return_value = completed_future
+
+    future, timing = engine._execute_model(_scheduler_output(None))
+
+    assert future is completed_future
+    assert timing is None
+
+
+def test_enabled_execution_timer_waits_for_final_batch_future():
+    execute_future: Future[None] = Future()
+    execute_future.set_result(None)
+    final_future: Future[None] = Future()
+    engine = object.__new__(EngineCore)
+    engine.model_executor = Mock()
+    engine.model_executor.execute_model.return_value = execute_future
+
+    _, timing = engine._execute_model(_scheduler_output("prefill", contended=True))
+    assert timing is not None
+    assert timing.completed_at is None
+
+    timing.bind(final_future)
+    assert timing.completed_at is None
+    final_future.set_result(None)
+    assert timing.completed_at is not None
+
+
+def test_queued_feedback_stays_paired_with_exact_batch():
+    engine = object.__new__(EngineCore)
+    engine.scheduler = Mock()
+    decode_output = _scheduler_output("decode", contended=True)
+    prefill_output = _scheduler_output("prefill", contended=True)
+    decode_timing = _ModelExecutionTiming()
+    decode_timing.completed_at = decode_timing.started_at + 0.1
+    prefill_timing = _ModelExecutionTiming()
+    prefill_timing.completed_at = prefill_timing.started_at + 0.3
+
+    # Queued batches are consumed oldest-first; each carries its own timing and
+    # class tag even when a later batch has already completed.
+    engine._record_compute_time(decode_output, decode_timing)
+    engine._record_compute_time(prefill_output, prefill_timing)
+
+    assert engine.scheduler.record_compute_time.call_args_list == [
+        call("decode", pytest.approx(0.1), contended=True),
+        call("prefill", pytest.approx(0.3), contended=True),
+    ]
+
+
+def test_empty_transfer_step_does_not_record_compute():
+    engine = object.__new__(EngineCore)
+    engine.scheduler = Mock()
+
+    engine._record_compute_time(_scheduler_output(None), None)
+
+    engine.scheduler.record_compute_time.assert_not_called()

--- a/tests/v1/engine/test_compute_fairness_feedback.py
+++ b/tests/v1/engine/test_compute_fairness_feedback.py
@@ -69,21 +69,25 @@ def test_enabled_execution_timer_waits_for_final_batch_future():
 def test_queued_feedback_stays_paired_with_exact_batch():
     engine = object.__new__(EngineCore)
     engine.scheduler = Mock()
+    engine._last_model_completion_time = None
     decode_output = _scheduler_output("decode", contended=True)
     prefill_output = _scheduler_output("prefill", contended=True)
     decode_timing = _ModelExecutionTiming()
-    decode_timing.completed_at = decode_timing.started_at + 0.1
+    decode_timing.started_at = 10.0
+    decode_timing.completed_at = 10.1
     prefill_timing = _ModelExecutionTiming()
-    prefill_timing.completed_at = prefill_timing.started_at + 0.3
+    prefill_timing.started_at = 10.01
+    prefill_timing.completed_at = 10.3
 
     # Queued batches are consumed oldest-first; each carries its own timing and
-    # class tag even when a later batch has already completed.
+    # class tag even when a later batch has already completed. The second
+    # charge excludes its 90 ms queued behind the first batch.
     engine._record_compute_time(decode_output, decode_timing)
     engine._record_compute_time(prefill_output, prefill_timing)
 
     assert engine.scheduler.record_compute_time.call_args_list == [
         call("decode", pytest.approx(0.1), contended=True),
-        call("prefill", pytest.approx(0.3), contended=True),
+        call("prefill", pytest.approx(0.2), contended=True),
     ]
 
 

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -144,6 +144,13 @@ class SchedulerConfig:
     """Schedule prefill work once every N engine steps while decode requests
     are running. Data-parallel engines align the cadence across DP ranks."""
 
+    prefill_compute_share: float | None = Field(default=None, gt=0.0, lt=1.0)
+    """Target fraction of contended model-execution time assigned to prefill.
+
+    When unset, scheduling behavior is unchanged. Values must be strictly
+    between zero and one so both decode and prefill continue to make progress.
+    """
+
     async_scheduling: bool | None = None
     """If set to False, disable async scheduling. Async scheduling helps to
     avoid gaps in GPU utilization, leading to better latency and throughput.
@@ -224,6 +231,15 @@ class SchedulerConfig:
         return None if value is None else handler(value)
 
     def __post_init__(self, max_model_len: int, is_encoder_decoder: bool) -> None:
+        if (
+            self.prefill_compute_share is not None
+            and self.prefill_schedule_interval > 1
+        ):
+            raise ValueError(
+                "prefill_compute_share cannot be combined with "
+                "prefill_schedule_interval greater than one"
+            )
+
         if is_encoder_decoder:
             # Chunked prefill should be disabled for encoder-decoder models.
             self.disable_chunked_mm_input = True

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1133,6 +1133,15 @@ class VllmConfig:
         # unset falls back to the stock ones.
         self.parallel_config.set_dcp_defaults()
 
+        if (
+            self.scheduler_config.prefill_compute_share is not None
+            and self.parallel_config.data_parallel_size > 1
+        ):
+            raise ValueError(
+                "prefill_compute_share does not yet support data parallelism; "
+                "all DP ranks must make one synchronized service-class decision"
+            )
+
         if self.model_config is not None:
             self.model_config.verify_with_parallel_config(self.parallel_config)
             self.model_config.verify_dual_chunk_attention_config(self.load_config)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -634,6 +634,7 @@ class EngineArgs:
 
     scheduler_reserve_full_isl: bool = SchedulerConfig.scheduler_reserve_full_isl
     prefill_schedule_interval: int = SchedulerConfig.prefill_schedule_interval
+    prefill_compute_share: float | None = SchedulerConfig.prefill_compute_share
 
     watermark: float = SchedulerConfig.watermark
 
@@ -1587,6 +1588,10 @@ class EngineArgs:
             **scheduler_kwargs["prefill_schedule_interval"],
         )
         scheduler_group.add_argument(
+            "--prefill-compute-share",
+            **scheduler_kwargs["prefill_compute_share"],
+        )
+        scheduler_group.add_argument(
             "--disable-hybrid-kv-cache-manager",
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"],
         )
@@ -2367,6 +2372,7 @@ class EngineArgs:
             scheduler_reserve_full_isl=self.scheduler_reserve_full_isl,
             watermark=self.watermark,
             prefill_schedule_interval=self.prefill_schedule_interval,
+            prefill_compute_share=self.prefill_compute_share,
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,

--- a/vllm/v1/core/sched/compute_fairness.py
+++ b/vllm/v1/core/sched/compute_fairness.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass
+from typing import Literal
+
+ComputeServiceClass = Literal["decode", "prefill"]
+
+
+@dataclass
+class PrefillComputeShareController:
+    """Allocate contended execution time with weighted virtual runtime."""
+
+    prefill_compute_share: float
+    decode_virtual_runtime: float = 0.0
+    prefill_virtual_runtime: float = 0.0
+    contention_active: bool = False
+
+    def select(
+        self, *, decode_runnable: bool, prefill_runnable: bool
+    ) -> ComputeServiceClass | None:
+        """Select the next runnable service class."""
+        if not decode_runnable or not prefill_runnable:
+            self.reset()
+            if decode_runnable:
+                return "decode"
+            if prefill_runnable:
+                return "prefill"
+            return None
+
+        if not self.contention_active:
+            self.decode_virtual_runtime = 0.0
+            self.prefill_virtual_runtime = 0.0
+            self.contention_active = True
+
+        if self.prefill_virtual_runtime < self.decode_virtual_runtime:
+            return "prefill"
+        return "decode"
+
+    def record(
+        self,
+        service_class: ComputeServiceClass,
+        elapsed_seconds: float,
+        *,
+        contended: bool,
+    ) -> None:
+        """Charge a completed execution quantum to its actual service class."""
+        if not contended or elapsed_seconds <= 0.0:
+            return
+
+        if service_class == "prefill":
+            charge = elapsed_seconds / self.prefill_compute_share
+            self.prefill_virtual_runtime += charge
+            if self.prefill_virtual_runtime - self.decode_virtual_runtime > charge:
+                self.decode_virtual_runtime = self.prefill_virtual_runtime - charge
+        else:
+            charge = elapsed_seconds / (1.0 - self.prefill_compute_share)
+            self.decode_virtual_runtime += charge
+            if self.decode_virtual_runtime - self.prefill_virtual_runtime > charge:
+                self.prefill_virtual_runtime = self.decode_virtual_runtime - charge
+
+    def reset(self) -> None:
+        """Discard credit when both classes are no longer runnable."""
+        self.decode_virtual_runtime = 0.0
+        self.prefill_virtual_runtime = 0.0
+        self.contention_active = False

--- a/vllm/v1/core/sched/compute_fairness.py
+++ b/vllm/v1/core/sched/compute_fairness.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import dataclass
+from collections import deque
+from dataclasses import dataclass, field
 from typing import Literal
 
 ComputeServiceClass = Literal["decode", "prefill"]
@@ -15,13 +16,18 @@ class PrefillComputeShareController:
     decode_virtual_runtime: float = 0.0
     prefill_virtual_runtime: float = 0.0
     contention_active: bool = False
+    last_decode_seconds: float | None = None
+    last_prefill_seconds: float | None = None
+    decode_reservations: deque[float] = field(default_factory=deque)
+    prefill_reservations: deque[float] = field(default_factory=deque)
 
     def select(
         self, *, decode_runnable: bool, prefill_runnable: bool
     ) -> ComputeServiceClass | None:
         """Select the next runnable service class."""
         if not decode_runnable or not prefill_runnable:
-            self.reset()
+            if not self.has_pending_reservations:
+                self.reset()
             if decode_runnable:
                 return "decode"
             if prefill_runnable:
@@ -33,9 +39,52 @@ class PrefillComputeShareController:
             self.prefill_virtual_runtime = 0.0
             self.contention_active = True
 
+        # Until a class has one measured completion, allow only one of its
+        # quanta in flight when the other class can run. This prevents an async
+        # batch queue from filling with duplicate, unpriced work at startup.
+        decode_unmeasured = self.last_decode_seconds is None and bool(
+            self.decode_reservations
+        )
+        prefill_unmeasured = self.last_prefill_seconds is None and bool(
+            self.prefill_reservations
+        )
+        if decode_unmeasured != prefill_unmeasured:
+            return "prefill" if decode_unmeasured else "decode"
+        if decode_unmeasured and prefill_unmeasured:
+            if len(self.decode_reservations) < len(self.prefill_reservations):
+                return "decode"
+            if len(self.prefill_reservations) < len(self.decode_reservations):
+                return "prefill"
+
         if self.prefill_virtual_runtime < self.decode_virtual_runtime:
             return "prefill"
         return "decode"
+
+    @property
+    def has_pending_reservations(self) -> bool:
+        return bool(self.decode_reservations or self.prefill_reservations)
+
+    def dispatch(self, service_class: ComputeServiceClass, *, contended: bool) -> None:
+        """Reserve estimated service before an async batch can be selected."""
+        if not contended:
+            return
+
+        if service_class == "prefill":
+            reservation = (
+                0.0
+                if self.last_prefill_seconds is None
+                else self.last_prefill_seconds / self.prefill_compute_share
+            )
+            self.prefill_virtual_runtime += reservation
+            self.prefill_reservations.append(reservation)
+        else:
+            reservation = (
+                0.0
+                if self.last_decode_seconds is None
+                else self.last_decode_seconds / (1.0 - self.prefill_compute_share)
+            )
+            self.decode_virtual_runtime += reservation
+            self.decode_reservations.append(reservation)
 
     def record(
         self,
@@ -45,17 +94,33 @@ class PrefillComputeShareController:
         contended: bool,
     ) -> None:
         """Charge a completed execution quantum to its actual service class."""
-        if not contended or elapsed_seconds <= 0.0:
+        if not contended:
             return
 
         if service_class == "prefill":
+            reservation = (
+                self.prefill_reservations.popleft()
+                if self.prefill_reservations
+                else 0.0
+            )
+            if elapsed_seconds <= 0.0:
+                self.prefill_virtual_runtime -= reservation
+                return
             charge = elapsed_seconds / self.prefill_compute_share
-            self.prefill_virtual_runtime += charge
+            self.prefill_virtual_runtime += charge - reservation
+            self.last_prefill_seconds = elapsed_seconds
             if self.prefill_virtual_runtime - self.decode_virtual_runtime > charge:
                 self.decode_virtual_runtime = self.prefill_virtual_runtime - charge
         else:
+            reservation = (
+                self.decode_reservations.popleft() if self.decode_reservations else 0.0
+            )
+            if elapsed_seconds <= 0.0:
+                self.decode_virtual_runtime -= reservation
+                return
             charge = elapsed_seconds / (1.0 - self.prefill_compute_share)
-            self.decode_virtual_runtime += charge
+            self.decode_virtual_runtime += charge - reservation
+            self.last_decode_seconds = elapsed_seconds
             if self.decode_virtual_runtime - self.prefill_virtual_runtime > charge:
                 self.prefill_virtual_runtime = self.decode_virtual_runtime - charge
 

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from vllm.config.kv_events import KVEventsConfig
     from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorBase
     from vllm.distributed.kv_transfer.kv_connector.v1 import KVConnectorBase_V1
+    from vllm.v1.core.sched.compute_fairness import ComputeServiceClass
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
     from vllm.v1.engine import EngineCoreOutputs
     from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -88,6 +89,16 @@ class SchedulerInterface(ABC):
             A SchedulerOutput object containing information about the scheduled
             requests.
         """
+        raise NotImplementedError
+
+    def record_compute_time(
+        self,
+        service_class: "ComputeServiceClass",
+        elapsed_seconds: float,
+        *,
+        contended: bool,
+    ) -> None:
+        """Record model-execution feedback for adaptive scheduling."""
         raise NotImplementedError
 
     @abstractmethod

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from vllm.config.ec_manager_config import EncoderCacheManagerMetadata
 from vllm.multimodal.utils import strip_covered_mm_data
+from vllm.v1.core.sched.compute_fairness import ComputeServiceClass
 
 if TYPE_CHECKING:
     import numpy as np
@@ -283,6 +284,11 @@ class SchedulerOutput:
     # Dynamic speculative decoding: optimal K chosen by scheduler.
     # Number of spec tokens to schedule for the next step.
     num_spec_tokens_to_schedule: int | None = None
+
+    # Explicit model-execution class used by adaptive compute fairness.
+    # None identifies a transfer-only or otherwise empty model step.
+    compute_service_class: ComputeServiceClass | None = None
+    compute_contention: bool = False
 
     @classmethod
     def make_empty(cls) -> "SchedulerOutput":

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -38,6 +38,10 @@ from vllm.v1.core.encoder_cache_manager import (
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import KVCacheBlock
+from vllm.v1.core.sched.compute_fairness import (
+    ComputeServiceClass,
+    PrefillComputeShareController,
+)
 from vllm.v1.core.sched.interface import PauseState, SchedulerInterface
 from vllm.v1.core.sched.output import (
     CachedRequestData,
@@ -332,6 +336,15 @@ class Scheduler(SchedulerInterface):
         # prefill batch fully drained the waiting queue. Prefill throttling
         # is disabled in this case.
         self.prefill_capacity_bound = False
+        prefill_compute_share = self.scheduler_config.prefill_compute_share
+        self.compute_share_controller = (
+            PrefillComputeShareController(prefill_compute_share)
+            if prefill_compute_share is not None
+            else None
+        )
+        if self.compute_share_controller is not None:
+            self._decode_compute_seconds = 0.0
+            self._prefill_compute_seconds = 0.0
         self.scheduler_reserve_full_isl = (
             self.scheduler_config.scheduler_reserve_full_isl
         )
@@ -579,6 +592,7 @@ class Scheduler(SchedulerInterface):
         scheduled_spec_decode_tokens: dict[str, list[int]] = {}
         # Whether the running batch contains any prefill requests.
         prefill_scheduled = False
+        scheduled_prefill_req_ids: set[str] = set()
 
         # For logging.
         scheduled_timestamp = time.monotonic()
@@ -594,223 +608,301 @@ class Scheduler(SchedulerInterface):
             and self.current_step >= request.next_decode_eligible_step
             for request in self.running
         )
-        defer_prefills = (
+        has_prefill_candidate = self._pause_state != PauseState.PAUSED_ALL and (
+            any(
+                request.is_prefill_chunk
+                and self.current_step >= request.next_decode_eligible_step
+                for request in self.running
+            )
+            or (
+                self._pause_state == PauseState.UNPAUSED
+                and bool(self.waiting or self.skipped_waiting)
+            )
+        )
+        selected_compute_class: ComputeServiceClass | None = None
+        compute_contention = False
+        if self.compute_share_controller is not None:
+            selected_compute_class = self.compute_share_controller.select(
+                decode_runnable=has_eligible_decode,
+                prefill_runnable=has_prefill_candidate,
+            )
+            compute_contention = has_eligible_decode and has_prefill_candidate
+
+        legacy_defer_prefills = (
             throttle_prefills and not self.prefill_capacity_bound
         ) and has_eligible_decode
+        adaptive_defer_prefills = (
+            selected_compute_class == "decode" and compute_contention
+        )
+        defer_prefills = legacy_defer_prefills or adaptive_defer_prefills
 
-        # First, schedule the RUNNING requests.
-        req_index = 0
-        while req_index < len(self.running) and token_budget > 0:
-            request = self.running[req_index]
-            if input_budget <= draft_slots:
-                break
+        running_req_ids_at_step_start = {request.request_id for request in self.running}
 
-            if (
-                request.num_output_placeholders > 0
-                # This is (num_computed_tokens + 1) - (num_output_placeholders - 1).
-                # Since output placeholders are also included in the computed tokens
-                # count, we subtract (num_output_placeholders - 1) to remove any draft
-                # tokens, so that we can be sure no further steps are needed even if
-                # they are all rejected.
-                and request.num_computed_tokens + 2 - request.num_output_placeholders
-                >= request.num_prompt_tokens + request.max_tokens
-            ):
-                # Async scheduling: Avoid scheduling an extra step when we are sure that
-                # the previous step has reached request.max_tokens. We don't schedule
-                # partial draft tokens since this prevents uniform decode optimizations.
-                req_index += 1
-                continue
+        def schedule_running_requests(
+            service_class: ComputeServiceClass | None = None,
+            *,
+            allow_preemption: bool = True,
+            enforce_lora_limit: bool = False,
+        ) -> None:
+            nonlocal encoder_compute_budget
+            nonlocal input_budget
+            nonlocal prefill_scheduled
+            nonlocal token_budget
+            req_index = 0
+            while req_index < len(self.running) and token_budget > 0:
+                request = self.running[req_index]
+                if (
+                    request.request_id not in running_req_ids_at_step_start
+                    or request.request_id in num_scheduled_tokens
+                ):
+                    req_index += 1
+                    continue
+                if service_class is not None and (
+                    ("prefill" if request.is_prefill_chunk else "decode")
+                    != service_class
+                ):
+                    req_index += 1
+                    continue
+                if (
+                    enforce_lora_limit
+                    and self.lora_config
+                    and request.lora_request
+                    and len(scheduled_loras) == self.lora_config.max_loras
+                    and request.lora_request.lora_int_id not in scheduled_loras
+                ):
+                    req_index += 1
+                    continue
+                if input_budget <= draft_slots:
+                    break
 
-            if self.current_step < request.next_decode_eligible_step:
-                # V2+PP+async: enforce `pp_size` steps between same-req decodes
-                # to match worker-side sampled-tokens broadcast slot ring cadence.
-                req_index += 1
-                continue
-
-            if defer_prefills and request.is_prefill_chunk:
-                # Defer this in-progress chunk to a cadence-aligned step;
-                # decodes still run to fill this step.
-                req_index += 1
-                continue
-
-            num_new_tokens = (
-                request.num_tokens_with_spec
-                + request.num_output_placeholders
-                - request.num_computed_tokens
-            )
-            if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
-                num_new_tokens = self.scheduler_config.long_prefill_token_threshold
-            num_new_tokens = min(
-                num_new_tokens, token_budget, input_budget - draft_slots
-            )
-
-            # Make sure the input position does not exceed the max model len.
-            # This is necessary when using spec decoding.
-            num_new_tokens = min(
-                num_new_tokens,
-                self.max_model_len
-                - request.num_computed_tokens
-                - self.num_sampled_tokens_per_step,
-            )
-
-            # Apply Mamba alignment before encoder caps.
-            if self.need_mamba_block_aligned_split:
-                num_new_tokens = self._mamba_block_aligned_split(
-                    request, num_new_tokens
-                )
-
-            # Schedule encoder inputs.
-            encoder_inputs_to_schedule = None
-            external_load_encoder_input: list[int] = []
-            new_encoder_compute_budget = encoder_compute_budget
-            if request.has_encoder_inputs:
-                (
-                    encoder_inputs_to_schedule,
-                    num_new_tokens,
-                    new_encoder_compute_budget,
-                    external_load_encoder_input,
-                ) = self._try_schedule_encoder_inputs(
-                    request,
-                    request.num_computed_tokens,
-                    num_new_tokens,
-                    encoder_compute_budget,
-                    shift_computed_tokens=self.num_prefill_lookahead,
-                )
-
-            # Multi-module MTP: avoid ending a prefill chunk within
-            # num_prefill_lookahead of the prefill end.
-            num_new_tokens = self._reserve_prefill_lookahead(
-                request, request.num_computed_tokens, num_new_tokens
-            )
-
-            if num_new_tokens == 0:
-                # The request cannot be scheduled because one of the following
-                # reasons:
-                # 1. No new tokens to schedule. This may happen when
-                #    (1) PP>1 and we have already scheduled all prompt tokens
-                #    but they are not finished yet.
-                #    (2) Async scheduling and the request has reached to either
-                #    its max_total_tokens or max_model_len.
-                # 2. The encoder budget is exhausted.
-                # 3. The encoder cache is exhausted.
-                # 4. Insufficient budget for a block-aligned chunk in hybrid
-                #    models with mamba cache mode \"align\".
-                # 5. Insufficient budget to keep a multi-module MTP prefill
-                #    chunk out of the prefill-lookahead window.
-                # NOTE(woosuk): Here, by doing `continue` instead of `break`,
-                # we do not strictly follow the FCFS scheduling policy and
-                # allow the lower-priority requests to be scheduled.
-                req_index += 1
-                continue
-
-            # Schedule newly needed KV blocks for the request.
-            with record_function_or_nullcontext("schedule: allocate_slots"):
-                while True:
-                    new_blocks = self.kv_cache_manager.allocate_slots(
-                        request,
-                        num_new_tokens,
-                        num_lookahead_tokens=self.num_lookahead_tokens,
-                    )
-
-                    if new_blocks is not None:
-                        # The request can be scheduled.
-                        break
-
-                    # The request cannot be scheduled.
-                    # Preempt the lowest-priority request.
-                    if self.policy == SchedulingPolicy.PRIORITY:
-                        preempted_req = max(
-                            self.running,
-                            key=lambda r: (r.priority, r.arrival_time),
-                        )
-                        # Record the index of the preemption victim to
-                        # maintain accurate loop state.
-                        victim_index = self.running.index(preempted_req)
-                        del self.running[victim_index]
-                        # Decrement the loop cursor if the removed request
-                        # preceded the current iteration, preventing the
-                        # silent omission of the subsequent request.
-                        if victim_index < req_index:
-                            req_index -= 1
-
-                        if preempted_req in scheduled_running_reqs:
-                            preempted_req_id = preempted_req.request_id
-                            scheduled_running_reqs.remove(preempted_req)
-                            restored = num_scheduled_tokens.pop(preempted_req_id)
-                            token_budget += restored
-                            input_budget += restored + draft_slots
-                            req_to_new_blocks.pop(preempted_req_id)
-                            scheduled_spec_decode_tokens.pop(preempted_req_id, None)
-                            preempted_encoder_inputs = scheduled_encoder_inputs.pop(
-                                preempted_req_id, None
-                            )
-                            if preempted_encoder_inputs:
-                                # Restore encoder compute budget if the preempted
-                                # request had encoder inputs scheduled in this step.
-                                num_embeds_to_restore = sum(
-                                    preempted_req.get_num_encoder_embeds(i)
-                                    for i in preempted_encoder_inputs
-                                )
-                                encoder_compute_budget += num_embeds_to_restore
-                    else:
-                        preempted_req = self.running.pop()
-
-                    self._preempt_request(
-                        preempted_req,
-                        scheduled_timestamp,
-                        drop_stale_output=self.requires_kv_delivery,
-                    )
-                    preempted_reqs.append(preempted_req)
-                    if preempted_req == request:
-                        # No more request to preempt. Cannot schedule this request.
-                        break
-
-            if new_blocks is None:
-                # Cannot schedule this request.
-                break
-
-            # Schedule the request.
-            scheduled_running_reqs.append(request)
-            prefill_scheduled |= request.is_prefill_chunk
-            request_id = request.request_id
-            req_to_new_blocks[request_id] = new_blocks
-            num_scheduled_tokens[request_id] = num_new_tokens
-            token_budget -= num_new_tokens
-            input_budget -= num_new_tokens + draft_slots
-            req_index += 1
-
-            # Speculative decode related.
-            if request.spec_token_ids:
-                num_scheduled_spec_tokens = (
-                    num_new_tokens
-                    + request.num_computed_tokens
-                    - request.num_tokens
+                if (
+                    request.num_output_placeholders > 0
+                    # This is (num_computed_tokens + 1) - (num_output_placeholders - 1).
+                    # Output placeholders are included in computed tokens, so
+                    # subtract (num_output_placeholders - 1) to remove draft
+                    # tokens and prove no further step is needed if all reject.
+                    and request.num_computed_tokens
+                    + 2
                     - request.num_output_placeholders
+                    >= request.num_prompt_tokens + request.max_tokens
+                ):
+                    # Async scheduling: avoid an extra step when the previous
+                    # one reached max_tokens. Do not schedule partial drafts;
+                    # that prevents uniform decode optimizations.
+                    req_index += 1
+                    continue
+
+                if self.current_step < request.next_decode_eligible_step:
+                    # V2+PP+async: enforce `pp_size` steps between same-req decodes
+                    # to match worker-side sampled-tokens broadcast slot ring cadence.
+                    req_index += 1
+                    continue
+
+                if defer_prefills and request.is_prefill_chunk:
+                    # Defer this in-progress chunk to a cadence-aligned step;
+                    # decodes still run to fill this step.
+                    req_index += 1
+                    continue
+
+                num_new_tokens = (
+                    request.num_tokens_with_spec
+                    + request.num_output_placeholders
+                    - request.num_computed_tokens
                 )
-                if num_scheduled_spec_tokens > 0:
-                    spec_token_ids = request.spec_token_ids
-                    if len(spec_token_ids) > num_scheduled_spec_tokens:
-                        spec_token_ids = spec_token_ids[:num_scheduled_spec_tokens]
-                    scheduled_spec_decode_tokens[request.request_id] = spec_token_ids
+                if (
+                    0
+                    < self.scheduler_config.long_prefill_token_threshold
+                    < num_new_tokens
+                ):
+                    num_new_tokens = self.scheduler_config.long_prefill_token_threshold
+                num_new_tokens = min(
+                    num_new_tokens, token_budget, input_budget - draft_slots
+                )
 
-                # New spec tokens will be set in `update_draft_token_ids` before the
-                # next step when applicable.
-                request.spec_token_ids = []
+                # Make sure the input position does not exceed the max model len.
+                # This is necessary when using spec decoding.
+                num_new_tokens = min(
+                    num_new_tokens,
+                    self.max_model_len
+                    - request.num_computed_tokens
+                    - self.num_sampled_tokens_per_step,
+                )
 
-            # Encoder-related.
-            if encoder_inputs_to_schedule:
-                scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule
-                # Allocate the encoder cache.
-                for i in encoder_inputs_to_schedule:
-                    self.encoder_cache_manager.allocate(request, i)
-                    if self.ec_connector is not None:
-                        self.ec_connector.update_state_after_alloc(request, i)
-                encoder_compute_budget = new_encoder_compute_budget
-            if external_load_encoder_input:
-                for i in external_load_encoder_input:
-                    self.encoder_cache_manager.allocate(request, i)
-                    if self.ec_connector is not None:
-                        self.ec_connector.update_state_after_alloc(request, i)
+                # Apply Mamba alignment before encoder caps.
+                if self.need_mamba_block_aligned_split:
+                    num_new_tokens = self._mamba_block_aligned_split(
+                        request, num_new_tokens
+                    )
+
+                # Schedule encoder inputs.
+                encoder_inputs_to_schedule = None
+                external_load_encoder_input: list[int] = []
+                new_encoder_compute_budget = encoder_compute_budget
+                if request.has_encoder_inputs:
+                    (
+                        encoder_inputs_to_schedule,
+                        num_new_tokens,
+                        new_encoder_compute_budget,
+                        external_load_encoder_input,
+                    ) = self._try_schedule_encoder_inputs(
+                        request,
+                        request.num_computed_tokens,
+                        num_new_tokens,
+                        encoder_compute_budget,
+                        shift_computed_tokens=self.num_prefill_lookahead,
+                    )
+
+                # Multi-module MTP: avoid ending a prefill chunk within
+                # num_prefill_lookahead of the prefill end.
+                num_new_tokens = self._reserve_prefill_lookahead(
+                    request, request.num_computed_tokens, num_new_tokens
+                )
+
+                if num_new_tokens == 0:
+                    # The request cannot be scheduled because one of the following
+                    # reasons:
+                    # 1. No new tokens to schedule. This may happen when
+                    #    (1) PP>1 and we have already scheduled all prompt tokens
+                    #    but they are not finished yet.
+                    #    (2) Async scheduling and the request has reached to either
+                    #    its max_total_tokens or max_model_len.
+                    # 2. The encoder budget is exhausted.
+                    # 3. The encoder cache is exhausted.
+                    # 4. Insufficient budget for a block-aligned chunk in hybrid
+                    #    models with mamba cache mode \"align\".
+                    # 5. Insufficient budget to keep a multi-module MTP prefill
+                    #    chunk out of the prefill-lookahead window.
+                    # NOTE(woosuk): Here, by doing `continue` instead of `break`,
+                    # we do not strictly follow the FCFS scheduling policy and
+                    # allow the lower-priority requests to be scheduled.
+                    req_index += 1
+                    continue
+
+                # Schedule newly needed KV blocks for the request.
+                with record_function_or_nullcontext("schedule: allocate_slots"):
+                    while True:
+                        new_blocks = self.kv_cache_manager.allocate_slots(
+                            request,
+                            num_new_tokens,
+                            num_lookahead_tokens=self.num_lookahead_tokens,
+                        )
+
+                        if new_blocks is not None:
+                            # The request can be scheduled.
+                            break
+
+                        if not allow_preemption:
+                            # Leftover service must not evict work selected and
+                            # admitted earlier in this model step.
+                            break
+
+                        # The request cannot be scheduled.
+                        # Preempt the lowest-priority request.
+                        if self.policy == SchedulingPolicy.PRIORITY:
+                            preempted_req = max(
+                                self.running,
+                                key=lambda r: (r.priority, r.arrival_time),
+                            )
+                            # Record the index of the preemption victim to
+                            # maintain accurate loop state.
+                            victim_index = self.running.index(preempted_req)
+                            del self.running[victim_index]
+                            # Decrement the loop cursor if the removed request
+                            # preceded the current iteration, preventing the
+                            # silent omission of the subsequent request.
+                            if victim_index < req_index:
+                                req_index -= 1
+
+                            if preempted_req in scheduled_running_reqs:
+                                preempted_req_id = preempted_req.request_id
+                                scheduled_running_reqs.remove(preempted_req)
+                                restored = num_scheduled_tokens.pop(preempted_req_id)
+                                token_budget += restored
+                                input_budget += restored + draft_slots
+                                scheduled_prefill_req_ids.discard(preempted_req_id)
+                                req_to_new_blocks.pop(preempted_req_id)
+                                scheduled_spec_decode_tokens.pop(preempted_req_id, None)
+                                preempted_encoder_inputs = scheduled_encoder_inputs.pop(
+                                    preempted_req_id, None
+                                )
+                                if preempted_encoder_inputs:
+                                    # Restore encoder compute budget if the preempted
+                                    # request had encoder inputs scheduled in this step.
+                                    num_embeds_to_restore = sum(
+                                        preempted_req.get_num_encoder_embeds(i)
+                                        for i in preempted_encoder_inputs
+                                    )
+                                    encoder_compute_budget += num_embeds_to_restore
+                        else:
+                            preempted_req = self.running.pop()
+
+                        self._preempt_request(
+                            preempted_req,
+                            scheduled_timestamp,
+                            drop_stale_output=self.requires_kv_delivery,
+                        )
+                        preempted_reqs.append(preempted_req)
+                        if preempted_req == request:
+                            # No more request to preempt. Cannot schedule this request.
+                            break
+
+                if new_blocks is None:
+                    # Cannot schedule this request.
+                    break
+
+                # Schedule the request.
+                scheduled_running_reqs.append(request)
+                prefill_scheduled |= request.is_prefill_chunk
+                if request.is_prefill_chunk:
+                    scheduled_prefill_req_ids.add(request.request_id)
+                request_id = request.request_id
+                req_to_new_blocks[request_id] = new_blocks
+                num_scheduled_tokens[request_id] = num_new_tokens
+                token_budget -= num_new_tokens
+                input_budget -= num_new_tokens + draft_slots
+                if enforce_lora_limit and request.lora_request:
+                    scheduled_loras.add(request.lora_request.lora_int_id)
+                req_index += 1
+
+                # Speculative decode related.
+                if request.spec_token_ids:
+                    num_scheduled_spec_tokens = (
+                        num_new_tokens
+                        + request.num_computed_tokens
+                        - request.num_tokens
+                        - request.num_output_placeholders
+                    )
+                    if num_scheduled_spec_tokens > 0:
+                        spec_token_ids = request.spec_token_ids
+                        if len(spec_token_ids) > num_scheduled_spec_tokens:
+                            spec_token_ids = spec_token_ids[:num_scheduled_spec_tokens]
+                        scheduled_spec_decode_tokens[request.request_id] = (
+                            spec_token_ids
+                        )
+
+                    # New spec tokens will be set in `update_draft_token_ids` before the
+                    # next step when applicable.
+                    request.spec_token_ids = []
+
+                # Encoder-related.
+                if encoder_inputs_to_schedule:
+                    scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule
+                    # Allocate the encoder cache.
+                    for i in encoder_inputs_to_schedule:
+                        self.encoder_cache_manager.allocate(request, i)
+                        if self.ec_connector is not None:
+                            self.ec_connector.update_state_after_alloc(request, i)
+                    encoder_compute_budget = new_encoder_compute_budget
+                if external_load_encoder_input:
+                    for i in external_load_encoder_input:
+                        self.encoder_cache_manager.allocate(request, i)
+                        if self.ec_connector is not None:
+                            self.ec_connector.update_state_after_alloc(request, i)
+
+        adaptive_prefill_turn = (
+            selected_compute_class == "prefill" and compute_contention
+        )
+        schedule_running_requests("prefill" if adaptive_prefill_turn else None)
 
         # Record the LoRAs in scheduled_running_reqs
         scheduled_loras: set[int] = set()
@@ -997,11 +1089,17 @@ class Scheduler(SchedulerInterface):
                     # KVTransfer: loading remote KV, do not allocate for new work.
                     assert num_external_computed_tokens > 0
                     num_new_tokens = 0
-                elif defer_prefills and num_computed_tokens < request.num_tokens - 1:
-                    # DP prefill balancing: defer this step's local prefill
-                    # compute to a cadence-aligned step.
-                    break
                 else:
+                    if defer_prefills and num_computed_tokens < request.num_tokens - 1:
+                        if adaptive_defer_prefills and not num_scheduled_tokens:
+                            # The selected decode class proved unrunnable after
+                            # its resource checks. Fall back immediately.
+                            adaptive_defer_prefills = False
+                            defer_prefills = legacy_defer_prefills
+                        else:
+                            # DP prefill balancing: defer this step's local
+                            # prefill compute to a cadence-aligned step.
+                            break
                     request_token_budget = min(token_budget, input_budget - draft_slots)
                     # Number of tokens to be scheduled.
                     # We use `request.num_tokens` instead of
@@ -1212,6 +1310,8 @@ class Scheduler(SchedulerInterface):
                     request_id
                 )
                 num_scheduled_tokens[request_id] = num_new_tokens
+                if num_computed_tokens < request.num_tokens - 1:
+                    scheduled_prefill_req_ids.add(request_id)
                 token_budget -= num_new_tokens
                 input_budget -= num_new_tokens + draft_slots
                 request.status = RequestStatus.RUNNING
@@ -1247,6 +1347,30 @@ class Scheduler(SchedulerInterface):
             # record whether it was capacity-bound.
             if not defer_prefills:
                 self.prefill_capacity_bound = bool(self.waiting)
+
+        # The coarse runnable check can race async-completion guards. If a
+        # selected decode turn produced no work, give an already-running
+        # prefill an immediate chance before returning an empty step.
+        if (
+            selected_compute_class == "decode"
+            and compute_contention
+            and not num_scheduled_tokens
+            and not legacy_defer_prefills
+        ):
+            adaptive_defer_prefills = False
+            defer_prefills = False
+            schedule_running_requests("prefill")
+
+        # A prefill turn gives prefills first use of the model-step capacity.
+        # Existing decodes then consume only capacity genuinely left over. New
+        # requests admitted above are excluded by running_req_ids_at_step_start,
+        # so no request can be scheduled twice in one step.
+        if adaptive_prefill_turn and token_budget > 0:
+            schedule_running_requests(
+                "decode",
+                allow_preemption=False,
+                enforce_lora_limit=True,
+            )
 
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
@@ -1380,6 +1504,20 @@ class Scheduler(SchedulerInterface):
             partial_tail_offloads=pending_partial_tail_offloads,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
             ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
+            compute_service_class=(
+                (
+                    "prefill"
+                    if any(
+                        req_id in num_scheduled_tokens
+                        for req_id in scheduled_prefill_req_ids
+                    )
+                    else "decode"
+                )
+                if self.compute_share_controller is not None
+                and total_num_scheduled_tokens > 0
+                else None
+            ),
+            compute_contention=compute_contention,
         )
 
         # NOTE(Kuntai): this function is designed for multiple purposes:
@@ -1405,6 +1543,27 @@ class Scheduler(SchedulerInterface):
         with record_function_or_nullcontext("schedule: update_after_schedule"):
             self._update_after_schedule(scheduler_output)
         return scheduler_output
+
+    def record_compute_time(
+        self,
+        service_class: ComputeServiceClass,
+        elapsed_seconds: float,
+        *,
+        contended: bool,
+    ) -> None:
+        """Apply execution feedback and accumulate metric deltas."""
+        if self.compute_share_controller is None:
+            return
+        if not contended or elapsed_seconds <= 0.0:
+            return
+        if self.log_stats:
+            if service_class == "prefill":
+                self._prefill_compute_seconds += elapsed_seconds
+            else:
+                self._decode_compute_seconds += elapsed_seconds
+        self.compute_share_controller.record(
+            service_class, elapsed_seconds, contended=True
+        )
 
     def _build_kv_connector_meta(
         self, connector: KVConnectorBase_V1, scheduler_output: SchedulerOutput
@@ -2762,6 +2921,15 @@ class Scheduler(SchedulerInterface):
         connector_stats_payload = (
             kv_connector_stats.data if kv_connector_stats else None
         )
+        decode_compute_seconds = 0.0
+        prefill_compute_seconds = 0.0
+        prefill_compute_share = 0.0
+        if self.compute_share_controller is not None:
+            decode_compute_seconds = self._decode_compute_seconds
+            prefill_compute_seconds = self._prefill_compute_seconds
+            prefill_compute_share = self.compute_share_controller.prefill_compute_share
+            self._decode_compute_seconds = 0.0
+            self._prefill_compute_seconds = 0.0
         return SchedulerStats(
             num_running_reqs=len(self.running),
             num_waiting_reqs=len(self.waiting),
@@ -2774,6 +2942,9 @@ class Scheduler(SchedulerInterface):
             kv_connector_stats=connector_stats_payload,
             cudagraph_stats=cudagraph_stats,
             perf_stats=perf_stats,
+            decode_compute_seconds=decode_compute_seconds,
+            prefill_compute_seconds=prefill_compute_seconds,
+            prefill_compute_share=prefill_compute_share,
         )
 
     def make_spec_decoding_stats(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1514,6 +1514,7 @@ class Scheduler(SchedulerInterface):
                     else "decode"
                 )
                 if self.compute_share_controller is not None
+                and compute_contention
                 and total_num_scheduled_tokens > 0
                 else None
             ),

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1542,6 +1542,14 @@ class Scheduler(SchedulerInterface):
 
         with record_function_or_nullcontext("schedule: update_after_schedule"):
             self._update_after_schedule(scheduler_output)
+        if (
+            self.compute_share_controller is not None
+            and scheduler_output.compute_service_class is not None
+        ):
+            self.compute_share_controller.dispatch(
+                scheduler_output.compute_service_class,
+                contended=scheduler_output.compute_contention,
+            )
         return scheduler_output
 
     def record_compute_time(
@@ -1554,9 +1562,9 @@ class Scheduler(SchedulerInterface):
         """Apply execution feedback and accumulate metric deltas."""
         if self.compute_share_controller is None:
             return
-        if not contended or elapsed_seconds <= 0.0:
+        if not contended:
             return
-        if self.log_stats:
+        if self.log_stats and elapsed_seconds > 0.0:
             if service_class == "prefill":
                 self._prefill_compute_seconds += elapsed_seconds
             else:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -102,6 +102,29 @@ HANDSHAKE_TIMEOUT_MINS = 5
 _R = TypeVar("_R")  # Return type for collective_rpc
 
 
+class _ModelExecutionTiming:
+    """Capture model completion time without charging queue residency."""
+
+    def __init__(self) -> None:
+        self.started_at = time.perf_counter()
+        self.completed_at: float | None = None
+
+    def bind(self, future: Future[Any]) -> None:
+        future.add_done_callback(self._record_completion)
+
+    def complete(self) -> None:
+        self.completed_at = time.perf_counter()
+
+    def _record_completion(self, _future: Future[Any]) -> None:
+        self.complete()
+
+    @property
+    def elapsed_seconds(self) -> float:
+        if self.completed_at is None:
+            raise RuntimeError("model execution timing read before completion")
+        return max(self.completed_at - self.started_at, 0.0)
+
+
 class EngineCore:
     """Inner loop of vLLM's Engine."""
 
@@ -209,7 +232,15 @@ class EngineCore:
         # to eliminate pipeline bubbles.
         self.batch_queue_size = vllm_config.max_concurrent_batches
         self.batch_queue: (
-            deque[tuple[Future[ModelRunnerOutput], SchedulerOutput, Future[Any]]] | None
+            deque[
+                tuple[
+                    Future[ModelRunnerOutput],
+                    SchedulerOutput,
+                    Future[Any],
+                    _ModelExecutionTiming | None,
+                ]
+            ]
+            | None
         ) = None
         if self.batch_queue_size > 1:
             logger.debug("Batch queue is enabled with size %d", self.batch_queue_size)
@@ -614,6 +645,32 @@ class EngineCore:
             )
         return current_step % interval != 0
 
+    def _execute_model(
+        self, scheduler_output: SchedulerOutput
+    ) -> tuple[Future[Any], _ModelExecutionTiming | None]:
+        timing = (
+            _ModelExecutionTiming()
+            if scheduler_output.compute_service_class is not None
+            else None
+        )
+        future = self.model_executor.execute_model(scheduler_output, non_block=True)
+        return future, timing
+
+    def _record_compute_time(
+        self,
+        scheduler_output: SchedulerOutput,
+        timing: _ModelExecutionTiming | None,
+    ) -> None:
+        if timing is None:
+            return
+        service_class = scheduler_output.compute_service_class
+        assert service_class is not None
+        self.scheduler.record_compute_time(
+            service_class,
+            timing.elapsed_seconds,
+            contended=scheduler_output.compute_contention,
+        )
+
     def step(self) -> tuple[dict[int, EngineCoreOutputs], bool]:
         """Schedule, execute, and make output.
 
@@ -626,7 +683,7 @@ class EngineCore:
         if not self.scheduler.has_requests():
             return {}, False
         scheduler_output = self.scheduler.schedule(self._should_throttle_prefills())
-        future = self.model_executor.execute_model(scheduler_output, non_block=True)
+        future, execution_timing = self._execute_model(scheduler_output)
         grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
         with (
             self.capture_iteration_details(scheduler_output) as iteration_details,
@@ -635,6 +692,9 @@ class EngineCore:
             model_output = future.result()
             if model_output is None:
                 model_output = self.model_executor.sample_tokens(grammar_output)
+            if execution_timing is not None:
+                execution_timing.complete()
+            self._record_compute_time(scheduler_output, execution_timing)
 
         # Before processing the model output, process any aborts that happened
         # during the model execution.
@@ -682,12 +742,11 @@ class EngineCore:
 
         model_executed = False
         deferred_scheduler_output = None
+        deferred_execution_timing = None
         if self.scheduler.has_requests():
             scheduler_output = self.scheduler.schedule(self._should_throttle_prefills())
             with self.log_error_detail(scheduler_output):
-                exec_future = self.model_executor.execute_model(
-                    scheduler_output, non_block=True
-                )
+                exec_future, execution_timing = self._execute_model(scheduler_output)
             if self.is_ec_consumer:
                 model_executed = scheduler_output.total_num_scheduled_tokens > 0
 
@@ -708,10 +767,15 @@ class EngineCore:
                     # We need to defer sampling until we have processed the model output
                     # from the prior step.
                     deferred_scheduler_output = scheduler_output
+                    deferred_execution_timing = execution_timing
 
             if not deferred_scheduler_output:
+                if execution_timing is not None:
+                    execution_timing.bind(future)
                 # Add this step's future to the queue.
-                batch_queue.appendleft((future, scheduler_output, exec_future))
+                batch_queue.appendleft(
+                    (future, scheduler_output, exec_future, execution_timing)
+                )
                 if len(batch_queue) < self.batch_queue_size and (
                     model_executed or self.scheduler.has_requests()
                 ):
@@ -726,12 +790,13 @@ class EngineCore:
             return None, False
 
         # Block until the next result is available.
-        future, scheduler_output, exec_model_fut = batch_queue.pop()
+        future, scheduler_output, exec_model_fut, execution_timing = batch_queue.pop()
         with (
             self.capture_iteration_details(scheduler_output) as iteration_details,
             self.log_error_detail(scheduler_output),
         ):
             model_output = future.result()
+            self._record_compute_time(scheduler_output, execution_timing)
             if model_output is None:
                 # None from sample_tokens() implies that the original execute_model()
                 # call failed - raise that exception.
@@ -767,7 +832,16 @@ class EngineCore:
                 deferred_scheduler_output
             )
             future = self.model_executor.sample_tokens(grammar_output, non_block=True)
-            batch_queue.appendleft((future, deferred_scheduler_output, exec_future))
+            if deferred_execution_timing is not None:
+                deferred_execution_timing.bind(future)
+            batch_queue.appendleft(
+                (
+                    future,
+                    deferred_scheduler_output,
+                    exec_future,
+                    deferred_execution_timing,
+                )
+            )
 
         return engine_core_outputs, model_executed
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -245,6 +245,7 @@ class EngineCore:
         if self.batch_queue_size > 1:
             logger.debug("Batch queue is enabled with size %d", self.batch_queue_size)
             self.batch_queue = deque(maxlen=self.batch_queue_size)
+        self._last_model_completion_time: float | None = None
 
         self.is_ec_consumer = (
             vllm_config.ec_transfer_config is None
@@ -665,9 +666,27 @@ class EngineCore:
             return
         service_class = scheduler_output.compute_service_class
         assert service_class is not None
+        completed_at = timing.completed_at
+        if completed_at is None:
+            raise RuntimeError("model execution timing read before completion")
+
+        # Multiple batches can already be queued on the executor when this
+        # batch is dispatched. Attribute only the wall-clock interval this
+        # completion adds after the previous batch, rather than charging the
+        # same executor queue residency to every in-flight batch.
+        previous_completion = self._last_model_completion_time
+        service_started_at = timing.started_at
+        if previous_completion is not None:
+            service_started_at = max(service_started_at, previous_completion)
+        elapsed_seconds = max(completed_at - service_started_at, 0.0)
+        self._last_model_completion_time = (
+            completed_at
+            if previous_completion is None
+            else max(completed_at, previous_completion)
+        )
         self.scheduler.record_compute_time(
             service_class,
-            timing.elapsed_seconds,
+            elapsed_seconds,
             contended=scheduler_output.compute_contention,
         )
 

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -510,6 +510,34 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             gauge_scheduler_waiting, per_engine_labelvalues
         )
 
+        gauge_prefill_compute_share = self._gauge_cls(
+            name="vllm:scheduler_prefill_compute_share",
+            documentation=(
+                "Configured target fraction of contended model execution "
+                "assigned to prefill; zero means disabled."
+            ),
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_prefill_compute_share = create_metric_per_engine(
+            gauge_prefill_compute_share, per_engine_labelvalues
+        )
+
+        counter_scheduler_compute_seconds = self._counter_cls(
+            name="vllm:scheduler_compute_seconds",
+            documentation="Model-execution time charged to each service class.",
+            labelnames=labelnames + ["class"],
+        )
+        self.counter_scheduler_compute_seconds = {
+            service_class: {
+                idx: counter_scheduler_compute_seconds.labels(
+                    model_name, str(idx), service_class
+                )
+                for idx in engine_indexes
+            }
+            for service_class in ("decode", "prefill")
+        }
+
         gauge_waiting_by_reason = self._gauge_cls(
             name="vllm:num_requests_waiting_by_reason",
             documentation=(
@@ -1121,6 +1149,15 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 scheduler_stats.num_skipped_waiting_reqs
             )
             self.gauge_kv_cache_usage[engine_idx].set(scheduler_stats.kv_cache_usage)
+            self.gauge_prefill_compute_share[engine_idx].set(
+                scheduler_stats.prefill_compute_share
+            )
+            self.counter_scheduler_compute_seconds["decode"][engine_idx].inc(
+                scheduler_stats.decode_compute_seconds
+            )
+            self.counter_scheduler_compute_seconds["prefill"][engine_idx].inc(
+                scheduler_stats.prefill_compute_seconds
+            )
 
             self.counter_prefix_cache_queries[engine_idx].inc(
                 scheduler_stats.prefix_cache_stats.queries

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -213,6 +213,10 @@ class SchedulerStats:
 
     perf_stats: PerfStats | None = None
 
+    decode_compute_seconds: float = 0.0
+    prefill_compute_seconds: float = 0.0
+    prefill_compute_share: float = 0.0
+
 
 @dataclass
 class RequestStateStats:


### PR DESCRIPTION
## Purpose

Add an opt-in, model-independent fairness controller for decode/prefill collisions. The production interface is:

```text
--prefill-compute-share 0.5
```

The value is the target fraction of **contended model-execution wall time** assigned to prefill. When the option is omitted, legacy scheduling remains unchanged.

## Design

- Select decode or prefill through weighted virtual runtime using measured completion time from the exact model batch future.
- Charge service only while both classes are runnable; reset credit when contention ends.
- Favor decode on ties, guarantee both classes progress (`0 < share < 1`), and bound timing-outlier lead to one service quantum.
- Carry the selected class with `SchedulerOutput`, including queued/async batches, so feedback is attributed to the correct execution.
- Preserve work conservation: a prefill turn gives prefill first use of capacity and then admits decode into genuine remainder; an unrunnable selected class immediately falls back.
- Treat full APC/external restores that proceed directly to generation as decode; partial local compute as prefill; zero-compute async loads receive no service charge.
- Reject DP>1 until service-class selection can be synchronized across DP ranks. TP and DCP remain one scheduler domain and require no synchronization.
- Reject combination with `prefill_schedule_interval > 1`.

Prometheus adds:

```text
vllm:scheduler_compute_seconds{class="decode"}
vllm:scheduler_compute_seconds{class="prefill"}
vllm:scheduler_prefill_compute_share
```

## Validation

Current `dev/jovian-judgement` (`83cb22a0e3`):

- 187 scheduler/controller/engine tests passed.
- Ruff lint and format checks passed for all 15 changed files.
- `git diff --check` passed.
- The sole pre-existing JJ scheduler-test failure was corrected by carrying forward the prior R18 fixture fix `bc3dd9c1bd` with Martin Vit's authorship preserved; it changes no runtime code.

GLM-5.3-Flash CN4 runtime, 8x RTX PRO 6000, exact R18 cache-complete integration, TP4/DCP4, batch 4096, GMU 0.93, LMCache L1+filesystem L2:

| KV cache | Mode | Measured prefill share | Isolated decode/target delta | Isolated prefill delta | Cold/APC/L1/L2 correctness |
|---|---:|---:|---:|---:|---:|
| FP8 | no-spec | 51.25% | -0.01% | +0.51% | pass |
| NVFP4 | no-spec | 51.29% | -0.02% | -0.19% | pass |
| FP8 | MTP3 | 51.27% | +0.13% | +1.67% | pass |
| NVFP4 | MTP3 | 51.30% | -0.72% | +0.37% | pass |
| FP8 | DFlash2 | 51.19% | -1.89% | -0.79% | pass |
| NVFP4 | DFlash2 | 51.27% | +1.64% | +0.14% | pass |

All six 111K-token collision needles returned every requested value exactly. The sustained 4-decode/4-prefill test completed all work with 50.32% prefill service, continuous decode progress, and a 0.92 s maximum decode gap. Focused FP8 and NVFP4 DCP1 collision plus cold/APC/L1/L2 restore tests also passed. TP8 was source-audited because hardware was unavailable: the patch has no TP/DCP-specific branch, and the final executor future spans the distributed batch.

## Relationship to #596

#596 is a separate opt-in fixed token-budget/partial-prefill/decode-step policy. This PR implements the requested simpler adaptive contract: one wall-clock compute-share target with no model-specific token-rate tuning. The two patches overlap heavily in the scheduler and should be evaluated as alternatives, not stacked.

## Scope

No LMCache, KV allocator, attention backend, model, sampling, or image-launcher changes are included. Development began on exact R18 source `8088aef08b`; only the focused fairness commits were rebased onto current JJ.

OpenAI Codex assisted with implementation, code review, and validation. Runtime artifacts and exact launch configuration are retained on CN4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added adaptive prefill compute-share scheduling to balance prefill and decode work during contention.
  * Added the `--prefill-compute-share` configuration option with validation for unsupported combinations.
  * Added scheduler statistics and Prometheus metrics for prefill/decode compute time and share.
  * Added execution-time feedback to continuously adjust scheduling decisions.

* **Tests**
  * Added comprehensive coverage for fairness, contention, queueing, reservations, configuration validation, and compute-time reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->