### PR TITLE
feat(scheduler): add selectable prefill fairness engines

### DIFF
--- a/tests/entrypoints/serve/dev/test_fairness.py
+++ b/tests/entrypoints/serve/dev/test_fairness.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.entrypoints.serve.dev.fairness.api_router import (
+    PrefillFairnessRequest,
+    get_prefill_fairness,
+    set_prefill_fairness,
+)
+
+
+class _FakeEngineClient:
+    def __init__(self, result):
+        self.result = result
+        self.received = None
+
+    async def get_prefill_fairness(self):
+        return self.result
+
+    async def set_prefill_fairness(self, config):
+        self.received = config
+        return self.result
+
+
+def _request(client):
+    return SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(engine_client=client))
+    )
+
+
+def test_get_prefill_fairness_returns_current_config():
+    current = {"fairness_engine": "compute_share", "prefill_compute_share": 0.5}
+    response = asyncio.run(get_prefill_fairness(_request(_FakeEngineClient(current))))
+    assert response.status_code == 200
+    assert json.loads(response.body) == current
+
+
+@pytest.mark.parametrize(
+    ("reason", "status_code"),
+    [("busy", 409), ("invalid", 422)],
+)
+def test_set_prefill_fairness_maps_rejection_status(reason, status_code):
+    result = {
+        "applied": False,
+        "reason": reason,
+        "message": "rejected",
+        "config": {"fairness_engine": None},
+    }
+    client = _FakeEngineClient(result)
+    config = PrefillFairnessRequest(
+        fairness_engine="compute_share", prefill_compute_share=0.5
+    )
+
+    response = asyncio.run(set_prefill_fairness(_request(client), config))
+
+    assert response.status_code == status_code
+    assert client.received == config.model_dump()

--- a/tests/v1/core/test_compute_fairness.py
+++ b/tests/v1/core/test_compute_fairness.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections import deque
+
+import pytest
+
+from vllm.v1.core.sched.compute_fairness import PrefillComputeShareController
+
+
+def _run_controller(
+    controller: PrefillComputeShareController,
+    *,
+    decode_cost: float,
+    prefill_cost: float,
+    steps: int,
+) -> dict[str, float]:
+    totals = {"decode": 0.0, "prefill": 0.0}
+    for _ in range(steps):
+        service_class = controller.select(decode_runnable=True, prefill_runnable=True)
+        assert service_class is not None
+        elapsed = prefill_cost if service_class == "prefill" else decode_cost
+        controller.dispatch(service_class, contended=True)
+        totals[service_class] += elapsed
+        controller.record(service_class, elapsed, contended=True)
+    return totals
+
+
+@pytest.mark.parametrize(
+    ("decode_cost", "prefill_cost"), [(1.0, 1.0), (0.1, 1.0), (2.0, 0.25)]
+)
+def test_controller_converges_for_equal_and_unequal_costs(
+    decode_cost: float, prefill_cost: float
+):
+    controller = PrefillComputeShareController(0.5)
+
+    totals = _run_controller(
+        controller,
+        decode_cost=decode_cost,
+        prefill_cost=prefill_cost,
+        steps=1000,
+    )
+
+    prefill_fraction = totals["prefill"] / sum(totals.values())
+    assert prefill_fraction == pytest.approx(0.5, abs=0.01)
+
+
+def test_runtime_cost_change_changes_selected_cadence():
+    controller = PrefillComputeShareController(0.5)
+
+    first = _run_controller(controller, decode_cost=0.1, prefill_cost=1.0, steps=200)
+    first_prefill_steps = first["prefill"] / 1.0
+
+    second = _run_controller(controller, decode_cost=0.1, prefill_cost=0.2, steps=200)
+    second_prefill_steps = second["prefill"] / 0.2
+
+    assert second_prefill_steps > first_prefill_steps
+
+
+def test_contention_transitions_reset_credit():
+    controller = PrefillComputeShareController(0.5)
+    controller.select(decode_runnable=True, prefill_runnable=True)
+    controller.dispatch("decode", contended=True)
+    controller.record("decode", 1.0, contended=True)
+    assert controller.decode_virtual_runtime > 0.0
+
+    assert controller.select(decode_runnable=True, prefill_runnable=False) == "decode"
+    assert controller.decode_virtual_runtime == 0.0
+    assert controller.prefill_virtual_runtime == 0.0
+    assert not controller.contention_active
+
+    assert controller.select(decode_runnable=True, prefill_runnable=True) == "decode"
+
+
+def test_single_runnable_class_receives_full_service():
+    controller = PrefillComputeShareController(0.5)
+
+    assert controller.select(decode_runnable=True, prefill_runnable=False) == "decode"
+    assert controller.select(decode_runnable=False, prefill_runnable=True) == "prefill"
+    assert controller.select(decode_runnable=False, prefill_runnable=False) is None
+
+
+@pytest.mark.parametrize("prefill_share", [0.2, 0.8, 0.9])
+def test_neither_class_starves_at_asymmetric_share(prefill_share: float):
+    controller = PrefillComputeShareController(prefill_share)
+    totals = _run_controller(controller, decode_cost=0.1, prefill_cost=1.0, steps=1000)
+
+    assert totals["decode"] > 0.0
+    assert totals["prefill"] > 0.0
+    assert totals["prefill"] / sum(totals.values()) == pytest.approx(
+        prefill_share, abs=0.02
+    )
+
+
+def test_outlier_lead_is_bounded_to_one_service_quantum():
+    controller = PrefillComputeShareController(0.5)
+    controller.select(decode_runnable=True, prefill_runnable=True)
+    controller.dispatch("prefill", contended=True)
+    controller.record("prefill", 100.0, contended=True)
+
+    normalized_quantum = 100.0 / controller.prefill_compute_share
+    lead = controller.prefill_virtual_runtime - controller.decode_virtual_runtime
+    assert 0.0 <= lead <= normalized_quantum
+
+
+def test_ties_favor_decode():
+    controller = PrefillComputeShareController(0.5)
+
+    assert controller.select(decode_runnable=True, prefill_runnable=True) == "decode"
+
+
+def test_two_deep_async_queue_converges_with_unequal_costs():
+    controller = PrefillComputeShareController(0.5)
+    pending: deque[str] = deque()
+    totals = {"decode": 0.0, "prefill": 0.0}
+
+    for _ in range(10_000):
+        while len(pending) < 2:
+            service_class = controller.select(
+                decode_runnable=True, prefill_runnable=True
+            )
+            assert service_class is not None
+            controller.dispatch(service_class, contended=True)
+            pending.append(service_class)
+
+        service_class = pending.popleft()
+        elapsed = 0.7 if service_class == "prefill" else 0.01
+        totals[service_class] += elapsed
+        controller.record(service_class, elapsed, contended=True)
+
+    prefill_fraction = totals["prefill"] / sum(totals.values())
+    assert prefill_fraction == pytest.approx(0.5, abs=0.01)
+
+
+def test_zero_elapsed_completion_releases_reservation():
+    controller = PrefillComputeShareController(0.5, last_decode_seconds=0.1)
+    service_class = controller.select(decode_runnable=True, prefill_runnable=True)
+    assert service_class == "decode"
+    controller.dispatch(service_class, contended=True)
+
+    assert controller.decode_reservations
+    controller.record(service_class, 0.0, contended=True)
+
+    assert not controller.decode_reservations
+    assert controller.decode_virtual_runtime == 0.0

--- a/tests/v1/core/test_micro_slicing.py
+++ b/tests/v1/core/test_micro_slicing.py
@@ -1,0 +1,362 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import time
+
+import pytest
+
+from vllm.config import SchedulerConfig
+from vllm.engine.arg_utils import EngineArgs
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+from vllm.v1.core.sched.micro_slicing import (
+    MicroSlicingController,
+    MicroSlicingSettings,
+)
+from vllm.v1.outputs import ModelRunnerOutput
+
+from .utils import create_requests, create_scheduler, mock_kv
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.fixture
+def opt_model_path(tmp_path):
+    (tmp_path / "config.json").write_text(
+        '{"architectures":["OPTForCausalLM"],"model_type":"opt",'
+        '"max_position_embeddings":32768}'
+    )
+    return str(tmp_path)
+
+
+def _settings(**kwargs) -> MicroSlicingSettings:
+    defaults = {"max_num_prefill_tokens_per_step": 4096}
+    defaults.update(kwargs)
+    return MicroSlicingSettings(**defaults)
+
+
+def _update(scheduler, output) -> None:
+    req_ids = list(output.num_scheduled_tokens)
+    sampled_token_ids = [
+        [] if scheduler.requests[req_id].is_prefill_chunk else [0] for req_id in req_ids
+    ]
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=req_ids,
+            req_id_to_index={req_id: index for index, req_id in enumerate(req_ids)},
+            sampled_token_ids=sampled_token_ids,
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+
+def _establish_decode(scheduler, req_id: str = "decode"):
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=8,
+        max_tokens=200,
+        req_ids=[req_id],
+    )
+    scheduler.add_request(request)
+    output = scheduler.schedule()
+    _update(scheduler, output)
+    assert not request.is_prefill_chunk
+    return request
+
+
+def _create_micro_scheduler(opt_model_path, **kwargs):
+    scheduler_kwargs = {
+        "max_num_batched_tokens": 8192,
+        "max_model_len": 32768,
+        "max_num_prefill_tokens_per_step": 4096,
+    }
+    scheduler_kwargs.update(kwargs)
+    return create_scheduler(
+        model=opt_model_path,
+        skip_tokenizer_init=True,
+        device="cpu",
+        fairness_engine="micro_slicing",
+        **scheduler_kwargs,
+    )
+
+
+def test_selector_requires_only_selected_engine_options():
+    with pytest.raises(ValueError, match="fairness_engine must be selected"):
+        SchedulerConfig(
+            max_model_len=128,
+            is_encoder_decoder=False,
+            prefill_compute_share=0.5,
+        )
+    with pytest.raises(ValueError, match="micro-slicing options"):
+        SchedulerConfig(
+            max_model_len=128,
+            is_encoder_decoder=False,
+            fairness_engine="compute_share",
+            prefill_compute_share=0.5,
+            max_num_prefill_tokens_per_step=64,
+        )
+    with pytest.raises(ValueError, match="prefill_compute_share cannot"):
+        SchedulerConfig(
+            max_model_len=128,
+            is_encoder_decoder=False,
+            fairness_engine="micro_slicing",
+            prefill_compute_share=0.5,
+            max_num_prefill_tokens_per_step=64,
+        )
+
+
+def test_micro_slicing_validation_and_cli_contract():
+    with pytest.raises(ValueError, match="max_num_prefill_tokens_per_step"):
+        SchedulerConfig(
+            max_model_len=128,
+            is_encoder_decoder=False,
+            fairness_engine="micro_slicing",
+        )
+    with pytest.raises(ValueError, match="decode_prefill_max_wait_ms"):
+        SchedulerConfig(
+            max_model_len=128,
+            is_encoder_decoder=False,
+            fairness_engine="micro_slicing",
+            max_num_prefill_tokens_per_step=64,
+            decode_prefill_max_wait_ms=100,
+        )
+
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    namespace = parser.parse_args(
+        [
+            "--fairness-engine",
+            "micro_slicing",
+            "--max-num-prefill-tokens-per-step",
+            "4096",
+            "--max-num-partial-prefills",
+            "2",
+            "--decode-prefill-min-decode-steps",
+            "4",
+            "--decode-prefill-max-wait-ms",
+            "250",
+        ]
+    )
+    args = EngineArgs.from_cli_args(namespace)
+    assert args.fairness_engine == "micro_slicing"
+    assert args.max_num_prefill_tokens_per_step == 4096
+    assert args.max_num_partial_prefills == 2
+    assert args.decode_prefill_min_decode_steps == 4
+    assert args.decode_prefill_max_wait_ms == 250
+
+
+def test_controller_distributes_full_budget_and_rotates():
+    controller = MicroSlicingController(_settings(max_num_prefill_tokens_per_step=8))
+    assert controller.select_running_limits(["a", "b", "c"], 8) == {
+        "a": 3,
+        "b": 3,
+        "c": 2,
+    }
+    assert controller.select_running_limits(["a", "b", "c"], 2) == {
+        "c": 1,
+        "a": 1,
+    }
+
+
+def test_controller_counts_decode_before_waiter_arrives():
+    controller = MicroSlicingController(_settings(decode_prefill_min_decode_steps=3))
+    for _ in range(3):
+        controller.observe_step(
+            has_eligible_decode=True,
+            had_pending_prefill=False,
+            scheduled_decode_tokens=1,
+            scheduled_prefill_tokens=0,
+            deadline_bypass_candidate=False,
+        )
+    defer, bypass = controller.should_defer_prefill(
+        has_eligible_decode=True,
+        has_pending_prefill=True,
+        oldest_waiter_age_ms=0,
+    )
+    assert not defer
+    assert not bypass
+
+
+def test_deadline_metric_requires_actual_prefill_service():
+    controller = MicroSlicingController(
+        _settings(
+            decode_prefill_min_decode_steps=4,
+            decode_prefill_max_wait_ms=100,
+        )
+    )
+    defer, bypass = controller.should_defer_prefill(
+        has_eligible_decode=True,
+        has_pending_prefill=True,
+        oldest_waiter_age_ms=101,
+    )
+    assert not defer and bypass
+    controller.observe_step(
+        has_eligible_decode=True,
+        had_pending_prefill=True,
+        scheduled_decode_tokens=1,
+        scheduled_prefill_tokens=0,
+        deadline_bypass_candidate=bypass,
+    )
+    assert controller.fairness_bypasses == 0
+
+
+def test_blocked_waiter_budget_is_reclaimed_by_running_prefills(opt_model_path):
+    scheduler = _create_micro_scheduler(
+        opt_model_path,
+        max_num_partial_prefills=2,
+    )
+    _establish_decode(scheduler)
+    prefills = create_requests(
+        num_requests=2,
+        num_tokens=12000,
+        req_ids=["p0", "p1"],
+    )
+    for request in prefills:
+        scheduler.add_request(request)
+    first = scheduler.schedule()
+    _update(scheduler, first)
+    second = scheduler.schedule()
+    _update(scheduler, second)
+    assert scheduler.num_active_local_partial_prefills == 2
+
+    (waiter,) = create_requests(
+        num_requests=1,
+        num_tokens=12000,
+        req_ids=["waiter"],
+    )
+    scheduler.add_request(waiter)
+    output = scheduler.schedule()
+
+    assert waiter in scheduler.waiting
+    assert sum(output.num_scheduled_tokens[req.request_id] for req in prefills) == 4096
+    assert output.num_scheduled_tokens["decode"] > 0
+
+
+def test_partial_cap_allows_waiter_that_finishes_in_quantum(opt_model_path):
+    scheduler = _create_micro_scheduler(
+        opt_model_path,
+        max_num_partial_prefills=1,
+    )
+    _establish_decode(scheduler)
+    (partial,) = create_requests(
+        num_requests=1,
+        num_tokens=12000,
+        req_ids=["partial"],
+    )
+    scheduler.add_request(partial)
+    first = scheduler.schedule()
+    _update(scheduler, first)
+    assert scheduler.num_active_local_partial_prefills == 1
+
+    (finisher,) = create_requests(
+        num_requests=1,
+        num_tokens=1024,
+        req_ids=["finisher"],
+    )
+    scheduler.add_request(finisher)
+    output = scheduler.schedule()
+
+    assert finisher in scheduler.running
+    assert output.num_scheduled_tokens[finisher.request_id] == 1024
+
+
+def test_decode_burst_and_deadline_use_actual_bypass(opt_model_path):
+    scheduler = _create_micro_scheduler(
+        opt_model_path,
+        decode_prefill_min_decode_steps=2,
+        decode_prefill_max_wait_ms=100,
+    )
+    _establish_decode(scheduler)
+    (waiter,) = create_requests(
+        num_requests=1,
+        num_tokens=12000,
+        req_ids=["waiter"],
+    )
+    waiter.arrival_time = time.time() - 1.0
+    scheduler.add_request(waiter)
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens[waiter.request_id] == 4096
+    assert scheduler.micro_slicing_controller is not None
+    assert scheduler.micro_slicing_controller.fairness_bypasses == 1
+
+
+def test_idle_policy_switch_replaces_controller_without_touching_cache(opt_model_path):
+    scheduler = create_scheduler(
+        model=opt_model_path,
+        skip_tokenizer_init=True,
+        device="cpu",
+        max_num_batched_tokens=8192,
+        max_model_len=32768,
+    )
+    cache_manager = scheduler.kv_cache_manager
+
+    compute = scheduler.set_prefill_fairness(
+        {
+            "fairness_engine": "compute_share",
+            "prefill_compute_share": 0.65,
+        }
+    )
+    assert compute["fairness_engine"] == "compute_share"
+    assert scheduler.compute_share_controller is not None
+    assert scheduler.micro_slicing_controller is None
+
+    micro = scheduler.set_prefill_fairness(
+        {
+            "fairness_engine": "micro_slicing",
+            "max_num_prefill_tokens_per_step": 4096,
+            "max_num_partial_prefills": 2,
+            "decode_prefill_min_decode_steps": 3,
+            "decode_prefill_max_wait_ms": 250,
+        }
+    )
+    assert micro["fairness_engine"] == "micro_slicing"
+    assert scheduler.compute_share_controller is None
+    assert scheduler.micro_slicing_controller is not None
+
+    disabled = scheduler.set_prefill_fairness({"fairness_engine": None})
+    assert disabled["fairness_engine"] is None
+    assert scheduler.compute_share_controller is None
+    assert scheduler.micro_slicing_controller is None
+    assert scheduler.kv_cache_manager is cache_manager
+
+
+def test_invalid_live_policy_does_not_replace_current_controller(opt_model_path):
+    scheduler = _create_micro_scheduler(opt_model_path)
+    controller = scheduler.micro_slicing_controller
+    scheduler.prefill_fairness_quantum = 4096
+    with pytest.raises(ValueError, match="prefill quantum"):
+        scheduler.set_prefill_fairness(
+            {
+                "fairness_engine": "micro_slicing",
+                "max_num_prefill_tokens_per_step": 4095,
+            }
+        )
+    assert scheduler.micro_slicing_controller is controller
+
+
+def test_async_external_restore_does_not_consume_local_partial_slot(opt_model_path):
+    scheduler = _create_micro_scheduler(
+        opt_model_path,
+        max_num_batched_tokens=128,
+        max_model_len=128,
+        max_num_prefill_tokens_per_step=64,
+        max_num_partial_prefills=1,
+        enable_prefix_caching=True,
+        block_size=16,
+        use_kv_connector=mock_kv(matched_tokens=32, is_async=True),
+    )
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=64,
+        req_ids=["restore"],
+    )
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert output.total_num_scheduled_tokens == 0
+    assert scheduler.num_active_local_partial_prefills == 0
+    assert request in scheduler._inflight_prefills

