### PR TITLE
perf(kimi-k3): prelaunch shared experts before routed preparation

### DIFF
--- a/tests/model_executor/layers/fused_moe/test_shared_experts_stream.py
+++ b/tests/model_executor/layers/fused_moe/test_shared_experts_stream.py
@@ -372,3 +372,51 @@ def test_reused_shared_input_reduces_latent_output_in_place(monkeypatch) -> None
     assert actual.data_ptr() == shared_input_ptr
     assert reduced_ptrs == [fused_output_ptr, shared_input_ptr]
     torch.testing.assert_close(actual, torch.full_like(actual, 16.0))
+
+
+def test_prelaunch_defers_consumer_wait_until_normal_join(monkeypatch) -> None:
+    shared_experts = object.__new__(SharedExperts)
+    aux_stream = Mock()
+    consumer_stream = Mock()
+    output = Mock()
+    shared_experts_input = Mock()
+    shared_experts._stream = aux_stream
+    shared_experts._layer = Mock(return_value=output)
+    shared_experts._output = [None, None]
+    shared_experts._prelaunched = [False, False]
+    shared_experts.enable_dbo = False
+    shared_experts._determine_shared_experts_order = Mock(
+        return_value=shared_module.SharedExpertsOrder.MULTI_STREAM_OVERLAPPED
+    )
+
+    @contextmanager
+    def use_stream(stream):
+        assert stream is aux_stream
+        yield
+
+    monkeypatch.setattr(torch.cuda, "stream", use_stream)
+    monkeypatch.setattr(shared_module, "current_stream", lambda: consumer_stream)
+
+    assert shared_experts.prelaunch(shared_experts_input)
+    shared_experts_input.record_stream.assert_called_once_with(aux_stream)
+    aux_stream.wait_stream.assert_called_once_with(consumer_stream)
+    consumer_stream.wait_stream.assert_not_called()
+    assert shared_experts._output[0] is output
+
+    shared_experts.forward(
+        shared_experts_input,
+        shared_module.SharedExpertsOrder.MULTI_STREAM_OVERLAPPED,
+    )
+    consumer_stream.wait_stream.assert_called_once_with(aux_stream)
+    output.record_stream.assert_called_once_with(consumer_stream)
+    assert not shared_experts._prelaunched[0]
+    assert shared_experts.output is output
+
+
+def test_prelaunch_is_inert_when_shared_stream_overlap_is_not_selected() -> None:
+    shared_experts = object.__new__(SharedExperts)
+    shared_experts._determine_shared_experts_order = Mock(
+        return_value=shared_module.SharedExpertsOrder.NO_OVERLAP
+    )
+
+    assert not shared_experts.prelaunch(Mock())

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -339,6 +339,7 @@ if TYPE_CHECKING:
     VLLM_DEBUG_WORKSPACE: bool = False
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_DISABLE_FUSED_MOE_OUTPUT_ALIAS: bool = False
+    VLLM_KIMI_PRELAUNCH_SHARED_EXPERTS: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
@@ -2295,6 +2296,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # has a lifetime that overlaps the expert kernel's writeback.
     "VLLM_DISABLE_FUSED_MOE_OUTPUT_ALIAS": lambda: bool(
         int(os.getenv("VLLM_DISABLE_FUSED_MOE_OUTPUT_ALIAS", "0"))
+    ),
+    # Begin Kimi-K3's read-only shared-expert branch before the independent
+    # router and routed-down projection; the normal stream join still owns it.
+    "VLLM_KIMI_PRELAUNCH_SHARED_EXPERTS": lambda: bool(
+        int(os.getenv("VLLM_KIMI_PRELAUNCH_SHARED_EXPERTS", "0"))
     ),
     # Limits when we run shared_experts in a separate stream.
     # We found out that for large batch sizes, the separate stream

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -839,6 +839,12 @@ class MoERunner(MoERunnerInterface):
             assert shared_experts_input is not None
             self._shared_experts.maybe_sync_shared_experts_stream(shared_experts_input)
 
+    def prelaunch_shared_experts(self, shared_experts_input: torch.Tensor) -> bool:
+        """Start an eligible shared-expert branch before routed preparation."""
+        if self._shared_experts is None:
+            return False
+        return self._shared_experts.prelaunch(shared_experts_input)
+
     def _maybe_add_zero_expert_output(
         self,
         result: torch.Tensor,

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -52,6 +52,7 @@ class SharedExperts(torch.nn.Module):
         # index is always 0 and the second output list element is ignored.
         self.enable_dbo = enable_dbo
         self._output: list[torch.Tensor | None] = [None, None]
+        self._prelaunched = [False, False]
         self._layer = layer
         self._moe_config = moe_config
 
@@ -115,6 +116,8 @@ class SharedExperts(torch.nn.Module):
         self,
         shared_experts_input: torch.Tensor,
     ):
+        if self._prelaunched[self._output_idx]:
+            return
         experts_order = self._determine_shared_experts_order(shared_experts_input)
 
         if experts_order == SharedExpertsOrder.MULTI_STREAM_OVERLAPPED:
@@ -128,6 +131,37 @@ class SharedExperts(torch.nn.Module):
             # Mark sync start point for the aux stream since we will
             # run in parallel with router/gate.
             self._stream.wait_stream(current_stream())
