### PR TITLE
perf(glm5next): make KDA gate overlap graph-safe

### DIFF
--- a/tests/models/test_glm5next_kda_gate_stream.py
+++ b/tests/models/test_glm5next_kda_gate_stream.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The GLM-5.3 KDA gate side stream: same result as the sequential forward,
+gate projections off the main stream, graph-capturable."""
+
+import pytest
+import torch
+
+from vllm.models.glm5next.nvidia import kda as kda_module
+from vllm.models.glm5next.nvidia.kda import Glm5NextLinearAttention
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+HIDDEN, HEADS, HEAD_DIM, GATE_RANK = 64, 2, 16, 8
+PROJ = HEADS * HEAD_DIM
+
+
+class _Linear:
+    """Stands in for a vLLM linear layer: returns (y, None) and records the
+    CUDA stream it ran on."""
+
+    def __init__(self, name, weight, log):
+        self.name, self.weight, self.log = name, weight, log
+
+    def __call__(self, x):
+        self.log.append((self.name, torch.cuda.current_stream(x.device).cuda_stream))
+        return x @ self.weight, None
+
+
+def _make_layer(device, log, generator):
+    def w(rows, cols):
+        return (torch.randn(rows, cols, generator=generator) / rows**0.5).to(
+            device, torch.bfloat16
+        )
+
+    layer = Glm5NextLinearAttention.__new__(Glm5NextLinearAttention)
+    torch.nn.Module.__init__(layer)
+    layer.use_full_rank_gate = False
+    layer.local_projection_size = PROJ
+    layer.local_num_heads = HEADS
+    layer.head_dim = HEAD_DIM
+    layer.in_proj_qkvgfab = _Linear(
+        "in_proj", w(HIDDEN, 3 * PROJ + HEADS + HEAD_DIM), log
+    )
+    layer.g_a_proj = _Linear("g_a", w(HIDDEN, GATE_RANK), log)
+    layer.g_b_proj = _Linear("g_b", w(GATE_RANK, PROJ), log)
+    layer.f_b_proj = _Linear("f_b", w(HEAD_DIM, PROJ), log)
+    layer.o_proj = _Linear("o_proj", w(PROJ, HIDDEN), log)
+
+    def core(*, mixed_qkv, g1, g2, beta, core_attn_out):
+        n = mixed_qkv.shape[0]
+        q = mixed_qkv[:, :PROJ].reshape(1, n, HEADS, HEAD_DIM)
+        core_attn_out.copy_(q * g2 + g1 * beta.reshape(1, n, HEADS, 1))
+
+    layer._forward = core
+    return layer
+
+
+def _run(layer, hidden_states):
+    out = layer(hidden_states, positions=None)
+    torch.cuda.synchronize(hidden_states.device)
+    return out
+
+
+def test_gate_side_stream_matches_sequential_forward(monkeypatch):
+    device = torch.device("cuda", 0)
+    generator = torch.Generator().manual_seed(11)
+    log: list[tuple[str, int]] = []
+    layer = _make_layer(device, log, generator)
+    x = (torch.randn(8, HIDDEN, generator=generator)).to(device, torch.bfloat16)
+
+    monkeypatch.setattr(kda_module, "_GATE_SIDE_STREAM", True)
+    overlapped = _run(layer, x)
+    main = torch.cuda.current_stream(device).cuda_stream
+    streams = dict(log)
+    assert streams["g_a"] != main and streams["g_b"] == streams["g_a"]
+    assert streams["in_proj"] == main and streams["o_proj"] == main
+    log.clear()
+
+    monkeypatch.setattr(kda_module, "_GATE_SIDE_STREAM", False)
+    sequential = _run(layer, x)
+    assert all(stream == main for _, stream in log)
+    assert torch.equal(overlapped, sequential)
+
+
+def test_gate_side_stream_is_graph_capturable(monkeypatch):
+    device = torch.device("cuda", 0)
+    generator = torch.Generator().manual_seed(5)
+    log: list[tuple[str, int]] = []
+    layer = _make_layer(device, log, generator)
+    static = (torch.randn(4, HIDDEN, generator=generator)).to(device, torch.bfloat16)
+    monkeypatch.setattr(kda_module, "_GATE_SIDE_STREAM", True)
+    eager = _run(layer, static)
+
+    stream = torch.cuda.Stream(device=device)
+    stream.wait_stream(torch.cuda.current_stream(device))
+    with torch.cuda.stream(stream):
+        for _ in range(2):
+            layer(static, positions=None)
+    torch.cuda.current_stream(device).wait_stream(stream)
+    torch.cuda.synchronize(device)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        captured = layer(static, positions=None)
+    for _ in range(3):
+        graph.replay()
+        torch.cuda.synchronize(device)
+        assert torch.equal(captured, eager)

--- a/tests/models/test_glm5next_kda_gate_stream.py
+++ b/tests/models/test_glm5next_kda_gate_stream.py
@@ -98,12 +98,15 @@ def test_gate_overlap_is_enabled_for_regular_full_capture(monkeypatch):
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_gate_side_stream_matches_sequential_forward(monkeypatch):
+    from vllm.compilation import monitor
+
     device = torch.device("cuda", 0)
     generator = torch.Generator().manual_seed(11)
     log: list[tuple[str, int]] = []
     layer = _make_layer(device, log, generator)
     x = (torch.randn(8, HIDDEN, generator=generator)).to(device, torch.bfloat16)
 
+    monkeypatch.setattr(monitor, "is_cudagraph_capturing_enabled", lambda: False)
     monkeypatch.setattr(kda_module, "_GATE_SIDE_STREAM", True)
     overlapped = _run(layer, x)
     main = torch.cuda.current_stream(device).cuda_stream

--- a/tests/models/test_glm5next_kda_gate_stream.py
+++ b/tests/models/test_glm5next_kda_gate_stream.py
@@ -6,10 +6,9 @@ gate projections off the main stream, graph-capturable."""
 import pytest
 import torch
 
