### PR TITLE
feat(dspark): add a floor for dynamic draft depth

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -49,6 +49,16 @@ def test_p2p_side_channel_defaults_and_override(monkeypatch: pytest.MonkeyPatch)
     assert envs.VLLM_P2P_SIDE_CHANNEL_PORT == 5799
 
 
+def test_dspark_dynamic_draft_min_depth_default_and_override(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("VLLM_DSPARK_DYNAMIC_DRAFT_MIN_DEPTH", raising=False)
+    assert envs.VLLM_DSPARK_DYNAMIC_DRAFT_MIN_DEPTH == 1
+
+    monkeypatch.setenv("VLLM_DSPARK_DYNAMIC_DRAFT_MIN_DEPTH", "5")
+    assert envs.VLLM_DSPARK_DYNAMIC_DRAFT_MIN_DEPTH == 5
+
+
 def _clear_unknown_vllm_envs(monkeypatch: pytest.MonkeyPatch) -> None:
     """Remove inherited VLLM variables not known by this source tree."""
     for name in list(os.environ):

--- a/tests/v1/worker/test_gpu_model_runner_v2_draft_capacity.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_draft_capacity.py
@@ -149,6 +149,65 @@ def test_dynamic_draft_depth_applies_profiled_load_budget():
     assert controller.observe(capacities, attempted) == 5
 
 
+def test_dynamic_draft_depth_default_min_depth_keeps_floor_of_one():
+    controller = DSparkDynamicDraftDepthController(max_depth=5, observation_window=2)
+    attempted = np.full(2, 5, dtype=np.int32)
+    zero_capacity = np.zeros(2, dtype=np.int32)
+
+    assert controller.observe(zero_capacity, attempted) == 5
+    assert controller.observe(zero_capacity, attempted) == 1
+
+
+def test_dynamic_draft_depth_min_depth_floors_capacity_collapse():
+    controller = DSparkDynamicDraftDepthController(
+        max_depth=7,
+        observation_window=2,
+        min_depth=5,
+    )
+    attempted = np.full(2, 7, dtype=np.int32)
+    capacities = np.array([2, 3], dtype=np.int32)
+
+    assert controller.observe(capacities, attempted) == 7
+    assert controller.observe(capacities, attempted) == 5
+    assert controller.observe(capacities, attempted) == 5
+
+
+def test_dynamic_draft_depth_min_depth_is_clamped_to_valid_range():
+    assert DSparkDynamicDraftDepthController(5, 2, min_depth=0).min_depth == 1
+    assert DSparkDynamicDraftDepthController(5, 2, min_depth=-3).min_depth == 1
+    assert DSparkDynamicDraftDepthController(5, 2, min_depth=9).min_depth == 5
+
+
+def test_dynamic_draft_depth_load_budget_wins_over_min_depth():
+    controller = DSparkDynamicDraftDepthController(
+        max_depth=7,
+        observation_window=2,
+        min_depth=5,
+    )
+    controller.set_draft_token_budget(21)
+    attempted = np.full(8, 7, dtype=np.int32)
+    capacities = np.full(8, 7, dtype=np.int32)
+
+    assert controller.observe(capacities, attempted) == 7
+    assert controller.observe(capacities, attempted) == 3
+
+
+def test_dynamic_draft_depth_min_depth_still_probes_upward():
+    controller = DSparkDynamicDraftDepthController(
+        max_depth=7,
+        observation_window=2,
+        min_depth=5,
+    )
+    attempted = np.full(2, 7, dtype=np.int32)
+    capacities = np.full(2, 5, dtype=np.int32)
+
+    assert controller.observe(capacities, attempted) == 7
+    assert controller.observe(capacities, attempted) == 5
+    for _ in range(controller._PROBE_AFTER_WINDOWS * 2 - 1):
+        assert controller.observe(capacities, attempted) == 5
+    assert controller.observe(capacities, attempted) == 6
+
+
 def test_capacity_kernel_supports_shorter_logical_width_than_storage_stride():
     device = torch.device("cuda")
     confidence_probs = torch.full((2, 5), 0.01, device=device)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -205,6 +205,7 @@ if TYPE_CHECKING:
     VLLM_MLA_DISABLE: bool = False
     VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH: bool = False
     VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW: int = 8
+    VLLM_DSPARK_DYNAMIC_DRAFT_MIN_DEPTH: int = 1
     VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE: int = 0
     VLLM_RAY_PER_WORKER_GPUS: float = 1.0
     VLLM_RAY_BUNDLE_INDICES: str = ""
@@ -1664,6 +1665,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW": lambda: int(
         os.getenv("VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW", "8")
+    ),
+    "VLLM_DSPARK_DYNAMIC_DRAFT_MIN_DEPTH": lambda: int(
+        os.getenv("VLLM_DSPARK_DYNAMIC_DRAFT_MIN_DEPTH", "1")
     ),
     # Capture low-load DSpark draft graphs without confidence/capacity kernels.
     # 0 keeps capacity active at every batch size; a positive value must match