+
+    def prelaunch(self, shared_experts_input: torch.Tensor) -> bool:
+        """Launch the async shared branch before routed preparation.
+
+        The normal shared/routed join remains the consumer synchronization
+        point; this only advances the independent branch's start time.
+        """
+        experts_order = self._determine_shared_experts_order(shared_experts_input)
+        if experts_order != SharedExpertsOrder.MULTI_STREAM_OVERLAPPED:
+            return False
+        assert self._stream is not None
+        output_idx = self._output_idx
+        if self._output[output_idx] is not None or self._prelaunched[output_idx]:
+            raise RuntimeError("Shared experts already have an outstanding output")
+        shared_experts_input.record_stream(self._stream)
+        self._stream.wait_stream(current_stream())
+        with torch.cuda.stream(self._stream):
+            self._output[output_idx] = self._layer(shared_experts_input)
+        self._prelaunched[output_idx] = True
+        return True
+
+    def _finish_prelaunch(self) -> None:
+        output_idx = self._output_idx
+        assert self._prelaunched[output_idx]
+        assert self._stream is not None
+        output = self._output[output_idx]
+        assert output is not None
+        consumer_stream = current_stream()
+        consumer_stream.wait_stream(self._stream)
+        output.record_stream(consumer_stream)
+        self._prelaunched[output_idx] = False
 
     def _run_in_aux_stream(
         self,
@@ -189,8 +223,15 @@ class SharedExperts(torch.nn.Module):
         if order != experts_order:
             return None
 
-        assert self._output[self._output_idx] is None
+        output_idx = self._output_idx
+        if (
+            order == SharedExpertsOrder.MULTI_STREAM_OVERLAPPED
+            and self._prelaunched[output_idx]
+        ):
+            self._finish_prelaunch()
+            return None
 
+        assert self._output[output_idx] is None
         if reuse_input:
             if order != SharedExpertsOrder.NO_OVERLAP or not self.can_reuse_input(
                 shared_experts_input
@@ -199,15 +240,13 @@ class SharedExperts(torch.nn.Module):
                     "Shared-expert input reuse requires synchronous execution "
                     "and an input-reuse-capable layer"
                 )
-            self._output[self._output_idx] = self._layer(
+            self._output[output_idx] = self._layer(
                 shared_experts_input,
                 output=shared_experts_input,
             )
         elif order == SharedExpertsOrder.MULTI_STREAM_OVERLAPPED:
-            self._output[self._output_idx] = self._run_in_aux_stream(
-                shared_experts_input
-            )
-        else:
-            self._output[self._output_idx] = self._layer(shared_experts_input)
+            self._output[output_idx] = self._run_in_aux_stream(shared_experts_input)
 
-        assert self._output[self._output_idx] is not None
+        else:
+            self._output[output_idx] = self._layer(shared_experts_input)
+        assert self._output[output_idx] is not None

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -1408,6 +1408,8 @@ class KimiMoE(nn.Module):
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         num_tokens, hidden_size = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_size)
+        if not self.use_mega_moe and envs.VLLM_KIMI_PRELAUNCH_SHARED_EXPERTS:
+            self.experts.prelaunch_shared_experts(hidden_states)
         # Overlap the gate with the routed down projection; the returned hidden
         # states are already down-projected. Keep the original ``hidden_states``
         # for the shared experts.


### PR DESCRIPTION
## Resulting behavior

Kimi-K3 computes its router gate and routed-down projection from the original hidden states, then enters MoERunner. The existing multi-stream shared-expert path is not started until that point, so it cannot overlap the independent routed preparation.

With opt-in `VLLM_KIMI_PRELAUNCH_SHARED_EXPERTS=1`, `KimiMoE.forward` asks MoERunner to start an eligible shared-expert branch before `_maybe_overlap_router_and_down_proj`. `SharedExperts.prelaunch` uses the existing auxiliary stream, records the input on that stream, and retains the output in the existing DBO-indexed slot. The consumer wait and output `record_stream` remain at the runner's normal shared/routed join.

The shared/routed branch math, join, output ownership, input-reuse policy, and tensor-parallel reduction are unchanged. Non-CUDA, disabled-stream, sharded sequence-parallel, and internally overlapped modular-kernel modes decline the prelaunch and use the existing path. The switch is off by default.

## Status

**Research-only:** the mechanism and focused lifecycle tests are complete; full linked-model and serving performance are not yet qualified. Do not enable by default or deploy it before those measurements show a win.

## Validation

Production Kimi-K3 image after rebasing onto `dev/infernal-invocation` `b5f995e73e`:

```text
pytest -q -p no:cacheprovider --noconftest \
  tests/model_executor/layers/fused_moe/test_shared_experts_stream.py
8 passed
```

Tests cover the prelaunch's deferred consumer wait, input/output `record_stream` ownership, normal-join consumption, ineligible no-op path, and the current base's synchronous input-reuse / in-place reduction contracts. Ruff and `git diff --check` pass.

The implementation is a minimal current-infernal port of the exact-math experiment preserved in historical commit `27399cda9b`; it intentionally omits its unrelated launcher and routing changes.

AI assistance (Claude Code) was used for this change; the submitter reviewed the diff and ran the validation above.


## Publication status

Published as a non-draft on 2026-09-07 at the operator’s explicit request to expose all prepared PRs in local-inference-lab. Research-only code is exposed for review; unmeasured/unsupported paths above remain unqualified. No code, deployment configuration, merge approval or automatic merge is changed by this status update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxvNwugeU8RJFd7WRYwNLG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-in setting, `VLLM_KIMI_PRELAUNCH_SHARED_EXPERTS`, for Kimi-K3 to begin shared-expert processing earlier and improve execution overlap.
  - Shared-expert work can now run asynchronously and synchronize only when needed, avoiding duplicate processing.

- **Tests**
  - Added coverage for stream synchronization and behavior when the new overlap option is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->