+from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
 from vllm.models.glm5next.nvidia import kda as kda_module
 from vllm.models.glm5next.nvidia.kda import Glm5NextLinearAttention
-
-pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 
 HIDDEN, HEADS, HEAD_DIM, GATE_RANK = 64, 2, 16, 8
 PROJ = HEADS * HEAD_DIM
@@ -58,10 +57,46 @@ def _make_layer(device, log, generator):
 
 def _run(layer, hidden_states):
     out = layer(hidden_states, positions=None)
-    torch.cuda.synchronize(hidden_states.device)
+    torch.accelerator.synchronize(hidden_states.device)
     return out
 
 
+def test_gate_overlap_is_disabled_for_the_entire_breakable_capture(monkeypatch):
+    monkeypatch.setattr(
+        BreakableCUDAGraphCapture,
+        "current",
+        classmethod(lambda cls: object()),
+    )
+    assert not kda_module._gate_overlap_allowed()
+
+
+def test_gate_overlap_is_disabled_for_uncaptured_graph_warmup(monkeypatch):
+    from vllm.compilation import monitor
+
+    monkeypatch.setattr(
+        BreakableCUDAGraphCapture,
+        "current",
+        classmethod(lambda cls: None),
+    )
+    monkeypatch.setattr(monitor, "is_cudagraph_capturing_enabled", lambda: True)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    assert not kda_module._gate_overlap_allowed()
+
+
+def test_gate_overlap_is_enabled_for_regular_full_capture(monkeypatch):
+    from vllm.compilation import monitor
+
+    monkeypatch.setattr(
+        BreakableCUDAGraphCapture,
+        "current",
+        classmethod(lambda cls: None),
+    )
+    monkeypatch.setattr(monitor, "is_cudagraph_capturing_enabled", lambda: True)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+    assert kda_module._gate_overlap_allowed()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_gate_side_stream_matches_sequential_forward(monkeypatch):
     device = torch.device("cuda", 0)
     generator = torch.Generator().manual_seed(11)
