### PR TITLE
distributed: vote across ranks before the MNNVL symmetric-memory rendezvous

### DIFF
--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -258,17 +258,66 @@ class CustomAllreduce:
             self.close()
             self.disabled = True
 
+    def _all_ranks_agree(self, ok: bool) -> bool:
+        """Reduce a per-rank boolean with MIN over the (CPU) group.
+
+        The symmetric-memory rendezvous and the barrier in
+        ``_init_mnnvl_buffer`` are collectives. A rank that fails a local step
+        must not enter them alone, and a rank that succeeds must not enter them
+        while a peer has already given up, or the group hangs at start-up.
+        Every collective there is therefore preceded by a vote so all ranks
+        take the same branch.
+
+        Args:
+            ok: Whether the local step succeeded on this rank.
+
+        Returns:
+            True when every rank in the group reported success.
+        """
+        vote = torch.tensor([1 if ok else 0], dtype=torch.int32)
+        dist.all_reduce(vote, op=dist.ReduceOp.MIN, group=self.group)
+        return bool(vote.item())
+
     def _init_mnnvl_buffer(self, stage_size: int) -> None:
+        """Set up the MNNVL Lamport all-gather/reduce-scatter staging buffer.
+
+        Allocates a symmetric-memory buffer, performs the rendezvous, registers
+        the peer buffers and publishes the ``mnnvl_*`` attributes. Each
+        collective step is gated by a rank-wide vote so that a failure on any
+        rank makes every rank skip the remaining steps together.
+
+        Args:
+            stage_size: Bytes reserved per Lamport stage; the buffer holds six
+                stages (three for all-gather and three for reduce-scatter).
+        """
         if torch_symm_mem is None or not current_platform.is_cuda():
             return
+        buffer_size = stage_size * 6
+        buffer = None
         try:
-            buffer_size = stage_size * 6
             buffer = torch_symm_mem.empty(
                 buffer_size, dtype=torch.uint8, device=self.device
             )
+        except RuntimeError as error:
+            logger.debug(
+                "MNNVL AG/RS buffer allocation failed on rank %d: %s",
+                self.rank,
+                error,
+            )
+        if not self._all_ranks_agree(buffer is not None):
+            return
+        handle = None
+        try:
             handle = torch_symm_mem.rendezvous(buffer, self.group.group_name)
