### PR TITLE
perf(attention): minimize DCP full-CKV rank padding

### DIFF
--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -35,10 +35,12 @@ from vllm.v1.attention.backends.mla.b12x_mla_sparse import (
     B12xMLASparseImpl,
     B12xMLASparseMetadata,
     B12xMLASparseMetadataBuilder,
+    _ckv_rank_token_alignment,
     _global_causal_lens_for_ckv_gather,
     _is_glm_next_ckv_source_layout,
     _is_speculative_decode_batch,
     _max_speculative_decode_query_len,
+    _round_up_ckv_rank_tokens,
     _selected_index_block_stride_rows,
     _use_b12x_full_ckv_gather,
 )
@@ -385,6 +387,26 @@ def test_b12x_glm5_next_ckv_source_layout() -> None:
     )
     assert _is_glm_next_ckv_source_layout(cache, page_size=64)
     assert not _is_glm_next_ckv_source_layout(cache[:, :, ::2], page_size=64)
+
+
+@pytest.mark.parametrize(
+    ("page_size", "dcp_world_size", "alignment"),
+    [(2048, 4, 512), (2048, 2, 1024), (512, 4, 128), (512, 3, 512)],
+)
+def test_full_ckv_rank_alignment_only_pads_the_concatenated_cache_to_pages(
+    page_size: int,
+    dcp_world_size: int,
+    alignment: int,
+) -> None:
+    assert _ckv_rank_token_alignment(page_size, dcp_world_size) == alignment
+    padded = _round_up_ckv_rank_tokens(
+        1025,
+        page_size=page_size,
+        dcp_world_size=dcp_world_size,
+    )
+    assert padded >= 1025
+    assert padded % alignment == 0
+    assert padded * dcp_world_size % page_size == 0
 
 
 @pytest.mark.parametrize("record_bytes", [528, 656])

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -3,7 +3,7 @@
 """B12x sparse MLA attention backend."""
 
 from dataclasses import dataclass, replace
-from math import prod
+from math import gcd, prod
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
 
 import numpy as np
@@ -191,6 +191,28 @@ def _use_b12x_full_ckv_gather(
         and num_tokens > min_tokens
         and num_tokens <= max_tokens
     )
+
+
+def _ckv_rank_token_alignment(page_size: int, dcp_world_size: int) -> int:
+    """Per-rank padding that makes the gathered CKV page-addressable.
+
+    All-gather concatenates one equally sized token span from every DCP rank.
+    Individual rank boundaries do not need to coincide with KV-page boundaries;
+    only the concatenated span must contain an integral number of pages.
+    """
+    if page_size <= 0 or dcp_world_size <= 0:
+        raise ValueError("CKV page size and DCP world size must be positive")
+    return page_size // gcd(page_size, dcp_world_size)
+
+
+def _round_up_ckv_rank_tokens(
+    token_count: int,
+    *,
+    page_size: int,
+    dcp_world_size: int,
+) -> int:
+    alignment = _ckv_rank_token_alignment(page_size, dcp_world_size)
+    return (token_count + alignment - 1) // alignment * alignment
 
 
 def _dcp_all_gather_current_stream(
@@ -885,21 +907,17 @@ class B12xMLASparseMetadataBuilder(
             rank_totals = rank_req_lens.sum(dim=1).tolist()
             local_total_tokens = int(rank_totals[self.dcp_rank])
             page_size = int(self.kv_cache_spec.block_size)
-            padded_total_tokens = (
-                (max(int(total) for total in rank_totals) + page_size - 1)
-                // page_size
-                * page_size
+            padded_total_tokens = _round_up_ckv_rank_tokens(
+                max(int(total) for total in rank_totals),
+                page_size=page_size,
+                dcp_world_size=self.dcp_world_size,
             )
-            max_local_capacity = (
-                (
-                    (envs.VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS + self.dcp_world_size - 1)
-                    // self.dcp_world_size
-                    + self._ckv_max_reqs * self.cp_kv_cache_interleave_size
-                    + page_size
-                    - 1
-                )
-                // page_size
-                * page_size
+            max_local_capacity = _round_up_ckv_rank_tokens(
+                (envs.VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS + self.dcp_world_size - 1)
+                // self.dcp_world_size
+                + self._ckv_max_reqs * self.cp_kv_cache_interleave_size,
+                page_size=page_size,
+                dcp_world_size=self.dcp_world_size,
             )
             if 0 < padded_total_tokens <= max_local_capacity:
                 metadata.ckv_selected_indices = self.ckv_selected_indices_buffer[
@@ -1159,10 +1177,10 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         if self._ckv_extend_plan is not None:
             plans.append(self._ckv_extend_plan)
         self._scratch_nbytes = max(int(plan.layout.nbytes) for plan in plans)
-        self._ckv_local_capacity = (
-            (self._ckv_capacity_tokens + kernel_page_size - 1)
-            // kernel_page_size
-            * kernel_page_size
+        self._ckv_local_capacity = _round_up_ckv_rank_tokens(
+            self._ckv_capacity_tokens,
+            page_size=kernel_page_size,
+            dcp_world_size=self.dcp_world_size,
         )
         self._kernel_page_size = kernel_page_size
         self._reserve_planned_workspaces()


### PR DESCRIPTION
## Resulting behavior

GLM complete-KV DCP prefill pads each rank-local cache span only enough for the concatenated all-gather result to contain integral cache pages. For cache page size `P` and DCP world size `D`, the required rank-local alignment is `P / gcd(P, D)`.

The runtime metadata span and persistent gather workspaces use the same alignment.

## Technical reason

All-gather concatenates equal token spans from every DCP rank. Cache pages need to divide the concatenated result; individual rank boundaries do not need to coincide with page boundaries. Rounding every rank to a complete page transfers and ranks unnecessary padding, especially with 2,048-token pages.

## Compatibility

The gathered buffer remains page-addressable and contains the same visible cache records. DCP1 and serving paths that do not select complete-KV prefill are unchanged. The helper validates positive page and world sizes.

## Validation

- Focused tests cover 2,048-token and 512-token pages with DCP2, DCP3, and DCP4 and verify both rank-local and concatenated divisibility.
- Repository hooks passed Ruff, formatting, MyPy, SPDX, import, configuration-default, and CUDA API checks.
- TP4/DCP4 GLM-5.3 with 2,048-token pages completed 32K prefill and C1 decode in no-speculative, MTP3, and DFlash2 modes on NVIDIA RTX PRO 6000 Blackwell GPUs.
- Qualified stock-clock 32K prefill was 13,552 prompt tokens/s without speculation, 13,188 with MTP3, and 13,362 with DFlash2.

OpenAI Codex assisted with implementation and validation. The submitter reviewed the resulting source and evidence.