@@ -83,6 +118,7 @@ def test_gate_side_stream_matches_sequential_forward(monkeypatch):
     assert torch.equal(overlapped, sequential)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_gate_side_stream_is_graph_capturable(monkeypatch):
     device = torch.device("cuda", 0)
     generator = torch.Generator().manual_seed(5)
@@ -98,11 +134,11 @@ def test_gate_side_stream_is_graph_capturable(monkeypatch):
         for _ in range(2):
             layer(static, positions=None)
     torch.cuda.current_stream(device).wait_stream(stream)
-    torch.cuda.synchronize(device)
+    torch.accelerator.synchronize(device)
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph, stream=stream):
         captured = layer(static, positions=None)
     for _ in range(3):
         graph.replay()
-        torch.cuda.synchronize(device)
+        torch.accelerator.synchronize(device)
         assert torch.equal(captured, eager)

--- a/tests/models/test_glm5next_kda_gate_stream.py
+++ b/tests/models/test_glm5next_kda_gate_stream.py
@@ -141,7 +141,12 @@ def test_gate_side_stream_is_graph_capturable(monkeypatch):
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph, stream=stream):
         captured = layer(static, positions=None)
+    graph.replay()
+    torch.accelerator.synchronize(device)
+    assert torch.equal(captured, eager)
     for _ in range(3):
+        static.copy_(torch.randn_like(static))
+        expected = _run(layer, static)
         graph.replay()
         torch.accelerator.synchronize(device)
-        assert torch.equal(captured, eager)
+        assert torch.equal(captured, expected)