--- a/vllm/v1/worker/gpu/spec_decode/capacity.py
+++ b/vllm/v1/worker/gpu/spec_decode/capacity.py
@@ -93,13 +93,19 @@ class DSparkDynamicDraftDepthController:
 
     _PROBE_AFTER_WINDOWS = 8
 
-    def __init__(self, max_depth: int, observation_window: int) -> None:
+    def __init__(
+        self,
+        max_depth: int,
+        observation_window: int,
+        min_depth: int = 1,
+    ) -> None:
         if max_depth < 1:
             raise ValueError("max_depth must be at least one")
         if observation_window < 1:
             raise ValueError("observation_window must be at least one")
         self.max_depth = max_depth
         self.observation_window = observation_window
+        self.min_depth = min(max(1, min_depth), max_depth)
         self.depth = max_depth
         self._steps = 0
         self._max_capacity = 0
@@ -193,7 +199,9 @@ class DSparkDynamicDraftDepthController:
         mean_capacity = self._capacity_sum / self._num_drafts
         mean_attempted = self._attempted_sum / self._num_drafts
         load_limited_depth = self._load_limited_depth(batch_size)
-        target = max(1, min(load_limited_depth, self._max_capacity))
+        # The floor is a soft lower bound; the load/token budget stays hard
+        # and may still force the target below it.
+        target = min(load_limited_depth, max(self.min_depth, self._max_capacity))
 
         previous_depth = self.depth
         if target < self.depth:
@@ -266,6 +274,7 @@ class CapacityBasedVerificationManager:
             DSparkDynamicDraftDepthController(
                 req_states.num_speculative_steps,
                 envs.VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW,
+                min_depth=envs.VLLM_DSPARK_DYNAMIC_DRAFT_MIN_DEPTH,
             )
             if envs.VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH
             else None


### PR DESCRIPTION
# `feat(dspark): add a floor for dynamic draft depth`

## Problem / guarded invariant

The DSpark dynamic draft-depth controller adapts the batch-wide physical
draft width to the maximum useful observed capacity, with a floor of one.
Poorly-accepting observation windows can therefore collapse the width to one
and destroy throughput through a capacity collapse. This change adds a
configurable soft floor: the selected target never falls below
`VLLM_DSPARK_DYNAMIC_DRAFT_MIN_DEPTH`, while the draft-token load budget
remains the hard upper bound and may still force the depth below the floor.

Invariant guarded by the tests:

```text
target = min(load_limited_depth, max(min_depth, observed_max_capacity))
```

with `min_depth` clamped to `[1, max_depth]`.

## Not a duplicate / dependencies

- GitHub search (`repo:local-inference-lab/vllm is:pr "draft min depth"`):
  0 results. No open or merged PR covers a DSpark dynamic-depth floor.
