### PR TITLE
Register speculative CUDA graph row counts during B12X warmup

### DIFF
--- a/tests/model_executor/test_b12x_warmup.py
+++ b/tests/model_executor/test_b12x_warmup.py
@@ -248,6 +248,11 @@ def test_b12x_warmup_deduplicates_registered_signatures(monkeypatch) -> None:
 
     worker = SimpleNamespace(
         get_model=lambda: SimpleNamespace(modules=modules),
+        model_runner=SimpleNamespace(
+            cudagraph_manager=SimpleNamespace(
+                planned_token_counts=lambda: [6, 12],
+            )
+        ),
         scheduler_config=SimpleNamespace(
             max_num_batched_tokens=8,
             max_num_scheduled_tokens=32,
@@ -274,8 +279,8 @@ def test_b12x_warmup_deduplicates_registered_signatures(monkeypatch) -> None:
 
     assert scans == 1
     assert calls == [
-        ("first", (1, 2, 4, 8, 16, 29, 32), torch.bfloat16),
-        ("second", (1, 2, 4, 8, 16, 29, 32), torch.bfloat16),
+        ("first", (1, 2, 4, 6, 8, 12, 16, 29, 32), torch.bfloat16),
+        ("second", (1, 2, 4, 6, 8, 12, 16, 29, 32), torch.bfloat16),
     ]
     assert synchronized == [True]
 

--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -321,6 +321,12 @@ def test_uniform_decode_exact_match_is_not_over_padded(monkeypatch):
     assert desc.num_reqs == 3
 
 
+def test_planned_token_counts_include_speculative_decode_rows(monkeypatch):
+    manager = _make_spec_decode_manager(monkeypatch)
+
+    assert manager.planned_token_counts() == [1, 2, 3, 4, 6, 8, 9, 16, 18, 24]
+
+
 def test_mixed_batch_never_selects_a_uniform_decode_graph(monkeypatch):
     manager = _make_spec_decode_manager(monkeypatch)
 

--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -235,20 +235,25 @@ def _create_decode_vllm_config(
     vllm_config.scheduler_config = SchedulerConfig.default_factory(max_num_seqs=8)
     vllm_config.parallel_config = ParallelConfig()
     vllm_config.num_speculative_tokens = num_speculative_tokens
-    if dynamic_spec_num_tokens is None:
+    if dynamic_spec_num_tokens is None and num_speculative_tokens == 0:
         vllm_config.speculative_config = None
     else:
         speculative_config = MagicMock()
-        speculative_config.uses_dynamic_speculative_decoding.return_value = True
+        speculative_config.uses_dynamic_speculative_decoding.return_value = (
+            dynamic_spec_num_tokens is not None
+        )
         speculative_config.uses_batch_size_dynamic_speculative_decoding.return_value = (
-            True
+            dynamic_spec_num_tokens is not None
         )
         speculative_config.uses_acceptance_length_adaptation.return_value = False
-        # Each entry is (range_start, range_end, num_speculative_tokens); only
-        # the third element is read by the manager.
-        speculative_config.num_speculative_tokens_per_batch_size = [
-            (0, 0, n) for n in dynamic_spec_num_tokens
-        ]
+        if dynamic_spec_num_tokens is None:
+            speculative_config.num_speculative_tokens_per_batch_size = None
+        else:
+            # Each entry is (range_start, range_end, num_speculative_tokens);
+            # only the third element is read by the manager.
+            speculative_config.num_speculative_tokens_per_batch_size = [
+                (0, 0, n) for n in dynamic_spec_num_tokens
+            ]
         vllm_config.speculative_config = speculative_config
     return vllm_config
 
@@ -322,9 +327,21 @@ def test_uniform_decode_exact_match_is_not_over_padded(monkeypatch):
 
 
 def test_planned_token_counts_include_speculative_decode_rows(monkeypatch):
-    manager = _make_spec_decode_manager(monkeypatch)
+    capture_sizes = [1, 2, 4, 8, 16, 24]
+    manager = _make_spec_decode_manager(
+        monkeypatch,
+        decode_query_len=6,
+        capture_sizes=capture_sizes,
+        num_speculative_tokens=5,
+    )
+    target_only = _make_spec_decode_manager(
+        monkeypatch,
+        decode_query_len=1,
+        capture_sizes=capture_sizes,
+    )
 
-    assert manager.planned_token_counts() == [1, 2, 3, 4, 6, 8, 9, 16, 18, 24]
+    assert manager.planned_token_counts() == [1, 2, 4, 6, 8, 12, 16, 18, 24]
+    assert 12 not in target_only.planned_token_counts()
 
 
 def test_mixed_batch_never_selects_a_uniform_decode_graph(monkeypatch):

--- a/vllm/model_executor/warmup/b12x_warmup.py
+++ b/vllm/model_executor/warmup/b12x_warmup.py
@@ -68,6 +68,14 @@ def b12x_warmup(worker: "Worker", cudagraph_capture_sizes: list[int]) -> None:
         *cudagraph_capture_sizes,
         *(size for size in compile_sizes if isinstance(size, int)),
     ]
+    cudagraph_manager = getattr(
+        getattr(worker, "model_runner", None), "cudagraph_manager", None
+    )
+    planned_token_counts = getattr(cudagraph_manager, "planned_token_counts", None)
+    if callable(planned_token_counts):
+        # Speculative decode graphs round scheduler buckets to verifier-row
+        # multiples. Those model shapes must be planned before graph capture.
+        serving_sizes.extend(planned_token_counts())
     max_tokens = max_num_batched_tokens
     max_num_scheduled_tokens = worker.scheduler_config.max_num_scheduled_tokens
     if max_num_scheduled_tokens is not None:

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -492,6 +492,16 @@ class CudaGraphManager:
     def needs_capture(self) -> bool:
         return len(self._capture_descs) > 0
 
+    def planned_token_counts(self) -> list[int]:
+        """Return model-row counts staged for decoder graph capture."""
+        return sorted(
+            {
+                desc.num_tokens
+                for descs in self._capture_descs.values()
+                for desc in descs
+            }
+        )
+
     def reset_graphs(self) -> None:
         """Destroy FULL graph executables while retaining captured resources."""
         for graph in self.graphs.values():

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -493,7 +493,11 @@ class CudaGraphManager:
         return len(self._capture_descs) > 0
 
     def planned_token_counts(self) -> list[int]:
-        """Return model-row counts staged for decoder graph capture."""
+        """Return model-row counts staged for decoder graph capture.
+
+        Returns:
+            Sorted, unique ``num_tokens`` values from the capture descriptors.
+        """
         return sorted(
             {
                 desc.num_tokens


### PR DESCRIPTION
## Status

**Implemented and TP2-qualified** for DeepSeek-V4-Flash-0731 with fixed probabilistic DSpark K5 on NVIDIA SM120.

## Operation contract

B12X MoE launch plans must exist for every model-row count represented by a CUDA graph before graph capture begins. Speculative decode graph descriptors include verifier-row counts that are not necessarily members of the scheduler request-count capture list. DeepSeek-V4-Flash-0731 with DSpark K5 and one live request executes six target verifier rows, so `M=6` must be registered explicitly.

## Resulting behavior

`CudaGraphManager.planned_token_counts()` exposes the distinct `num_tokens` values represented by staged graph descriptors. B12X warmup unions those values with scheduler capture sizes and compile sizes before preparing MoE signatures.

The change does not alter graph selection, scheduling, model arithmetic, or sampling. Non-speculative graphs remain covered by the same union operation.

## Compatibility

- Backends that do not consume B12X warmup signatures are unaffected.
- The method reports descriptor metadata already owned by `CudaGraphManager`; it does not create additional graph shapes.
- B12X prepares only the row counts reachable under the configured graph contract.

## Validation

Qualified source composition:

- vLLM base: `dev/jovian-judgement@b7e3d033676d5db46fb7d6cdd40d760365a1e239`
- vLLM integration tree: `a67b59a4099457fbcdadce4476c88504fafaf083`
- B12X integration tree: `aa76f044cbe43c191d33c0c9232e42193b16a544`
- CUDA 13.3, PyTorch 2.13, RTX PRO 6000 Blackwell, TP2/DCP1
- DSpark K5, MNS8, MNB4096, 48-row cap, `FULL_AND_PIECEWISE`

Results from `voipmonitor/vllm:jovian-judgement-vllma67b59a-b12xaa76f04-fi803c466-cu133-torch213-20260905-r6`:

- Focused CUDA graph and B12X warmup suite: 31 passed.
- Target graph capture: 9/9 PIECEWISE and 7/7 FULL shapes.
- DSpark graph capture: 6/6 FULL shapes.
- Sustained CC1: 201.1 output tok/s and 72.6 engine steps/s.
- A 144,028-token LMCache cold/restore cycle completed without a missing launch plan; all 16 rank/group byte comparisons matched.
- No graph-capture, allocation, or service error occurred during qualification.

Machine-readable receipt: https://github.com/local-inference-lab/blackwell-llm-docker/blob/main/validation/jovian-judgement-ds4-r6-engine-driven-lmcache.json

## Development disclosure

The implementation and validation were completed with OpenAI Codex assistance under human direction.