--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -411,6 +411,7 @@ def test_glm5next_loads_mxfp8_fused_projection_scales(
 def test_glm5next_kda_adapts_shared_out_buffer_forward(monkeypatch) -> None:
     layer = Glm5NextLinearAttention.__new__(Glm5NextLinearAttention)
     torch.nn.Module.__init__(layer)
+    layer.use_full_rank_gate = True
     hidden_states = torch.randn(2, 4)
     positions = torch.arange(2)
 

--- a/vllm/models/glm5next/nvidia/kda.py
+++ b/vllm/models/glm5next/nvidia/kda.py
@@ -1,12 +1,37 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""GLM-5.3 KDA modeling adapter."""
+"""GLM-5.3 KDA modeling adapter.
+
+Decode-latency variant of the shared KDA forward: the two low-rank output-gate
+projections (``g_a_proj`` then ``g_b_proj``) depend only on the layer input, so
+they are issued on a side CUDA stream and overlap the large fused
+``in_proj_qkvgfab`` GEMM instead of trailing it on the main stream. Kernels,
+shapes and reduction orders are unchanged, so results are bitwise identical to
+the sequential path; only the stream fork/join edges are new. The fork/join
+uses ``wait_stream``, which CUDA graph capture records as dependency edges.
+``VLLM_GLM53_KDA_GATE_SIDE_STREAM=0`` restores the sequential forward.
+"""
+
+import os
 
 import torch
+from einops import rearrange
 
 from vllm.model_executor.layers.mamba.gdn.kimi_gdn_linear_attn import (
     KimiGatedDeltaNetAttention,
 )
+
+_GATE_SIDE_STREAM = os.getenv("VLLM_GLM53_KDA_GATE_SIDE_STREAM", "1") != "0"
+_side_streams: dict[int, torch.cuda.Stream] = {}
+
+
+def _gate_stream(device: torch.device) -> torch.cuda.Stream:
+    index = device.index if device.index is not None else torch.cuda.current_device()
+    stream = _side_streams.get(index)
+    if stream is None:
+        stream = torch.cuda.Stream(device=torch.device("cuda", index))
+        _side_streams[index] = stream
+    return stream
 
 
 class Glm5NextLinearAttention(KimiGatedDeltaNetAttention):
@@ -21,8 +46,66 @@ class Glm5NextLinearAttention(KimiGatedDeltaNetAttention):
         positions: torch.Tensor,
     ) -> torch.Tensor:
         output = torch.empty_like(hidden_states)
-        super().forward(hidden_states, positions, output)
+        if _GATE_SIDE_STREAM and not self.use_full_rank_gate:
+            self._forward_gate_overlap(hidden_states, output)
+        else:
+            super().forward(hidden_states, positions, output)
         return output
+
+    def _forward_gate_overlap(
+        self,
+        hidden_states: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        num_tokens = hidden_states.size(0)
+        main = torch.cuda.current_stream(hidden_states.device)
+        side = _gate_stream(hidden_states.device)
+
+        # Fork: the gate projections read only hidden_states.
+        side.wait_stream(main)
+        # Keep hidden_states alive for the side stream (allocator safety in
+        # eager/warmup mode; a no-op inside graph capture).
+        hidden_states.record_stream(side)
+        with torch.cuda.stream(side):
+            g_proj_states = self.g_b_proj(self.g_a_proj(hidden_states)[0])[0]
+
+        projected_qkvgfab = self.in_proj_qkvgfab(hidden_states)[0]
+        # Same optional callback the shared forward offers after its first
+        # projection (e.g. the L2 weight prefetch of o_proj).
+        hook = getattr(self, "_l2_prefetch_hook", None)
+        if hook is not None:
+            hook(num_tokens)
+        mixed_qkv, beta, f_a = projected_qkvgfab.split(
+            [
+                3 * self.local_projection_size,
+                self.local_num_heads,
+                self.head_dim,
+            ],
+            dim=-1,
+        )
+        g1 = self.f_b_proj(f_a)[0]
+        beta = beta.unsqueeze(0)
+        g1 = rearrange(g1, "n (h d) -> 1 n h d", d=self.head_dim)
+
+        # Join before anything reads the gate states.
+        main.wait_stream(side)
+        g_proj_states.record_stream(main)
+        g2 = rearrange(g_proj_states, "... (h d) -> ... h d", d=self.head_dim)
+
+        core_attn_out = torch.empty(
+            (1, num_tokens, self.local_num_heads, self.head_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        self._forward(
+            mixed_qkv=mixed_qkv,
+            g1=g1,
+            g2=g2,
+            beta=beta,
+            core_attn_out=core_attn_out,
+        )
+        core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
+        output[:] = self.o_proj(core_attn_out)[0]
 
 
 __all__ = ["Glm5NextLinearAttention"]

--- a/vllm/models/glm5next/nvidia/kda.py
+++ b/vllm/models/glm5next/nvidia/kda.py
@@ -25,8 +25,36 @@ _GATE_SIDE_STREAM = os.getenv("VLLM_GLM53_KDA_GATE_SIDE_STREAM", "1") != "0"
 _side_streams: dict[int, torch.cuda.Stream] = {}
 
 
+def _gate_overlap_allowed() -> bool:
+    """Use the gate side stream only in runtime or regular FULL capture.
+
+    Breakable capture alternates captured segments with eager operations.  A
+    side-stream fork in either portion can outlive a segment boundary even when
+    the main stream has enqueued a later event wait.  Graph preparation also
+    runs uncaptured warmup forwards; overlapping multiple auxiliary streams in
+    those forwards can race allocator reuse before the following capture.
+    Regular FULL capture and serving execution retain the overlapped path.
+    """
+    try:
+        from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
+        from vllm.compilation.monitor import is_cudagraph_capturing_enabled
+
+        if BreakableCUDAGraphCapture.current() is not None:
+            return False
+        return (
+            not is_cudagraph_capturing_enabled()
+            or torch.cuda.is_current_stream_capturing()
+        )
+    except Exception:  # noqa: BLE001
+        return not torch.cuda.is_current_stream_capturing()
+
+
 def _gate_stream(device: torch.device) -> torch.cuda.Stream:
-    index = device.index if device.index is not None else torch.cuda.current_device()
+    index = (
+        device.index
+        if device.index is not None
+        else torch.accelerator.current_device_index()
+    )
     stream = _side_streams.get(index)
     if stream is None:
         stream = torch.cuda.Stream(device=torch.device("cuda", index))
@@ -46,7 +74,11 @@ class Glm5NextLinearAttention(KimiGatedDeltaNetAttention):
         positions: torch.Tensor,
     ) -> torch.Tensor:
         output = torch.empty_like(hidden_states)
-        if _GATE_SIDE_STREAM and not self.use_full_rank_gate:
+        if (
+            _GATE_SIDE_STREAM
+            and not self.use_full_rank_gate
+            and _gate_overlap_allowed()
+        ):
             self._forward_gate_overlap(hidden_states, output)
         else:
             super().forward(hidden_states, positions, output)
@@ -67,7 +99,13 @@ class Glm5NextLinearAttention(KimiGatedDeltaNetAttention):
         # eager/warmup mode; a no-op inside graph capture).
         hidden_states.record_stream(side)
         with torch.cuda.stream(side):
-            g_proj_states = self.g_b_proj(self.g_a_proj(hidden_states)[0])[0]
+            g_a_states = self.g_a_proj(hidden_states)[0]
+            # Some linear backends allocate their caller-owned output before
+            # entering the active CUDA stream. Record the asynchronous consumer
+            # explicitly so the caching allocator cannot recycle this
+            # intermediate while g_b_proj is still reading it.
+            g_a_states.record_stream(side)
+            g_proj_states = self.g_b_proj(g_a_states)[0]
 
         projected_qkvgfab = self.in_proj_qkvgfab(hidden_states)[0]
         # Same optional callback the shared forward offers after its first


### PR DESCRIPTION
## Resulting behavior

GLM-5.3 runs the low-rank KDA gate projections on a dedicated CUDA stream while the main stream computes the packed Q/K/V projection. The streams join before the gate values are consumed.

The overlap is enabled during serving and regular FULL CUDA graph capture. It is disabled during uncaptured graph-preparation forwards and throughout breakable graph capture. The intermediate gate projection records its asynchronous consumer stream so the caching allocator cannot recycle its storage while the second projection is reading it.

## Technical reason

The gate and packed projections are independent and can overlap during decode. Uncontained side-stream work can, however, cross an uncaptured-warmup or breakable-capture boundary and race temporary-storage reuse. The lifecycle guard retains the decode optimization while enforcing the CUDA graph boundary.

## Compatibility

`VLLM_GLM53_KDA_GATE_SIDE_STREAM=0` retains sequential execution. Full-rank gates and unsupported execution contexts also retain the shared sequential implementation. Model weights and arithmetic are unchanged.

This branch preserves MadeBy561 as the author of the original side-stream implementation from #582. The lifecycle correction depends on #617.

## Validation

- Sequential and overlapped forwards produce identical tensors.
- The side-stream forward replays from a CUDA graph with identical output.
- Focused lifecycle tests cover breakable capture, uncaptured warmup, and regular FULL capture.
- Repository hooks passed Ruff, formatting, MyPy, SPDX, import, configuration-default, and CUDA API checks.
- A TP4 GLM-5.3 composition containing this source completed three consecutive combined KDA/L2 FULL CUDA graph startups in no-speculative, MTP3, and DFlash2 modes on NVIDIA RTX PRO 6000 Blackwell GPUs.

OpenAI Codex assisted with lifecycle isolation, implementation, and validation. The submitter reviewed the resulting source and evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved CUDA execution for GLM-5.3 attention workloads by overlapping compatible gate calculations, potentially reducing decode latency.
  - Added the `VLLM_GLM53_KDA_GATE_SIDE_STREAM` environment variable to control this behavior; it is enabled by default.
  - Preserved sequential execution during CUDA graph capture and for full-rank gate configurations.

- **Tests**
  - Added coverage for stream-overlap eligibility, sequential-output parity, and CUDA graph compatibility across supported execution states.
  - Expanded testing for full-rank gate configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->