### PR TITLE
fix(cudagraph): synchronize auxiliary warmup streams

### DIFF
--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -150,6 +150,71 @@ def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):
     mock_cuda_graph.assert_called_once()
 
 
+def test_capture_synchronizes_auxiliary_warmup_streams(monkeypatch):
+    """CUDA graph capture starts only after warmup work has completed."""
+    lifecycle: list[str] = []
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    monkeypatch.setattr(
+        gpu_cudagraph_utils.current_platform,
+        "get_global_graph_pool",
+        lambda: object(),
+    )
+
+    manager = gpu_cudagraph_utils.CudaGraphManager(
+        vllm_config=_create_vllm_config(),
+        device=torch.device("cpu"),
+        cudagraph_mode=CUDAGraphMode.FULL,
+        decode_query_len=1,
+    )
+    desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.FULL,
+        num_tokens=4,
+        num_reqs=4,
+        uniform_token_count=1,
+    )
+    manager._capture_descs[CUDAGraphMode.FULL] = [desc]
+
+    def create_forward_fn(_desc, warmup):
+        def forward_fn(_mode):
+            lifecycle.append("warmup-forward" if warmup else "capture-forward")
+
+        return forward_fn
+
+    @contextmanager
+    def fake_graph_capture(*args, **kwargs):
+        yield SimpleNamespace(stream=MagicMock())
+
+    @contextmanager
+    def fake_cuda_graph(*args, **kwargs):
+        lifecycle.append("capture-begin")
+        yield
+
+    fake_offloader = MagicMock()
+    with (
+        patch.object(gpu_cudagraph_utils, "graph_capture", fake_graph_capture),
+        patch.object(gpu_cudagraph_utils, "get_offloader", lambda: fake_offloader),
+        patch.object(gpu_cudagraph_utils.torch.cuda, "CUDAGraph"),
+        patch.object(gpu_cudagraph_utils.torch.cuda, "graph", fake_cuda_graph),
+        patch.object(
+            gpu_cudagraph_utils.torch.accelerator,
+            "synchronize",
+            side_effect=lambda: lifecycle.append("warmup-synchronize"),
+        ),
+    ):
+        manager.capture(create_forward_fn)
+
+    assert lifecycle == [
+        "warmup-forward",
+        "warmup-synchronize",
+        "capture-begin",
+        "capture-forward",
+    ]
+
+
 _DECODE_QUERY_LEN = 3
 
 

--- a/vllm/compilation/monitor.py
+++ b/vllm/compilation/monitor.py
@@ -102,3 +102,8 @@ def validate_cudagraph_capturing_enabled() -> None:
 def set_cudagraph_capturing_enabled(enabled: bool) -> None:
     global cudagraph_capturing_enabled
     cudagraph_capturing_enabled = enabled
+
+
+def is_cudagraph_capturing_enabled() -> bool:
+    """Return whether the model runner is preparing or capturing CUDA graphs."""
+    return cudagraph_capturing_enabled

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -537,6 +537,12 @@ class CudaGraphManager:
 
                     # Warmup
                     forward_fn(CUDAGraphMode.NONE)
+                    # A model forward may fork work onto auxiliary streams and
+                    # join them with events queued on the compute stream.  CUDA
+                    # graph capture must not begin while those warmup kernels
+                    # are still executing, even though the queued event waits
+                    # preserve normal stream ordering.
+                    torch.accelerator.synchronize()
 
                     # Capture
                     logger.debug(


### PR DESCRIPTION
## Resulting behavior

CUDA graph setup synchronizes the accelerator after each uncaptured warmup forward and before `torch.cuda.graph` begins. The compilation monitor exposes whether graph preparation is active so model code can disable auxiliary overlap during uncaptured warmups while retaining overlap during serving and regular FULL capture.

## Technical reason

A model forward may fork kernels onto auxiliary streams and enqueue only event waits on the compute stream. Stream ordering is sufficient for normal execution, but CUDA graph capture must not begin while an uncaptured auxiliary kernel still owns temporary allocator storage. Starting capture at that boundary can race allocator reuse and surface as an illegal memory access in a later kernel.

## Compatibility

The additional synchronization runs only during graph construction. It does not add synchronization to graph replay or serving. Models that do not use auxiliary streams retain the same captured graph and runtime execution.

## Validation

- The focused regression verifies `warmup forward -> accelerator synchronization -> capture begin -> capture forward` ordering.
- Repository hooks passed Ruff, formatting, MyPy, SPDX, import, configuration-default, and CUDA API checks.
- A TP4 GLM-5.3 composition using the monitor state for both KDA-gate and L2-prefetch streams completed three consecutive FULL CUDA graph startups for no-speculative, MTP3, and DFlash2 serving on NVIDIA RTX PRO 6000 Blackwell GPUs.

OpenAI Codex assisted with the failure isolation, implementation, and validation. The submitter reviewed the resulting source and evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CUDA graph capture reliability by ensuring warmup operations on auxiliary streams finish before capture begins.
  - Added safeguards to prevent incomplete warmup work from affecting captured execution.

- **Tests**
  - Added coverage verifying the expected order of warmup execution, stream synchronization, and CUDA graph capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->