### PR TITLE
fix(structured-output): consolidate speculative grammar correctness

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3443,6 +3443,7 @@ def test_get_grammar_bitmask_forwards_invalid_draft_counts(
     }
     scheduler.structured_output_manager = Mock()
     scheduler.structured_output_manager.grammar_bitmask.return_value = Mock()
+    scheduler.structured_output_manager.has_grammar_bonus_token.return_value = True
     scheduler_output = SimpleNamespace(
         has_structured_output_requests=True,
         num_scheduled_tokens={"plain": 1, "structured": 4},
@@ -3455,11 +3456,15 @@ def test_get_grammar_bitmask_forwards_invalid_draft_counts(
     assert grammar_output is not None
     assert grammar_output.structured_output_request_ids == ["structured"]
     assert grammar_output.num_spec_tokens == [3]
+    assert grammar_output.has_bonus_token == [True]
     assert grammar_output.num_invalid_spec_tokens == expected_invalid_counts
     scheduler.structured_output_manager.grammar_bitmask.assert_called_once_with(
         scheduler.requests,
         ["structured"],
         scheduler_output.scheduled_spec_decode_tokens,
+    )
+    scheduler.structured_output_manager.has_grammar_bonus_token.assert_called_once_with(
+        [1, 2, 3]
     )
 
 

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import dataclasses
 from concurrent.futures import Future
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -3424,6 +3425,42 @@ def test_grammar_compile_error_finishes_only_request(async_grammar: bool):
     assert [req.req_id for req in next_output.scheduled_new_reqs] == [
         healthy_request.request_id
     ]
+
+
+@pytest.mark.parametrize(
+    "invalid_spec_tokens,expected_invalid_counts",
+    [({"structured": 2}, [2]), (None, [0])],
+)
+def test_get_grammar_bitmask_forwards_invalid_draft_counts(
+    invalid_spec_tokens, expected_invalid_counts
+):
+    scheduler = object.__new__(Scheduler)
+    scheduler.requests = {
+        "plain": SimpleNamespace(use_structured_output=False, is_prefill_chunk=False),
+        "structured": SimpleNamespace(
+            use_structured_output=True, is_prefill_chunk=False
+        ),
+    }
+    scheduler.structured_output_manager = Mock()
+    scheduler.structured_output_manager.grammar_bitmask.return_value = Mock()
+    scheduler_output = SimpleNamespace(
+        has_structured_output_requests=True,
+        num_scheduled_tokens={"plain": 1, "structured": 4},
+        scheduled_spec_decode_tokens={"structured": [1, 2, 3]},
+        num_invalid_spec_tokens=invalid_spec_tokens,
+    )
+
+    grammar_output = scheduler.get_grammar_bitmask(scheduler_output)
+
+    assert grammar_output is not None
+    assert grammar_output.structured_output_request_ids == ["structured"]
+    assert grammar_output.num_spec_tokens == [3]
+    assert grammar_output.num_invalid_spec_tokens == expected_invalid_counts
+    scheduler.structured_output_manager.grammar_bitmask.assert_called_once_with(
+        scheduler.requests,
+        ["structured"],
+        scheduler_output.scheduled_spec_decode_tokens,
+    )
 
 
 def test_abort_request_when_structured_output_fsm_cannot_advance():

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -839,6 +839,172 @@ def test_stop_via_update_from_output():
     assert list(requests[0].output_token_ids) == [EOS_TOKEN_ID, 10, 11]
 
 
+@pytest.mark.parametrize("async_scheduling", [False, True])
+@pytest.mark.parametrize(
+    "filtered_tokens,num_grammar_rejected,expected_accepted",
+    [
+        ([10, 11, 12], 1, 3),
+        ([10, 11], 2, 2),
+        ([], 4, 0),
+    ],
+)
+def test_speculative_grammar_filter_rolls_back_scheduler_state_and_stats(
+    async_scheduling: bool,
+    filtered_tokens: list[int],
+    num_grammar_rejected: int,
+    expected_accepted: int,
+):
+    """Rejected suffix tokens remain schedulable and are not accepted drafts."""
+    scheduler = create_scheduler(
+        num_speculative_tokens=3,
+        speculative_method="ngram_gpu",
+        async_scheduling=async_scheduling,
+    )
+    request = create_requests(num_requests=1)[0]
+    request.structured_output_request = Mock()
+    request.status = RequestStatus.RUNNING
+    request.num_computed_tokens = request.num_tokens + 4
+    request.num_output_placeholders = 4 if async_scheduling else 0
+    scheduler.requests[request.request_id] = request
+    scheduler.running.append(request)
+
+    manager = Mock()
+    manager.filter_speculative_grammar_tokens.return_value = (
+        filtered_tokens,
+        num_grammar_rejected,
+    )
+    manager.should_advance.return_value = False
+    scheduler.structured_output_manager = manager
+
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={request.request_id: 4},
+        total_num_scheduled_tokens=4,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={request.request_id: [10, 11, 12]},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+    model_output = ModelRunnerOutput(
+        req_ids=[request.request_id],
+        req_id_to_index={request.request_id: 0},
+        sampled_token_ids=[[10, 11, 12, 13]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    outputs = scheduler.update_from_output(scheduler_output, model_output)
+
+    assert request.num_computed_tokens == request.num_tokens
+    assert request.num_output_placeholders == 0
+    assert list(request.output_token_ids) == filtered_tokens
+    if filtered_tokens:
+        assert outputs[0].outputs[0].new_token_ids == filtered_tokens
+    manager.filter_speculative_grammar_tokens.assert_called_once_with(
+        request, [10, 11, 12, 13]
+    )
+    stats = outputs[0].scheduler_stats.spec_decoding_stats
+    assert stats is not None
+    assert stats.num_drafts == 1
+    assert stats.num_draft_tokens == 3
+    assert stats.num_accepted_tokens == expected_accepted
+    assert stats.num_accepted_tokens_per_pos == [
+        int(position < expected_accepted) for position in range(3)
+    ]
+
+
+def test_speculative_grammar_filter_is_not_called_for_unstructured_requests():
+    """Unstructured speculative decoding does not enter grammar validation."""
+    scheduler = create_scheduler(num_speculative_tokens=2)
+    request = create_requests(num_requests=1)[0]
+    request.status = RequestStatus.RUNNING
+    request.num_computed_tokens = request.num_tokens + 3
+    scheduler.requests[request.request_id] = request
+    scheduler.running.append(request)
+
+    manager = Mock()
+    manager.should_advance.return_value = False
+    scheduler.structured_output_manager = manager
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={request.request_id: 3},
+        total_num_scheduled_tokens=3,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={request.request_id: [10, 11]},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+    model_output = ModelRunnerOutput(
+        req_ids=[request.request_id],
+        req_id_to_index={request.request_id: 0},
+        sampled_token_ids=[[10, 11, 12]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    scheduler.update_from_output(scheduler_output, model_output)
+
+    assert list(request.output_token_ids) == [10, 11, 12]
+    manager.filter_speculative_grammar_tokens.assert_not_called()
+
+
+def test_speculative_grammar_filter_commits_and_advances_only_valid_prefix():
+    """Scheduler output and grammar state share the filtered token prefix."""
+    scheduler = create_scheduler(num_speculative_tokens=2)
+    request = create_requests(num_requests=1)[0]
+    grammar = Mock(spec=StructuredOutputGrammar)
+    grammar.accept_tokens.side_effect = lambda request_id, tokens: tokens == [10, 11]
+    request.structured_output_request = Mock(grammar=grammar)
+    request.status = RequestStatus.RUNNING
+    request.num_computed_tokens = request.num_tokens + 3
+    scheduler.requests[request.request_id] = request
+    scheduler.running.append(request)
+
+    manager = Mock()
+    manager.filter_speculative_grammar_tokens.return_value = ([10, 11], 1)
+    manager.should_advance.return_value = True
+    manager.trim_reasoning_for_advance.return_value = [10, 11]
+    scheduler.structured_output_manager = manager
+
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={request.request_id: 3},
+        total_num_scheduled_tokens=3,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={request.request_id: [10, 11]},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+    model_output = ModelRunnerOutput(
+        req_ids=[request.request_id],
+        req_id_to_index={request.request_id: 0},
+        sampled_token_ids=[[10, 11, 12]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    outputs = scheduler.update_from_output(scheduler_output, model_output)
+
+    assert request.status == RequestStatus.RUNNING
+    assert request.num_computed_tokens == request.num_tokens
+    assert list(request.output_token_ids) == [10, 11]
+    assert outputs[0].outputs[0].new_token_ids == [10, 11]
+    grammar.accept_tokens.assert_called_once_with(request.request_id, [10, 11])
+    stats = outputs[0].scheduler_stats.spec_decoding_stats
+    assert stats is not None
+    assert stats.num_draft_tokens == 2
+    assert stats.num_accepted_tokens == 2
+
+
 def test_check_stop_min_tokens():
     """Test that requests don't stop when min_tokens requirement isn't met."""
     from vllm.v1.core.sched.utils import check_stop

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -917,6 +917,85 @@ def test_speculative_grammar_filter_rolls_back_scheduler_state_and_stats(
     ]
 
 
+@pytest.mark.parametrize("async_scheduling", [False, True])
+@pytest.mark.parametrize(
+    "filtered_tokens,num_grammar_rejected,expected_computed_tokens",
+    [
+        ([], 1, 0),
+        ([13], 0, 1),
+    ],
+)
+def test_speculative_grammar_filter_validates_single_token_bonus(
+    async_scheduling: bool,
+    filtered_tokens: list[int],
+    num_grammar_rejected: int,
+    expected_computed_tokens: int,
+):
+    """A single-token accepted block reaches the filter and rolls back cleanly.
+
+    Fails on the old call gate (len > 1): the invalid bonus token was
+    committed unvalidated and later surfaced as the accept_tokens 500.
+    """
+    scheduler = create_scheduler(
+        num_speculative_tokens=3,
+        speculative_method="ngram_gpu",
+        async_scheduling=async_scheduling,
+    )
+    request = create_requests(num_requests=1)[0]
+    request.structured_output_request = Mock()
+    request.status = RequestStatus.RUNNING
+    request.num_computed_tokens = request.num_tokens + 4
+    request.num_output_placeholders = 4 if async_scheduling else 0
+    scheduler.requests[request.request_id] = request
+    scheduler.running.append(request)
+
+    manager = Mock()
+    manager.filter_speculative_grammar_tokens.return_value = (
+        filtered_tokens,
+        num_grammar_rejected,
+    )
+    manager.should_advance.return_value = False
+    scheduler.structured_output_manager = manager
+
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={request.request_id: 4},
+        total_num_scheduled_tokens=4,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={request.request_id: [10, 11, 12]},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+    model_output = ModelRunnerOutput(
+        req_ids=[request.request_id],
+        req_id_to_index={request.request_id: 0},
+        sampled_token_ids=[[13]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    num_tokens = request.num_tokens
+    outputs = scheduler.update_from_output(scheduler_output, model_output)
+
+    assert request.num_computed_tokens == num_tokens + expected_computed_tokens
+    # Rejection rollback, the grammar drop, and the commit each consume the
+    # placeholders staged for the sampled block.
+    assert request.num_output_placeholders == 0
+    assert list(request.output_token_ids) == filtered_tokens
+    if filtered_tokens:
+        assert outputs[0].outputs[0].new_token_ids == filtered_tokens
+    manager.filter_speculative_grammar_tokens.assert_called_once_with(request, [13])
+    stats = outputs[0].scheduler_stats.spec_decoding_stats
+    assert stats is not None
+    assert stats.num_drafts == 1
+    assert stats.num_draft_tokens == 3
+    assert stats.num_accepted_tokens == 0
+    assert stats.num_accepted_tokens_per_pos == [0, 0, 0]
+
+
 def test_speculative_grammar_filter_is_not_called_for_unstructured_requests():
     """Unstructured speculative decoding does not enter grammar validation."""
     scheduler = create_scheduler(num_speculative_tokens=2)

--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -14,6 +14,7 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import (
     PLACEHOLDER_TOKEN_ID,
     RejectionSampler,
+    force_reject_invalid_draft_suffixes,
     sample_recovered_tokens,
 )
 from vllm.v1.sample.sampler import Sampler, SamplerOutput
@@ -1183,3 +1184,77 @@ def test_placeholder_draft_token_rejected_random(rejection_sampler):
     assert sampled[0, 1].item() == vocab_size - 1
     recovered = sampled[0, 2].item()
     assert 0 <= recovered < vocab_size
+
+
+def test_forced_grammar_rejection_recovers_from_target_distribution(
+    rejection_sampler,
+):
+    logits = torch.tensor(
+        [[float("-inf"), 0.0, 0.0]], dtype=torch.float32, device=DEVICE_TYPE
+    )
+    draft_probs = torch.tensor(
+        [[0.0, 0.5, 0.5]], dtype=torch.float32, device=DEVICE_TYPE
+    )
+    metadata = create_sampling_metadata(
+        all_greedy=False,
+        temperature=torch.ones(1, dtype=torch.float32, device=DEVICE_TYPE),
+        generators={0: torch.Generator(device=DEVICE_TYPE).manual_seed(0)},
+    )
+    spec_decode_metadata = create_spec_decode_metadata([[0]], logits)
+    mock_sampler_output(
+        rejection_sampler, torch.tensor([1], dtype=torch.int32, device=DEVICE_TYPE)
+    )
+
+    output = rejection_sampler(
+        spec_decode_metadata,
+        draft_probs=draft_probs,
+        logits=logits,
+        sampling_metadata=metadata,
+        num_invalid_draft_tokens=[1],
+    )
+
+    assert output.sampled_token_ids[0, 0].item() in {1, 2}
+    assert output.sampled_token_ids[0, 1].item() == PLACEHOLDER_TOKEN_ID
+
+
+def test_force_rejects_only_the_invalid_suffix_for_each_request():
+    drafts = torch.tensor([10, 11, 12, 20, 21, 30], dtype=torch.int32)
+    draft_probs = torch.ones((6, 4), dtype=torch.float32)
+
+    sanitized, sanitized_probs = force_reject_invalid_draft_suffixes(
+        drafts,
+        draft_probs,
+        num_draft_tokens=[3, 2, 1],
+        num_invalid_draft_tokens=[1, 2, 0],
+    )
+
+    assert sanitized.tolist() == [10, 11, -1, -1, -1, 30]
+    assert drafts.tolist() == [10, 11, 12, 20, 21, 30]
+    assert sanitized_probs is not None
+    assert torch.equal(sanitized_probs[[0, 1, 5]], torch.ones((3, 4)))
+    assert not sanitized_probs[[2, 3, 4]].any()
+
+
+@pytest.mark.parametrize(
+    "drafts,widths,invalid",
+    [
+        ([1, 2], [2], [3]),
+        ([1, 2], [2], [1, 0]),
+        ([1], [2], [1]),
+    ],
+)
+def test_force_rejection_rejects_misaligned_metadata(drafts, widths, invalid):
+    with pytest.raises(ValueError):
+        force_reject_invalid_draft_suffixes(
+            torch.tensor(drafts, dtype=torch.int32), None, widths, invalid
+        )
+
+
+def test_force_rejection_rejects_misaligned_draft_probabilities():
+    with pytest.raises(ValueError):
+        force_reject_invalid_draft_suffixes(
+            torch.tensor([1, 2], dtype=torch.int32),
+            torch.ones((1, 4)),
+            [2],
+            [1],
+        )

--- a/tests/v1/spec_decode/test_mtp_structured_output.py
+++ b/tests/v1/spec_decode/test_mtp_structured_output.py
@@ -2,12 +2,17 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """grammar_bitmask under spec-decode draft padding (#44006)."""
 
+from collections.abc import Iterable, Sequence
+from typing import overload
+from unittest.mock import Mock
+
 import pytest
 from transformers import AutoTokenizer
 
 from vllm.config import StructuredOutputsConfig, VllmConfig
 from vllm.config.model import ModelConfig
 from vllm.config.speculative import SpeculativeConfig
+from vllm.reasoning.step3p5_reasoning_parser import Step3p5ReasoningParser
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.v1.request import Request
 from vllm.v1.structured_output import StructuredOutputManager
@@ -341,3 +346,154 @@ def test_trim_reasoning_for_advance():
     next_step = [post, post]
     request.append_output_token_ids(next_step)
     assert manager.trim_reasoning_for_advance(request, next_step) == next_step
+
+
+@pytest.mark.parametrize("backend", ["xgrammar", "guidance"])
+def test_speculative_grammar_filter_rejects_invalid_boundary_suffix(backend):
+    """Only the grammar-valid answer prefix may cross the commit boundary."""
+    tokenizer, manager, request, _, marker = _setup_boundary_request(backend)
+    reasoning_token = tokenizer.encode(" ")[0]
+    valid_answer_token = tokenizer.encode("{")[0]
+    invalid_answer_token = tokenizer.encode("z")[0]
+    sampled_tokens = [
+        reasoning_token,
+        marker,
+        valid_answer_token,
+        invalid_answer_token,
+    ]
+
+    filtered, rejected = manager.filter_speculative_grammar_tokens(
+        request, sampled_tokens
+    )
+
+    assert filtered == [reasoning_token, marker, valid_answer_token]
+    assert rejected == 1
+    grammar = request.structured_output_request.grammar
+    assert grammar.validate_tokens([valid_answer_token]) == [valid_answer_token]
+
+
+@pytest.mark.parametrize("backend", ["xgrammar", "guidance"])
+def test_speculative_grammar_filter_rejects_tokens_after_completion(backend):
+    """A sampled block cannot commit tokens past a completed grammar value."""
+    tokenizer, manager, request, _, _ = _setup_boundary_request(backend)
+    request.structured_output_request.reasoning_ended = True
+    complete_object = tokenizer.encode("{}")
+    invalid_suffix = tokenizer.encode("z")[0]
+
+    filtered, rejected = manager.filter_speculative_grammar_tokens(
+        request, [*complete_object, invalid_suffix]
+    )
+
+    assert filtered == complete_object
+    assert rejected == 1
+
+
+def test_reasoning_boundary_scan_does_not_copy_committed_history():
+    """Boundary detection can expose long history without materializing it."""
+    parser_calls = 0
+
+    class TokenHistory(Sequence[int]):
+        def __len__(self) -> int:
+            return 300_000
+
+        @overload
+        def __getitem__(self, index: int) -> int: ...
+
+        @overload
+        def __getitem__(self, index: slice) -> list[int]: ...
+
+        def __getitem__(self, index: int | slice) -> int | list[int]:
+            raise AssertionError("committed token history was materialized")
+
+    class EndTokenReasoner:
+        def is_reasoning_end_streaming(
+            self, input_ids: Sequence[int], delta_ids: Iterable[int]
+        ) -> bool:
+            nonlocal parser_calls
+            parser_calls += 1
+            assert len(input_ids) >= 300_000
+            return 99 in delta_ids
+
+    reasoner = EndTokenReasoner()
+    boundary = StructuredOutputManager._find_reasoning_end_offset(
+        reasoner, TokenHistory(), [10, 99, 20]
+    )
+
+    assert boundary == 1
+    assert parser_calls == 3
+
+
+def test_reasoning_boundary_scan_checks_nontransition_block_once():
+    """A sampled block without a transition requires one parser call."""
+    parser_calls = 0
+
+    class NoBoundaryReasoner:
+        def is_reasoning_end_streaming(
+            self, input_ids: Sequence[int], delta_ids: Iterable[int]
+        ) -> bool:
+            nonlocal parser_calls
+            parser_calls += 1
+            return False
+
+    reasoner = NoBoundaryReasoner()
+    boundary = StructuredOutputManager._find_reasoning_end_offset(
+        reasoner, [1, 2, 3], [10, 20, 30]
+    )
+
+    assert boundary is None
+    assert parser_calls == 1
+
+
+def test_reasoning_boundary_scan_preserves_stateful_parser():
+    """Pre-commit probing must not consume Step3.5's pending transition."""
+    tokenizer = Mock()
+    tokenizer.get_vocab.return_value = {"<think>": 1, "</think>": 2}
+    reasoner = Step3p5ReasoningParser(tokenizer)
+    reasoner._end_token_pending = True
+
+    boundary = StructuredOutputManager._find_reasoning_end_offset(
+        reasoner, [1, 2, 3], [10, 20]
+    )
+
+    assert boundary == 0
+    assert reasoner._end_token_pending
+
+
+def test_reasoning_boundary_scan_locates_multi_token_marker():
+    """A parser that examines cumulative deltas locates a multi-token marker."""
+
+    class MultiTokenReasoner:
+        def is_reasoning_end_streaming(
+            self, input_ids: Sequence[int], delta_ids: Iterable[int]
+        ) -> bool:
+            delta = list(delta_ids)
+            return any(
+                delta[index : index + 2] == [20, 30] for index in range(len(delta) - 1)
+            )
+
+    boundary = StructuredOutputManager._find_reasoning_end_offset(
+        MultiTokenReasoner(), [1, 2, 3], [20, 30, 40]
+    )
+
+    assert boundary == 1
+
+
+def test_reasoning_boundary_scan_handles_marker_across_blocks():
+    """A multi-token marker may start in history and finish in the new block."""
+
+    class CrossBlockReasoner:
+        def is_reasoning_end_streaming(
+            self, input_ids: Sequence[int], delta_ids: Iterable[int]
+        ) -> bool:
+            tokens = list(input_ids)
+            delta_len = len(list(delta_ids))
+            return any(
+                tokens[index : index + 3] == [7, 8, 9]
+                for index in range(max(0, len(tokens) - delta_len - 2), len(tokens))
+            )
+
+    boundary = StructuredOutputManager._find_reasoning_end_offset(
+        CrossBlockReasoner(), [1, 7, 8], [9, 10]
+    )
+
+    assert boundary == 0

--- a/tests/v1/spec_decode/test_mtp_structured_output.py
+++ b/tests/v1/spec_decode/test_mtp_structured_output.py
@@ -497,3 +497,83 @@ def test_reasoning_boundary_scan_handles_marker_across_blocks():
     )
 
     assert boundary == 0
+
+
+@pytest.mark.parametrize("backend", ["xgrammar", "guidance"])
+def test_speculative_grammar_filter_drops_invalid_single_token_bonus(backend):
+    """An invalid bonus is dropped without blocking the next valid commit.
+
+    Fails without the single-token gate: the token was committed unvalidated
+    and later surfaced as the accept_tokens invariant failure.
+    """
+    tokenizer, manager, request, prompt = _make_manager_and_request(
+        backend, prompt_str='{"a"'
+    )
+    grammar = request.structured_output_request.grammar
+    assert grammar.accept_tokens(request.request_id, prompt)
+
+    invalid_bonus = tokenizer.encode("z")[0]
+    filtered, rejected = manager.filter_speculative_grammar_tokens(
+        request, [invalid_bonus]
+    )
+
+    assert filtered == []
+    assert rejected == 1
+
+    # validate_tokens must leave the matcher unchanged so the next scheduler
+    # step can resample and commit from the same grammar state.
+    valid_bonus = tokenizer.encode(":")[0]
+    filtered, rejected = manager.filter_speculative_grammar_tokens(
+        request, [valid_bonus]
+    )
+
+    assert filtered == [valid_bonus]
+    assert rejected == 0
+    assert grammar.accept_tokens(request.request_id, filtered)
+
+
+@pytest.mark.parametrize("backend", ["xgrammar", "guidance"])
+def test_speculative_grammar_filter_keeps_valid_single_token_bonus(backend):
+    tokenizer, manager, request, prompt = _make_manager_and_request(
+        backend, prompt_str='{"a"'
+    )
+    grammar = request.structured_output_request.grammar
+    assert grammar.accept_tokens(request.request_id, prompt)
+
+    valid_bonus = tokenizer.encode(":")[0]
+    filtered, rejected = manager.filter_speculative_grammar_tokens(
+        request, [valid_bonus]
+    )
+
+    assert filtered == [valid_bonus]
+    assert rejected == 0
+
+
+@pytest.mark.parametrize("backend", ["xgrammar", "guidance"])
+def test_terminated_grammar_single_token_bonus_is_dropped(backend):
+    """A token after grammar completion is dropped like the multi-token path."""
+    tokenizer, manager, request, prompt = _make_manager_and_request(backend)
+    grammar = request.structured_output_request.grammar
+    assert grammar.accept_tokens(request.request_id, prompt)
+    assert grammar.accept_tokens(request.request_id, [tokenizer.eos_token_id])
+    assert grammar.is_terminated()
+
+    stray = tokenizer.encode("z")[0]
+    filtered, rejected = manager.filter_speculative_grammar_tokens(request, [stray])
+
+    assert filtered == []
+    assert rejected == 1
+
+
+@pytest.mark.parametrize("backend", ["xgrammar", "guidance"])
+def test_single_token_bonus_inside_reasoning_passes_through(backend):
+    """A single token inside reasoning is not grammar content yet."""
+    tokenizer, manager, request, prompt, _ = _setup_boundary_request(backend)
+    reasoning_token = tokenizer.encode(" ")[0]
+
+    filtered, rejected = manager.filter_speculative_grammar_tokens(
+        request, [reasoning_token]
+    )
+
+    assert filtered == [reasoning_token]
+    assert rejected == 0

--- a/tests/v1/spec_decode/test_rejection_sampler_utils.py
+++ b/tests/v1/spec_decode/test_rejection_sampler_utils.py
@@ -367,6 +367,37 @@ def test_placeholder_draft_token_rejected():
     assert (recovered >= 0).all() and (recovered < VOCAB_SIZE).all()
 
 
+def test_placeholder_stochastic_recovery_matches_target_distribution():
+    """A forced grammar rejection must recover from p, not residual p - q."""
+    torch.manual_seed(0)
+    device = "cuda"
+    num_trials = 8192
+    K = 1
+
+    target_logits_1d = torch.full(
+        (VOCAB_SIZE,), float("-inf"), device=device, dtype=torch.float32
+    )
+    target_logits_1d[:4] = torch.tensor([0.7, 0.1, -0.4, -0.9], device=device)
+    draft_logits_1d = torch.full_like(target_logits_1d, float("-inf"))
+    draft_logits_1d[:4] = torch.tensor([-1.0, 1.5, -0.5, 0.5], device=device)
+
+    inputs = _build_rejection_sample_inputs(
+        target_logits_1d,
+        draft_logits_1d,
+        K,
+        temperature=1.0,
+        num_trials=num_trials,
+    )
+    inputs["draft_sampled"].view(num_trials, K + 1)[:, 1:] = -1
+
+    sampled, num_sampled = rejection_sample(**inputs, num_speculative_steps=K)
+
+    assert torch.equal(num_sampled, torch.ones_like(num_sampled))
+    _assert_distribution_match(
+        sampled[:, 0], torch.softmax(target_logits_1d, dim=0), device
+    )
+
+
 @pytest.mark.parametrize("has_draft_logits", [True, False])
 @pytest.mark.parametrize("num_placeholders", [1, 2])
 def test_block_verification_placeholder_truncates_block(

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -15,7 +15,7 @@ from vllm.v1.structured_output.backend_types import StructuredOutputOptions
 
 class MockReasoner:
     def __init__(self, tokenizer):
-        self.is_reasoning_end = Mock(return_value=False)
+        self.is_reasoning_end_for_prompt = Mock(return_value=False)
         self.is_reasoning_end_streaming = Mock(return_value=False)
 
 
@@ -137,7 +137,7 @@ class TestReasoningStructuredOutput:
             def __init__(self, tokenizer, chat_template_kwargs=None):
                 self.chat_template_kwargs = chat_template_kwargs or {}
 
-            def is_reasoning_end(self, input_ids):
+            def is_reasoning_end_for_prompt(self, input_ids):
                 return not self.chat_template_kwargs.get("enable_thinking", False)
 
         manager = StructuredOutputManager(mock_vllm_config)

--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -134,6 +134,7 @@ def test_apply_grammar_bitmask_preserves_source_offsets_after_draft_trimming(
             dtype=np.int32,
         ),
         num_spec_tokens=[3, 3],
+        num_invalid_spec_tokens=[0, 0],
     )
     input_batch = SimpleNamespace(req_ids=["trimmed-request", "full-request"])
     logits = torch.zeros((6, 32))

--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -1,8 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import pytest
+from types import SimpleNamespace
 
+import numpy as np
+import pytest
+import torch
+
+from vllm.v1.core.sched.output import GrammarOutput
+from vllm.v1.structured_output import utils
 from vllm.v1.structured_output.backend_xgrammar import (
     has_xgrammar_unsupported_json_features,
 )
@@ -104,3 +110,53 @@ def test_supported_json_features(supported_schema):
     assert not has_xgrammar_unsupported_json_features(supported_schema), (
         "Schema should be supported"
     )
+
+
+def test_apply_grammar_bitmask_preserves_source_offsets_after_draft_trimming(
+    monkeypatch,
+):
+    """A trimmed request must not shift another request's grammar rows.
+
+    The scheduler serializes masks at its scheduled speculative width. A worker
+    may trim grammar-invalid drafts before applying those masks, so source and
+    destination offsets must be advanced with their respective widths.
+    """
+    scheduler_output = SimpleNamespace(
+        scheduled_spec_decode_tokens={
+            "trimmed-request": [1],
+            "full-request": [2, 3, 4],
+        }
+    )
+    grammar_output = GrammarOutput(
+        structured_output_request_ids=["trimmed-request", "full-request"],
+        grammar_bitmask=np.array(
+            [[10], [11], [12], [13], [20], [21], [22], [23]],
+            dtype=np.int32,
+        ),
+        num_spec_tokens=[3, 3],
+    )
+    input_batch = SimpleNamespace(req_ids=["trimmed-request", "full-request"])
+    logits = torch.zeros((6, 32))
+    applied_bitmask = None
+
+    def capture_bitmask(logits, bitmask, indices):
+        nonlocal applied_bitmask
+        applied_bitmask = bitmask.clone()
+        assert indices is None
+
+    monkeypatch.setattr(
+        utils,
+        "xgr",
+        SimpleNamespace(apply_token_bitmask_inplace=capture_bitmask),
+    )
+    monkeypatch.setattr(utils, "PIN_MEMORY", False)
+
+    utils.apply_grammar_bitmask(
+        scheduler_output,
+        grammar_output,
+        input_batch,
+        logits,
+    )
+
+    assert applied_bitmask is not None
+    assert applied_bitmask[:, 0].tolist() == [10, 13, 20, 21, 22, 23]

--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -134,6 +134,7 @@ def test_apply_grammar_bitmask_preserves_source_offsets_after_draft_trimming(
             dtype=np.int32,
         ),
         num_spec_tokens=[3, 3],
+        has_bonus_token=[True, True],
         num_invalid_spec_tokens=[0, 0],
     )
     input_batch = SimpleNamespace(req_ids=["trimmed-request", "full-request"])
@@ -161,3 +162,47 @@ def test_apply_grammar_bitmask_preserves_source_offsets_after_draft_trimming(
 
     assert applied_bitmask is not None
     assert applied_bitmask[:, 0].tolist() == [10, 13, 20, 21, 22, 23]
+
+
+def test_apply_grammar_bitmask_skips_omitted_diffusion_bonus_rows(monkeypatch):
+    """An omitted source bonus row must not consume the next request's mask."""
+    scheduler_output = SimpleNamespace(
+        scheduled_spec_decode_tokens={
+            "diffusion-request": [1],
+            "later-request": [2, 3, 4],
+        }
+    )
+    grammar_output = GrammarOutput(
+        structured_output_request_ids=["diffusion-request", "later-request"],
+        grammar_bitmask=np.array([[10], [20], [21], [22], [23]], dtype=np.int32),
+        num_spec_tokens=[1, 3],
+        has_bonus_token=[False, True],
+        num_invalid_spec_tokens=[0, 0],
+    )
+    input_batch = SimpleNamespace(req_ids=["diffusion-request", "later-request"])
+    logits = torch.zeros((6, 32))
+    applied_bitmask = None
+    applied_indices = None
+
+    def capture_bitmask(logits, bitmask, indices):
+        nonlocal applied_bitmask, applied_indices
+        applied_bitmask = bitmask.clone()
+        applied_indices = indices
+
+    monkeypatch.setattr(
+        utils,
+        "xgr",
+        SimpleNamespace(apply_token_bitmask_inplace=capture_bitmask),
+    )
+    monkeypatch.setattr(utils, "PIN_MEMORY", False)
+
+    utils.apply_grammar_bitmask(
+        scheduler_output,
+        grammar_output,
+        input_batch,
+        logits,
+    )
+
+    assert applied_bitmask is not None
+    assert applied_bitmask[:, 0].tolist() == [10, -1, 20, 21, 22, 23]
+    assert applied_indices == [0, 2, 3, 4, 5]

--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -119,7 +119,9 @@ def test_apply_grammar_bitmask_preserves_source_offsets_after_draft_trimming(
 
     The scheduler serializes masks at its scheduled speculative width. A worker
     may trim grammar-invalid drafts before applying those masks, so source and
-    destination offsets must be advanced with their respective widths.
+    destination offsets must be advanced with their respective widths. The
+    trimmed request's bonus row describes the state after its worker width,
+    not the full serialized window.
     """
     scheduler_output = SimpleNamespace(
         scheduled_spec_decode_tokens={
@@ -161,7 +163,7 @@ def test_apply_grammar_bitmask_preserves_source_offsets_after_draft_trimming(
     )
 
     assert applied_bitmask is not None
-    assert applied_bitmask[:, 0].tolist() == [10, 13, 20, 21, 22, 23]
+    assert applied_bitmask[:, 0].tolist() == [10, 11, 20, 21, 22, 23]
 
 
 def test_apply_grammar_bitmask_skips_omitted_diffusion_bonus_rows(monkeypatch):
@@ -206,3 +208,45 @@ def test_apply_grammar_bitmask_skips_omitted_diffusion_bonus_rows(monkeypatch):
     assert applied_bitmask is not None
     assert applied_bitmask[:, 0].tolist() == [10, -1, 20, 21, 22, 23]
     assert applied_indices == [0, 2, 3, 4, 5]
+
+
+def test_apply_grammar_bitmask_uses_first_row_for_zero_draft_bonus(monkeypatch):
+    """A request without scheduled drafts masks its bonus with row zero.
+
+    k=0 is the dynamic-depth shape that previously read the final window row,
+    i.e. a grammar state the commit never reaches.
+    """
+    scheduler_output = SimpleNamespace(
+        scheduled_spec_decode_tokens={"zero-draft": [], "later-request": [2]}
+    )
+    grammar_output = GrammarOutput(
+        structured_output_request_ids=["zero-draft", "later-request"],
+        grammar_bitmask=np.array([[10], [11], [12], [20], [21]], dtype=np.int32),
+        num_spec_tokens=[2, 1],
+        has_bonus_token=[True, True],
+        num_invalid_spec_tokens=[0, 0],
+    )
+    input_batch = SimpleNamespace(req_ids=["zero-draft", "later-request"])
+    logits = torch.zeros((3, 32))
+    applied_bitmask = None
+
+    def capture_bitmask(logits, bitmask, indices):
+        nonlocal applied_bitmask
+        applied_bitmask = bitmask.clone()
+
+    monkeypatch.setattr(
+        utils,
+        "xgr",
+        SimpleNamespace(apply_token_bitmask_inplace=capture_bitmask),
+    )
+    monkeypatch.setattr(utils, "PIN_MEMORY", False)
+
+    utils.apply_grammar_bitmask(
+        scheduler_output,
+        grammar_output,
+        input_batch,
+        logits,
+    )
+
+    assert applied_bitmask is not None
+    assert applied_bitmask[:, 0].tolist() == [10, 20, 21]

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -38,7 +38,12 @@ from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.attention.backend import MultipleOf
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.core.kv_cache_utils import estimate_max_model_len, get_kv_cache_configs
-from vllm.v1.core.sched.output import CachedRequestData, NewRequestData, SchedulerOutput
+from vllm.v1.core.sched.output import (
+    CachedRequestData,
+    GrammarOutput,
+    NewRequestData,
+    SchedulerOutput,
+)
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -144,6 +149,72 @@ def model_runner():
 
 
 model_runner_2 = model_runner
+
+
+def test_invalid_grammar_suffix_counts_follow_compact_worker_order():
+    runner = SimpleNamespace(
+        input_batch=SimpleNamespace(req_ids=["plain", "structured-a", "structured-b"])
+    )
+    grammar_output = GrammarOutput(
+        structured_output_request_ids=["structured-b", "structured-a"],
+        grammar_bitmask=np.empty((0, 0), dtype=np.int32),
+        num_spec_tokens=[4, 3],
+        num_invalid_spec_tokens=[3, 1],
+    )
+    spec_decode_metadata = SimpleNamespace(num_draft_tokens=[1, 2, 3])
+
+    assert GPUModelRunner._get_invalid_draft_counts(
+        runner, grammar_output, spec_decode_metadata
+    ) == [0, 0, 2]
+
+
+@pytest.mark.parametrize(
+    "request_ids,widths,invalid,error",
+    [
+        (["a", "a"], [1, 1], [0, 0], "duplicate"),
+        (["a"], [1, 2], [0], "align"),
+        (["a"], [1], None, "missing"),
+        (["a"], [1], [2], "outside"),
+    ],
+)
+def test_invalid_grammar_suffix_counts_validate_serialized_metadata(
+    request_ids, widths, invalid, error
+):
+    runner = SimpleNamespace(input_batch=SimpleNamespace(req_ids=["a"]))
+    grammar_output = GrammarOutput(
+        structured_output_request_ids=request_ids,
+        grammar_bitmask=np.empty((0, 0), dtype=np.int32),
+        num_spec_tokens=widths,
+        num_invalid_spec_tokens=invalid,
+    )
+    spec_decode_metadata = SimpleNamespace(num_draft_tokens=[1])
+
+    with pytest.raises(ValueError, match=error):
+        GPUModelRunner._get_invalid_draft_counts(
+            runner, grammar_output, spec_decode_metadata
+        )
+
+
+def test_sample_forwards_invalid_draft_counts_to_rejection_sampler():
+    runner = object.__new__(GPUModelRunner)
+    runner.input_batch = SimpleNamespace(
+        sampling_metadata=Mock(),
+        update_async_output_token_ids=Mock(),
+    )
+    runner.use_async_scheduling = False
+    runner._get_spec_decode_draft_probs = Mock(return_value=None)
+    runner.rejection_sampler = Mock(return_value="sampler-output")
+    spec_decode_metadata = SimpleNamespace()
+
+    output = GPUModelRunner._sample(
+        runner,
+        torch.zeros(1, 2),
+        spec_decode_metadata,
+        [1],
+    )
+
+    assert output == "sampler-output"
+    assert runner.rejection_sampler.call_args.args[4] == [1]
 
 
 def _schedule_new_request(*req_ids: str) -> SchedulerOutput:

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -159,6 +159,7 @@ def test_invalid_grammar_suffix_counts_follow_compact_worker_order():
         structured_output_request_ids=["structured-b", "structured-a"],
         grammar_bitmask=np.empty((0, 0), dtype=np.int32),
         num_spec_tokens=[4, 3],
+        has_bonus_token=[True, True],
         num_invalid_spec_tokens=[3, 1],
     )
     spec_decode_metadata = SimpleNamespace(num_draft_tokens=[1, 2, 3])
@@ -185,6 +186,7 @@ def test_invalid_grammar_suffix_counts_validate_serialized_metadata(
         structured_output_request_ids=request_ids,
         grammar_bitmask=np.empty((0, 0), dtype=np.int32),
         num_spec_tokens=widths,
+        has_bonus_token=[True] * len(request_ids),
         num_invalid_spec_tokens=invalid,
     )
     spec_decode_metadata = SimpleNamespace(num_draft_tokens=[1])

--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -19,6 +19,7 @@ def _grammar_output() -> GrammarOutput:
         structured_output_request_ids=["structured-b", "structured-a"],
         grammar_bitmask=np.empty((0, 0), dtype=np.int32),
         num_spec_tokens=[4, 3],
+        has_bonus_token=[True, True],
         num_invalid_spec_tokens=[3, 1],
     )
 
@@ -60,6 +61,7 @@ def test_invalid_grammar_suffix_counts_project_active_width(
         structured_output_request_ids=["structured"],
         grammar_bitmask=np.empty((0, 0), dtype=np.int32),
         num_spec_tokens=[source_width],
+        has_bonus_token=[True],
         num_invalid_spec_tokens=[source_invalid],
     )
     input_batch = SimpleNamespace(
@@ -87,6 +89,7 @@ def test_invalid_grammar_suffix_counts_validate_metadata(
         structured_output_request_ids=request_ids,
         grammar_bitmask=np.empty((0, 0), dtype=np.int32),
         num_spec_tokens=widths,
+        has_bonus_token=[True] * len(request_ids),
         num_invalid_spec_tokens=invalid,
     )
     input_batch = SimpleNamespace(

--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU coverage for V2 structured-output/speculative-decode transport."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.v1.core.sched.output import GrammarOutput
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner, _get_invalid_draft_counts
+
+
+def _grammar_output() -> GrammarOutput:
+    return GrammarOutput(
+        structured_output_request_ids=["structured-b", "structured-a"],
+        grammar_bitmask=np.empty((0, 0), dtype=np.int32),
+        num_spec_tokens=[4, 3],
+        num_invalid_spec_tokens=[3, 1],
+    )
+
+
+def _grammar_input_batch() -> SimpleNamespace:
+    return SimpleNamespace(
+        req_ids=["plain", "structured-a", "structured-b"],
+        num_draft_tokens_per_req=np.array([0, 2, 3], dtype=np.int32),
+        cu_num_logits_np=np.array([0, 1, 4, 8], dtype=np.int32),
+    )
+
+
+def test_invalid_grammar_suffix_counts_follow_reorder_and_compaction():
+    assert _get_invalid_draft_counts(_grammar_output(), _grammar_input_batch()) == [
+        0,
+        0,
+        2,
+    ]
+    new_request_batch = SimpleNamespace(
+        req_ids=["new"],
+        num_draft_tokens_per_req=np.array([2], dtype=np.int32),
+    )
+    assert _get_invalid_draft_counts(_grammar_output(), new_request_batch) is None
+
+
+@pytest.mark.parametrize(
+    "source_width,source_invalid,active_width,expected",
+    [
+        (4, 0, 4, None),
+        (4, 4, 4, [4]),
+        (4, 3, 2, [1]),
+        (4, 3, 1, None),
+    ],
+)
+def test_invalid_grammar_suffix_counts_project_active_width(
+    source_width, source_invalid, active_width, expected
+):
+    grammar_output = GrammarOutput(
+        structured_output_request_ids=["structured"],
+        grammar_bitmask=np.empty((0, 0), dtype=np.int32),
+        num_spec_tokens=[source_width],
+        num_invalid_spec_tokens=[source_invalid],
+    )
+    input_batch = SimpleNamespace(
+        req_ids=["structured"],
+        num_draft_tokens_per_req=np.array([active_width], dtype=np.int32),
+    )
+
+    assert _get_invalid_draft_counts(grammar_output, input_batch) == expected
+
+
+@pytest.mark.parametrize(
+    "request_ids,widths,invalid,active_widths,error",
+    [
+        (["a", "a"], [1, 1], [0, 0], [1], "duplicate"),
+        (["a"], [1, 2], [0], [1], "align"),
+        (["a"], [1], None, [1], "missing"),
+        (["a"], [1], [2], [1], "outside"),
+        (["a"], [1], [0], [2], "active"),
+    ],
+)
+def test_invalid_grammar_suffix_counts_validate_metadata(
+    request_ids, widths, invalid, active_widths, error
+):
+    grammar_output = GrammarOutput(
+        structured_output_request_ids=request_ids,
+        grammar_bitmask=np.empty((0, 0), dtype=np.int32),
+        num_spec_tokens=widths,
+        num_invalid_spec_tokens=invalid,
+    )
+    input_batch = SimpleNamespace(
+        req_ids=["a"],
+        num_draft_tokens_per_req=np.array(active_widths, dtype=np.int32),
+    )
+
+    with pytest.raises(ValueError, match=error):
+        _get_invalid_draft_counts(grammar_output, input_batch)
+
+
+def test_sample_forwards_projected_grammar_rejections():
+    input_batch = _grammar_input_batch()
+    input_batch.num_draft_tokens = 5
+    input_batch.logits_indices = torch.arange(8)
+    input_batch.max_query_len = 4
+    runner: Any = GPUModelRunner.__new__(GPUModelRunner)
+    runner.model = SimpleNamespace(compute_logits=lambda _: torch.zeros(8, 4))
+    runner.structured_outputs_worker = SimpleNamespace(
+        apply_grammar_bitmask=lambda *_: None
+    )
+    runner.rejection_sampler = Mock(
+        return_value=SimpleNamespace(num_sampled=None, num_rejected=None)
+    )
+    runner.speculator = SimpleNamespace(draft_logits=None, online_sts=None)
+    runner.verification_capacity_manager = None
+
+    GPUModelRunner.sample(runner, torch.zeros(8, 1), input_batch, _grammar_output())
+
+    assert runner.rejection_sampler.call_args.args[3] == [0, 0, 2]
+
+
+def test_sample_without_grammar_forwards_no_invalid_counts():
+    input_batch = _grammar_input_batch()
+    input_batch.num_draft_tokens = 5
+    input_batch.logits_indices = torch.arange(8)
+    input_batch.max_query_len = 4
+    runner: Any = GPUModelRunner.__new__(GPUModelRunner)
+    runner.model = SimpleNamespace(compute_logits=lambda _: torch.zeros(8, 4))
+    runner.rejection_sampler = Mock(
+        return_value=SimpleNamespace(num_sampled=None, num_rejected=None)
+    )
+    runner.speculator = SimpleNamespace(draft_logits=None, online_sts=None)
+    runner.verification_capacity_manager = None
+
+    GPUModelRunner.sample(runner, torch.zeros(8, 1), input_batch, None)
+
+    assert runner.rejection_sampler.call_args.args[3] is None

--- a/tests/v1/worker/test_gpu_rejection_sampler_chunking.py
+++ b/tests/v1/worker/test_gpu_rejection_sampler_chunking.py
@@ -13,6 +13,7 @@ from vllm.platforms import current_platform
 from vllm.v1.worker.gpu.spec_decode.rejection_sampler import (
     RejectionSampler,
     _iter_request_chunks,
+    force_reject_invalid_draft_suffixes,
 )
 
 
@@ -24,6 +25,36 @@ def test_iter_request_chunks_preserves_request_boundaries():
         (2, 3),
         (3, 4),
     ]
+
+
+def test_force_reject_invalid_draft_suffixes_marks_only_compact_tail():
+    draft_sampled = torch.tensor([90, 91, 11, 12, 92, 21, 22, 23])
+    sanitized = force_reject_invalid_draft_suffixes(
+        draft_sampled,
+        np.array([0, 1, 4, 8], dtype=np.int32),
+        [0, 0, 2],
+    )
+
+    assert sanitized.tolist() == [90, 91, 11, 12, 92, 21, -1, -1]
+    assert draft_sampled.tolist() == [90, 91, 11, 12, 92, 21, 22, 23]
+
+
+@pytest.mark.parametrize(
+    "draft_sampled,cu_num_logits,invalid_counts",
+    [
+        (torch.tensor([1, 2]), np.array([0, 2], dtype=np.int32), [3]),
+        (torch.tensor([1, 2]), np.array([0, 2], dtype=np.int32), [1, 0]),
+        (torch.tensor([1]), np.array([0, 2], dtype=np.int32), [1]),
+        (torch.tensor([1, 2]), np.array([[0, 2]], dtype=np.int32), [1]),
+    ],
+)
+def test_force_reject_invalid_draft_suffixes_validates_metadata(
+    draft_sampled, cu_num_logits, invalid_counts
+):
+    with pytest.raises(ValueError):
+        force_reject_invalid_draft_suffixes(
+            draft_sampled, cu_num_logits, invalid_counts
+        )
 
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")

--- a/tests/v1/worker/test_gpu_structured_outputs.py
+++ b/tests/v1/worker/test_gpu_structured_outputs.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import numpy as np
+
+from vllm.v1.worker.gpu.structured_outputs import _build_grammar_row_mapping
+
+
+def test_grammar_mapping_preserves_bonus_rows_after_zero_draft_budget():
+    """Zero draft capacity retains each request's scheduled bonus mask."""
+    source_indices, logits_indices = _build_grammar_row_mapping(
+        req_ids=["low", "high", "prefill"],
+        grammar_req_ids=["low", "high", "prefill"],
+        grammar_num_spec_tokens=[2, 2, 0],
+        cu_num_logits_np=np.array([0, 1, 2, 3], dtype=np.int32),
+        num_draft_tokens_per_req=np.array([0, 0, 0], dtype=np.int32),
+        num_bonus_tokens=1,
+    )
+
+    assert source_indices == [2, 5, 6]
+    assert logits_indices == [0, 1, 2]
+
+
+def test_grammar_mapping_selects_active_drafts_from_each_source_group():
+    """Compaction preserves per-request draft rows and the final bonus row."""
+    source_indices, logits_indices = _build_grammar_row_mapping(
+        req_ids=["plain", "trimmed", "full"],
+        grammar_req_ids=["trimmed", "full"],
+        grammar_num_spec_tokens=[3, 3],
+        cu_num_logits_np=np.array([0, 1, 3, 7], dtype=np.int32),
+        num_draft_tokens_per_req=np.array([0, 1, 3], dtype=np.int32),
+        num_bonus_tokens=1,
+    )
+
+    assert source_indices == [0, 3, 4, 5, 6, 7]
+    assert logits_indices == [1, 2, 3, 4, 5, 6]
+
+
+def test_grammar_mapping_supports_non_speculative_batches():
+    """A batch without draft tokens maps one bonus row per grammar request."""
+    source_indices, logits_indices = _build_grammar_row_mapping(
+        req_ids=["plain", "grammar"],
+        grammar_req_ids=["grammar"],
+        grammar_num_spec_tokens=[0],
+        cu_num_logits_np=np.array([0, 1, 2], dtype=np.int32),
+        num_draft_tokens_per_req=None,
+        num_bonus_tokens=1,
+    )
+
+    assert source_indices == [0]
+    assert logits_indices == [1]

--- a/tests/v1/worker/test_gpu_structured_outputs.py
+++ b/tests/v1/worker/test_gpu_structured_outputs.py
@@ -12,6 +12,7 @@ def test_grammar_mapping_preserves_bonus_rows_after_zero_draft_budget():
         req_ids=["low", "high", "prefill"],
         grammar_req_ids=["low", "high", "prefill"],
         grammar_num_spec_tokens=[2, 2, 0],
+        grammar_has_bonus_token=[True, True, True],
         cu_num_logits_np=np.array([0, 1, 2, 3], dtype=np.int32),
         num_draft_tokens_per_req=np.array([0, 0, 0], dtype=np.int32),
         num_bonus_tokens=1,
@@ -27,6 +28,7 @@ def test_grammar_mapping_selects_active_drafts_from_each_source_group():
         req_ids=["plain", "trimmed", "full"],
         grammar_req_ids=["trimmed", "full"],
         grammar_num_spec_tokens=[3, 3],
+        grammar_has_bonus_token=[True, True],
         cu_num_logits_np=np.array([0, 1, 3, 7], dtype=np.int32),
         num_draft_tokens_per_req=np.array([0, 1, 3], dtype=np.int32),
         num_bonus_tokens=1,
@@ -42,6 +44,7 @@ def test_grammar_mapping_supports_non_speculative_batches():
         req_ids=["plain", "grammar"],
         grammar_req_ids=["grammar"],
         grammar_num_spec_tokens=[0],
+        grammar_has_bonus_token=[True],
         cu_num_logits_np=np.array([0, 1, 2], dtype=np.int32),
         num_draft_tokens_per_req=None,
         num_bonus_tokens=1,
@@ -49,3 +52,19 @@ def test_grammar_mapping_supports_non_speculative_batches():
 
     assert source_indices == [0]
     assert logits_indices == [1]
+
+
+def test_grammar_mapping_advances_past_unmapped_diffusion_bonus_rows():
+    """Serialized diffusion bonus rows advance source offsets without logits."""
+    source_indices, logits_indices = _build_grammar_row_mapping(
+        req_ids=["diffusion", "no-canvas", "later"],
+        grammar_req_ids=["diffusion", "no-canvas", "later"],
+        grammar_num_spec_tokens=[1, 0, 2],
+        grammar_has_bonus_token=[False, True, False],
+        cu_num_logits_np=np.array([0, 1, 1, 3], dtype=np.int32),
+        num_draft_tokens_per_req=np.array([1, 0, 2], dtype=np.int32),
+        num_bonus_tokens=0,
+    )
+
+    assert source_indices == [0, 2, 3]
+    assert logits_indices == [0, 1, 2]

--- a/tests/v1/worker/test_gpu_structured_outputs.py
+++ b/tests/v1/worker/test_gpu_structured_outputs.py
@@ -6,8 +6,8 @@ import numpy as np
 from vllm.v1.worker.gpu.structured_outputs import _build_grammar_row_mapping
 
 
-def test_grammar_mapping_preserves_bonus_rows_after_zero_draft_budget():
-    """Zero draft capacity retains each request's scheduled bonus mask."""
+def test_grammar_mapping_uses_active_width_row_for_bonus_after_zero_drafts():
+    """A zero-draft request masks its bonus with the state after zero drafts."""
     source_indices, logits_indices = _build_grammar_row_mapping(
         req_ids=["low", "high", "prefill"],
         grammar_req_ids=["low", "high", "prefill"],
@@ -18,12 +18,12 @@ def test_grammar_mapping_preserves_bonus_rows_after_zero_draft_budget():
         num_bonus_tokens=1,
     )
 
-    assert source_indices == [2, 5, 6]
+    assert source_indices == [0, 3, 6]
     assert logits_indices == [0, 1, 2]
 
 
 def test_grammar_mapping_selects_active_drafts_from_each_source_group():
-    """Compaction preserves per-request draft rows and the final bonus row."""
+    """The bonus row tracks the active width, not the full serialized window."""
     source_indices, logits_indices = _build_grammar_row_mapping(
         req_ids=["plain", "trimmed", "full"],
         grammar_req_ids=["trimmed", "full"],
@@ -34,7 +34,7 @@ def test_grammar_mapping_selects_active_drafts_from_each_source_group():
         num_bonus_tokens=1,
     )
 
-    assert source_indices == [0, 3, 4, 5, 6, 7]
+    assert source_indices == [0, 1, 4, 5, 6, 7]
     assert logits_indices == [1, 2, 3, 4, 5, 6]
 
 
@@ -68,3 +68,25 @@ def test_grammar_mapping_advances_past_unmapped_diffusion_bonus_rows():
 
     assert source_indices == [0, 2, 3]
     assert logits_indices == [0, 1, 2]
+
+
+def test_grammar_mapping_mixed_active_widths_and_reordering():
+    """k=0/k=1/k=K requests select their bonus row at the active width.
+
+    Grammar groups arrive reordered relative to the batch and include the
+    last request; the last group must not read past its source rows.
+    """
+    source_indices, logits_indices = _build_grammar_row_mapping(
+        req_ids=["zero", "one", "full"],
+        grammar_req_ids=["full", "zero", "one"],
+        grammar_num_spec_tokens=[7, 7, 7],
+        grammar_has_bonus_token=[True, True, True],
+        cu_num_logits_np=np.array([0, 1, 3, 11], dtype=np.int32),
+        num_draft_tokens_per_req=np.array([0, 1, 7], dtype=np.int32),
+        num_bonus_tokens=1,
+    )
+
+    # full: rows 0..6 drafts, bonus row 7; zero: bonus row 8; one: draft row 16,
+    # bonus row 17.
+    assert source_indices == [0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 17]
+    assert logits_indices == [3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2]

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -299,3 +299,6 @@ class GrammarOutput:
     # structured output request. Worker-side draft trimming may reduce the
     # number of logits without changing this compact source layout.
     num_spec_tokens: list[int]
+    # Number of grammar-invalid draft tokens per structured request. This is
+    # forwarded to the worker so a stale draft snapshot cannot be accepted.
+    num_invalid_spec_tokens: list[int]

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -295,3 +295,7 @@ class GrammarOutput:
     structured_output_request_ids: list[str]
     # Bitmask ordered as structured_output_request_ids.
     grammar_bitmask: "npt.NDArray[np.int32]"
+    # Number of speculative rows represented in grammar_bitmask for each
+    # structured output request. Worker-side draft trimming may reduce the
+    # number of logits without changing this compact source layout.
+    num_spec_tokens: list[int]

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -299,6 +299,9 @@ class GrammarOutput:
     # structured output request. Worker-side draft trimming may reduce the
     # number of logits without changing this compact source layout.
     num_spec_tokens: list[int]
+    # Whether grammar_bitmask contains the per-request bonus row. Diffusion
+    # requests that already have scheduled positions omit this source row.
+    has_bonus_token: list[bool]
     # Number of grammar-invalid draft tokens per structured request. This is
     # forwarded to the worker so a stale draft snapshot cannot be accepted.
     num_invalid_spec_tokens: list[int]

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1835,9 +1835,13 @@ class Scheduler(SchedulerInterface):
             scheduled_spec_token_ids = (
                 scheduler_output.scheduled_spec_decode_tokens.get(req_id)
             )
+            observed_spec_decode = False
+            num_draft_tokens = 0
+            num_accepted = 0
             if scheduled_spec_token_ids and (
                 generated_token_ids or self.num_sampled_tokens_per_step == 0
             ):
+                observed_spec_decode = True
                 num_draft_tokens = len(scheduled_spec_token_ids)
                 num_sampled = self.num_sampled_tokens_per_step
                 num_accepted = max(len(generated_token_ids) - num_sampled, 0)
@@ -1855,13 +1859,6 @@ class Scheduler(SchedulerInterface):
                         request.num_computed_tokens -= num_rejected
                     if request.num_output_placeholders > 0:
                         request.num_output_placeholders -= num_rejected
-                spec_decoding_stats = self.make_spec_decoding_stats(
-                    spec_decoding_stats,
-                    num_draft_tokens=num_draft_tokens,
-                    num_accepted_tokens=num_accepted,
-                    num_invalid_spec_tokens=scheduler_output.num_invalid_spec_tokens,
-                    request_id=req_id,
-                )
 
             # Free encoder inputs only after the step has actually executed.
             if request.has_encoder_inputs:
@@ -1876,6 +1873,40 @@ class Scheduler(SchedulerInterface):
             prefill_stats = None
             status_before_stop = request.status
             num_output_tokens_before = len(request._output_token_ids)
+
+            if (
+                len(new_token_ids) > 1
+                and scheduled_spec_token_ids
+                and request.use_structured_output
+                and not output_is_stale
+            ):
+                new_token_ids, num_grammar_rejected = (
+                    self.structured_output_manager.filter_speculative_grammar_tokens(
+                        request, new_token_ids
+                    )
+                )
+                if num_grammar_rejected > 0:
+                    if request.num_computed_tokens > 0:
+                        request.num_computed_tokens -= num_grammar_rejected
+                    if request.num_output_placeholders > 0:
+                        request.num_output_placeholders -= num_grammar_rejected
+                    # Target-sampled tokens occupy the end of the output block.
+                    # Removing that tail changes the accepted-draft count only
+                    # when the rejected suffix extends into draft positions.
+                    num_accepted -= max(
+                        num_grammar_rejected - self.num_sampled_tokens_per_step,
+                        0,
+                    )
+                    assert num_accepted >= 0
+
+            if observed_spec_decode:
+                spec_decoding_stats = self.make_spec_decoding_stats(
+                    spec_decoding_stats,
+                    num_draft_tokens=num_draft_tokens,
+                    num_accepted_tokens=num_accepted,
+                    num_invalid_spec_tokens=scheduler_output.num_invalid_spec_tokens,
+                    request_id=req_id,
+                )
 
             # Check for stop and update request status.
             if new_token_ids:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1723,7 +1723,15 @@ class Scheduler(SchedulerInterface):
             structured_output_request_ids,
             scheduler_output.scheduled_spec_decode_tokens,
         )
-        return GrammarOutput(structured_output_request_ids, bitmask)
+        num_spec_tokens = [
+            len(scheduler_output.scheduled_spec_decode_tokens.get(req_id, ()))
+            for req_id in structured_output_request_ids
+        ]
+        return GrammarOutput(
+            structured_output_request_ids,
+            bitmask,
+            num_spec_tokens,
+        )
 
     def update_from_output(
         self,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1727,6 +1727,12 @@ class Scheduler(SchedulerInterface):
             len(scheduler_output.scheduled_spec_decode_tokens.get(req_id, ()))
             for req_id in structured_output_request_ids
         ]
+        has_bonus_token = [
+            self.structured_output_manager.has_grammar_bonus_token(
+                scheduler_output.scheduled_spec_decode_tokens.get(req_id, ())
+            )
+            for req_id in structured_output_request_ids
+        ]
         invalid_spec_tokens = scheduler_output.num_invalid_spec_tokens or {}
         num_invalid_spec_tokens = [
             invalid_spec_tokens.get(req_id, 0)
@@ -1736,6 +1742,7 @@ class Scheduler(SchedulerInterface):
             structured_output_request_ids,
             bitmask,
             num_spec_tokens,
+            has_bonus_token,
             num_invalid_spec_tokens,
         )
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1727,10 +1727,16 @@ class Scheduler(SchedulerInterface):
             len(scheduler_output.scheduled_spec_decode_tokens.get(req_id, ()))
             for req_id in structured_output_request_ids
         ]
+        invalid_spec_tokens = scheduler_output.num_invalid_spec_tokens or {}
+        num_invalid_spec_tokens = [
+            invalid_spec_tokens.get(req_id, 0)
+            for req_id in structured_output_request_ids
+        ]
         return GrammarOutput(
             structured_output_request_ids,
             bitmask,
             num_spec_tokens,
+            num_invalid_spec_tokens,
         )
 
     def update_from_output(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1896,7 +1896,7 @@ class Scheduler(SchedulerInterface):
             num_output_tokens_before = len(request._output_token_ids)
 
             if (
-                len(new_token_ids) > 1
+                len(new_token_ids) >= 1
                 and scheduled_spec_token_ids
                 and request.use_structured_output
                 and not output_is_stale

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -35,6 +35,48 @@ GREEDY_TEMPERATURE: tl.constexpr = 0
 MAX_SPEC_LEN = 128
 
 
+def force_reject_invalid_draft_suffixes(
+    draft_token_ids: torch.Tensor,
+    draft_probs: torch.Tensor | None,
+    num_draft_tokens: list[int],
+    num_invalid_draft_tokens: list[int] | None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Replace grammar-invalid draft suffixes with rejection placeholders."""
+    if num_invalid_draft_tokens is None:
+        return draft_token_ids, draft_probs
+    if len(num_invalid_draft_tokens) != len(num_draft_tokens):
+        raise ValueError("invalid draft counts must align with batch requests")
+
+    total_drafts = sum(num_draft_tokens)
+    if draft_token_ids.numel() != total_drafts:
+        raise ValueError("draft ids must align with per-request draft counts")
+    if not any(num_invalid_draft_tokens):
+        return draft_token_ids, draft_probs
+
+    sanitized = draft_token_ids.clone()
+    forced_reject_mask = torch.zeros(
+        total_drafts, dtype=torch.bool, device=draft_token_ids.device
+    )
+    offset = 0
+    for num_drafts, num_invalid in zip(
+        num_draft_tokens, num_invalid_draft_tokens, strict=True
+    ):
+        if not 0 <= num_invalid <= num_drafts:
+            raise ValueError("invalid draft count is outside its request width")
+        if num_invalid:
+            start = offset + num_drafts - num_invalid
+            sanitized[start : offset + num_drafts] = PLACEHOLDER_TOKEN_ID
+            forced_reject_mask[start : offset + num_drafts] = True
+        offset += num_drafts
+
+    if draft_probs is not None:
+        if draft_probs.shape[0] != total_drafts:
+            raise ValueError("draft probabilities must align with draft ids")
+        draft_probs = draft_probs.clone()
+        draft_probs.masked_fill_(forced_reject_mask.unsqueeze(1), 0)
+    return sanitized, draft_probs
+
+
 class RejectionSampler(nn.Module):
     """
     The implementation strictly follows the algorithm described in
@@ -97,6 +139,7 @@ class RejectionSampler(nn.Module):
         # [num_tokens + batch_size, vocab_size]
         logits: torch.Tensor,
         sampling_metadata: SamplingMetadata,
+        num_invalid_draft_tokens: list[int] | None = None,
     ) -> SamplerOutput:
         """
         Args:
@@ -170,8 +213,14 @@ class RejectionSampler(nn.Module):
             sampling_metadata,
         )
 
-        output_token_ids = rejection_sample(
+        draft_token_ids, draft_probs = force_reject_invalid_draft_suffixes(
             metadata.draft_token_ids,
+            draft_probs,
+            metadata.num_draft_tokens,
+            num_invalid_draft_tokens,
+        )
+        output_token_ids = rejection_sample(
+            draft_token_ids,
             metadata.num_draft_tokens,
             metadata.max_spec_len,
             metadata.cu_num_draft_tokens,

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -409,9 +409,7 @@ class StructuredOutputManager:
                 # After unifying the `openai_gptoss` and non-`openai_gptoss` styles,
                 # it can be removed.
                 request.structured_output_request.reasoning_ended = (
-                    reasoner.is_reasoning_end_for_prompt(
-                        request.prompt_token_ids or []
-                    )
+                    reasoner.is_reasoning_end_for_prompt(request.prompt_token_ids or [])
                 )
             return request.structured_output_request.reasoning_ended
         return True

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -4,7 +4,8 @@ import itertools
 import multiprocessing
 from collections.abc import Iterable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import TYPE_CHECKING
+from copy import copy
+from typing import TYPE_CHECKING, overload
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
@@ -30,6 +31,34 @@ else:
 
 
 logger = init_logger(__name__)
+
+
+class _TokenSequenceView(Sequence[int]):
+    """Read-only concatenation that does not copy committed token history."""
+
+    def __init__(self, prefix: Sequence[int], suffix: Sequence[int]) -> None:
+        self.prefix = prefix
+        self.suffix = suffix
+
+    def __len__(self) -> int:
+        return len(self.prefix) + len(self.suffix)
+
+    @overload
+    def __getitem__(self, index: int) -> int: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> list[int]: ...
+
+    def __getitem__(self, index: int | slice) -> int | list[int]:
+        if isinstance(index, slice):
+            return [self[i] for i in range(*index.indices(len(self)))]
+        if index < 0:
+            index += len(self)
+        if index < 0 or index >= len(self):
+            raise IndexError(index)
+        if index < len(self.prefix):
+            return self.prefix[index]
+        return self.suffix[index - len(self.prefix)]
 
 
 class StructuredOutputManager:
@@ -493,6 +522,106 @@ class StructuredOutputManager:
         if num_reasoning <= 0:
             return new_token_ids
         return new_token_ids[num_reasoning:]
+
+    @staticmethod
+    def _find_reasoning_end_offset(
+        reasoner: "ReasoningParser",
+        prior_token_ids: Sequence[int],
+        new_token_ids: list[int],
+    ) -> int | None:
+        """Return where a reasoning-end marker completes in a sampled block.
+
+        The first parser call keeps reasoning-only blocks at one check. When
+        the block contains a transition, cumulative delta prefixes locate
+        single-token and multi-token markers, including markers that start in
+        ``prior_token_ids`` and finish in ``new_token_ids``.
+
+        Args:
+            reasoner: Request-scoped parser that identifies the transition.
+            prior_token_ids: Tokens committed before the sampled block.
+            new_token_ids: Accepted tokens awaiting commit.
+
+        Returns:
+            The zero-based offset where the marker completes, or ``None`` if
+            the sampled block remains inside reasoning.
+        """
+        complete_tokens = _TokenSequenceView(prior_token_ids, new_token_ids)
+        if not copy(reasoner).is_reasoning_end_streaming(
+            complete_tokens, new_token_ids
+        ):
+            return None
+
+        for offset in range(len(new_token_ids)):
+            delta_ids = new_token_ids[: offset + 1]
+            token_ids = _TokenSequenceView(prior_token_ids, delta_ids)
+            # Streaming parsers may retain request-local transition state.
+            # A probe must not consume that state before the normal commit path.
+            if copy(reasoner).is_reasoning_end_streaming(token_ids, delta_ids):
+                return offset
+
+        # Some parsers report only that the complete block crossed a boundary.
+        # Treating the full block as reasoning avoids exposing an unknown suffix
+        # to the answer grammar.
+        return len(new_token_ids) - 1
+
+    def filter_speculative_grammar_tokens(
+        self,
+        request: "Request",
+        new_token_ids: list[int],
+    ) -> tuple[list[int], int]:
+        """Validate an accepted speculative block before it is committed.
+
+        Grammar masks cover scheduled draft positions, but an accepted block
+        can contain an unconstrained token immediately after a reasoning
+        transition or after the grammar completes. The filter retains the
+        grammar-valid prefix and reports the trailing tokens that must be
+        resampled. ``validate_tokens`` restores the grammar state before
+        returning, so the scheduler's normal commit path remains the only
+        operation that advances the matcher.
+
+        Args:
+            request: Request that owns the grammar and reasoning state.
+            new_token_ids: Accepted tokens awaiting scheduler commit.
+
+        Returns:
+            The tokens that are safe to commit and the rejected suffix length.
+        """
+        if self.vllm_config.speculative_config is None:
+            return new_token_ids, 0
+        if len(new_token_ids) < 2 or not request.use_structured_output:
+            return new_token_ids, 0
+
+        structured_request = request.structured_output_request
+        if structured_request is None:
+            return new_token_ids, 0
+        grammar = structured_request.grammar
+        if not isinstance(grammar, StructuredOutputGrammar):
+            return new_token_ids, 0
+
+        reasoner = self._get_reasoner(request)
+        grammar_start = 0
+        if (
+            reasoner is not None
+            and not self.enable_in_reasoning
+            and not structured_request.reasoning_ended
+        ):
+            boundary = self._find_reasoning_end_offset(
+                reasoner,
+                request.all_token_ids,
+                new_token_ids,
+            )
+            if boundary is None:
+                return new_token_ids, 0
+            grammar_start = boundary + 1
+
+        grammar_tokens = new_token_ids[grammar_start:]
+        if not grammar_tokens:
+            return new_token_ids, 0
+        valid_grammar_tokens = grammar.validate_tokens(grammar_tokens)
+        rejected = len(grammar_tokens) - len(valid_grammar_tokens)
+        if rejected == 0:
+            return new_token_ids, 0
+        return new_token_ids[:grammar_start] + valid_grammar_tokens, rejected
 
     def clear_backend(self) -> None:
         if self.backend is not None:

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -245,6 +245,14 @@ class StructuredOutputManager:
     ) -> Future:
         return self.executor_for_fillmask.submit(self._fill_bitmasks, batch)
 
+    def has_grammar_bonus_token(
+        self, scheduled_spec_decode_tokens: Sequence[int]
+    ) -> bool:
+        """Whether a request contributes a bonus row to the compact mask."""
+        return not (
+            self.vllm_config.model_config.is_diffusion and scheduled_spec_decode_tokens
+        )
+
     def grammar_bitmask(
         self,
         requests: dict[str, "Request"],
@@ -368,7 +376,7 @@ class StructuredOutputManager:
                     cumulative_index += 1
                 # Diffusion LLMs don't sample a bonus token after the
                 # scheduled positions, so skip its bitmask in that case.
-                if not (self.vllm_config.model_config.is_diffusion and req_tokens):
+                if self.has_grammar_bonus_token(req_tokens):
                     # bonus_apply must be True when the bonus-row position
                     # should be grammar-constrained. Two triggers:
                     # - should_fill_bitmask(request): reasoning was already

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -594,7 +594,29 @@ class StructuredOutputManager:
         """
         if self.vllm_config.speculative_config is None:
             return new_token_ids, 0
-        if len(new_token_ids) < 2 or not request.use_structured_output:
+        if not request.use_structured_output:
+            return new_token_ids, 0
+        if len(new_token_ids) < 2:
+            # A single-token speculative block can be the bonus-only result
+            # after all scheduled drafts were rejected or trimmed. Its
+            # active-depth mask should already constrain it; validate against
+            # the current grammar state as an independent fail-closed check
+            # before commit. An invalid bonus is dropped and resampled instead
+            # of corrupting the structured output.
+            if len(new_token_ids) == 1:
+                structured_request = request.structured_output_request
+                if structured_request is not None:
+                    grammar = structured_request.grammar
+                    if isinstance(grammar, StructuredOutputGrammar):
+                        reasoner = self._get_reasoner(request)
+                        if (
+                            reasoner is not None
+                            and not self.enable_in_reasoning
+                            and not structured_request.reasoning_ended
+                        ):
+                            return new_token_ids, 0
+                        if not grammar.validate_tokens(new_token_ids):
+                            return [], 1
             return new_token_ids, 0
 
         structured_request = request.structured_output_request

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -131,14 +131,24 @@ def apply_grammar_bitmask(
     )
     sorted_bitmask = sorted_bitmask_tensor.numpy()
     cumulative_index = 0
-    for req_id in grammar_output.structured_output_request_ids:
-        num_spec_tokens = len(spec_tokens.get(req_id, ()))
+    for req_id, num_grammar_spec_tokens in zip(
+        grammar_output.structured_output_request_ids,
+        grammar_output.num_spec_tokens,
+        strict=True,
+    ):
+        num_worker_spec_tokens = len(spec_tokens.get(req_id, ()))
+        assert num_worker_spec_tokens <= num_grammar_spec_tokens
         if (logit_idx := struct_out_req_batch_indices.get(req_id)) is not None:
-            for i in range(1 + num_spec_tokens):
+            for i in range(num_worker_spec_tokens):
                 bitmask_index = logit_idx + i
                 sorted_bitmask[bitmask_index] = grammar_bitmask[cumulative_index + i]
                 out_indices.append(bitmask_index)
-        cumulative_index += 1 + num_spec_tokens
+            bonus_index = logit_idx + num_worker_spec_tokens
+            sorted_bitmask[bonus_index] = grammar_bitmask[
+                cumulative_index + num_grammar_spec_tokens
+            ]
+            out_indices.append(bonus_index)
+        cumulative_index += 1 + num_grammar_spec_tokens
 
     # Copy async to device.
     grammar_bitmask = sorted_bitmask_tensor.to(logits.device, non_blocking=True)

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -131,9 +131,10 @@ def apply_grammar_bitmask(
     )
     sorted_bitmask = sorted_bitmask_tensor.numpy()
     cumulative_index = 0
-    for req_id, num_grammar_spec_tokens in zip(
+    for req_id, num_grammar_spec_tokens, has_bonus_token in zip(
         grammar_output.structured_output_request_ids,
         grammar_output.num_spec_tokens,
+        grammar_output.has_bonus_token,
         strict=True,
     ):
         num_worker_spec_tokens = len(spec_tokens.get(req_id, ()))
@@ -143,12 +144,13 @@ def apply_grammar_bitmask(
                 bitmask_index = logit_idx + i
                 sorted_bitmask[bitmask_index] = grammar_bitmask[cumulative_index + i]
                 out_indices.append(bitmask_index)
-            bonus_index = logit_idx + num_worker_spec_tokens
-            sorted_bitmask[bonus_index] = grammar_bitmask[
-                cumulative_index + num_grammar_spec_tokens
-            ]
-            out_indices.append(bonus_index)
-        cumulative_index += 1 + num_grammar_spec_tokens
+            if has_bonus_token:
+                bonus_index = logit_idx + num_worker_spec_tokens
+                sorted_bitmask[bonus_index] = grammar_bitmask[
+                    cumulative_index + num_grammar_spec_tokens
+                ]
+                out_indices.append(bonus_index)
+        cumulative_index += int(has_bonus_token) + num_grammar_spec_tokens
 
     # Copy async to device.
     grammar_bitmask = sorted_bitmask_tensor.to(logits.device, non_blocking=True)

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -146,8 +146,11 @@ def apply_grammar_bitmask(
                 out_indices.append(bitmask_index)
             if has_bonus_token:
                 bonus_index = logit_idx + num_worker_spec_tokens
+                # The bonus row describes the grammar state after the worker's
+                # active drafts, so it must be read at the worker width
+                # instead of the full serialized window.
                 sorted_bitmask[bonus_index] = grammar_bitmask[
-                    cumulative_index + num_grammar_spec_tokens
+                    cumulative_index + num_worker_spec_tokens
                 ]
                 out_indices.append(bonus_index)
         cumulative_index += int(has_bonus_token) + num_grammar_spec_tokens

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -230,6 +230,49 @@ def _profile_batch_phase(input_batch: InputBatch, dummy_run: bool = False) -> st
     return "prefill"
 
 
+def _get_invalid_draft_counts(
+    grammar_output: GrammarOutput | None, input_batch: InputBatch
+) -> list[int] | None:
+    """Map compact grammar-invalid suffixes to the active worker batch."""
+    if grammar_output is None or input_batch.num_draft_tokens_per_req is None:
+        return None
+    if grammar_output.num_invalid_spec_tokens is None:
+        raise ValueError("structured speculative batch is missing invalid draft counts")
+
+    request_ids = grammar_output.structured_output_request_ids
+    source_widths = grammar_output.num_spec_tokens
+    invalid_source_widths = grammar_output.num_invalid_spec_tokens
+    if not (len(request_ids) == len(source_widths) == len(invalid_source_widths)):
+        raise ValueError("grammar rejection counts must align with request ids")
+
+    invalid_by_request = dict(
+        zip(
+            request_ids,
+            zip(source_widths, invalid_source_widths, strict=True),
+            strict=True,
+        )
+    )
+    if len(invalid_by_request) != len(request_ids):
+        raise ValueError("grammar rejection counts contain duplicate request ids")
+
+    invalid_counts = []
+    for request_id, active_width in zip(
+        input_batch.req_ids, input_batch.num_draft_tokens_per_req, strict=True
+    ):
+        source_width, source_invalid = invalid_by_request.get(
+            request_id, (int(active_width), 0)
+        )
+        if not 0 <= source_invalid <= source_width:
+            raise ValueError("invalid draft count is outside its source width")
+        if not 0 <= active_width <= source_width:
+            raise ValueError("active draft width is outside its source width")
+        invalid_counts.append(
+            max(int(active_width) - (source_width - source_invalid), 0)
+        )
+
+    return invalid_counts if any(invalid_counts) else None
+
+
 class GPUModelRunner(LoRAModelRunnerMixin):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         self.vllm_config = vllm_config
@@ -1658,6 +1701,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # Rejection sampling for spec decoding.
             assert self.rejection_sampler is not None
             assert self.speculator is not None
+            num_invalid_draft_tokens = _get_invalid_draft_counts(
+                grammar_output, input_batch
+            )
             with record_function_or_nullcontext(
                 f"vllm:v2/target/{phase}/rejection_sample"
             ):
@@ -1666,6 +1712,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     input_batch,
                     # Draft logits are needed for probabilistic rejection sampling.
                     self.speculator.draft_logits,
+                    num_invalid_draft_tokens,
                 )
 
         online_sts = self.speculator.online_sts if self.speculator else None

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -511,6 +511,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 max_num_logits=self.max_num_reqs * self.decode_query_len,
                 vocab_size=self.vocab_size,
                 device=self.device,
+                num_bonus_tokens=self.model_state.num_new_sampled_tokens_per_step,
             )
 
         if self.is_pooling_model and self.is_last_pp_rank:
@@ -1646,6 +1647,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     input_batch,
                     grammar_output.structured_output_request_ids,
                     grammar_output.grammar_bitmask,
+                    grammar_output.num_spec_tokens,
                 )
 
         if input_batch.num_draft_tokens == 0 or self.rejection_sampler is None:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1691,6 +1691,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     grammar_output.structured_output_request_ids,
                     grammar_output.grammar_bitmask,
                     grammar_output.num_spec_tokens,
+                    grammar_output.has_bonus_token,
                 )
 
         if input_batch.num_draft_tokens == 0 or self.rejection_sampler is None:

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -32,6 +32,42 @@ MAX_CHUNK_BYTES = 2**30  # 1GB
 _FP32_BYTES = 4
 
 
+def force_reject_invalid_draft_suffixes(
+    draft_sampled: torch.Tensor,
+    cu_num_logits_np: np.ndarray,
+    num_invalid_draft_tokens: list[int] | None,
+) -> torch.Tensor:
+    """Replace grammar-rejected draft suffixes with rejection placeholders.
+
+    Async scheduling can leave this worker with an unfiltered draft snapshot
+    while the scheduler has already rejected a trailing grammar-invalid
+    suffix. The rejection kernels treat ``-1`` as a forced rejection and
+    recover from the grammar-masked target distribution.
+    """
+    if num_invalid_draft_tokens is None:
+        return draft_sampled
+    if cu_num_logits_np.ndim != 1 or cu_num_logits_np.size == 0:
+        raise ValueError("invalid cumulative logits metadata")
+    num_reqs = cu_num_logits_np.size - 1
+    if len(num_invalid_draft_tokens) != num_reqs:
+        raise ValueError("invalid draft counts must align with batch requests")
+    if draft_sampled.numel() != int(cu_num_logits_np[-1]):
+        raise ValueError("draft samples must align with cumulative logits")
+    if not any(num_invalid_draft_tokens):
+        return draft_sampled
+
+    sanitized = draft_sampled.clone()
+    for req_idx, num_invalid in enumerate(num_invalid_draft_tokens):
+        start = int(cu_num_logits_np[req_idx])
+        end = int(cu_num_logits_np[req_idx + 1])
+        num_drafts = end - start - 1
+        if not 0 <= num_invalid <= num_drafts:
+            raise ValueError("invalid draft count is outside its request width")
+        if num_invalid:
+            sanitized[end - num_invalid : end] = -1
+    return sanitized
+
+
 def _iter_request_chunks(
     cu_num_logits: np.ndarray, max_chunk_logits: int
 ) -> Iterator[tuple[int, int]]:
@@ -250,6 +286,7 @@ class RejectionSampler:
         logits: torch.Tensor,
         input_batch: InputBatch,
         draft_logits: torch.Tensor | None = None,
+        num_invalid_draft_tokens: list[int] | None = None,
     ) -> SamplerOutput:
         # NOTE(woosuk): We intentionally compute num_nans before sampling to make clear
         # that num_nans is computed before applying penalties and temperature.
@@ -258,6 +295,11 @@ class RejectionSampler:
         draft_sampled = input_batch.input_ids[input_batch.logits_indices]
         draft_sampled.masked_fill_(
             input_batch.is_padding[input_batch.logits_indices], -1
+        )
+        draft_sampled = force_reject_invalid_draft_suffixes(
+            draft_sampled,
+            input_batch.cu_num_logits_np,
+            num_invalid_draft_tokens,
         )
         pos = input_batch.positions[input_batch.logits_indices]
 

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -9,8 +9,61 @@ from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.input_batch import InputBatch
 
 
+def _build_grammar_row_mapping(
+    req_ids: list[str],
+    grammar_req_ids: list[str],
+    grammar_num_spec_tokens: list[int],
+    cu_num_logits_np: np.ndarray,
+    num_draft_tokens_per_req: np.ndarray | None,
+    num_bonus_tokens: int,
+) -> tuple[list[int], list[int]]:
+    """Map serialized grammar rows to the active compact logits layout."""
+    assert len(grammar_req_ids) == len(grammar_num_spec_tokens)
+    assert num_bonus_tokens in (0, 1)
+
+    req_id_to_idx = {req_id: i for i, req_id in enumerate(req_ids)}
+    source_indices: list[int] = []
+    logits_indices: list[int] = []
+    source_offset = 0
+
+    for grammar_req_id, num_source_drafts in zip(
+        grammar_req_ids,
+        grammar_num_spec_tokens,
+        strict=True,
+    ):
+        req_idx = req_id_to_idx[grammar_req_id]
+        num_active_drafts = (
+            0
+            if num_draft_tokens_per_req is None
+            else int(num_draft_tokens_per_req[req_idx])
+        )
+        assert 0 <= num_active_drafts <= num_source_drafts
+
+        logits_start = int(cu_num_logits_np[req_idx])
+        num_active_logits = int(
+            cu_num_logits_np[req_idx + 1] - cu_num_logits_np[req_idx]
+        )
+        assert num_active_logits == num_active_drafts + num_bonus_tokens
+
+        source_indices.extend(range(source_offset, source_offset + num_active_drafts))
+        logits_indices.extend(range(logits_start, logits_start + num_active_drafts))
+        if num_bonus_tokens:
+            source_indices.append(source_offset + num_source_drafts)
+            logits_indices.append(logits_start + num_active_drafts)
+
+        source_offset += num_source_drafts + num_bonus_tokens
+
+    return source_indices, logits_indices
+
+
 class StructuredOutputsWorker:
-    def __init__(self, max_num_logits: int, vocab_size: int, device: torch.device):
+    def __init__(
+        self,
+        max_num_logits: int,
+        vocab_size: int,
+        device: torch.device,
+        num_bonus_tokens: int,
+    ):
         self.logits_indices = torch.zeros(
             max_num_logits, dtype=torch.int32, device=device
         )
@@ -19,6 +72,7 @@ class StructuredOutputsWorker:
         )
         self.device = device
         self.copy_stream = torch.cuda.Stream()
+        self.num_bonus_tokens = num_bonus_tokens
 
     def apply_grammar_bitmask(
         self,
@@ -26,26 +80,30 @@ class StructuredOutputsWorker:
         input_batch: InputBatch,
         grammar_req_ids: list[str],
         grammar_bitmask: np.ndarray,
+        grammar_num_spec_tokens: list[int],
     ) -> None:
         if not grammar_req_ids:
             return
 
-        # Asynchronously copy the bitmask to GPU.
+        source_indices, mapping = _build_grammar_row_mapping(
+            input_batch.req_ids,
+            grammar_req_ids,
+            grammar_num_spec_tokens,
+            input_batch.cu_num_logits_np,
+            input_batch.num_draft_tokens_per_req,
+            self.num_bonus_tokens,
+        )
+        expected_source_rows = sum(
+            num_drafts + self.num_bonus_tokens for num_drafts in grammar_num_spec_tokens
+        )
+        assert grammar_bitmask.shape[0] == expected_source_rows
+        grammar_bitmask = grammar_bitmask[source_indices]
+
+        # Asynchronously copy the active bitmask rows to GPU.
         with torch.cuda.stream(self.copy_stream):
             bitmask = async_copy_to_gpu(
                 grammar_bitmask, out=self.grammar_bitmask[: grammar_bitmask.shape[0]]
             )
-
-        # Construct bitmask -> logits mapping
-        mapping: list[int] = []
-        req_ids = input_batch.req_ids
-        cu_num_logits = input_batch.cu_num_logits_np.tolist()
-        req_id_to_idx = {req_id: i for i, req_id in enumerate(req_ids)}
-        for grammar_req_id in grammar_req_ids:
-            req_idx = req_id_to_idx[grammar_req_id]
-            logits_start_idx = cu_num_logits[req_idx]
-            logits_end_idx = cu_num_logits[req_idx + 1]
-            mapping.extend(range(logits_start_idx, logits_end_idx))
 
         # Asynchronously copy the mapping to GPU.
         with torch.cuda.stream(self.copy_stream):

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -13,12 +13,17 @@ def _build_grammar_row_mapping(
     req_ids: list[str],
     grammar_req_ids: list[str],
     grammar_num_spec_tokens: list[int],
+    grammar_has_bonus_token: list[bool],
     cu_num_logits_np: np.ndarray,
     num_draft_tokens_per_req: np.ndarray | None,
     num_bonus_tokens: int,
 ) -> tuple[list[int], list[int]]:
     """Map serialized grammar rows to the active compact logits layout."""
-    assert len(grammar_req_ids) == len(grammar_num_spec_tokens)
+    assert (
+        len(grammar_req_ids)
+        == len(grammar_num_spec_tokens)
+        == len(grammar_has_bonus_token)
+    )
     assert num_bonus_tokens in (0, 1)
 
     req_id_to_idx = {req_id: i for i, req_id in enumerate(req_ids)}
@@ -26,9 +31,10 @@ def _build_grammar_row_mapping(
     logits_indices: list[int] = []
     source_offset = 0
 
-    for grammar_req_id, num_source_drafts in zip(
+    for grammar_req_id, num_source_drafts, has_source_bonus_token in zip(
         grammar_req_ids,
         grammar_num_spec_tokens,
+        grammar_has_bonus_token,
         strict=True,
     ):
         req_idx = req_id_to_idx[grammar_req_id]
@@ -48,10 +54,11 @@ def _build_grammar_row_mapping(
         source_indices.extend(range(source_offset, source_offset + num_active_drafts))
         logits_indices.extend(range(logits_start, logits_start + num_active_drafts))
         if num_bonus_tokens:
+            assert has_source_bonus_token
             source_indices.append(source_offset + num_source_drafts)
             logits_indices.append(logits_start + num_active_drafts)
 
-        source_offset += num_source_drafts + num_bonus_tokens
+        source_offset += num_source_drafts + int(has_source_bonus_token)
 
     return source_indices, logits_indices
 
@@ -81,6 +88,7 @@ class StructuredOutputsWorker:
         grammar_req_ids: list[str],
         grammar_bitmask: np.ndarray,
         grammar_num_spec_tokens: list[int],
+        grammar_has_bonus_token: list[bool],
     ) -> None:
         if not grammar_req_ids:
             return
@@ -89,12 +97,16 @@ class StructuredOutputsWorker:
             input_batch.req_ids,
             grammar_req_ids,
             grammar_num_spec_tokens,
+            grammar_has_bonus_token,
             input_batch.cu_num_logits_np,
             input_batch.num_draft_tokens_per_req,
             self.num_bonus_tokens,
         )
         expected_source_rows = sum(
-            num_drafts + self.num_bonus_tokens for num_drafts in grammar_num_spec_tokens
+            num_drafts + int(has_bonus_token)
+            for num_drafts, has_bonus_token in zip(
+                grammar_num_spec_tokens, grammar_has_bonus_token, strict=True
+            )
         )
         assert grammar_bitmask.shape[0] == expected_source_rows
         grammar_bitmask = grammar_bitmask[source_indices]

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -55,7 +55,10 @@ def _build_grammar_row_mapping(
         logits_indices.extend(range(logits_start, logits_start + num_active_drafts))
         if num_bonus_tokens:
             assert has_source_bonus_token
-            source_indices.append(source_offset + num_source_drafts)
+            # The bonus row describes the grammar state after the active
+            # drafts, so it must be read at the active width instead of the
+            # full window width.
+            source_indices.append(source_offset + num_active_drafts)
             logits_indices.append(logits_start + num_active_drafts)
 
         source_offset += num_source_drafts + int(has_source_bonus_token)

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -367,7 +367,9 @@ def warmup_kernels(
                 (len(req_ids), bitmask_width), fill_value=-1, dtype=np.int32
             )
             grammar_output = GrammarOutput(
-                structured_output_request_ids=req_ids, grammar_bitmask=grammar_bitmask
+                structured_output_request_ids=req_ids,
+                grammar_bitmask=grammar_bitmask,
+                num_spec_tokens=[0] * len(req_ids),
             )
 
         worker_sample_tokens(grammar_output)

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -370,6 +370,7 @@ def warmup_kernels(
                 structured_output_request_ids=req_ids,
                 grammar_bitmask=grammar_bitmask,
                 num_spec_tokens=[0] * len(req_ids),
+                has_bonus_token=[True] * len(req_ids),
                 num_invalid_spec_tokens=[0] * len(req_ids),
             )
 

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -370,6 +370,7 @@ def warmup_kernels(
                 structured_output_request_ids=req_ids,
                 grammar_bitmask=grammar_bitmask,
                 num_spec_tokens=[0] * len(req_ids),
+                num_invalid_spec_tokens=[0] * len(req_ids),
             )
 
         worker_sample_tokens(grammar_output)

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -583,6 +583,7 @@ def _profile_sps_curve(
         if sps_debug:
             events = model_runner._sps_debug_events
             model_runner._sps_debug_events = None
+            assert events is not None
             # Skip the warmup iters; report mean verify/draft GPU ms.
             timed = events[warmup_iters:]
             if timed:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -256,6 +256,19 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+def _project_invalid_draft_suffix_count(
+    source_width: int,
+    source_invalid: int,
+    active_width: int,
+) -> int:
+    """Project a serialized invalid suffix onto the worker's compact width."""
+    if not 0 <= source_invalid <= source_width:
+        raise ValueError("invalid draft count is outside its source width")
+    if not 0 <= active_width <= source_width:
+        raise ValueError("active draft width is outside its source width")
+    return max(active_width - (source_width - source_invalid), 0)
+
+
 def _get_parameter_for_reload(model: nn.Module, name: str) -> nn.Parameter:
     """Resolve checkpoint names without changing the model's module tree."""
     module_name, _, parameter_name = name.rpartition(".")
@@ -3792,6 +3805,7 @@ class GPUModelRunner(
         self,
         logits: torch.Tensor | None,
         spec_decode_metadata: SpecDecodeMetadata | None,
+        num_invalid_draft_tokens: list[int] | None = None,
     ) -> SamplerOutput:
         # Sample the next token and get logprobs if needed.
         sampling_metadata = self.input_batch.sampling_metadata
@@ -3816,8 +3830,54 @@ class GPUModelRunner(
             draft_probs,
             logits,
             sampling_metadata,
+            num_invalid_draft_tokens,
         )
         return sampler_output
+
+    def _get_invalid_draft_counts(
+        self,
+        grammar_output: "GrammarOutput | None",
+        spec_decode_metadata: SpecDecodeMetadata | None,
+    ) -> list[int] | None:
+        """Translate scheduler grammar rejections to worker batch order."""
+        if grammar_output is None or spec_decode_metadata is None:
+            return None
+        if grammar_output.num_invalid_spec_tokens is None:
+            raise ValueError(
+                "structured speculative batch is missing invalid draft counts"
+            )
+
+        request_ids = grammar_output.structured_output_request_ids
+        source_widths = grammar_output.num_spec_tokens
+        invalid_source_widths = grammar_output.num_invalid_spec_tokens
+        if not (len(request_ids) == len(source_widths) == len(invalid_source_widths)):
+            raise ValueError("grammar rejection counts must align with request ids")
+
+        invalid_by_request = dict(
+            zip(
+                request_ids,
+                zip(source_widths, invalid_source_widths, strict=True),
+                strict=True,
+            )
+        )
+        if len(invalid_by_request) != len(request_ids):
+            raise ValueError("grammar rejection counts contain duplicate request ids")
+
+        invalid_counts = []
+        for request_id, active_width in zip(
+            self.input_batch.req_ids,
+            spec_decode_metadata.num_draft_tokens,
+            strict=True,
+        ):
+            source_width, source_invalid = invalid_by_request.get(
+                request_id, (active_width, 0)
+            )
+            invalid_counts.append(
+                _project_invalid_draft_suffix_count(
+                    source_width, source_invalid, active_width
+                )
+            )
+        return invalid_counts if any(invalid_counts) else None
 
     def _bookkeeping_sync(
         self,
@@ -4745,8 +4805,13 @@ class GPUModelRunner(
                 scheduler_output, grammar_output, self.input_batch, logits
             )
 
+        num_invalid_draft_tokens = self._get_invalid_draft_counts(
+            grammar_output, spec_decode_metadata
+        )
         with record_function_or_nullcontext("gpu_model_runner: sample"):
-            sampler_output = self._sample(logits, spec_decode_metadata)
+            sampler_output = self._sample(
+                logits, spec_decode_metadata, num_invalid_draft_tokens
+            )
 
         self._update_states_after_model_execute(
             sampler_output.sampled_token_ids, scheduler_output


### PR DESCRIPTION
# `fix(structured-output): consolidate speculative grammar correctness`

## Stacked release-input contract

This is intentionally a stacked, nine-commit pull request against
`local-inference-lab/vllm:dev/infernal-invocation` at
`b5f995e73e6b7fe27c9927477e277a151ebcc9e9`.

The target repository's release composer consumes immutable pull-request
heads; the prerequisite pull requests are not expected to land on the target
branch first. This head therefore consolidates patch-equivalent copies of:

- local-inference-lab/vllm#320: accepted speculative-block validation
  (2 commits);
- local-inference-lab/vllm#476: grammar-mask layout and invalid-draft
  rejection (6 commits, including #294 transitively);
- the new active-depth bonus-row fix (1 commit).

The visible GitHub diff is consequently the full stack: **9 commits, 20 files,
`+1665/-36`**. This breadth is deliberate and is described below; it is not a
single-commit diff accidentally opened against the wrong base.

For a future release manifest, pin this pull-request head **instead of** the
separate #320 and #476 heads. Do not append all three: the local commits are
patch-equivalent rather than shared ancestors, so merging all three entries
creates duplicate-history conflicts. A composer simulation retaining the
other 29 pinned heads, then adding this umbrella head and the independent
minimum-depth PR, merged cleanly. Its resulting source tree is byte-identical
to retaining #320/#476 in the existing composition and applying only the two
new PR changes.

## Problems and guarded contracts

The consolidated stack guards three connected structured-output invariants:

1. An accepted speculative block is validated against the current grammar
   before scheduler commit. An invalid suffix is removed, scheduler progress
   is rolled back, and speculative metrics describe only committed drafts.
2. Grammar-invalid draft suffixes are force-rejected in both rejection-sampler
   paths. Scheduler-side serialized widths, invalid counts, and per-request
   bonus presence remain aligned when workers compact or trim drafts.
3. With scheduled width K and active width k (`0 <= k <= K`), draft row i uses
   source row i and the bonus after k drafts uses the grammar state after k
   committed drafts—not the final serialized row K.

The third invariant fixes the remaining variable-width failure: if all drafts
are rejected or trimmed, a bonus-only block must be sampled and validated at
the current grammar state. Otherwise a token legal only at the K-state can
reach `accept_tokens` and terminate the request with an invariant error.

## Relationship to existing work

- #320 and #476 are intentionally consolidated, not claimed as new work.
- #294 is already an ancestor of #476 and is therefore transitively included;
  it is not a separate dependency entry.
- `vllm-project/vllm#52477` selects mask rows from device-side logit counts in
  a different fixed-stride layout on upstream main.
- `vllm-project/vllm#54442` fail-closes permissive rows after missing drafts,
  but does not correct the k < K bonus-row selection in this compact layout.
- `vllm-project/vllm#52452` is the upstream counterpart of the validation work
  carried by #320; the bonus-only block is the additional guarded shape here.

## Commit stack

```text
de880c2312  #320: validate speculative blocks before commit
b41a749c92  #320: use the prompt-aware reasoner contract
edb266ce8f  #476/#294: preserve serialized grammar source widths
487da8989c  #476/#294: map compacted grammar rows
659bcfce3c  #476/#294: retain the warmup event typing invariant
55ffc5c6ec  #476: reject invalid compact V2 draft suffixes
24f3260d21  #476: mirror invalid-draft rejection in V1
87dc204ddd  #476: track serialized grammar bonus rows
1292bc1976  new: mask the bonus row at active draft depth
```

The first eight commits preserve the code and authorship provenance of their
source PRs while using local cherry-pick SHAs. The final commit is the new
change being added by this umbrella PR.

## Visible files changed (20 files, +1665/-36)

Source paths:

- `vllm/v1/core/sched/output.py`
- `vllm/v1/core/sched/scheduler.py`
- `vllm/v1/sample/rejection_sampler.py`
- `vllm/v1/structured_output/__init__.py`
- `vllm/v1/structured_output/utils.py`
- `vllm/v1/worker/gpu/model_runner.py`
- `vllm/v1/worker/gpu/spec_decode/rejection_sampler.py`
- `vllm/v1/worker/gpu/structured_outputs.py`
- `vllm/v1/worker/gpu/warmup.py`
- `vllm/v1/worker/gpu_model_runner.py`

Test paths:

- `tests/v1/core/test_scheduler.py`
- `tests/v1/sample/test_rejection_sampler.py`
- `tests/v1/spec_decode/test_mtp_structured_output.py`
- `tests/v1/spec_decode/test_rejection_sampler_utils.py`
- `tests/v1/structured_output/test_reasoning_structured_output.py`
- `tests/v1/structured_output/test_utils.py`
- `tests/v1/worker/test_gpu_model_runner.py`
- `tests/v1/worker/test_gpu_model_runner_v2.py`
- `tests/v1/worker/test_gpu_rejection_sampler_chunking.py`
- `tests/v1/worker/test_gpu_structured_outputs.py`

The final active-depth commit changes 8 of those files (`+264/-11`). It maps
the V1 and V2 bonus row at k, widens the pre-commit call gate to single-token
blocks, validates the bonus without permanently advancing the matcher, and
adds k=0/k=1/k=K, ordering, rollback, termination, reasoning, and next-valid-
commit coverage.

## Negative controls

With only the final tests applied to the prerequisite stack and the final
source change reverted:

- 3 V2 mapping tests fail;
- 2 V1 mapping tests fail;
- 4 scheduler single-token cases fail;
- 4 real-backend single-token/termination cases fail.

After the fix, all of those cases pass. Mixed-request tests also guard the
next request's source offset and the final group's bounds.

## Test commands and results

Core stack and active-depth suites:

```text
.venv/bin/python -m pytest -q \
  tests/v1/core/test_scheduler.py \
  tests/v1/spec_decode/test_mtp_structured_output.py \
  tests/v1/structured_output/test_utils.py \
  tests/v1/worker/test_gpu_structured_outputs.py
```

Result: **206 passed, 3 failed**. The same three failures reproduce on the
prerequisite base without the active-depth commit: one environment-gated PP
prerequisite is unavailable and two pre-existing mamba-align expectations
differ.

The additional changed dependency tests were run in fresh pytest processes to
avoid cross-module Torch default-device leakage:

```text
tests/v1/sample/test_rejection_sampler.py                 6 passed
tests/v1/spec_decode/test_rejection_sampler_utils.py      1 passed
tests/v1/structured_output/test_reasoning_structured_output.py
                                                          11 passed
tests/v1/worker/test_gpu_model_runner.py                  6 passed
tests/v1/worker/test_gpu_model_runner_v2.py              12 passed
tests/v1/worker/test_gpu_rejection_sampler_chunking.py    5 passed
```

Total isolated umbrella evidence: **247 passed, 3 pre-existing/environment
failures**.

An exploratory single-process invocation of all ten modules produced
`383 passed, 26 failed, 12 errors`: three were the known scheduler failures;
the rest were default-device/pinned-memory test-isolation failures. The added
tests all pass in fresh processes, so the contaminated aggregate is not used
as correctness evidence.

Additional checks:

```text
.venv/bin/pre-commit run --files <all 20 changed files>
  -> all default hooks passed, including mypy-3.10
.venv/bin/pre-commit run mypy-3.12 --hook-stage manual --files <changed sources>
  -> passed
git diff --check
  -> clean
```

## Serving evaluation

The serving smoke for the umbrella change completed successfully. This is a
correctness and operability result only; no performance claim is made.

## Disclosure

AI assistance was used to draft the new active-depth change and this
consolidated description.