--- a/tests/v1/core/test_prefill_compute_share_scheduler.py
+++ b/tests/v1/core/test_prefill_compute_share_scheduler.py
@@ -1,0 +1,449 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.config import SchedulerConfig
+from vllm.engine.arg_utils import EngineArgs
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+from vllm.v1.outputs import ModelRunnerOutput
+
+from .utils import create_requests, create_scheduler, mock_kv
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.fixture
+def opt_model_path(tmp_path):
+    (tmp_path / "config.json").write_text(
+        '{"architectures":["OPTForCausalLM"],"model_type":"opt",'
+        '"max_position_embeddings":32768}'
+    )
+    return str(tmp_path)
+
+
+def _create_fair_scheduler(opt_model_path, **kwargs):
+    return create_scheduler(
+        model=opt_model_path,
+        skip_tokenizer_init=True,
+        fairness_engine="compute_share",
+        prefill_compute_share=0.5,
+        device="cpu",
+        **kwargs,
+    )
+
+
+def _update(scheduler, output) -> None:
+    req_ids = list(output.num_scheduled_tokens)
+    sampled_token_ids = [
+        [] if scheduler.requests[req_id].is_prefill_chunk else [0] for req_id in req_ids
+    ]
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=req_ids,
+            req_id_to_index={req_id: index for index, req_id in enumerate(req_ids)},
+            sampled_token_ids=sampled_token_ids,
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+
+def _establish_decode(scheduler, req_id: str = "decode"):
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=4,
+        max_tokens=100,
+        req_ids=[req_id],
+    )
+    scheduler.add_request(request)
+    output = scheduler.schedule()
+    assert output.compute_service_class is None
+    assert not output.compute_contention
+    _update(scheduler, output)
+    assert not request.is_prefill_chunk
+    return request
+
+
+@pytest.mark.parametrize("share", [0.0, 1.0, -0.1, 1.1])
+def test_prefill_compute_share_rejects_invalid_values(share: float):
+    with pytest.raises(ValueError, match="prefill_compute_share"):
+        SchedulerConfig(
+            max_model_len=128,
+            is_encoder_decoder=False,
+            fairness_engine="compute_share",
+            prefill_compute_share=share,
+        )
+
+
+def test_prefill_compute_share_cli_contract():
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+
+    namespace = parser.parse_args(
+        [
+            "--fairness-engine",
+            "compute_share",
+            "--prefill-compute-share",
+            "0.65",
+        ]
+    )
+    engine_args = EngineArgs.from_cli_args(namespace)
+
+    assert engine_args.prefill_compute_share == pytest.approx(0.65)
+    assert engine_args.fairness_engine == "compute_share"
+
+
+def test_prefill_compute_share_rejects_fixed_cadence():
+    with pytest.raises(ValueError, match="fairness_engine"):
+        SchedulerConfig(
+            max_model_len=128,
+            is_encoder_decoder=False,
+            fairness_engine="compute_share",
+            prefill_compute_share=0.5,
+            prefill_schedule_interval=2,
+        )
+
+
+def test_prefill_compute_share_rejects_unsynchronized_dp(opt_model_path):
+    with pytest.raises(ValueError, match="synchronized fairness decision"):
+        _create_fair_scheduler(opt_model_path, data_parallel_size=2)
+
+
+def test_disabled_scheduler_emits_no_compute_policy(opt_model_path):
+    scheduler = create_scheduler(
+        model=opt_model_path,
+        skip_tokenizer_init=True,
+        device="cpu",
+    )
+    (request,) = create_requests(num_requests=1, req_ids=["legacy"])
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert scheduler.compute_share_controller is None
+    assert output.compute_service_class is None
+    assert not output.compute_contention
+
+
+def test_decode_tie_then_prefill_and_work_conserving_fallback(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_batched_tokens=16,
+        max_model_len=128,
+    )
+    _establish_decode(scheduler)
+    (prefill,) = create_requests(
+        num_requests=1,
+        num_tokens=4,
+        req_ids=["prefill"],
+    )
+    scheduler.add_request(prefill)
+
+    decode_output = scheduler.schedule()
+    assert decode_output.compute_service_class == "decode"
+    assert decode_output.compute_contention
+    assert set(decode_output.num_scheduled_tokens) == {"decode"}
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+
+    prefill_output = scheduler.schedule()
+    assert prefill_output.compute_service_class == "prefill"
+    assert prefill_output.compute_contention
+    assert "prefill" in prefill_output.num_scheduled_tokens
+    # The selected short prefill cannot fill the batch, so decode consumes the
+    # genuinely remaining capacity in the same model step.
+    assert "decode" in prefill_output.num_scheduled_tokens
+
+
+def test_prefill_fcfs_and_capacity_bound_does_not_bypass_share(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_seqs=4,
+        max_num_batched_tokens=8,
+        max_model_len=128,
+    )
+    _establish_decode(scheduler)
+    first, second = create_requests(
+        num_requests=2,
+        num_tokens=16,
+        req_ids=["first", "second"],
+    )
+    scheduler.add_request(first)
+    scheduler.add_request(second)
+
+    decode_output = scheduler.schedule()
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+
+    # The legacy cadence escape must have no effect in adaptive mode.
+    scheduler.prefill_capacity_bound = True
+    prefill_output = scheduler.schedule()
+    assert prefill_output.compute_service_class == "prefill"
+    assert prefill_output.num_scheduled_tokens == {"first": 8}
+    assert second in scheduler.waiting
+
+
+def test_running_prefills_retain_fcfs_order(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_seqs=4,
+        max_num_batched_tokens=16,
+        max_model_len=128,
+        long_prefill_token_threshold=8,
+    )
+    _establish_decode(scheduler)
+    first, second = create_requests(
+        num_requests=2,
+        num_tokens=32,
+        req_ids=["first", "second"],
+    )
+    scheduler.add_request(first)
+    scheduler.add_request(second)
+
+    decode_output = scheduler.schedule()
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+    first_prefill_output = scheduler.schedule()
+    assert list(first_prefill_output.num_scheduled_tokens) == ["first", "second"]
+    scheduler.record_compute_time("prefill", 0.01, contended=True)
+    _update(scheduler, first_prefill_output)
+
+    second_decode_output = scheduler.schedule()
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, second_decode_output)
+    second_prefill_output = scheduler.schedule()
+
+    assert list(second_prefill_output.num_scheduled_tokens) == ["first", "second"]
+
+
+def test_prefill_turn_falls_back_when_prefill_is_alignment_blocked(
+    opt_model_path, monkeypatch
+):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_batched_tokens=16,
+        max_model_len=128,
+    )
+    _establish_decode(scheduler)
+    (prefill,) = create_requests(
+        num_requests=1,
+        num_tokens=32,
+        req_ids=["blocked-prefill"],
+    )
+    scheduler.add_request(prefill)
+    decode_output = scheduler.schedule()
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+
+    scheduler.need_mamba_block_aligned_split = True
+
+    def block_prefill(request, num_new_tokens, *_args):
+        return 0 if request.request_id == prefill.request_id else num_new_tokens
+
+    monkeypatch.setattr(scheduler, "_mamba_block_aligned_split", block_prefill)
+    output = scheduler.schedule()
+
+    assert output.compute_service_class == "decode"
+    assert output.num_scheduled_tokens == {"decode": 1}
+
+
+def test_decode_turn_falls_back_when_decode_is_no_longer_runnable(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_batched_tokens=16,
+        max_model_len=128,
+    )
+    decode = _establish_decode(scheduler)
+    # Model the async guard that can make a coarsely eligible decode unable to
+    # consume another step after the class decision has already been made.
+    decode.num_output_placeholders = 1
+    decode.max_tokens = 0
+    decode.sampling_params.max_tokens = 0
+    (prefill,) = create_requests(
+        num_requests=1,
+        num_tokens=32,
+        req_ids=["fallback-prefill"],
+    )
+    scheduler.add_request(prefill)
+
+    output = scheduler.schedule()
+
+    assert output.compute_service_class == "prefill"
+    assert output.num_scheduled_tokens == {prefill.request_id: 16}
+
+
+def test_decode_turn_falls_back_to_running_prefill(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_batched_tokens=16,
+        max_model_len=128,
+        long_prefill_token_threshold=8,
+    )
+    decode = _establish_decode(scheduler)
+    (prefill,) = create_requests(
+        num_requests=1,
+        num_tokens=32,
+        req_ids=["running-prefill"],
+    )
+    scheduler.add_request(prefill)
+    decode_output = scheduler.schedule()
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+    prefill_output = scheduler.schedule()
+    scheduler.record_compute_time("prefill", 0.01, contended=True)
+    _update(scheduler, prefill_output)
+    assert prefill.is_prefill_chunk
+
+    decode.num_output_placeholders = 1
+    decode.max_tokens = 0
+    decode.sampling_params.max_tokens = 0
+    fallback_output = scheduler.schedule()
+
+    assert fallback_output.compute_service_class == "prefill"
+    assert fallback_output.num_scheduled_tokens == {prefill.request_id: 8}
+
+
+def test_full_apc_hit_is_decode_not_prefill(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        enable_prefix_caching=True,
+        block_size=16,
+        max_model_len=128,
+    )
+    warm, hit = create_requests(
+        num_requests=2,
+        num_tokens=33,
+        same_prompt=True,
+        max_tokens=1,
+        req_ids=["warm", "hit"],
+    )
+    scheduler.add_request(warm)
+    warm_output = scheduler.schedule()
+    _update(scheduler, warm_output)
+    assert warm.request_id in scheduler.finished_req_ids
+
+    _establish_decode(scheduler)
+    scheduler.add_request(hit)
+    hit_output = scheduler.schedule()
+    assert hit_output.compute_service_class == "decode"
+    assert hit_output.num_scheduled_tokens["hit"] == 1
+
+
+def test_async_external_load_does_not_consume_service_credit(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        enable_prefix_caching=True,
+        block_size=16,
+        max_model_len=128,
+        use_kv_connector=mock_kv(matched_tokens=32, is_async=True),
+    )
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=64,
+        req_ids=["restore"],
+    )
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+    assert output.total_num_scheduled_tokens == 0
+    assert output.compute_service_class is None
+    assert not output.compute_contention
+    controller = scheduler.compute_share_controller
+    assert controller is not None
+    assert controller.decode_virtual_runtime == 0.0
+    assert controller.prefill_virtual_runtime == 0.0
+
+
+def test_partial_external_hit_is_prefill_compute(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        enable_prefix_caching=True,
+        block_size=16,
+        max_model_len=128,
+        use_kv_connector=mock_kv(matched_tokens=32, is_async=False),
+    )
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=64,
+        req_ids=["partial-restore"],
+    )
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    # The local remainder is prefill work, but there is no competing decode,
+    # so the controller does not install timing on this model step.
+    assert output.compute_service_class is None
+    assert not output.compute_contention
+    assert output.num_scheduled_tokens[request.request_id] == 32
+
+
+def test_only_contended_compute_is_exported_and_stats_drain(opt_model_path):
+    scheduler = _create_fair_scheduler(opt_model_path)
+
+    scheduler.record_compute_time("decode", 1.0, contended=False)
+    scheduler.record_compute_time("decode", 0.25, contended=True)
+    scheduler.record_compute_time("prefill", 0.75, contended=True)
+    stats = scheduler.make_stats()
+
+    assert stats is not None
+    assert stats.decode_compute_seconds == pytest.approx(0.25)
+    assert stats.prefill_compute_seconds == pytest.approx(0.75)
+    assert stats.prefill_compute_share == pytest.approx(0.5)
+
+    drained = scheduler.make_stats()
+    assert drained is not None
+    assert drained.decode_compute_seconds == 0.0
+    assert drained.prefill_compute_seconds == 0.0
+
+
+def test_speculative_decode_preserves_selected_prefill_quantum(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_batched_tokens=16,
+        max_model_len=128,
+        num_speculative_tokens=3,
+    )
+    _establish_decode(scheduler)
+    (prefill,) = create_requests(
+        num_requests=1,
+        num_tokens=32,
+        req_ids=["spec-prefill"],
+    )
+    scheduler.add_request(prefill)
+
+    decode_output = scheduler.schedule()
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+    prefill_output = scheduler.schedule()
+
+    assert prefill_output.compute_service_class == "prefill"
+    assert prefill_output.num_scheduled_tokens[prefill.request_id] == 16
+    assert "decode" not in prefill_output.num_scheduled_tokens
+
+
+def test_async_scheduler_preserves_compute_class_selection(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        async_scheduling=True,
+        max_num_batched_tokens=16,
+        max_model_len=128,
+    )
+    _establish_decode(scheduler)
+    (prefill,) = create_requests(
+        num_requests=1,
+        num_tokens=32,
+        req_ids=["async-prefill"],
+    )
+    scheduler.add_request(prefill)
+
+    decode_output = scheduler.schedule()
+    assert decode_output.compute_service_class == "decode"
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+    prefill_output = scheduler.schedule()
+
+    assert prefill_output.compute_service_class == "prefill"
+    assert prefill_output.num_scheduled_tokens[prefill.request_id] == 16

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3418,6 +3418,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.return_sampling_mask = False
     scheduler.recompute_kv_load_failures = False
     scheduler.defer_block_free = False