- local-inference-lab/vllm#109 introduces the related load-aware dynamic-depth
  controller on `dev/fathomless-firmament`, but retains a hardcoded floor of
  one (`max(1, min(load_limited_depth, observed_max_capacity))`). It neither
  exposes `VLLM_DSPARK_DYNAMIC_DRAFT_MIN_DEPTH` nor implements a configurable
  soft floor. This PR is the narrow follow-up for the Infernal Invocation
  controller, not a competing implementation of that controller.
- `repo:vllm-project/vllm is:pr "dynamic draft depth"`: only closed #28693
  (Elastic Speculation: confidence-based early exit) — a different feature.
- No dependencies; the diff applies cleanly to
  `local-inference-lab/vllm:dev/infernal-invocation` at
  `b5f995e73e6b7fe27c9927477e277a151ebcc9e9`.

## Files changed (commit diff; 4 files, +84/−2)

- `vllm/envs.py`: typed definition `VLLM_DSPARK_DYNAMIC_DRAFT_MIN_DEPTH: int
  = 1` and lazy-loader entry (default `1`), next to the existing
  `VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH[_WINDOW]` entries.
- `vllm/v1/worker/gpu/spec_decode/capacity.py`:
  - `DSparkDynamicDraftDepthController.__init__` gains `min_depth: int = 1`,
    stored clamped to `[1, max_depth]`.
  - `observe` uses the target formula above; the floor is soft, the load/token
    budget hard.
  - the controller is constructed with
    `min_depth=envs.VLLM_DSPARK_DYNAMIC_DRAFT_MIN_DEPTH` (no separate
    `os.environ.get`).
- `tests/v1/worker/test_gpu_model_runner_v2_draft_capacity.py`: 5 controller
  tests (default keeps floor of one; floor stops capacity collapse; clamping;
  load budget wins below the floor; probing upward still works).
- `tests/test_envs.py`: env default `1` and explicit value `5` are read.

## Negative control

The new floor tests were added on the unmodified base and run before the
code change: 4 of 5 failed (`TypeError: unexpected keyword argument
'min_depth'`); the 5th (default-behavior guard) passes trivially without the
parameter. After the patch all 5 pass.

## Test commands and results (repo `.venv`, writable Triton cache)

```text
.venv/bin/python -m pytest -q \
  tests/v1/worker/test_gpu_model_runner_v2_draft_capacity.py
  -> 32 passed (full suite)
.venv/bin/python -m pytest -q \
  tests/v1/worker/test_gpu_model_runner_v2_draft_capacity.py \
  -k dynamic_draft_depth
  -> 8 passed, 24 deselected
.venv/bin/python -m pytest -q tests/test_envs.py
  -> 63 passed
.venv/bin/pre-commit run --files vllm/envs.py \
  vllm/v1/worker/gpu/spec_decode/capacity.py tests/test_envs.py \
  tests/v1/worker/test_gpu_model_runner_v2_draft_capacity.py
  -> all default hooks passed (incl. mypy-3.10)
.venv/bin/pre-commit run mypy-3.12 --files <same files> --hook-stage manual
  -> passed (manual stage; run separately, the default pre-commit command
     does not run manual-stage hooks)
git diff --check -> clean
```

With the default (`1`) the controller's existing behavior is unchanged; the
knob is opt-in and only alters the adaptive lower bound.

## Serving evaluation

The serving smoke with the option enabled completed successfully. This is a
correctness and operability result only; no performance claim is made.

## Disclosure

AI assistance was used to draft this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration for setting the minimum dynamic draft depth through `VLLM_DSPARK_DYNAMIC_DRAFT_MIN_DEPTH`.
  * The minimum depth defaults to 1 and is constrained to valid values.
  * Capacity limits and load budgets continue to take precedence when determining draft depth.

* **Tests**
  * Added coverage for default, configured, invalid, capacity-constrained, and upward-probing draft-depth behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->