### PR TITLE
fix(ds4): clear custom all-reduce selectors in NCCL mode

### DIFF
--- a/serve-ds4-flash.sh
+++ b/serve-ds4-flash.sh
@@ -199,6 +199,11 @@ case "${allreduce_mode}" in
     ;;
   nccl)
     export VLLM_ENABLE_PCIE_ALLREDUCE=0
+    # Base images may export a backend value for an earlier vLLM release.
+    # NCCL mode must not expose an inactive custom-backend selector because
+    # every registered vLLM environment variable is validated at worker init.
+    unset VLLM_PCIE_ALLREDUCE_BACKEND
+    unset VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE
     export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
     allreduce_args=(--disable-custom-all-reduce)
     ;;


### PR DESCRIPTION
## Resulting behavior

`serve-ds4-flash.sh` selects NCCL without exposing B12X custom all-reduce selector variables to vLLM workers.

`ALLREDUCE_MODE=nccl` now:

- sets `VLLM_ENABLE_PCIE_ALLREDUCE=0`;
- removes `VLLM_PCIE_ALLREDUCE_BACKEND`;
- removes `VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE`;
- passes `--disable-custom-all-reduce`.

## Technical reason

A container base can export custom all-reduce defaults for another vLLM release. Jovian Judgement validates registered vLLM environment variables during worker initialization. Leaving an inactive backend selector such as `VLLM_PCIE_ALLREDUCE_BACKEND=cpp` in an NCCL launch causes worker startup to fail even though `--disable-custom-all-reduce` correctly disables that code path.

The launcher owns the `ALLREDUCE_MODE` policy and must produce a complete, internally consistent environment for each mode.

## Compatibility

- `ALLREDUCE_MODE=auto` and `ALLREDUCE_MODE=b12x` are unchanged.
- NCCL collective behavior is unchanged; the patch removes only selectors for a disabled custom backend.
- No model arithmetic, cache layout, graph policy, or default mode changes.

## Validation

- `bash -n serve-ds4-flash.sh`: pass.
- `ALLREDUCE_MODE=nccl` DS4 TP2 startup reached model serving with custom all-reduce disabled in the CUDA 13.3 / PyTorch 2.13 Jovian Judgement runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NCCL launch reliability by preventing incompatible inherited configuration from affecting worker initialization.
  * Ensured the launcher consistently uses the intended all-reduce backend settings when starting workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->