+    scheduler.acceptance_length_controller = None
     scheduler.make_stats = Mock(return_value=None)
     scheduler.max_model_len = 128
 

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -7,6 +7,7 @@ import vllm.envs as envs
 from tests.v1.kv_connector.unit.utils import MockKVConfig
 from vllm.config import (
     CacheConfig,
+    DeviceConfig,
     ECTransferConfig,
     KVTransferConfig,
     ModelConfig,
@@ -55,6 +56,13 @@ def create_scheduler(
     enable_chunked_prefill: bool = True,
     enable_prefix_caching: bool = False,
     long_prefill_token_threshold: int = 0,
+    fairness_engine: str | None = None,
+    prefill_compute_share: float | None = None,
+    max_num_prefill_tokens_per_step: int = 0,
+    max_num_partial_prefills: int = 0,
+    decode_prefill_min_decode_steps: int = 0,
+    decode_prefill_max_wait_ms: int = 0,
+    device: str = "auto",
     disable_chunked_mm_input: bool = False,
     use_kv_connector: None | bool | str | MockKVConfig = None,
     kv_role: str = "kv_both",
@@ -106,6 +114,12 @@ def create_scheduler(
         max_num_batched_tokens=max_num_batched_tokens,
         max_model_len=max_model_len,
         long_prefill_token_threshold=long_prefill_token_threshold,
+        fairness_engine=fairness_engine,
+        prefill_compute_share=prefill_compute_share,
+        max_num_prefill_tokens_per_step=max_num_prefill_tokens_per_step,
+        max_num_partial_prefills=max_num_partial_prefills,
+        decode_prefill_min_decode_steps=decode_prefill_min_decode_steps,
+        decode_prefill_max_wait_ms=decode_prefill_max_wait_ms,
         disable_chunked_mm_input=disable_chunked_mm_input,
         enable_chunked_prefill=enable_chunked_prefill,
         async_scheduling=async_scheduling,
@@ -182,6 +196,7 @@ def create_scheduler(
     )
 
     vllm_config = VllmConfig(
+        device_config=DeviceConfig(device=device),
         scheduler_config=scheduler_config,
         model_config=model_config,
         cache_config=cache_config,

--- a/tests/v1/engine/test_compute_fairness_feedback.py
+++ b/tests/v1/engine/test_compute_fairness_feedback.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from concurrent.futures import Future
+from unittest.mock import Mock, call, patch
+
+import pytest
+
+from vllm.v1.core.sched.compute_fairness import ComputeServiceClass
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.engine.core import EngineCore, _ModelExecutionTiming
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _scheduler_output(
+    service_class: ComputeServiceClass | None,
+    *,
+    contended: bool = False,
+) -> SchedulerOutput:
+    output = SchedulerOutput.make_empty()
+    output.compute_service_class = service_class
+    output.compute_contention = contended
+    return output
+
+
+def test_completion_callback_excludes_later_batch_queue_residency():
+    future: Future[None] = Future()
+    with patch("vllm.v1.engine.core.time.perf_counter", side_effect=[10.0, 10.25]):
+        timing = _ModelExecutionTiming()
+        timing.bind(future)
+        future.set_result(None)
+
+    # Reading much later must use the completion callback's timestamp.
+    assert timing.elapsed_seconds == pytest.approx(0.25)
+
+
+def test_disabled_output_does_not_install_execution_timing():
+    completed_future: Future[None] = Future()
+    completed_future.set_result(None)
+    engine = object.__new__(EngineCore)
+    engine.model_executor = Mock()
+    engine.model_executor.execute_model.return_value = completed_future
+
+    future, timing = engine._execute_model(_scheduler_output(None))
+
+    assert future is completed_future
+    assert timing is None
+
+
+def test_enabled_execution_timer_waits_for_final_batch_future():
+    execute_future: Future[None] = Future()
+    execute_future.set_result(None)
+    final_future: Future[None] = Future()
+    engine = object.__new__(EngineCore)
+    engine.model_executor = Mock()
+    engine.model_executor.execute_model.return_value = execute_future
+
+    _, timing = engine._execute_model(_scheduler_output("prefill", contended=True))
+    assert timing is not None
+    assert timing.completed_at is None
+
+    timing.bind(final_future)
+    assert timing.completed_at is None
+    final_future.set_result(None)
+    assert timing.completed_at is not None
+
+
+def test_queued_feedback_stays_paired_with_exact_batch():
+    engine = object.__new__(EngineCore)
+    engine.scheduler = Mock()
+    engine._last_model_completion_time = None
+    decode_output = _scheduler_output("decode", contended=True)
+    prefill_output = _scheduler_output("prefill", contended=True)
+    decode_timing = _ModelExecutionTiming()
+    decode_timing.started_at = 10.0
+    decode_timing.completed_at = 10.1
+    prefill_timing = _ModelExecutionTiming()
+    prefill_timing.started_at = 10.01
+    prefill_timing.completed_at = 10.3
+
+    # Queued batches are consumed oldest-first; each carries its own timing and
+    # class tag even when a later batch has already completed. The second
+    # charge excludes its 90 ms queued behind the first batch.
+    engine._record_compute_time(decode_output, decode_timing)
+    engine._record_compute_time(prefill_output, prefill_timing)
+
+    assert engine.scheduler.record_compute_time.call_args_list == [
+        call("decode", pytest.approx(0.1), contended=True),
+        call("prefill", pytest.approx(0.2), contended=True),
+    ]
+
+
+def test_empty_transfer_step_does_not_record_compute():
+    engine = object.__new__(EngineCore)
+    engine.scheduler = Mock()
+
+    engine._record_compute_time(_scheduler_output(None), None)
+
+    engine.scheduler.record_compute_time.assert_not_called()

--- a/tests/v1/engine/test_prefill_fairness_runtime.py
+++ b/tests/v1/engine/test_prefill_fairness_runtime.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from vllm.v1.engine.core import EngineCore
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_engine_core_rejects_busy_policy_change():
+    scheduler = Mock()
+    scheduler.has_unfinished_requests.return_value = True
+    scheduler.get_prefill_fairness.return_value = {"fairness_engine": None}
+    core = SimpleNamespace(scheduler=scheduler, batch_queue=None)
+
+    result = EngineCore.set_prefill_fairness(
+        core,
+        {
+            "fairness_engine": "compute_share",
+            "prefill_compute_share": 0.5,
+        },
+    )
+
+    assert result["applied"] is False
+    assert result["reason"] == "busy"
+    scheduler.set_prefill_fairness.assert_not_called()
+
+
+def test_engine_core_rejects_queued_batch_policy_change():
+    scheduler = Mock()
+    scheduler.has_unfinished_requests.return_value = False
+    scheduler.get_prefill_fairness.return_value = {"fairness_engine": None}
+    core = SimpleNamespace(scheduler=scheduler, batch_queue=[object()])
+
+    result = EngineCore.set_prefill_fairness(core, {"fairness_engine": None})
+
+    assert result["applied"] is False
+    assert result["reason"] == "busy"
+    scheduler.set_prefill_fairness.assert_not_called()
+
+
+def test_engine_core_applies_idle_policy_change():
+    scheduler = Mock()
+    scheduler.has_unfinished_requests.return_value = False
+    scheduler.set_prefill_fairness.return_value = {
+        "fairness_engine": "compute_share",
+        "prefill_compute_share": 0.5,
+    }
+    core = SimpleNamespace(scheduler=scheduler, batch_queue=None)
+    config = {
+        "fairness_engine": "compute_share",
+        "prefill_compute_share": 0.5,
+    }
+
+    result = EngineCore.set_prefill_fairness(core, config)
+
+    assert result["applied"] is True
+    assert result["config"] == scheduler.set_prefill_fairness.return_value
+    scheduler.set_prefill_fairness.assert_called_once_with(config)
+
+
+def test_engine_core_returns_invalid_policy_without_mutating_engine():
+    scheduler = Mock()
+    scheduler.has_unfinished_requests.return_value = False
+    scheduler.set_prefill_fairness.side_effect = ValueError("bad policy")
+    scheduler.get_prefill_fairness.return_value = {"fairness_engine": None}
+    core = SimpleNamespace(scheduler=scheduler, batch_queue=None)
+
+    result = EngineCore.set_prefill_fairness(core, {"fairness_engine": "bad"})
+
+    assert result["applied"] is False
+    assert result["reason"] == "invalid"
+    assert result["config"] == {"fairness_engine": None}

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -20,6 +20,7 @@ logger = init_logger(__name__)
 
 RunnerType = Literal["generate", "pooling", "draft"]
 SchedulerPolicy = Literal["fcfs", "priority"]
+FairnessEngine = Literal["compute_share", "micro_slicing"]
 
 
 @config
@@ -144,6 +145,48 @@ class SchedulerConfig:
     """Schedule prefill work once every N engine steps while decode requests
     are running. Data-parallel engines align the cadence across DP ranks."""
 
+    fairness_engine: FairnessEngine | None = None
+    """Optional decode/prefill fairness policy.
+
+    ``compute_share`` uses measured accelerator time to target a prefill share.
+    ``micro_slicing`` bounds local prefill work in mixed decode/prefill steps.
+    When unset, the legacy scheduler path is unchanged.
+    """
+
+    prefill_compute_share: float | None = Field(default=None, gt=0.0, lt=1.0)
+    """Target fraction of contended model-execution time assigned to prefill.
+
+    When unset, scheduling behavior is unchanged. Values must be strictly
+    between zero and one so both decode and prefill continue to make progress.
+    """
+
+    max_num_prefill_tokens_per_step: int = Field(default=0, ge=0)
+    """Maximum local prefill tokens in a step that also has eligible decode.
+
+    Used only by ``micro_slicing``. Zero disables the separate mixed-step
+    budget; prefill-only steps retain the normal batched-token budget.
+    """
+
+    max_num_partial_prefills: int = Field(default=0, ge=0)
+    """Maximum locally-computing partial prefills under ``micro_slicing``.
+
+    Zero means unlimited. Asynchronous external-cache restores do not consume
+    this limit because they do not use model compute.
+    """
+
+    decode_prefill_min_decode_steps: int = Field(default=0, ge=0)
+    """Minimum decode-only steps between mixed-prefill service opportunities.
+
+    Used only by ``micro_slicing``; zero disables decode-burst spacing.
+    """
+
+    decode_prefill_max_wait_ms: int = Field(default=0, ge=0)
+    """Maximum prefill waiter age before bypassing decode-burst spacing.
+
+    Zero disables the deadline. A positive value requires a positive
+    ``decode_prefill_min_decode_steps``.
+    """
+
     async_scheduling: bool | None = None
     """If set to False, disable async scheduling. Async scheduling helps to
     avoid gaps in GPU utilization, leading to better latency and throughput.
@@ -224,6 +267,64 @@ class SchedulerConfig:
         return None if value is None else handler(value)
 
     def __post_init__(self, max_model_len: int, is_encoder_decoder: bool) -> None:
+        compute_configured = self.prefill_compute_share is not None
+        micro_values = (
+            self.max_num_prefill_tokens_per_step,
+            self.max_num_partial_prefills,
+            self.decode_prefill_min_decode_steps,
+            self.decode_prefill_max_wait_ms,
+        )
+        micro_configured = any(micro_values)
+
+        if self.fairness_engine is None and (compute_configured or micro_configured):
+            raise ValueError(
+                "fairness_engine must be selected when fairness tuning options "
+                "are configured"
+            )
+        if self.fairness_engine == "compute_share":
+            if not compute_configured:
+                raise ValueError(
+                    "prefill_compute_share is required for fairness_engine="
+                    "compute_share"
+                )
+            if micro_configured:
+                raise ValueError(
+                    "micro-slicing options cannot be combined with "
+                    "fairness_engine=compute_share"
+                )
+        elif self.fairness_engine == "micro_slicing":
+            if compute_configured:
+                raise ValueError(
+                    "prefill_compute_share cannot be combined with "
+                    "fairness_engine=micro_slicing"
+                )
+            if self.max_num_prefill_tokens_per_step <= 0:
+                raise ValueError(
+                    "max_num_prefill_tokens_per_step must be positive for "
+                    "fairness_engine=micro_slicing"
+                )
+            if self.max_num_prefill_tokens_per_step > self.max_num_batched_tokens:
+                raise ValueError(
+                    "max_num_prefill_tokens_per_step cannot exceed "
+                    "max_num_batched_tokens"
+                )
+            if self.max_num_partial_prefills > self.max_num_seqs:
+                raise ValueError("max_num_partial_prefills cannot exceed max_num_seqs")
+            if (
+                self.decode_prefill_max_wait_ms > 0
+                and self.decode_prefill_min_decode_steps == 0
+            ):
+                raise ValueError(
+                    "decode_prefill_max_wait_ms requires a positive "
+                    "decode_prefill_min_decode_steps"
+                )
+
+        if self.fairness_engine is not None and self.prefill_schedule_interval > 1:
+            raise ValueError(
+                "fairness_engine cannot be combined with "
+                "prefill_schedule_interval greater than one"
+            )
+
         if is_encoder_decoder:
             # Chunked prefill should be disabled for encoder-decoder models.
             self.disable_chunked_mm_input = True

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1133,6 +1133,15 @@ class VllmConfig:
         # unset falls back to the stock ones.
         self.parallel_config.set_dcp_defaults()
 
+        if (
+            self.scheduler_config.fairness_engine is not None
+            and self.parallel_config.data_parallel_size > 1
+        ):
+            raise ValueError(
+                "fairness_engine does not yet support data parallelism; all DP "
+                "ranks must make one synchronized fairness decision"
+            )
+
         if self.model_config is not None:
             self.model_config.verify_with_parallel_config(self.parallel_config)
             self.model_config.verify_dual_chunk_attention_config(self.load_config)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -634,6 +634,16 @@ class EngineArgs:
 
     scheduler_reserve_full_isl: bool = SchedulerConfig.scheduler_reserve_full_isl
     prefill_schedule_interval: int = SchedulerConfig.prefill_schedule_interval
+    fairness_engine: str | None = SchedulerConfig.fairness_engine
+    prefill_compute_share: float | None = SchedulerConfig.prefill_compute_share
+    max_num_prefill_tokens_per_step: int = (
+        SchedulerConfig.max_num_prefill_tokens_per_step
+    )
+    max_num_partial_prefills: int = SchedulerConfig.max_num_partial_prefills
+    decode_prefill_min_decode_steps: int = (
+        SchedulerConfig.decode_prefill_min_decode_steps
+    )
+    decode_prefill_max_wait_ms: int = SchedulerConfig.decode_prefill_max_wait_ms
 
     watermark: float = SchedulerConfig.watermark
 
@@ -1587,6 +1597,30 @@ class EngineArgs:
             **scheduler_kwargs["prefill_schedule_interval"],
         )
         scheduler_group.add_argument(
+            "--fairness-engine",
+            **scheduler_kwargs["fairness_engine"],
+        )
+        scheduler_group.add_argument(
+            "--prefill-compute-share",
+            **scheduler_kwargs["prefill_compute_share"],
+        )
+        scheduler_group.add_argument(
+            "--max-num-prefill-tokens-per-step",
+            **scheduler_kwargs["max_num_prefill_tokens_per_step"],
+        )
+        scheduler_group.add_argument(
+            "--max-num-partial-prefills",
+            **scheduler_kwargs["max_num_partial_prefills"],
+        )
+        scheduler_group.add_argument(
+            "--decode-prefill-min-decode-steps",
+            **scheduler_kwargs["decode_prefill_min_decode_steps"],
+        )
+        scheduler_group.add_argument(
+            "--decode-prefill-max-wait-ms",
+            **scheduler_kwargs["decode_prefill_max_wait_ms"],
+        )
+        scheduler_group.add_argument(
             "--disable-hybrid-kv-cache-manager",
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"],
         )
@@ -2367,6 +2401,12 @@ class EngineArgs:
             scheduler_reserve_full_isl=self.scheduler_reserve_full_isl,
             watermark=self.watermark,
             prefill_schedule_interval=self.prefill_schedule_interval,
+            fairness_engine=self.fairness_engine,
+            prefill_compute_share=self.prefill_compute_share,
+            max_num_prefill_tokens_per_step=(self.max_num_prefill_tokens_per_step),
+            max_num_partial_prefills=self.max_num_partial_prefills,
+            decode_prefill_min_decode_steps=(self.decode_prefill_min_decode_steps),
+            decode_prefill_max_wait_ms=self.decode_prefill_max_wait_ms,
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -163,6 +163,16 @@ class EngineClient(ABC):
         ...
 
     @abstractmethod
+    async def get_prefill_fairness(self) -> dict[str, Any]:
+        """Return the active decode/prefill fairness policy."""
+        ...
+
+    @abstractmethod
+    async def set_prefill_fairness(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Replace fairness policy settings without reloading the model."""
+        ...
+
+    @abstractmethod
     async def sleep(self, level: int = 1, mode: "PauseMode" = "abort") -> None:
         """Sleep the engine"""
         ...

--- a/vllm/entrypoints/serve/__init__.py
+++ b/vllm/entrypoints/serve/__init__.py
@@ -50,6 +50,10 @@ def register_vllm_dev_api_routers(app: FastAPI):
 
     attach_cache_router(app)
 
+    from .dev.fairness.api_router import attach_router as attach_fairness_router
+
+    attach_fairness_router(app)
+
     from .dev.rlhf.api_router import attach_router as attach_rlhf_router
 
     attach_rlhf_router(app)

--- a/vllm/entrypoints/serve/dev/fairness/api_router.py
+++ b/vllm/entrypoints/serve/dev/fairness/api_router.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, FastAPI, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from vllm.engine.protocol import EngineClient
+
+router = APIRouter()
+
+
+class PrefillFairnessRequest(BaseModel):
+    """Complete replacement configuration for prefill fairness."""
+
+    fairness_engine: Literal["compute_share", "micro_slicing"] | None = None
+    prefill_compute_share: Annotated[float | None, Field(gt=0.0, lt=1.0)] = None
+    max_num_prefill_tokens_per_step: Annotated[int, Field(ge=0)] = 0
+    max_num_partial_prefills: Annotated[int, Field(ge=0)] = 0
+    decode_prefill_min_decode_steps: Annotated[int, Field(ge=0)] = 0
+    decode_prefill_max_wait_ms: Annotated[int, Field(ge=0)] = 0
+
+
+def engine_client(request: Request) -> EngineClient:
+    return request.app.state.engine_client
+
+
+@router.get("/prefill_fairness")
+async def get_prefill_fairness(raw_request: Request):
+    """Return the active fairness engine and all tuning parameters."""
+    config = await engine_client(raw_request).get_prefill_fairness()
+    return JSONResponse(content=config)
+
+
+@router.post("/prefill_fairness")
+async def set_prefill_fairness(raw_request: Request, config: PrefillFairnessRequest):
+    """Switch policy at idle without reloading weights or clearing caches."""
+    result = await engine_client(raw_request).set_prefill_fairness(config.model_dump())
+    status_code = 200
+    if not result["applied"]:
+        status_code = 409 if result["reason"] == "busy" else 422
+    return JSONResponse(content=result, status_code=status_code)
+
+
+def attach_router(app: FastAPI):
+    app.include_router(router)

--- a/vllm/v1/core/sched/compute_fairness.py
+++ b/vllm/v1/core/sched/compute_fairness.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Literal
+
+ComputeServiceClass = Literal["decode", "prefill"]
+
+
+@dataclass
+class PrefillComputeShareController:
+    """Allocate contended execution time with weighted virtual runtime."""
+
+    prefill_compute_share: float
+    decode_virtual_runtime: float = 0.0
+    prefill_virtual_runtime: float = 0.0
+    contention_active: bool = False
+    last_decode_seconds: float | None = None
+    last_prefill_seconds: float | None = None
+    decode_reservations: deque[float] = field(default_factory=deque)
+    prefill_reservations: deque[float] = field(default_factory=deque)
+
+    def select(
+        self, *, decode_runnable: bool, prefill_runnable: bool
+    ) -> ComputeServiceClass | None:
+        """Select the next runnable service class."""
+        if not decode_runnable or not prefill_runnable:
+            if not self.has_pending_reservations:
+                self.reset()
+            if decode_runnable:
+                return "decode"
+            if prefill_runnable:
+                return "prefill"
+            return None
+
+        if not self.contention_active:
+            self.decode_virtual_runtime = 0.0
+            self.prefill_virtual_runtime = 0.0
+            self.contention_active = True
+
+        # Until a class has one measured completion, allow only one of its
+        # quanta in flight when the other class can run. This prevents an async
+        # batch queue from filling with duplicate, unpriced work at startup.
+        decode_unmeasured = self.last_decode_seconds is None and bool(
+            self.decode_reservations
+        )
+        prefill_unmeasured = self.last_prefill_seconds is None and bool(
+            self.prefill_reservations
+        )
+        if decode_unmeasured != prefill_unmeasured:
+            return "prefill" if decode_unmeasured else "decode"
+        if decode_unmeasured and prefill_unmeasured:
+            if len(self.decode_reservations) < len(self.prefill_reservations):
+                return "decode"
+            if len(self.prefill_reservations) < len(self.decode_reservations):
+                return "prefill"
+
+        if self.prefill_virtual_runtime < self.decode_virtual_runtime:
+            return "prefill"
+        return "decode"
+
+    @property
+    def has_pending_reservations(self) -> bool:
+        return bool(self.decode_reservations or self.prefill_reservations)
+
+    def dispatch(self, service_class: ComputeServiceClass, *, contended: bool) -> None:
+        """Reserve estimated service before an async batch can be selected."""
+        if not contended:
+            return
+
+        if service_class == "prefill":
+            reservation = (
+                0.0
+                if self.last_prefill_seconds is None
+                else self.last_prefill_seconds / self.prefill_compute_share
+            )
+            self.prefill_virtual_runtime += reservation
+            self.prefill_reservations.append(reservation)
+        else:
+            reservation = (
+                0.0
+                if self.last_decode_seconds is None
+                else self.last_decode_seconds / (1.0 - self.prefill_compute_share)
+            )
+            self.decode_virtual_runtime += reservation
+            self.decode_reservations.append(reservation)
+
+    def record(
+        self,
+        service_class: ComputeServiceClass,
+        elapsed_seconds: float,
+        *,
+        contended: bool,
+    ) -> None:
+        """Charge a completed execution quantum to its actual service class."""
+        if not contended:
+            return
+
+        if service_class == "prefill":
+            reservation = (
+                self.prefill_reservations.popleft()
+                if self.prefill_reservations
+                else 0.0
+            )
+            if elapsed_seconds <= 0.0:
+                self.prefill_virtual_runtime -= reservation
+                return
+            charge = elapsed_seconds / self.prefill_compute_share
+            self.prefill_virtual_runtime += charge - reservation
+            self.last_prefill_seconds = elapsed_seconds
+            if self.prefill_virtual_runtime - self.decode_virtual_runtime > charge:
+                self.decode_virtual_runtime = self.prefill_virtual_runtime - charge
+        else:
+            reservation = (
+                self.decode_reservations.popleft() if self.decode_reservations else 0.0
+            )
+            if elapsed_seconds <= 0.0:
+                self.decode_virtual_runtime -= reservation
+                return
+            charge = elapsed_seconds / (1.0 - self.prefill_compute_share)
+            self.decode_virtual_runtime += charge - reservation
+            self.last_decode_seconds = elapsed_seconds
+            if self.decode_virtual_runtime - self.prefill_virtual_runtime > charge:
+                self.prefill_virtual_runtime = self.decode_virtual_runtime - charge
+
+    def reset(self) -> None:
+        """Discard credit when both classes are no longer runnable."""
+        self.decode_virtual_runtime = 0.0
+        self.prefill_virtual_runtime = 0.0
+        self.contention_active = False

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -3,7 +3,7 @@
 import enum
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from vllm.config.kv_events import KVEventsConfig
     from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorBase
     from vllm.distributed.kv_transfer.kv_connector.v1 import KVConnectorBase_V1
+    from vllm.v1.core.sched.compute_fairness import ComputeServiceClass
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
     from vllm.v1.engine import EngineCoreOutputs
     from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -88,6 +89,16 @@ class SchedulerInterface(ABC):
             A SchedulerOutput object containing information about the scheduled
             requests.
         """
+        raise NotImplementedError
+
+    def record_compute_time(
+        self,
+        service_class: "ComputeServiceClass",
+        elapsed_seconds: float,
+        *,
+        contended: bool,
+    ) -> None:
+        """Record model-execution feedback for adaptive scheduling."""
         raise NotImplementedError
 
     @abstractmethod
@@ -227,6 +238,14 @@ class SchedulerInterface(ABC):
                 will only reset the KV prefix cache when there is no running request
                 taking KV cache.
         """
+        raise NotImplementedError
+
+    def get_prefill_fairness(self) -> dict[str, Any]:
+        """Return the active decode/prefill fairness configuration."""
+        raise NotImplementedError
+
+    def set_prefill_fairness(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Replace the fairness configuration at an idle engine boundary."""
         raise NotImplementedError
 
     @abstractmethod

--- a/vllm/v1/core/sched/micro_slicing.py
+++ b/vllm/v1/core/sched/micro_slicing.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MicroSlicingSettings:
+    """Runtime-tunable parameters for mixed decode/prefill micro-slicing."""
+
+    max_num_prefill_tokens_per_step: int
+    max_num_partial_prefills: int = 0
+    decode_prefill_min_decode_steps: int = 0
+    decode_prefill_max_wait_ms: int = 0
+
+
+@dataclass
+class MicroSlicingController:
+    """Bound local prefill work while preserving decode progress.
+
+    The controller owns policy state only. Request admission, KV allocation,
+    and external-cache transfers remain scheduler responsibilities.
+    """
+
+    settings: MicroSlicingSettings
+    quantum: int = 1
+    steps_since_prefill: int = 0
+    rotation: int = 0
+    scheduled_prefill_tokens: int = 0
+    decode_only_steps: int = 0
+    fairness_bypasses: int = 0
+
+    def __post_init__(self) -> None:
+        self._validate(self.settings)
+
+    def update(self, settings: MicroSlicingSettings) -> None:
+        """Replace settings and discard policy history at an idle boundary."""
+        self._validate(settings)
+        self.settings = settings
+        self.steps_since_prefill = 0
+        self.rotation = 0
+
+    def should_defer_prefill(
+        self,
+        *,
+        has_eligible_decode: bool,
+        has_pending_prefill: bool,
+        oldest_waiter_age_ms: float,
+    ) -> tuple[bool, bool]:
+        """Return ``(defer, deadline_bypass_candidate)`` for this step."""
+        min_decode_steps = self.settings.decode_prefill_min_decode_steps
+        burst_would_defer = (
+            min_decode_steps > 0
+            and has_eligible_decode
+            and has_pending_prefill
+            and self.steps_since_prefill < min_decode_steps
+        )
+        deadline_bypass = (
+            burst_would_defer
+            and self.settings.decode_prefill_max_wait_ms > 0
+            and oldest_waiter_age_ms >= self.settings.decode_prefill_max_wait_ms
+        )
+        return burst_would_defer and not deadline_bypass, deadline_bypass
+
+    def select_running_limits(
+        self, request_ids: list[str], available_tokens: int
+    ) -> dict[str, int]:
+        """Distribute the remaining mixed-step budget in rotating quanta."""
+        num_quanta = available_tokens // self.quantum
+        if num_quanta <= 0 or not request_ids:
+            return {}
+
+        start = self.rotation % len(request_ids)
+        base_quanta, remainder = divmod(num_quanta, len(request_ids))
+        limits = {
+            request_id: base_quanta * self.quantum
+            for request_id in request_ids
+            if base_quanta > 0
+        }
+        for offset in range(remainder):
+            request_id = request_ids[(start + offset) % len(request_ids)]
+            limits[request_id] = limits.get(request_id, 0) + self.quantum
+
+        # Rotate even when every request received the same number of quanta so
+        # a later, smaller budget does not always begin with the same request.
+        advance = remainder if remainder else 1
+        self.rotation = (start + advance) % len(request_ids)
+        return limits
+
+    def observe_step(
+        self,
+        *,
+        has_eligible_decode: bool,
+        had_pending_prefill: bool,
+        scheduled_decode_tokens: int,
+        scheduled_prefill_tokens: int,
+        deadline_bypass_candidate: bool,
+    ) -> None:
+        """Advance burst history and interval counters from actual work."""
+        if scheduled_prefill_tokens > 0:
+            self.steps_since_prefill = 0
+            self.scheduled_prefill_tokens += scheduled_prefill_tokens
+            if deadline_bypass_candidate:
+                self.fairness_bypasses += 1
+            return
+
+        if has_eligible_decode and scheduled_decode_tokens > 0:
+            # Decode service before a waiter arrives still satisfies the future
+            # minimum-decode interval. Saturation keeps the counter bounded.
+            min_decode_steps = self.settings.decode_prefill_min_decode_steps
+            if min_decode_steps > 0:
+                self.steps_since_prefill = min(
+                    self.steps_since_prefill + 1, min_decode_steps
+                )
+            if had_pending_prefill:
+                self.decode_only_steps += 1
+            return
+
+        if not has_eligible_decode:
+            self.steps_since_prefill = 0
+
+    def drain_stats(self, *, active_partial_prefills: int) -> dict[str, int]:
+        stats = {
+            "scheduled_prefill_tokens": self.scheduled_prefill_tokens,
+            "active_partial_prefills": active_partial_prefills,
+            "decode_only_steps": self.decode_only_steps,
+            "fairness_bypasses": self.fairness_bypasses,
+        }
+        self.scheduled_prefill_tokens = 0
+        self.decode_only_steps = 0
+        self.fairness_bypasses = 0
+        return stats
+
+    def _validate(self, settings: MicroSlicingSettings) -> None:
+        if settings.max_num_prefill_tokens_per_step <= 0:
+            raise ValueError("max_num_prefill_tokens_per_step must be positive")
+        if settings.max_num_prefill_tokens_per_step % self.quantum != 0:
+            raise ValueError(
+                "max_num_prefill_tokens_per_step must be a multiple of "
+                f"the scheduler prefill quantum ({self.quantum})"
+            )
+        if settings.max_num_partial_prefills < 0:
+            raise ValueError("max_num_partial_prefills cannot be negative")
+        if settings.decode_prefill_min_decode_steps < 0:
+            raise ValueError("decode_prefill_min_decode_steps cannot be negative")
+        if settings.decode_prefill_max_wait_ms < 0:
+            raise ValueError("decode_prefill_max_wait_ms cannot be negative")
+        if (
+            settings.decode_prefill_max_wait_ms > 0
+            and settings.decode_prefill_min_decode_steps == 0
+        ):
+            raise ValueError(
+                "decode_prefill_max_wait_ms requires decode_prefill_min_decode_steps"
+            )

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from vllm.config.ec_manager_config import EncoderCacheManagerMetadata
 from vllm.multimodal.utils import strip_covered_mm_data
+from vllm.v1.core.sched.compute_fairness import ComputeServiceClass
 
 if TYPE_CHECKING:
     import numpy as np
@@ -283,6 +284,11 @@ class SchedulerOutput:
     # Dynamic speculative decoding: optimal K chosen by scheduler.
     # Number of spec tokens to schedule for the next step.
     num_spec_tokens_to_schedule: int | None = None
+
+    # Explicit model-execution class used by adaptive compute fairness.
+    # None identifies a transfer-only or otherwise empty model step.
+    compute_service_class: ComputeServiceClass | None = None
+    compute_contention: bool = False
 
     @classmethod
     def make_empty(cls) -> "SchedulerOutput":

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
+import math
 import time
 from collections import defaultdict, deque
 from collections.abc import Iterable
@@ -38,7 +39,15 @@ from vllm.v1.core.encoder_cache_manager import (
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import KVCacheBlock
+from vllm.v1.core.sched.compute_fairness import (
+    ComputeServiceClass,
+    PrefillComputeShareController,
+)
 from vllm.v1.core.sched.interface import PauseState, SchedulerInterface
+from vllm.v1.core.sched.micro_slicing import (
+    MicroSlicingController,
+    MicroSlicingSettings,
+)
 from vllm.v1.core.sched.output import (
     CachedRequestData,
     GrammarOutput,
@@ -332,6 +341,16 @@ class Scheduler(SchedulerInterface):
         # prefill batch fully drained the waiting queue. Prefill throttling
         # is disabled in this case.
         self.prefill_capacity_bound = False
+        fairness_engine = self.scheduler_config.fairness_engine
+        prefill_compute_share = self.scheduler_config.prefill_compute_share
+        self.compute_share_controller = (
+            PrefillComputeShareController(prefill_compute_share)
+            if fairness_engine == "compute_share" and prefill_compute_share is not None
+            else None
+        )
+        self.micro_slicing_controller: MicroSlicingController | None = None
+        self._decode_compute_seconds = 0.0
+        self._prefill_compute_seconds = 0.0
         self.scheduler_reserve_full_isl = (
             self.scheduler_config.scheduler_reserve_full_isl
         )
@@ -344,6 +363,35 @@ class Scheduler(SchedulerInterface):
         self.need_mamba_block_aligned_split = (
             self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
         )
+        mamba_block_sizes = [
+            group.kv_cache_spec.block_size
+            for group in kv_cache_config.kv_cache_groups
+            if isinstance(group.kv_cache_spec, MambaSpec)
+        ]
+        prefill_quantum = (
+            math.lcm(*mamba_block_sizes)
+            if self.need_mamba_block_aligned_split and mamba_block_sizes
+            else 1
+        )
+        self.prefill_fairness_quantum = prefill_quantum
+        if fairness_engine == "micro_slicing":
+            self.micro_slicing_controller = MicroSlicingController(
+                settings=MicroSlicingSettings(
+                    max_num_prefill_tokens_per_step=(
+                        self.scheduler_config.max_num_prefill_tokens_per_step
+                    ),
+                    max_num_partial_prefills=(
+                        self.scheduler_config.max_num_partial_prefills
+                    ),
+                    decode_prefill_min_decode_steps=(
+                        self.scheduler_config.decode_prefill_min_decode_steps
+                    ),
+                    decode_prefill_max_wait_ms=(
+                        self.scheduler_config.decode_prefill_max_wait_ms
+                    ),
+                ),
+                quantum=prefill_quantum,
+            )
         glm5_next_mtp_has_independent_draft_state = (
             speculative_config is not None
             and speculative_config.method == "mtp"
@@ -544,6 +592,34 @@ class Scheduler(SchedulerInterface):
             num_new_tokens -= self.num_prefill_lookahead - remaining
         return max(num_new_tokens, 0)
 
+    @staticmethod
+    def _request_has_local_prefill(request: Request) -> bool:
+        """Whether a request still needs model compute for its input."""
+        return request.is_prefill_chunk or (
+            request.status in (RequestStatus.WAITING, RequestStatus.PREEMPTED)
+            and request.num_computed_tokens < request.num_tokens - 1
+        )
+
+    def _has_pending_local_prefill(self) -> bool:
+        return any(
+            self._request_has_local_prefill(request)
+            for request in (*self.running, *self.waiting, *self.skipped_waiting)
+        )
+
+    def _oldest_local_prefill_waiter_age_ms(self, now: float) -> float:
+        arrival_times = (
+            request.arrival_time
+            for request in (*self.waiting, *self.skipped_waiting)
+            if self._request_has_local_prefill(request)
+        )
+        oldest_arrival = min(arrival_times, default=now)
+        return max((now - oldest_arrival) * 1000.0, 0.0)
+
+    @property
+    def num_active_local_partial_prefills(self) -> int:
+        """Count model-compute partials, excluding async KV-only restores."""
+        return sum(request.is_prefill_chunk for request in self.running)
+
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         self.current_step += 1
         # NOTE(woosuk) on the scheduling algorithm:
@@ -579,6 +655,7 @@ class Scheduler(SchedulerInterface):
         scheduled_spec_decode_tokens: dict[str, list[int]] = {}
         # Whether the running batch contains any prefill requests.
         prefill_scheduled = False
+        scheduled_prefill_req_ids: set[str] = set()
 
         # For logging.
         scheduled_timestamp = time.monotonic()
@@ -594,223 +671,392 @@ class Scheduler(SchedulerInterface):
             and self.current_step >= request.next_decode_eligible_step
             for request in self.running
         )
-        defer_prefills = (
+        selected_compute_class: ComputeServiceClass | None = None
+        compute_contention = False
+        if self.compute_share_controller is not None:
+            has_prefill_candidate = self._pause_state != PauseState.PAUSED_ALL and (
+                any(
+                    request.is_prefill_chunk
+                    and self.current_step >= request.next_decode_eligible_step
+                    for request in self.running
+                )
+                or (
+                    self._pause_state == PauseState.UNPAUSED
+                    and bool(self.waiting or self.skipped_waiting)
+                )
+            )
+            selected_compute_class = self.compute_share_controller.select(
+                decode_runnable=has_eligible_decode,
+                prefill_runnable=has_prefill_candidate,
+            )
+            compute_contention = has_eligible_decode and has_prefill_candidate
+
+        legacy_defer_prefills = (
             throttle_prefills and not self.prefill_capacity_bound
         ) and has_eligible_decode
-
-        # First, schedule the RUNNING requests.
-        req_index = 0
-        while req_index < len(self.running) and token_budget > 0:
-            request = self.running[req_index]
-            if input_budget <= draft_slots:
-                break
-
+        adaptive_defer_prefills = (
+            selected_compute_class == "decode" and compute_contention
+        )
+        micro_controller = self.micro_slicing_controller
+        micro_has_pending_prefill = False
+        micro_defer_prefills = False
+        micro_deadline_bypass_candidate = False
+        micro_prefill_budget_remaining: int | None = None
+        micro_waiter_prefill_limit = 0
+        micro_running_prefill_limits: dict[str, int] = {}
+        micro_waiter_scheduled = False
+        micro_prefill_tokens_scheduled = 0
+        if micro_controller is not None:
+            micro_has_pending_prefill = self._has_pending_local_prefill()
+            oldest_waiter_age_ms = self._oldest_local_prefill_waiter_age_ms(time.time())
+            (
+                micro_defer_prefills,
+                micro_deadline_bypass_candidate,
+            ) = micro_controller.should_defer_prefill(
+                has_eligible_decode=has_eligible_decode,
+                has_pending_prefill=micro_has_pending_prefill,
+                oldest_waiter_age_ms=oldest_waiter_age_ms,
+            )
             if (
-                request.num_output_placeholders > 0
-                # This is (num_computed_tokens + 1) - (num_output_placeholders - 1).
-                # Since output placeholders are also included in the computed tokens
-                # count, we subtract (num_output_placeholders - 1) to remove any draft
-                # tokens, so that we can be sure no further steps are needed even if
-                # they are all rejected.
-                and request.num_computed_tokens + 2 - request.num_output_placeholders
-                >= request.num_prompt_tokens + request.max_tokens
+                has_eligible_decode
+                and micro_has_pending_prefill
+                and not legacy_defer_prefills
+                and not micro_defer_prefills
             ):
-                # Async scheduling: Avoid scheduling an extra step when we are sure that
-                # the previous step has reached request.max_tokens. We don't schedule
-                # partial draft tokens since this prevents uniform decode optimizations.
-                req_index += 1
-                continue
-
-            if self.current_step < request.next_decode_eligible_step:
-                # V2+PP+async: enforce `pp_size` steps between same-req decodes
-                # to match worker-side sampled-tokens broadcast slot ring cadence.
-                req_index += 1
-                continue
-
-            if defer_prefills and request.is_prefill_chunk:
-                # Defer this in-progress chunk to a cadence-aligned step;
-                # decodes still run to fill this step.
-                req_index += 1
-                continue
-
-            num_new_tokens = (
-                request.num_tokens_with_spec
-                + request.num_output_placeholders
-                - request.num_computed_tokens
-            )
-            if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
-                num_new_tokens = self.scheduler_config.long_prefill_token_threshold
-            num_new_tokens = min(
-                num_new_tokens, token_budget, input_budget - draft_slots
-            )
-
-            # Make sure the input position does not exceed the max model len.
-            # This is necessary when using spec decoding.
-            num_new_tokens = min(
-                num_new_tokens,
-                self.max_model_len
-                - request.num_computed_tokens
-                - self.num_sampled_tokens_per_step,
-            )
-
-            # Apply Mamba alignment before encoder caps.
-            if self.need_mamba_block_aligned_split:
-                num_new_tokens = self._mamba_block_aligned_split(
-                    request, num_new_tokens
+                micro_prefill_budget_remaining = min(
+                    micro_controller.settings.max_num_prefill_tokens_per_step,
+                    token_budget,
+                    input_budget,
                 )
-
-            # Schedule encoder inputs.
-            encoder_inputs_to_schedule = None
-            external_load_encoder_input: list[int] = []
-            new_encoder_compute_budget = encoder_compute_budget
-            if request.has_encoder_inputs:
-                (
-                    encoder_inputs_to_schedule,
-                    num_new_tokens,
-                    new_encoder_compute_budget,
-                    external_load_encoder_input,
-                ) = self._try_schedule_encoder_inputs(
-                    request,
-                    request.num_computed_tokens,
-                    num_new_tokens,
-                    encoder_compute_budget,
-                    shift_computed_tokens=self.num_prefill_lookahead,
+                num_running_prefills = sum(
+                    request.is_prefill_chunk
+                    and self.current_step >= request.next_decode_eligible_step
+                    for request in self.running
                 )
-
-            # Multi-module MTP: avoid ending a prefill chunk within
-            # num_prefill_lookahead of the prefill end.
-            num_new_tokens = self._reserve_prefill_lookahead(
-                request, request.num_computed_tokens, num_new_tokens
-            )
-
-            if num_new_tokens == 0:
-                # The request cannot be scheduled because one of the following
-                # reasons:
-                # 1. No new tokens to schedule. This may happen when
-                #    (1) PP>1 and we have already scheduled all prompt tokens
-                #    but they are not finished yet.
-                #    (2) Async scheduling and the request has reached to either
-                #    its max_total_tokens or max_model_len.
-                # 2. The encoder budget is exhausted.
-                # 3. The encoder cache is exhausted.
-                # 4. Insufficient budget for a block-aligned chunk in hybrid
-                #    models with mamba cache mode \"align\".
-                # 5. Insufficient budget to keep a multi-module MTP prefill
-                #    chunk out of the prefill-lookahead window.
-                # NOTE(woosuk): Here, by doing `continue` instead of `break`,
-                # we do not strictly follow the FCFS scheduling policy and
-                # allow the lower-priority requests to be scheduled.
-                req_index += 1
-                continue
-
-            # Schedule newly needed KV blocks for the request.
-            with record_function_or_nullcontext("schedule: allocate_slots"):
-                while True:
-                    new_blocks = self.kv_cache_manager.allocate_slots(
-                        request,
-                        num_new_tokens,
-                        num_lookahead_tokens=self.num_lookahead_tokens,
+                available_quanta = (
+                    micro_prefill_budget_remaining // micro_controller.quantum
+                )
+                if available_quanta > 0:
+                    # Give a newly admitted waiter a proportional slice instead
+                    # of a single token on non-Mamba models. Mamba-aligned
+                    # models naturally receive one or more complete pages.
+                    waiter_quanta = max(
+                        available_quanta // (num_running_prefills + 1), 1
                     )
-
-                    if new_blocks is not None:
-                        # The request can be scheduled.
-                        break
-
-                    # The request cannot be scheduled.
-                    # Preempt the lowest-priority request.
-                    if self.policy == SchedulingPolicy.PRIORITY:
-                        preempted_req = max(
-                            self.running,
-                            key=lambda r: (r.priority, r.arrival_time),
-                        )
-                        # Record the index of the preemption victim to
-                        # maintain accurate loop state.
-                        victim_index = self.running.index(preempted_req)
-                        del self.running[victim_index]
-                        # Decrement the loop cursor if the removed request
-                        # preceded the current iteration, preventing the
-                        # silent omission of the subsequent request.
-                        if victim_index < req_index:
-                            req_index -= 1
-
-                        if preempted_req in scheduled_running_reqs:
-                            preempted_req_id = preempted_req.request_id
-                            scheduled_running_reqs.remove(preempted_req)
-                            restored = num_scheduled_tokens.pop(preempted_req_id)
-                            token_budget += restored
-                            input_budget += restored + draft_slots
-                            req_to_new_blocks.pop(preempted_req_id)
-                            scheduled_spec_decode_tokens.pop(preempted_req_id, None)
-                            preempted_encoder_inputs = scheduled_encoder_inputs.pop(
-                                preempted_req_id, None
-                            )
-                            if preempted_encoder_inputs:
-                                # Restore encoder compute budget if the preempted
-                                # request had encoder inputs scheduled in this step.
-                                num_embeds_to_restore = sum(
-                                    preempted_req.get_num_encoder_embeds(i)
-                                    for i in preempted_encoder_inputs
-                                )
-                                encoder_compute_budget += num_embeds_to_restore
-                    else:
-                        preempted_req = self.running.pop()
-
-                    self._preempt_request(
-                        preempted_req,
-                        scheduled_timestamp,
-                        drop_stale_output=self.requires_kv_delivery,
+                    micro_waiter_prefill_limit = (
+                        waiter_quanta * micro_controller.quantum
                     )
-                    preempted_reqs.append(preempted_req)
-                    if preempted_req == request:
-                        # No more request to preempt. Cannot schedule this request.
-                        break
+        defer_prefills = (
+            legacy_defer_prefills or adaptive_defer_prefills or micro_defer_prefills
+        )
 
-            if new_blocks is None:
-                # Cannot schedule this request.
-                break
+        needs_multiple_running_passes = (
+            self.compute_share_controller is not None
+            or micro_prefill_budget_remaining is not None
+        )
+        running_req_ids_at_step_start = (
+            {request.request_id for request in self.running}
+            if needs_multiple_running_passes
+            else None
+        )
 
-            # Schedule the request.
-            scheduled_running_reqs.append(request)
-            prefill_scheduled |= request.is_prefill_chunk
-            request_id = request.request_id
-            req_to_new_blocks[request_id] = new_blocks
-            num_scheduled_tokens[request_id] = num_new_tokens
-            token_budget -= num_new_tokens
-            input_budget -= num_new_tokens + draft_slots
-            req_index += 1
+        def schedule_running_requests(
+            service_class: ComputeServiceClass | None = None,
+            *,
+            allow_preemption: bool = True,
+            enforce_lora_limit: bool = False,
+        ) -> None:
+            nonlocal encoder_compute_budget
+            nonlocal input_budget
+            nonlocal micro_prefill_budget_remaining
+            nonlocal micro_prefill_tokens_scheduled
+            nonlocal prefill_scheduled
+            nonlocal token_budget
+            req_index = 0
+            while req_index < len(self.running) and token_budget > 0:
+                request = self.running[req_index]
+                if request.request_id in num_scheduled_tokens or (
+                    running_req_ids_at_step_start is not None
+                    and request.request_id not in running_req_ids_at_step_start
+                ):
+                    req_index += 1
+                    continue
+                if service_class is not None and (
+                    ("prefill" if request.is_prefill_chunk else "decode")
+                    != service_class
+                ):
+                    req_index += 1
+                    continue
+                if (
+                    enforce_lora_limit
+                    and self.lora_config
+                    and request.lora_request
+                    and len(scheduled_loras) == self.lora_config.max_loras
+                    and request.lora_request.lora_int_id not in scheduled_loras
+                ):
+                    req_index += 1
+                    continue
+                if input_budget <= draft_slots:
+                    break
 
-            # Speculative decode related.
-            if request.spec_token_ids:
-                num_scheduled_spec_tokens = (
-                    num_new_tokens
-                    + request.num_computed_tokens
-                    - request.num_tokens
+                if (
+                    request.num_output_placeholders > 0
+                    # This is (num_computed_tokens + 1) - (num_output_placeholders - 1).
+                    # Output placeholders are included in computed tokens, so
+                    # subtract (num_output_placeholders - 1) to remove draft
+                    # tokens and prove no further step is needed if all reject.
+                    and request.num_computed_tokens
+                    + 2
                     - request.num_output_placeholders
+                    >= request.num_prompt_tokens + request.max_tokens
+                ):
+                    # Async scheduling: avoid an extra step when the previous
+                    # one reached max_tokens. Do not schedule partial drafts;
+                    # that prevents uniform decode optimizations.
+                    req_index += 1
+                    continue
+
+                if self.current_step < request.next_decode_eligible_step:
+                    # V2+PP+async: enforce `pp_size` steps between same-req decodes
+                    # to match worker-side sampled-tokens broadcast slot ring cadence.
+                    req_index += 1
+                    continue
+
+                if defer_prefills and request.is_prefill_chunk:
+                    # Defer this in-progress chunk to a cadence-aligned step;
+                    # decodes still run to fill this step.
+                    req_index += 1
+                    continue
+
+                running_prefill_limit = None
+                if (
+                    request.is_prefill_chunk
+                    and micro_prefill_budget_remaining is not None
+                ):
+                    running_prefill_limit = micro_running_prefill_limits.get(
+                        request.request_id, 0
+                    )
+                    if (
+                        running_prefill_limit <= 0
+                        or micro_prefill_budget_remaining <= 0
+                    ):
+                        req_index += 1
+                        continue
+
+                num_new_tokens = (
+                    request.num_tokens_with_spec
+                    + request.num_output_placeholders
+                    - request.num_computed_tokens
                 )
-                if num_scheduled_spec_tokens > 0:
-                    spec_token_ids = request.spec_token_ids
-                    if len(spec_token_ids) > num_scheduled_spec_tokens:
-                        spec_token_ids = spec_token_ids[:num_scheduled_spec_tokens]
-                    scheduled_spec_decode_tokens[request.request_id] = spec_token_ids
+                if (
+                    0
+                    < self.scheduler_config.long_prefill_token_threshold
+                    < num_new_tokens
+                ):
+                    num_new_tokens = self.scheduler_config.long_prefill_token_threshold
+                num_new_tokens = min(
+                    num_new_tokens, token_budget, input_budget - draft_slots
+                )
+                if running_prefill_limit is not None:
+                    num_new_tokens = min(
+                        num_new_tokens,
+                        running_prefill_limit,
+                        micro_prefill_budget_remaining,
+                    )
 
-                # New spec tokens will be set in `update_draft_token_ids` before the
-                # next step when applicable.
-                request.spec_token_ids = []
+                # Make sure the input position does not exceed the max model len.
+                # This is necessary when using spec decoding.
+                num_new_tokens = min(
+                    num_new_tokens,
+                    self.max_model_len
+                    - request.num_computed_tokens
+                    - self.num_sampled_tokens_per_step,
+                )
 
-            # Encoder-related.
-            if encoder_inputs_to_schedule:
-                scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule
-                # Allocate the encoder cache.
-                for i in encoder_inputs_to_schedule:
-                    self.encoder_cache_manager.allocate(request, i)
-                    if self.ec_connector is not None:
-                        self.ec_connector.update_state_after_alloc(request, i)
-                encoder_compute_budget = new_encoder_compute_budget
-            if external_load_encoder_input:
-                for i in external_load_encoder_input:
-                    self.encoder_cache_manager.allocate(request, i)
-                    if self.ec_connector is not None:
-                        self.ec_connector.update_state_after_alloc(request, i)
+                # Apply Mamba alignment before encoder caps.
+                if self.need_mamba_block_aligned_split:
+                    num_new_tokens = self._mamba_block_aligned_split(
+                        request, num_new_tokens
+                    )
+
+                # Schedule encoder inputs.
+                encoder_inputs_to_schedule = None
+                external_load_encoder_input: list[int] = []
+                new_encoder_compute_budget = encoder_compute_budget
+                if request.has_encoder_inputs:
+                    (
+                        encoder_inputs_to_schedule,
+                        num_new_tokens,
+                        new_encoder_compute_budget,
+                        external_load_encoder_input,
+                    ) = self._try_schedule_encoder_inputs(
+                        request,
+                        request.num_computed_tokens,
+                        num_new_tokens,
+                        encoder_compute_budget,
+                        shift_computed_tokens=self.num_prefill_lookahead,
+                    )
+
+                # Multi-module MTP: avoid ending a prefill chunk within
+                # num_prefill_lookahead of the prefill end.
+                num_new_tokens = self._reserve_prefill_lookahead(
+                    request, request.num_computed_tokens, num_new_tokens
+                )
+
+                if num_new_tokens == 0:
+                    # The request cannot be scheduled because one of the following
+                    # reasons:
+                    # 1. No new tokens to schedule. This may happen when
+                    #    (1) PP>1 and we have already scheduled all prompt tokens
+                    #    but they are not finished yet.
+                    #    (2) Async scheduling and the request has reached to either
+                    #    its max_total_tokens or max_model_len.
+                    # 2. The encoder budget is exhausted.
+                    # 3. The encoder cache is exhausted.
+                    # 4. Insufficient budget for a block-aligned chunk in hybrid
+                    #    models with mamba cache mode \"align\".
+                    # 5. Insufficient budget to keep a multi-module MTP prefill
+                    #    chunk out of the prefill-lookahead window.
+                    # NOTE(woosuk): Here, by doing `continue` instead of `break`,
+                    # we do not strictly follow the FCFS scheduling policy and
+                    # allow the lower-priority requests to be scheduled.
+                    req_index += 1
+                    continue
+
+                # Schedule newly needed KV blocks for the request.
+                with record_function_or_nullcontext("schedule: allocate_slots"):
+                    while True:
+                        new_blocks = self.kv_cache_manager.allocate_slots(
+                            request,
+                            num_new_tokens,
+                            num_lookahead_tokens=self.num_lookahead_tokens,
+                        )
+
+                        if new_blocks is not None:
+                            # The request can be scheduled.
+                            break
+
+                        if not allow_preemption:
+                            # Leftover service must not evict work selected and
+                            # admitted earlier in this model step.
+                            break
+
+                        # The request cannot be scheduled.
+                        # Preempt the lowest-priority request.
+                        if self.policy == SchedulingPolicy.PRIORITY:
+                            preempted_req = max(
+                                self.running,
+                                key=lambda r: (r.priority, r.arrival_time),
+                            )
+                            # Record the index of the preemption victim to
+                            # maintain accurate loop state.
+                            victim_index = self.running.index(preempted_req)
+                            del self.running[victim_index]
+                            # Decrement the loop cursor if the removed request
+                            # preceded the current iteration, preventing the
+                            # silent omission of the subsequent request.
+                            if victim_index < req_index:
+                                req_index -= 1
+
+                            if preempted_req in scheduled_running_reqs:
+                                preempted_req_id = preempted_req.request_id
+                                scheduled_running_reqs.remove(preempted_req)
+                                restored = num_scheduled_tokens.pop(preempted_req_id)
+                                token_budget += restored
+                                input_budget += restored + draft_slots
+                                scheduled_prefill_req_ids.discard(preempted_req_id)
+                                req_to_new_blocks.pop(preempted_req_id)
+                                scheduled_spec_decode_tokens.pop(preempted_req_id, None)
+                                preempted_encoder_inputs = scheduled_encoder_inputs.pop(
+                                    preempted_req_id, None
+                                )
+                                if preempted_encoder_inputs:
+                                    # Restore encoder compute budget if the preempted
+                                    # request had encoder inputs scheduled in this step.
+                                    num_embeds_to_restore = sum(
+                                        preempted_req.get_num_encoder_embeds(i)
+                                        for i in preempted_encoder_inputs
+                                    )
+                                    encoder_compute_budget += num_embeds_to_restore
+                        else:
+                            preempted_req = self.running.pop()
+
+                        self._preempt_request(
+                            preempted_req,
+                            scheduled_timestamp,
+                            drop_stale_output=self.requires_kv_delivery,
+                        )
+                        preempted_reqs.append(preempted_req)
+                        if preempted_req == request:
+                            # No more request to preempt. Cannot schedule this request.
+                            break
+
+                if new_blocks is None:
+                    # Cannot schedule this request.
+                    break
+
+                # Schedule the request.
+                scheduled_running_reqs.append(request)
+                prefill_scheduled |= request.is_prefill_chunk
+                if request.is_prefill_chunk:
+                    scheduled_prefill_req_ids.add(request.request_id)
+                request_id = request.request_id
+                req_to_new_blocks[request_id] = new_blocks
+                num_scheduled_tokens[request_id] = num_new_tokens
+                token_budget -= num_new_tokens
+                input_budget -= num_new_tokens + draft_slots
+                if running_prefill_limit is not None:
+                    micro_prefill_budget_remaining -= num_new_tokens
+                    micro_prefill_tokens_scheduled += num_new_tokens
+                if enforce_lora_limit and request.lora_request:
+                    scheduled_loras.add(request.lora_request.lora_int_id)
+                req_index += 1
+
+                # Speculative decode related.
+                if request.spec_token_ids:
+                    num_scheduled_spec_tokens = (
+                        num_new_tokens
+                        + request.num_computed_tokens
+                        - request.num_tokens
+                        - request.num_output_placeholders
+                    )
+                    if num_scheduled_spec_tokens > 0:
+                        spec_token_ids = request.spec_token_ids
+                        if len(spec_token_ids) > num_scheduled_spec_tokens:
+                            spec_token_ids = spec_token_ids[:num_scheduled_spec_tokens]
+                        scheduled_spec_decode_tokens[request.request_id] = (
+                            spec_token_ids
+                        )
+
+                    # New spec tokens will be set in `update_draft_token_ids` before the
+                    # next step when applicable.
+                    request.spec_token_ids = []
+
+                # Encoder-related.
+                if encoder_inputs_to_schedule:
+                    scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule
+                    # Allocate the encoder cache.
+                    for i in encoder_inputs_to_schedule:
+                        self.encoder_cache_manager.allocate(request, i)
+                        if self.ec_connector is not None:
+                            self.ec_connector.update_state_after_alloc(request, i)
+                    encoder_compute_budget = new_encoder_compute_budget
+                if external_load_encoder_input:
+                    for i in external_load_encoder_input:
+                        self.encoder_cache_manager.allocate(request, i)
+                        if self.ec_connector is not None:
+                            self.ec_connector.update_state_after_alloc(request, i)
+
+        adaptive_prefill_turn = (
+            selected_compute_class == "prefill" and compute_contention
+        )
+        micro_mixed_step = micro_prefill_budget_remaining is not None
+        initial_service_class: ComputeServiceClass | None = (
+            "decode"
+            if micro_mixed_step
+            else ("prefill" if adaptive_prefill_turn else None)
+        )
+        schedule_running_requests(initial_service_class)
 
         # Record the LoRAs in scheduled_running_reqs
         scheduled_loras: set[int] = set()
@@ -992,17 +1238,42 @@ class Scheduler(SchedulerInterface):
                 external_load_encoder_input = []
                 new_encoder_compute_budget = encoder_compute_budget
                 pad_spec_decode = False
+                has_local_prefill = (
+                    not load_kv_async and num_computed_tokens < request.num_tokens - 1
+                )
+                waiting_micro_limit = None
 
                 if load_kv_async:
                     # KVTransfer: loading remote KV, do not allocate for new work.
                     assert num_external_computed_tokens > 0
                     num_new_tokens = 0
-                elif defer_prefills and num_computed_tokens < request.num_tokens - 1:
-                    # DP prefill balancing: defer this step's local prefill
-                    # compute to a cadence-aligned step.
-                    break
                 else:
+                    if defer_prefills and has_local_prefill:
+                        if adaptive_defer_prefills and not num_scheduled_tokens:
+                            # The selected decode class proved unrunnable after
+                            # its resource checks. Fall back immediately.
+                            adaptive_defer_prefills = False
+                            defer_prefills = legacy_defer_prefills
+                        else:
+                            # DP prefill balancing: defer this step's local
+                            # prefill compute to a cadence-aligned step.
+                            break
                     request_token_budget = min(token_budget, input_budget - draft_slots)
+                    if has_local_prefill and micro_prefill_budget_remaining is not None:
+                        if (
+                            micro_waiter_scheduled
+                            or micro_prefill_budget_remaining <= 0
+                        ):
+                            break
+                        waiting_micro_limit = min(
+                            micro_waiter_prefill_limit,
+                            micro_prefill_budget_remaining,
+                        )
+                        if waiting_micro_limit <= 0:
+                            break
+                        request_token_budget = min(
+                            request_token_budget, waiting_micro_limit
+                        )
                     # Number of tokens to be scheduled.
                     # We use `request.num_tokens` instead of
                     # `request.num_prompt_tokens` to consider the resumed
@@ -1083,6 +1354,21 @@ class Scheduler(SchedulerInterface):
                     if num_new_tokens == 0:
                         # The request cannot be scheduled.
                         break
+
+                will_remain_partial = (
+                    has_local_prefill
+                    and num_computed_tokens + num_new_tokens < request.num_tokens
+                )
+                if (
+                    will_remain_partial
+                    and micro_controller is not None
+                    and micro_controller.settings.max_num_partial_prefills > 0
+                    and self.num_active_local_partial_prefills
+                    >= micro_controller.settings.max_num_partial_prefills
+                ):
+                    # A request that finishes its prefill inside this quantum is
+                    # still admitted when all partial slots are occupied.
+                    break
 
                 # During async KV load, no forward pass is run yet.
                 # Allocate speculative lookahead slots later to avoid
@@ -1212,8 +1498,14 @@ class Scheduler(SchedulerInterface):
                     request_id
                 )
                 num_scheduled_tokens[request_id] = num_new_tokens
+                if num_computed_tokens < request.num_tokens - 1:
+                    scheduled_prefill_req_ids.add(request_id)
                 token_budget -= num_new_tokens
                 input_budget -= num_new_tokens + draft_slots
+                if waiting_micro_limit is not None:
+                    micro_prefill_budget_remaining -= num_new_tokens
+                    micro_prefill_tokens_scheduled += num_new_tokens
+                    micro_waiter_scheduled = True
                 request.status = RequestStatus.RUNNING
                 request.num_computed_tokens = num_computed_tokens
                 if pad_spec_decode:
@@ -1248,9 +1540,84 @@ class Scheduler(SchedulerInterface):
             if not defer_prefills:
                 self.prefill_capacity_bound = bool(self.waiting)
 
+        # In a micro-sliced mixed step, waiting admission gets the first
+        # prefill quantum after decodes. Any unused portion is immediately
+        # redistributed across already-running prefills, so a blocked waiter
+        # can never strand model capacity.
+        if (
+            micro_mixed_step
+            and micro_prefill_budget_remaining is not None
+            and micro_prefill_budget_remaining > 0
+        ):
+            assert micro_controller is not None
+            assert running_req_ids_at_step_start is not None
+            running_prefill_ids = [
+                request.request_id
+                for request in self.running
+                if request.request_id in running_req_ids_at_step_start
+                and request.request_id not in num_scheduled_tokens
+                and request.is_prefill_chunk
+                and self.current_step >= request.next_decode_eligible_step
+            ]
+            micro_running_prefill_limits = micro_controller.select_running_limits(
+                running_prefill_ids, micro_prefill_budget_remaining
+            )
+            schedule_running_requests(
+                "prefill",
+                allow_preemption=False,
+                enforce_lora_limit=True,
+            )
+
+        # The coarse runnable check can race async-completion guards. If a
+        # selected decode turn produced no work, give an already-running
+        # prefill an immediate chance before returning an empty step.
+        if (
+            selected_compute_class == "decode"
+            and compute_contention
+            and not num_scheduled_tokens
+            and not legacy_defer_prefills
+        ):
+            adaptive_defer_prefills = False
+            defer_prefills = False
+            schedule_running_requests("prefill")
+
+        # A prefill turn gives prefills first use of the model-step capacity.
+        # Existing decodes then consume only capacity genuinely left over. New
+        # requests admitted above are excluded by running_req_ids_at_step_start,
+        # so no request can be scheduled twice in one step.
+        if adaptive_prefill_turn and token_budget > 0:
+            schedule_running_requests(
+                "decode",
+                allow_preemption=False,
+                enforce_lora_limit=True,
+            )
+
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
         assert total_num_scheduled_tokens <= self.max_num_scheduled_tokens
+        if micro_mixed_step:
+            assert micro_controller is not None
+            assert (
+                micro_prefill_tokens_scheduled
+                <= micro_controller.settings.max_num_prefill_tokens_per_step
+            )
+
+        if micro_controller is not None:
+            scheduled_prefill_tokens = sum(
+                num_scheduled_tokens[request_id]
+                for request_id in scheduled_prefill_req_ids
+            )
+            micro_controller.observe_step(
+                has_eligible_decode=has_eligible_decode,
+                had_pending_prefill=micro_has_pending_prefill,
+                scheduled_decode_tokens=(
+                    total_num_scheduled_tokens - scheduled_prefill_tokens
+                ),
+                scheduled_prefill_tokens=(
+                    micro_prefill_tokens_scheduled if micro_mixed_step else 0
+                ),
+                deadline_bypass_candidate=micro_deadline_bypass_candidate,
+            )
 
         assert token_budget >= 0
         assert input_budget >= 0
@@ -1380,6 +1747,21 @@ class Scheduler(SchedulerInterface):
             partial_tail_offloads=pending_partial_tail_offloads,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
             ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
+            compute_service_class=(
+                (
+                    "prefill"
+                    if any(
+                        req_id in num_scheduled_tokens
+                        for req_id in scheduled_prefill_req_ids
+                    )
+                    else "decode"
+                )
+                if self.compute_share_controller is not None
+                and compute_contention
+                and total_num_scheduled_tokens > 0
+                else None
+            ),
+            compute_contention=compute_contention,
         )
 
         # NOTE(Kuntai): this function is designed for multiple purposes:
@@ -1404,7 +1786,141 @@ class Scheduler(SchedulerInterface):
 
         with record_function_or_nullcontext("schedule: update_after_schedule"):
             self._update_after_schedule(scheduler_output)
+        if (
+            self.compute_share_controller is not None
+            and scheduler_output.compute_service_class is not None
+        ):
+            self.compute_share_controller.dispatch(
+                scheduler_output.compute_service_class,
+                contended=scheduler_output.compute_contention,
+            )
         return scheduler_output
+
+    def record_compute_time(
+        self,
+        service_class: ComputeServiceClass,
+        elapsed_seconds: float,
+        *,
+        contended: bool,
+    ) -> None:
+        """Apply execution feedback and accumulate metric deltas."""
+        if self.compute_share_controller is None:
+            return
+        if not contended:
+            return
+        if self.log_stats and elapsed_seconds > 0.0:
+            if service_class == "prefill":
+                self._prefill_compute_seconds += elapsed_seconds
+            else:
+                self._decode_compute_seconds += elapsed_seconds
+        self.compute_share_controller.record(
+            service_class, elapsed_seconds, contended=True
+        )
+
+    def get_prefill_fairness(self) -> dict[str, Any]:
+        """Return the active fairness policy and its complete tuning state."""
+        return {
+            "fairness_engine": self.scheduler_config.fairness_engine,
+            "prefill_compute_share": self.scheduler_config.prefill_compute_share,
+            "max_num_prefill_tokens_per_step": (
+                self.scheduler_config.max_num_prefill_tokens_per_step
+            ),
+            "max_num_partial_prefills": (
+                self.scheduler_config.max_num_partial_prefills
+            ),
+            "decode_prefill_min_decode_steps": (
+                self.scheduler_config.decode_prefill_min_decode_steps
+            ),
+            "decode_prefill_max_wait_ms": (
+                self.scheduler_config.decode_prefill_max_wait_ms
+            ),
+            "prefill_quantum": self.prefill_fairness_quantum,
+        }
+
+    def set_prefill_fairness(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Replace the fairness policy at an engine-enforced idle boundary."""
+        fairness_engine = config.get("fairness_engine")
+        prefill_compute_share = config.get("prefill_compute_share")
+        max_prefill_tokens = int(config.get("max_num_prefill_tokens_per_step", 0))
+        max_partial_prefills = int(config.get("max_num_partial_prefills", 0))
+        min_decode_steps = int(config.get("decode_prefill_min_decode_steps", 0))
+        max_wait_ms = int(config.get("decode_prefill_max_wait_ms", 0))
+
+        if fairness_engine not in (None, "compute_share", "micro_slicing"):
+            raise ValueError(f"unknown fairness_engine: {fairness_engine!r}")
+
+        micro_configured = any(
+            (
+                max_prefill_tokens,
+                max_partial_prefills,
+                min_decode_steps,
+                max_wait_ms,
+            )
+        )
+        if fairness_engine is None:
+            if prefill_compute_share is not None or micro_configured:
+                raise ValueError(
+                    "fairness tuning options must be cleared when fairness_engine "
+                    "is disabled"
+                )
+        elif fairness_engine == "compute_share":
+            if prefill_compute_share is None or not 0.0 < prefill_compute_share < 1.0:
+                raise ValueError(
+                    "prefill_compute_share must be strictly between zero and one"
+                )
+            if micro_configured:
+                raise ValueError(
+                    "micro-slicing options cannot be set for compute_share"
+                )
+        else:
+            if prefill_compute_share is not None:
+                raise ValueError(
+                    "prefill_compute_share cannot be set for micro_slicing"
+                )
+            if max_prefill_tokens > self.scheduler_config.max_num_batched_tokens:
+                raise ValueError(
+                    "max_num_prefill_tokens_per_step cannot exceed "
+                    "max_num_batched_tokens"
+                )
+            if max_partial_prefills > self.max_num_running_reqs:
+                raise ValueError("max_num_partial_prefills cannot exceed max_num_seqs")
+
+        if fairness_engine is not None:
+            if self.scheduler_config.prefill_schedule_interval > 1:
+                raise ValueError(
+                    "fairness_engine cannot be combined with "
+                    "prefill_schedule_interval greater than one"
+                )
+            if self.parallel_config.data_parallel_size > 1:
+                raise ValueError("fairness_engine does not support data parallelism")
+
+        micro_controller = None
+        compute_controller = None
+        if fairness_engine == "compute_share":
+            assert prefill_compute_share is not None
+            compute_controller = PrefillComputeShareController(prefill_compute_share)
+        elif fairness_engine == "micro_slicing":
+            micro_controller = MicroSlicingController(
+                MicroSlicingSettings(
+                    max_num_prefill_tokens_per_step=max_prefill_tokens,
+                    max_num_partial_prefills=max_partial_prefills,
+                    decode_prefill_min_decode_steps=min_decode_steps,
+                    decode_prefill_max_wait_ms=max_wait_ms,
+                ),
+                quantum=self.prefill_fairness_quantum,
+            )
+
+        self.compute_share_controller = compute_controller
+        self.micro_slicing_controller = micro_controller
+        self._decode_compute_seconds = 0.0
+        self._prefill_compute_seconds = 0.0
+        self.scheduler_config.fairness_engine = fairness_engine
+        self.scheduler_config.prefill_compute_share = prefill_compute_share
+        self.scheduler_config.max_num_prefill_tokens_per_step = max_prefill_tokens
+        self.scheduler_config.max_num_partial_prefills = max_partial_prefills
+        self.scheduler_config.decode_prefill_min_decode_steps = min_decode_steps
+        self.scheduler_config.decode_prefill_max_wait_ms = max_wait_ms
+        return self.get_prefill_fairness()
 
     def _build_kv_connector_meta(
         self, connector: KVConnectorBase_V1, scheduler_output: SchedulerOutput
@@ -2762,6 +3278,25 @@ class Scheduler(SchedulerInterface):
         connector_stats_payload = (
             kv_connector_stats.data if kv_connector_stats else None
         )
+        decode_compute_seconds = 0.0
+        prefill_compute_seconds = 0.0
+        prefill_compute_share = 0.0
+        if self.compute_share_controller is not None:
+            decode_compute_seconds = self._decode_compute_seconds
+            prefill_compute_seconds = self._prefill_compute_seconds
+            prefill_compute_share = self.compute_share_controller.prefill_compute_share
+            self._decode_compute_seconds = 0.0
+            self._prefill_compute_seconds = 0.0
+        micro_stats = {
+            "scheduled_prefill_tokens": 0,
+            "active_partial_prefills": 0,
+            "decode_only_steps": 0,
+            "fairness_bypasses": 0,
+        }
+        if self.micro_slicing_controller is not None:
+            micro_stats = self.micro_slicing_controller.drain_stats(
+                active_partial_prefills=self.num_active_local_partial_prefills
+            )
         return SchedulerStats(
             num_running_reqs=len(self.running),
             num_waiting_reqs=len(self.waiting),
@@ -2774,6 +3309,13 @@ class Scheduler(SchedulerInterface):
             kv_connector_stats=connector_stats_payload,
             cudagraph_stats=cudagraph_stats,
             perf_stats=perf_stats,
+            decode_compute_seconds=decode_compute_seconds,
+            prefill_compute_seconds=prefill_compute_seconds,
+            prefill_compute_share=prefill_compute_share,
+            scheduled_prefill_tokens=micro_stats["scheduled_prefill_tokens"],
+            active_partial_prefills=micro_stats["active_partial_prefills"],
+            decode_only_steps=micro_stats["decode_only_steps"],
+            fairness_bypasses=micro_stats["fairness_bypasses"],
         )
 
     def make_spec_decoding_stats(

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -966,6 +966,12 @@ class AsyncLLM(EngineClient):
             reset_running_requests, reset_connector
         )
 
+    async def get_prefill_fairness(self) -> dict[str, Any]:
+        return await self.engine_core.get_prefill_fairness_async()
+
+    async def set_prefill_fairness(self, config: dict[str, Any]) -> dict[str, Any]:
+        return await self.engine_core.set_prefill_fairness_async(config)
+
     async def reset_encoder_cache(self) -> None:
         await self.engine_core.reset_encoder_cache_async()
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -102,6 +102,29 @@ HANDSHAKE_TIMEOUT_MINS = 5
 _R = TypeVar("_R")  # Return type for collective_rpc
 
 
+class _ModelExecutionTiming:
+    """Capture model completion time without charging queue residency."""
+
+    def __init__(self) -> None:
+        self.started_at = time.perf_counter()
+        self.completed_at: float | None = None
+
+    def bind(self, future: Future[Any]) -> None:
+        future.add_done_callback(self._record_completion)
+
+    def complete(self) -> None:
+        self.completed_at = time.perf_counter()
+
+    def _record_completion(self, _future: Future[Any]) -> None:
+        self.complete()
+
+    @property
+    def elapsed_seconds(self) -> float:
+        if self.completed_at is None:
+            raise RuntimeError("model execution timing read before completion")
+        return max(self.completed_at - self.started_at, 0.0)
+
+
 class EngineCore:
     """Inner loop of vLLM's Engine."""
 
@@ -209,11 +232,20 @@ class EngineCore:
         # to eliminate pipeline bubbles.
         self.batch_queue_size = vllm_config.max_concurrent_batches
         self.batch_queue: (
-            deque[tuple[Future[ModelRunnerOutput], SchedulerOutput, Future[Any]]] | None
+            deque[
+                tuple[
+                    Future[ModelRunnerOutput],
+                    SchedulerOutput,
+                    Future[Any],
+                    _ModelExecutionTiming | None,
+                ]
+            ]
+            | None
         ) = None
         if self.batch_queue_size > 1:
             logger.debug("Batch queue is enabled with size %d", self.batch_queue_size)
             self.batch_queue = deque(maxlen=self.batch_queue_size)
+        self._last_model_completion_time: float | None = None
 
         self.is_ec_consumer = (
             vllm_config.ec_transfer_config is None
@@ -614,6 +646,50 @@ class EngineCore:
             )
         return current_step % interval != 0
 
+    def _execute_model(
+        self, scheduler_output: SchedulerOutput
+    ) -> tuple[Future[Any], _ModelExecutionTiming | None]:
+        timing = (
+            _ModelExecutionTiming()
+            if scheduler_output.compute_service_class is not None
+            else None
+        )
+        future = self.model_executor.execute_model(scheduler_output, non_block=True)
+        return future, timing
+
+    def _record_compute_time(
+        self,
+        scheduler_output: SchedulerOutput,
+        timing: _ModelExecutionTiming | None,
+    ) -> None:
+        if timing is None:
+            return
+        service_class = scheduler_output.compute_service_class
+        assert service_class is not None
+        completed_at = timing.completed_at
+        if completed_at is None:
+            raise RuntimeError("model execution timing read before completion")
+
+        # Multiple batches can already be queued on the executor when this
+        # batch is dispatched. Attribute only the wall-clock interval this
+        # completion adds after the previous batch, rather than charging the
+        # same executor queue residency to every in-flight batch.
+        previous_completion = self._last_model_completion_time
+        service_started_at = timing.started_at
+        if previous_completion is not None:
+            service_started_at = max(service_started_at, previous_completion)
+        elapsed_seconds = max(completed_at - service_started_at, 0.0)
+        self._last_model_completion_time = (
+            completed_at
+            if previous_completion is None
+            else max(completed_at, previous_completion)
+        )
+        self.scheduler.record_compute_time(
+            service_class,
+            elapsed_seconds,
+            contended=scheduler_output.compute_contention,
+        )
+
     def step(self) -> tuple[dict[int, EngineCoreOutputs], bool]:
         """Schedule, execute, and make output.
 
@@ -626,7 +702,7 @@ class EngineCore:
         if not self.scheduler.has_requests():
             return {}, False
         scheduler_output = self.scheduler.schedule(self._should_throttle_prefills())
-        future = self.model_executor.execute_model(scheduler_output, non_block=True)
+        future, execution_timing = self._execute_model(scheduler_output)
         grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
         with (
             self.capture_iteration_details(scheduler_output) as iteration_details,
@@ -635,6 +711,9 @@ class EngineCore:
             model_output = future.result()
             if model_output is None:
                 model_output = self.model_executor.sample_tokens(grammar_output)
+            if execution_timing is not None:
+                execution_timing.complete()
+            self._record_compute_time(scheduler_output, execution_timing)
 
         # Before processing the model output, process any aborts that happened
         # during the model execution.
@@ -682,12 +761,11 @@ class EngineCore:
 
         model_executed = False
         deferred_scheduler_output = None
+        deferred_execution_timing = None
         if self.scheduler.has_requests():
             scheduler_output = self.scheduler.schedule(self._should_throttle_prefills())
             with self.log_error_detail(scheduler_output):
-                exec_future = self.model_executor.execute_model(
-                    scheduler_output, non_block=True
-                )
+                exec_future, execution_timing = self._execute_model(scheduler_output)
             if self.is_ec_consumer:
                 model_executed = scheduler_output.total_num_scheduled_tokens > 0
 
@@ -708,10 +786,15 @@ class EngineCore:
                     # We need to defer sampling until we have processed the model output
                     # from the prior step.
                     deferred_scheduler_output = scheduler_output
+                    deferred_execution_timing = execution_timing
 
             if not deferred_scheduler_output:
+                if execution_timing is not None:
+                    execution_timing.bind(future)
                 # Add this step's future to the queue.
-                batch_queue.appendleft((future, scheduler_output, exec_future))
+                batch_queue.appendleft(
+                    (future, scheduler_output, exec_future, execution_timing)
+                )
                 if len(batch_queue) < self.batch_queue_size and (
                     model_executed or self.scheduler.has_requests()
                 ):
@@ -726,12 +809,13 @@ class EngineCore:
             return None, False
 
         # Block until the next result is available.
-        future, scheduler_output, exec_model_fut = batch_queue.pop()
+        future, scheduler_output, exec_model_fut, execution_timing = batch_queue.pop()
         with (
             self.capture_iteration_details(scheduler_output) as iteration_details,
             self.log_error_detail(scheduler_output),
         ):
             model_output = future.result()
+            self._record_compute_time(scheduler_output, execution_timing)
             if model_output is None:
                 # None from sample_tokens() implies that the original execute_model()
                 # call failed - raise that exception.
@@ -767,7 +851,16 @@ class EngineCore:
                 deferred_scheduler_output
             )
             future = self.model_executor.sample_tokens(grammar_output, non_block=True)
-            batch_queue.appendleft((future, deferred_scheduler_output, exec_future))
+            if deferred_execution_timing is not None:
+                deferred_execution_timing.bind(future)
+            batch_queue.appendleft(
+                (
+                    future,
+                    deferred_scheduler_output,
+                    exec_future,
+                    deferred_execution_timing,
+                )
+            )
 
         return engine_core_outputs, model_executed
 
@@ -823,6 +916,31 @@ class EngineCore:
         return self.scheduler.reset_prefix_cache(
             reset_running_requests, reset_connector
         )
+
+    def get_prefill_fairness(self) -> dict[str, Any]:
+        return self.scheduler.get_prefill_fairness()
+
+    def set_prefill_fairness(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Apply a complete fairness configuration only at an idle boundary."""
+        if self.scheduler.has_unfinished_requests() or bool(self.batch_queue):
+            return {
+                "applied": False,
+                "reason": "busy",
+                "message": (
+                    "fairness policy can only be changed while the engine is idle"
+                ),
+                "config": self.scheduler.get_prefill_fairness(),
+            }
+        try:
+            updated = self.scheduler.set_prefill_fairness(config)
+        except (TypeError, ValueError) as exc:
+            return {
+                "applied": False,
+                "reason": "invalid",
+                "message": str(exc),
+                "config": self.scheduler.get_prefill_fairness(),
+            }
+        return {"applied": True, "config": updated}
 
     def reset_encoder_cache(self) -> None:
         """Reset the encoder cache to invalidate all cached encoder outputs.

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -161,6 +161,12 @@ class EngineCoreClient(ABC):
     ) -> bool:
         raise NotImplementedError
 
+    def get_prefill_fairness(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def set_prefill_fairness(self, config: dict[str, Any]) -> dict[str, Any]:
+        raise NotImplementedError
+
     def reset_encoder_cache(self) -> None:
         raise NotImplementedError
 
@@ -251,6 +257,14 @@ class EngineCoreClient(ABC):
     async def reset_prefix_cache_async(
         self, reset_running_requests: bool = False, reset_connector: bool = False
     ) -> bool:
+        raise NotImplementedError
+
+    async def get_prefill_fairness_async(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    async def set_prefill_fairness_async(
+        self, config: dict[str, Any]
+    ) -> dict[str, Any]:
         raise NotImplementedError
 
     async def reset_encoder_cache_async(self) -> None:
@@ -347,6 +361,12 @@ class InprocClient(EngineCoreClient):
         return self.engine_core.reset_prefix_cache(
             reset_running_requests, reset_connector
         )
+
+    def get_prefill_fairness(self) -> dict[str, Any]:
+        return self.engine_core.get_prefill_fairness()
+
+    def set_prefill_fairness(self, config: dict[str, Any]) -> dict[str, Any]:
+        return self.engine_core.set_prefill_fairness(config)
 
     def reset_encoder_cache(self) -> None:
         self.engine_core.reset_encoder_cache()
@@ -927,6 +947,12 @@ class SyncMPClient(MPClient):
             "reset_prefix_cache", reset_running_requests, reset_connector
         )
 
+    def get_prefill_fairness(self) -> dict[str, Any]:
+        return self.call_utility("get_prefill_fairness")
+
+    def set_prefill_fairness(self, config: dict[str, Any]) -> dict[str, Any]:
+        return self.call_utility("set_prefill_fairness", config)
+
     def reset_encoder_cache(self) -> None:
         self.call_utility("reset_encoder_cache")
 
@@ -1180,6 +1206,14 @@ class AsyncMPClient(MPClient):
         return await self.call_utility_async(
             "reset_prefix_cache", reset_running_requests, reset_connector
         )
+
+    async def get_prefill_fairness_async(self) -> dict[str, Any]:
+        return await self.call_utility_async("get_prefill_fairness")
+
+    async def set_prefill_fairness_async(
+        self, config: dict[str, Any]
+    ) -> dict[str, Any]:
+        return await self.call_utility_async("set_prefill_fairness", config)
 
     async def reset_encoder_cache_async(self) -> None:
         await self.call_utility_async("reset_encoder_cache")

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -353,6 +353,12 @@ class LLMEngine:
             reset_running_requests, reset_connector
         )
 
+    def get_prefill_fairness(self) -> dict[str, Any]:
+        return self.engine_core.get_prefill_fairness()
+
+    def set_prefill_fairness(self, config: dict[str, Any]) -> dict[str, Any]:
+        return self.engine_core.set_prefill_fairness(config)
+
     def reset_encoder_cache(self) -> None:
         """Reset the encoder cache to invalidate all cached encoder outputs.
 

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -510,6 +510,73 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             gauge_scheduler_waiting, per_engine_labelvalues
         )
 
+        gauge_prefill_compute_share = self._gauge_cls(
+            name="vllm:scheduler_prefill_compute_share",
+            documentation=(
+                "Configured target fraction of contended model execution "
+                "assigned to prefill; zero means disabled."
+            ),
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_prefill_compute_share = create_metric_per_engine(
+            gauge_prefill_compute_share, per_engine_labelvalues
+        )
+
+        counter_scheduler_compute_seconds = self._counter_cls(
+            name="vllm:scheduler_compute_seconds",
+            documentation="Model-execution time charged to each service class.",
+            labelnames=labelnames + ["class"],
+        )
+        self.counter_scheduler_compute_seconds = {
+            service_class: {
+                idx: counter_scheduler_compute_seconds.labels(
+                    model_name, str(idx), service_class
+                )
+                for idx in engine_indexes
+            }
+            for service_class in ("decode", "prefill")
+        }
+
+        counter_decode_prefill_scheduled_tokens = self._counter_cls(
+            name="vllm:decode_prefill_scheduled_tokens",
+            documentation=(
+                "Local prefill tokens governed by mixed-step micro-slicing."
+            ),
+            labelnames=labelnames,
+        )
+        self.counter_decode_prefill_scheduled_tokens = create_metric_per_engine(
+            counter_decode_prefill_scheduled_tokens, per_engine_labelvalues
+        )
+        gauge_decode_prefill_active_partial_prefills = self._gauge_cls(
+            name="vllm:decode_prefill_active_partial_prefills",
+            documentation="Active requests performing local partial prefill.",
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_decode_prefill_active_partial_prefills = create_metric_per_engine(
+            gauge_decode_prefill_active_partial_prefills,
+            per_engine_labelvalues,
+        )
+        counter_decode_prefill_decode_only_steps = self._counter_cls(
+            name="vllm:decode_prefill_decode_only_steps",
+            documentation=(
+                "Decode-only steps taken while local prefill work was pending."
+            ),
+            labelnames=labelnames,
+        )
+        self.counter_decode_prefill_decode_only_steps = create_metric_per_engine(
+            counter_decode_prefill_decode_only_steps, per_engine_labelvalues
+        )
+        counter_decode_prefill_fairness_bypasses = self._counter_cls(
+            name="vllm:decode_prefill_fairness_bypasses",
+            documentation="Prefill releases caused by the oldest-waiter deadline.",
+            labelnames=labelnames,
+        )
+        self.counter_decode_prefill_fairness_bypasses = create_metric_per_engine(
+            counter_decode_prefill_fairness_bypasses, per_engine_labelvalues
+        )
+
         gauge_waiting_by_reason = self._gauge_cls(
             name="vllm:num_requests_waiting_by_reason",
             documentation=(
@@ -1121,6 +1188,27 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 scheduler_stats.num_skipped_waiting_reqs
             )
             self.gauge_kv_cache_usage[engine_idx].set(scheduler_stats.kv_cache_usage)
+            self.gauge_prefill_compute_share[engine_idx].set(
+                scheduler_stats.prefill_compute_share
+            )
+            self.counter_scheduler_compute_seconds["decode"][engine_idx].inc(
+                scheduler_stats.decode_compute_seconds
+            )
+            self.counter_scheduler_compute_seconds["prefill"][engine_idx].inc(
+                scheduler_stats.prefill_compute_seconds
+            )
+            self.counter_decode_prefill_scheduled_tokens[engine_idx].inc(
+                scheduler_stats.scheduled_prefill_tokens
+            )
+            self.gauge_decode_prefill_active_partial_prefills[engine_idx].set(
+                scheduler_stats.active_partial_prefills
+            )
+            self.counter_decode_prefill_decode_only_steps[engine_idx].inc(
+                scheduler_stats.decode_only_steps
+            )
+            self.counter_decode_prefill_fairness_bypasses[engine_idx].inc(
+                scheduler_stats.fairness_bypasses
+            )
 
             self.counter_prefix_cache_queries[engine_idx].inc(
                 scheduler_stats.prefix_cache_stats.queries

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -213,6 +213,14 @@ class SchedulerStats:
 
     perf_stats: PerfStats | None = None
 
+    decode_compute_seconds: float = 0.0
+    prefill_compute_seconds: float = 0.0
+    prefill_compute_share: float = 0.0
+    scheduled_prefill_tokens: int = 0
+    active_partial_prefills: int = 0
+    decode_only_steps: int = 0
+    fairness_bypasses: int = 0
+
 
 @dataclass
 class RequestStateStats:


### PR DESCRIPTION
Closes #624.

Consolidates the two JJ scheduler-fairness approaches from #596 and #612 behind
one explicit selector. This PR is a single commit against the current
`dev/jovian-judgement` head and contains no image, launcher, benchmark, or build
artifacts.

## Summary

- Add `--fairness-engine {compute_share,micro_slicing}`.
- Keep stock scheduler behavior when no fairness engine is selected.
- Add measured, self-correcting `--prefill-compute-share` scheduling.
- Add repaired micro-slicing with per-step token limits, rotating partial
  prefills, decode-step cadence, and an oldest-waiter deadline.
- Validate engine-specific options as mutually exclusive.
- Exclude asynchronous LMCache KV-only restores from local prefill-compute
  accounting.
- Avoid fairness timing and request scans on the disabled/uncontended paths.
- Export compute-share and micro-slicing scheduler metrics.
- Add development-mode `GET/POST /prefill_fairness` for atomic idle-only policy
  replacement without a model reload or cache clear.

The commit preserves `logprobz` as co-author for the #596-derived micro-slicing
work.

## Testing

Source validation on the image-tested R18 tree:

- 39 focused tests passed.
- 57 expanded scheduler/configuration/feedback/runtime/API tests passed.
- 238 broader tests passed; one unrelated exact-R18 synthetic `AsyncScheduler`
  fixture failure was pre-existing and is documented in #624.
- Ruff and `git diff --check` passed.

The consolidation replayed cleanly onto the current JJ head. The proposed tree
passes Python syntax compilation and `git diff --check`; CI on this exact replay
is still required.

Live validation used 4× RTX PRO 6000 Blackwell, GLM-5.3-Flash-NVFP4,
TP4/DCP1, NVFP4 and FP8 KV, 4,096 batched tokens, and LMCache:

- The measured controller tracked 0.2/0.5/0.8 targets across C1/C4/C8 at about
  0.202/0.513/0.813 actual prefill compute share.
- Idle live switching preserved the EngineCore PID and caches; busy switching
  returned 409 without changing state.
- A 111k-token integrity probe passed cold, L1 restore, and restart-surviving L2
  restore with all needles exact.
- A 120-second seeded mixed-traffic sweep produced:

| Policy | Avg. normalized work | Decode retention | Completed prefills | End backlog |
|---|---:|---:|---:|---:|
| off | 80.0% | 44.9–48.1% | 12/14 | 86k tokens |
| compute 0.2 | 94.0% | 78.4–82.3% | 6/14 | 290k tokens |
| compute 0.5 | 92.7% | 63.5–65.9% | 11/14 | 147k tokens |
| compute 0.8 | **95.3%** | 60.6–62.4% | 12/14 | 86k tokens |
| micro-slicing | 77.0% | 48.1–50.0% | 11/14 | 147k tokens |

Exact public test image:

```text
ghcr.io/yatesdr/jovian-judgement-glm53-lmcache:20260903-r18-fairness-engines-5d42195d-test
sha256:036ad54e878edc7f72a13060371499033df7acad5690f31f68f1922c5070b7cf
```

## Known qualification gaps

- The fixed-window sweep was NVFP4, TP4/DCP1, no-spec, and LMCache; the complete
  KV/DCP/MTP/DFlash2 matrix has not run.
- TP8 has source/unit audit only because live TP8 hardware was unavailable.
- A realistic short/medium/long answer workload has not yet measured full
  response latency, completion rate, or output quality.
- The synthetic arrival rate intentionally overloaded every policy and does not
  establish sustainable production capacity.
- One 4,096-token prefill quantum can still cause roughly 0.5-second decode
  stalls; one compute-0.5 C1 cell observed a 2.28-second maximum outlier.
- The tested micro-slicing settings did not outperform compute-share and have
  not received an exhaustive parameter search.
- Runtime switching is development-mode-only and idle-only. Fairness engines do
  not currently support data parallelism and require
  `prefill_schedule_interval=1`.

The full methodology, backlog interpretation, and acceptance criteria are in
#624.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable decode/prefill fairness scheduling with compute-share and micro-slicing policies.
  * Added command-line options for fairness tuning, including token budgets, partial-prefill limits, and decode wait settings.
  * Added development API endpoints to view and update fairness settings at runtime.
  * Added Prometheus metrics for compute allocation, prefill activity, decode-only steps, and fairness bypasses.
  * Runtime policy changes are validated and rejected while the engine is busy.

* **Tests**
  * Added comprehensive coverage for fairness scheduling, configuration validation, runtime updates, API responses, metrics, and execution accounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->