-            if handle.multicast_ptr == 0:
-                return
+        except RuntimeError as error:
+            logger.debug(
+                "MNNVL AG/RS rendezvous failed on rank %d: %s", self.rank, error
+            )
+        if not self._all_ranks_agree(handle is not None and handle.multicast_ptr != 0):
+            return
+        assert handle is not None
+        ready = False
+        try:
             peer_buffers = [
                 handle.get_buffer(
                     peer,
@@ -293,23 +342,28 @@ class CustomAllreduce:
                 device=self.device,
             )
             torch.accelerator.synchronize()
-            dist.barrier(group=self.group)
-
-            self.mnnvl_buffer = buffer
-            self.mnnvl_handle = handle
-            self.mnnvl_peer_buffers = peer_buffers
-            self.mnnvl_multicast_ptr = handle.multicast_ptr
-            self.mnnvl_buffer_size = stage_size
-            self.mnnvl_lamport_ag_local_ptr = lamport_ag_ptrs[self.rank]
-            self.mnnvl_lamport_ag_multicast_ptr = (
-                handle.multicast_ptr + lamport_ag_offset
-            )
-            self.mnnvl_lamport_rs_local_ptr = lamport_rs_ptrs[self.rank]
-            self.mnnvl_lamport_epochs = epochs
-            self.mnnvl_lamport_ag_epoch_ptr = epochs[0].data_ptr()
-            self.mnnvl_lamport_rs_epoch_ptr = epochs[1].data_ptr()
+            ready = True
         except RuntimeError as error:
-            logger.debug("MNNVL AG/RS initialization failed: %s", error)
+            logger.debug(
+                "MNNVL AG/RS buffer registration failed on rank %d: %s",
+                self.rank,
+                error,
+            )
+        if not self._all_ranks_agree(ready):
+            return
+        dist.barrier(group=self.group)
+
+        self.mnnvl_buffer = buffer
+        self.mnnvl_handle = handle
+        self.mnnvl_peer_buffers = peer_buffers
+        self.mnnvl_multicast_ptr = handle.multicast_ptr
+        self.mnnvl_buffer_size = stage_size
+        self.mnnvl_lamport_ag_local_ptr = lamport_ag_ptrs[self.rank]
+        self.mnnvl_lamport_ag_multicast_ptr = handle.multicast_ptr + lamport_ag_offset
+        self.mnnvl_lamport_rs_local_ptr = lamport_rs_ptrs[self.rank]
+        self.mnnvl_lamport_epochs = epochs
+        self.mnnvl_lamport_ag_epoch_ptr = epochs[0].data_ptr()
+        self.mnnvl_lamport_rs_epoch_ptr = epochs[1].data_ptr()
 
     @contextmanager
     def capture(self):


### PR DESCRIPTION
## What

`CustomAllreduce._init_mnnvl_buffer` now takes a MIN-vote over the CPU group before each of its collectives (the symmetric-memory rendezvous and the closing barrier), so every rank either enters the collective or skips it together.

## Why

The method wraps `torch_symm_mem.empty()`, `torch_symm_mem.rendezvous()` and `dist.barrier()` in a single `try/except RuntimeError`. If the allocation or the rendezvous raises on one rank, that rank logs at debug level and returns; its peers are already inside the collective and wait forever. The engine never finishes `init_device`.

We hit this on a four-node DGX Spark (GB10, TP4, one rank per node, `dev/jovian-judgement@9c4dd054` and `@2e67b303`) in two of the first four boots of an otherwise unchanged configuration. py-spy at the time:

- rank 0: past `CustomAllreduce.__init__`, logged "Custom collectives are disabled because this multi-node group does not support MNNVL multicast", blocked in the `broadcast_object_list` of `in_the_same_node_as` for the next group.
- ranks 1 and 2: `rendezvous (torch/distributed/_symmetric_memory/__init__.py)` ← `_init_mnnvl_buffer (custom_all_reduce.py:269)`.

Rank 0 had left the method on the exception path before the rendezvous; the others had entered it.

The workaround was `--disable-custom-all-reduce`, which has a side effect worth knowing about: `cuda_communicator.py` only constructs the b12x PCIe and RoCEnante adapters when custom all-reduce is enabled, so that flag also switches RoCEnante off silently (the backend list still shows `B12X_ROCENANTE` as a candidate, tp:0 stays on `PYNCCL`). With this fix the flag is not needed on multi-node Spark.

## Change

- New `_all_ranks_agree(ok)`: `dist.all_reduce(MIN)` of a 1-element int32 tensor over `self.group` (the CPU/gloo group the class is attached to).
- `_init_mnnvl_buffer`: allocate → vote → rendezvous → vote on `handle.multicast_ptr != 0` → register buffers, fill, epochs, synchronize → vote → barrier → publish the `mnnvl_*` attributes. Any local failure is logged at debug level with the rank, as before.
- Behaviour on the happy path is unchanged apart from three gloo all-reduces of one int32 at start-up. Multicast-less groups (the common non-NVLink case) now return after the second vote instead of after the rendezvous, before the barrier, on every rank.

## Duplicate check

`gh pr list --state open --search "rendezvous OR MNNVL OR custom_all_reduce"` returns only this PR; no open PR touches `_init_mnnvl_buffer`. #597 (RoCEnante) avoids the problem for its own adapter by voting capability over the CPU group before constructing anything; this PR gives `CustomAllreduce` the same discipline.

## Testing

Commands (four-node DGX Spark, one TP rank per node):

```
vllm serve local-inference-lab/GLM-5.3-Flash-NVFP4-Spark -tp 4 --decode-context-parallel-size 1 \
  --block-size 256 --attention-backend B12X --moe-backend b12x --linear-backend b12x \
  --mamba-cache-mode align --enable-prefix-caching --enable-chunked-prefill --kv-cache-dtype fp8 \
  -O2 --compilation-config '{"cudagraph_mode": "FULL"}' --max-cudagraph-capture-size 128 \
  --speculative-config '{"method": "dflash", "model": "local-inference-lab/GLM-5.3-Flash-DFlash2", "num_speculative_tokens": 7, "kv_cache_dtype": "auto", "attention_backend": "FLASH_ATTN"}' \
  --max-num-batched-tokens 1024 --max-model-len 1000000 --max-num-seqs 16 --gpu-memory-utilization 0.82
# then 3 rounds x 4 concurrent 90k-token needle prompts, temperature 1.0 (script in #616)
```

Results:

Four-node DGX Spark, TP4, one rank per node, image built from this branch on top of `2e67b303`, GLM-5.3-Flash-NVFP4-Spark with the DFlash2 draft, custom all-reduce enabled (no `--disable-custom-all-reduce`):

- Three consecutive boots went through `_init_mnnvl_buffer` without hanging. Each time rank 0 logs "Custom collectives are disabled because this multi-node group does not support MNNVL multicast" and the TP group continues on `PYNCCL`, which is the correct outcome for a group without multicast.
- Full engine start: weights, profiling, FULL cudagraph capture, KV pool of 5,680,584 tokens at 1M context.
- Concurrency check after boot: four simultaneous 90k-token needle prompts at temperature 1.0, three rounds, 12/12 correct.

Before the patch the same configuration hung at start-up in two of four attempts on this cluster (stacks in the description); the other two boots were fine, which is what a race looks like. One boot of an earlier build with this patch hit a transient `ibv_reg_mr_iova2: Cannot allocate memory` in NCCL during the profile run; it did not recur across the next three boots and does not involve this code path.

## AI assistance

The stack traces, the bisect and the patch were produced with AI assistance (Claude); the change was reviewed line by line and every test above was run on our cluster by the submitter. `ruff check` / `ruff format` (0.14.0, repo config) pass on the touched file; the commit is DCO signed.

## Not covered

- I could not construct a deterministic reproducer for the race; the evidence is the py-spy stacks above and the boot counts. The change is defensive by construction: it only adds agreement before collectives that were already unconditional.
- Single-node NVLink groups were not exercised here (no such hardware); the code path is identical apart from the votes.
