### PR TITLE
[JJ] Bound native filesystem KV offload and revalidate stored blocks

### DIFF
--- a/tests/v1/kv_offload/tiering/test_async_lookup.py
+++ b/tests/v1/kv_offload/tiering/test_async_lookup.py
@@ -104,6 +104,28 @@ class TestAsyncLookupManager:
         assert _key(1) not in mgr._lookup_state
         mgr.shutdown()
 
+    def test_stale_result_ignored_after_cleanup_and_key_reuse(self):
+        key = _key(1)
+        mgr = InMemoryLookupManager()
+        ctx_a = _ctx("req_a")
+        ctx_b = _ctx("req_b")
+        assert mgr.lookup(key, ctx_a) is None
+        stale_generation = mgr._lookup_state[key].generation
+        mgr.cleanup("req_a")
+
+        assert mgr.lookup(key, ctx_b) is None
+        generation = mgr._lookup_state[key].generation
+        assert generation != stale_generation
+
+        mgr._pending_results.put([(key, stale_generation, True)])
+        mgr.drain_results()
+        assert mgr.lookup(key, ctx_b) is None
+
+        mgr._pending_results.put([(key, generation, False)])
+        mgr.drain_results()
+        assert mgr.lookup(key, ctx_b) is False
+        mgr.shutdown()
+
     def test_flush_no_queue_post_when_empty(self):
         mgr = InMemoryLookupManager()
         mgr.flush()
@@ -220,7 +242,8 @@ class TestAsyncLookupManager:
 
         # (b) A stray/duplicate result for the now-decided key violates the
         # enqueue-once invariant and must trip the assert.
-        mgr._pending_results.put([(_key(1), True)])
+        generation = mgr._lookup_state[_key(1)].generation
+        mgr._pending_results.put([(_key(1), generation, True)])
         with pytest.raises(AssertionError):
             mgr.drain_results()
         mgr.shutdown()

--- a/tests/v1/kv_offload/tiering/test_async_lookup.py
+++ b/tests/v1/kv_offload/tiering/test_async_lookup.py
@@ -222,6 +222,32 @@ class TestAsyncLookupManager:
         assert "reqA" not in mgr._req_keys
         mgr.shutdown()
 
+    def test_mark_present_supersedes_miss_and_pending_probe(self):
+        """A completed store is authoritative over cached and in-flight
+        absence checks for the same key."""
+        mgr = InMemoryLookupManager(existing_keys=set())
+        ctx = _ctx("reqA")
+
+        assert mgr.lookup(_key(1), ctx) is None
+        probe_generation = mgr._lookup_state[_key(1)].generation
+        mgr.mark_present([_key(1)])
+        assert mgr.lookup(_key(1), ctx) is True
+        assert mgr._lookup_state[_key(1)].generation != probe_generation
+
+        mgr.flush()
+        mgr._results_ready.wait()
+        mgr._results_ready.clear()
+        assert mgr.lookup(_key(1), ctx) is True
+
+        mgr.mark_miss([_key(1)])
+        assert mgr.lookup(_key(1), ctx) is False
+        mgr.mark_present([_key(1)])
+        assert mgr.lookup(_key(1), ctx) is True
+
+        mgr.mark_present([_key(99)])
+        assert _key(99) not in mgr._lookup_state
+        mgr.shutdown()
+
     def test_enqueue_once_invariant_enforced(self):
         """A key is enqueued for probing exactly once, so drain_results() may
         receive at most one result per key. Normal operation resolves a key a

--- a/tests/v1/kv_offload/tiering/test_fs_gc.py
+++ b/tests/v1/kv_offload/tiering/test_fs_gc.py
@@ -71,6 +71,20 @@ def _make_gc(mapper: FileMapper, **kwargs) -> FsGCManager:
     return FsGCManager(mapper, **params)  # type: ignore[arg-type]
 
 
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"max_bytes": 0}, "max_bytes must be positive"),
+        ({"interval_s": 0}, "interval_s must be positive"),
+        ({"stamp_interval_s": 0}, "stamp_interval_s must be positive"),
+        ({"max_tracked": 0}, "max_tracked must be positive"),
+    ],
+)
+def test_rejects_nonpositive_limits(mapper, overrides, message):
+    with pytest.raises(ValueError, match=message):
+        _make_gc(mapper, **overrides)
+
+
 def test_rejects_grace_not_exceeding_stamp_interval(mapper):
     # Otherwise a block in active use can be stamped, then age past the grace
     # window before its next stamp is due, and be swept while still hot.

--- a/tests/v1/kv_offload/tiering/test_fs_gc.py
+++ b/tests/v1/kv_offload/tiering/test_fs_gc.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unit tests for FsGCManager, the fs secondary tier's capacity bound.
+
+These use real files on disk with explicitly set mtimes, since mtime is the
+GC's single source of truth for recency. The background thread is neutralized
+by giving every manager a very long `interval_s` and driving `sweep()` directly,
+so nothing here depends on timing except the two stamping tests, which poll.
+"""
+
+import hashlib
+import os
+import time
+
+import pytest
+
+from vllm.v1.kv_offload.base import make_offload_key
+from vllm.v1.kv_offload.file_mapper import FileMapper
+from vllm.v1.kv_offload.tiering.fs.gc_manager import FsGCManager
+
+_BLOCK_BYTES = 4096
+
+
+def _make_file_mapper(root_dir: str) -> FileMapper:
+    return FileMapper(
+        root_dir=root_dir,
+        model_name="test/model",
+        tokens_per_hash=16,
+        blocks_per_file=1,
+        tp_size=1,
+        pp_size=1,
+        pcp_size=1,
+        dcp_size=1,
+        rank=0,
+        dtype="float32",
+    )
+
+
+def _key(index: int):
+    return make_offload_key(hashlib.sha256(str(index).encode()).digest()[:16], 0)
+
+
+def _write_block(mapper: FileMapper, index: int, age_s: float) -> str:
+    """Create a block file for `index` whose mtime is `age_s` in the past."""
+    path = mapper.get_file_name(_key(index))
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(b"\0" * _BLOCK_BYTES)
+    stamp = time.time() - age_s
+    os.utime(path, (stamp, stamp))
+    return path
+
+
+@pytest.fixture
+def mapper(tmp_path):
+    return _make_file_mapper(str(tmp_path))
+
+
+def _make_gc(mapper: FileMapper, **kwargs) -> FsGCManager:
+    params = dict(
+        max_bytes=10 * _BLOCK_BYTES,
+        low_watermark=0.8,
+        # Long enough that the background thread never sweeps on its own; each
+        # test calls sweep() explicitly so assertions are deterministic.
+        interval_s=3600.0,
+        stamp_interval_s=1.0,
+        grace_s=60.0,
+    )
+    params.update(kwargs)
+    return FsGCManager(mapper, **params)  # type: ignore[arg-type]
+
+
+def test_rejects_grace_not_exceeding_stamp_interval(mapper):
+    # Otherwise a block in active use can be stamped, then age past the grace
+    # window before its next stamp is due, and be swept while still hot.
+    with pytest.raises(ValueError, match="must exceed stamp_interval_s"):
+        _make_gc(mapper, stamp_interval_s=60.0, grace_s=60.0)
+
+
+def test_rejects_out_of_range_low_watermark(mapper):
+    with pytest.raises(ValueError, match="low_watermark"):
+        _make_gc(mapper, low_watermark=1.5)
+
+
+def test_under_cap_is_a_noop(mapper):
+    gc = _make_gc(mapper)
+    try:
+        paths = [_write_block(mapper, i, age_s=1000) for i in range(5)]
+        assert gc.sweep() == 0
+        assert all(os.path.exists(p) for p in paths)
+    finally:
+        gc.shutdown()
+
+
+def test_evicts_in_mtime_order_down_to_the_low_watermark(mapper):
+    gc = _make_gc(mapper)
+    try:
+        # 15 blocks over a 10-block cap, oldest first. The sweep must free down
+        # to the 8-block watermark, i.e. remove exactly the 7 oldest.
+        paths = [_write_block(mapper, i, age_s=1000 - i) for i in range(15)]
+
+        freed = gc.sweep()
+
+        assert freed == 7 * _BLOCK_BYTES
+        assert not any(os.path.exists(p) for p in paths[:7])
+        assert all(os.path.exists(p) for p in paths[7:])
+    finally:
+        gc.shutdown()
+
+
+def test_grace_window_keeps_recently_used_blocks_even_over_cap(mapper):
+    gc = _make_gc(mapper, grace_s=60.0)
+    try:
+        # Everything is inside the grace window, so the tier is knowingly left
+        # over its cap rather than evicting blocks that are still in use.
+        paths = [_write_block(mapper, i, age_s=1) for i in range(15)]
+
+        assert gc.sweep() == 0
+        assert all(os.path.exists(p) for p in paths)
+    finally:
+        gc.shutdown()
+
+
+def test_protect_keeps_an_lru_block_a_sweep_would_otherwise_evict(mapper):
+    """The one case the grace window cannot cover.
+
+    A promotion stamps its keys when the scheduler matches them, but the read
+    itself can execute much later -- queued behind other reads on a busy tier.
+    Once the mtime ages past grace_s the sweep would happily unlink the file out
+    from under the in-flight read, so submit_load/submit_store pin the keys.
+    """
+    gc = _make_gc(mapper)
+    try:
+        # All 15 are far outside the grace window, so recency protects nothing.
+        paths = [_write_block(mapper, i, age_s=1000 - i) for i in range(15)]
+
+        # The 3 oldest have reads in flight; they are exactly the blocks the
+        # sweep wants to remove first.
+        gc.protect([_key(0), _key(1), _key(2)])
+
+        freed = gc.sweep()
+
+        # Still frees the full 7 blocks needed to reach the watermark, just
+        # taking the next-oldest unprotected ones instead.
+        assert freed == 7 * _BLOCK_BYTES
+        assert all(os.path.exists(p) for p in paths[:3]), "in-flight blocks unlinked"
+        assert not any(os.path.exists(p) for p in paths[3:10])
+        assert all(os.path.exists(p) for p in paths[10:])
+
+        # Once the jobs finish the blocks become evictable again. Refill past
+        # the cap first: the previous sweep left the tier at its watermark, so
+        # another sweep would legitimately have nothing to do.
+        gc.release([_key(0), _key(1), _key(2)])
+        for i in range(15, 20):
+            _write_block(mapper, i, age_s=1)
+
+        # 13 blocks over a 10-block cap needs 5 freed, and the released blocks
+        # are still the oldest on disk, so they are now the first to go.
+        assert gc.sweep() == 5 * _BLOCK_BYTES
+        assert not any(os.path.exists(p) for p in paths[:3]), (
+            "still pinned after release"
+        )
+    finally:
+        gc.shutdown()
+
+
+def test_release_is_refcounted(mapper):
+    """Two tiers' jobs can protect the same key; one finishing must not unpin it."""
+    gc = _make_gc(mapper)
+    try:
+        paths = [_write_block(mapper, i, age_s=1000 - i) for i in range(15)]
+
+        gc.protect([_key(0)])
+        gc.protect([_key(0)])
+        gc.release([_key(0)])
+
+        gc.sweep()
+        assert os.path.exists(paths[0]), "unpinned while a job was still in flight"
+    finally:
+        gc.shutdown()
+
+
+def test_touch_stamps_mtime_so_eviction_order_follows_use(mapper):
+    gc = _make_gc(mapper)
+    try:
+        path = _write_block(mapper, 0, age_s=1000)
+        before = os.stat(path).st_mtime
+
+        gc.touch([_key(0)])
+
+        deadline = time.monotonic() + 5.0
+        while os.stat(path).st_mtime == before and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert os.stat(path).st_mtime > before
+    finally:
+        gc.shutdown()
+
+
+def test_touch_rate_limits_repeat_stamps_of_the_same_key(mapper):
+    """touch() arrives once per request per scheduling attempt with every key of
+    the request, so an unthrottled utime per call would be thousands of syscalls
+    per step."""
+    gc = _make_gc(mapper, stamp_interval_s=30.0, grace_s=60.0)
+    try:
+        path = _write_block(mapper, 0, age_s=1000)
+        gc.touch([_key(0)])
+
+        deadline = time.monotonic() + 5.0
+        while os.stat(path).st_mtime < time.time() - 900 and (
+            time.monotonic() < deadline
+        ):
+            time.sleep(0.01)
+        stamped = os.stat(path).st_mtime
+
+        # Backdate the file, then touch again well inside stamp_interval_s: the
+        # second touch must be dropped, leaving the backdated mtime in place.
+        old = time.time() - 1000
+        os.utime(path, (old, old))
+        gc.touch([_key(0)])
+        time.sleep(0.5)
+
+        assert os.stat(path).st_mtime == pytest.approx(old)
+        assert stamped > old
+    finally:
+        gc.shutdown()
+
+
+def test_touch_tolerates_keys_with_no_file(mapper):
+    """A block can live only in the DRAM primary tier, or its cascade to disk
+    can have failed; neither is an error."""
+    gc = _make_gc(mapper)
+    try:
+        gc.touch([_key(0), _key(1)])
+        time.sleep(0.2)
+        assert gc.sweep() == 0
+    finally:
+        gc.shutdown()
+
+
+def test_sweep_ignores_non_block_files(mapper):
+    """store_block writes <dest>.tmp before os.replace, and config.json must
+    survive; only .bin files are eviction candidates."""
+    gc = _make_gc(mapper, max_bytes=_BLOCK_BYTES)
+    try:
+        paths = [_write_block(mapper, i, age_s=1000 - i) for i in range(4)]
+        tmp_path = paths[0] + ".tmp"
+        with open(tmp_path, "wb") as f:
+            f.write(b"\0" * _BLOCK_BYTES)
+        stamp = time.time() - 2000
+        os.utime(tmp_path, (stamp, stamp))
+
+        gc.sweep()
+
+        assert os.path.exists(tmp_path), "in-progress store was unlinked"
+    finally:
+        gc.shutdown()

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -605,6 +605,29 @@ def test_failed_load_corrects_verdict_and_removes_corrupt_file(
     assert lookup_and_wait(tier, [key(1)], ctx=fresh) == [LookupResult.MISS]
 
 
+def test_successful_store_revalidates_cached_lookup(fs_tier):
+    """A rewritten block supersedes a failed load's cached MISS."""
+    tier, _ = fs_tier
+    block_key = key(1)
+    tier.submit_store(make_job(1, [block_key], [0]))
+    assert all(r.success for r in drain(tier))
+
+    ctx = ReqContext(req_id="restore-source")
+    assert lookup_and_wait(tier, [block_key], ctx=ctx) == [LookupResult.HIT]
+    os.unlink(tier.file_mapper.get_file_name(block_key))
+    tier.submit_load(make_job(2, [block_key], [0], is_promotion=True))
+    assert not drain(tier)[0].success
+    assert tier.lookup(block_key, ctx) == LookupResult.MISS
+
+    overlapping_ctx = ReqContext(req_id="restore-observer")
+    assert tier.lookup(block_key, overlapping_ctx) == LookupResult.MISS
+
+    tier.submit_store(make_job(3, [block_key], [0]))
+    assert all(r.success for r in drain(tier))
+    assert tier.lookup(block_key, ctx) == LookupResult.HIT
+    assert tier.lookup(block_key, overlapping_ctx) == LookupResult.HIT
+
+
 @pytest.mark.parametrize("use_c_ext", [True, False])
 def test_batched_partial_load_failure_keeps_loaded_blocks(
     fs_tier, monkeypatch, use_c_ext

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -307,6 +307,42 @@ def test_factory_forwards_locality_to_fs_tier(tmp_path):
         tier.shutdown()
 
 
+def test_capacity_config_bounds_stored_blocks(tmp_path):
+    """The public tier config constructs GC and enforces its byte budget."""
+    tensor = _page_aligned_zero_tensor(_NUM_BLOCKS, _BLOCK_ELEMENTS)
+    block_bytes = tensor.stride(0) * tensor.element_size()
+    tier = FileSystemTierManager(
+        offloading_spec=_MOCK_OFFLOADING_SPEC,
+        primary_kv_view=memoryview(tensor.numpy()),
+        tier_type="fs",
+        root_dir=str(tmp_path),
+        n_read_threads=1,
+        n_write_threads=1,
+        gc_max_size_gb=(2 * block_bytes) / 2**30,
+        gc_low_watermark=0.5,
+        gc_interval_s=3600.0,
+        gc_stamp_interval_s=1.0,
+        gc_grace_s=60.0,
+    )
+    try:
+        keys = [key(1), key(2), key(3)]
+        tier.submit_store(make_job(1, keys, [0, 1, 2]))
+        assert all(result.success for result in drain(tier))
+
+        paths = [tier.file_mapper.get_file_name(block_key) for block_key in keys]
+        old = time.time() - 1000
+        for path in paths:
+            os.utime(path, (old, old))
+
+        assert tier._gc_manager is not None
+        assert tier._gc_manager.sweep() == 2 * block_bytes
+        assert sum(os.path.getsize(path) for path in paths if os.path.exists(path)) == (
+            block_bytes
+        )
+    finally:
+        tier.shutdown()
+
+
 def test_failed_load_missing_file(fs_tier):
     """Test that loading a block whose file does not exist results in a failed job."""
     tier, _ = fs_tier

--- a/tests/v1/kv_offload/tiering/test_obj_tier.py
+++ b/tests/v1/kv_offload/tiering/test_obj_tier.py
@@ -365,6 +365,29 @@ class TestMockObjTierBasic:
         # though the object itself is still present in the mock store.
         assert lookup_and_wait(self.tier, [key(1)], ctx=ctx) == [LookupResult.MISS]
 
+    def test_successful_store_revalidates_cached_lookup(self):
+        """A rewritten object supersedes a failed load's cached MISS."""
+        block_key = key(1)
+        self.tier.submit_store(make_job(1, [block_key], [0]))
+        assert all(r.success for r in drain(self.tier))
+
+        ctx = ReqContext(req_id="restore-source")
+        assert lookup_and_wait(self.tier, [block_key], ctx=ctx) == [LookupResult.HIT]
+        original_check = self.agent.check_xfer_state
+        self.agent.check_xfer_state = lambda h: "ERR"
+        self.tier.submit_load(make_job(2, [block_key], [0]))
+        assert not drain(self.tier)[0].success
+        assert self.tier.lookup(block_key, ctx) == LookupResult.MISS
+
+        overlapping_ctx = ReqContext(req_id="restore-observer")
+        assert self.tier.lookup(block_key, overlapping_ctx) == LookupResult.MISS
+
+        self.agent.check_xfer_state = original_check
+        self.tier.submit_store(make_job(3, [block_key], [0]))
+        assert all(r.success for r in drain(self.tier))
+        assert self.tier.lookup(block_key, ctx) == LookupResult.HIT
+        assert self.tier.lookup(block_key, overlapping_ctx) == LookupResult.HIT
+
     def test_pending_transfer_not_returned_until_done(self):
         # First poll returns PROC; second poll returns DONE.
         call_count = [0]

--- a/vllm/v1/kv_offload/tiering/async_lookup.py
+++ b/vllm/v1/kv_offload/tiering/async_lookup.py
@@ -190,6 +190,20 @@ class AsyncLookupManager(ABC):
             if state is not None:
                 state.result = False
 
+    def mark_present(self, keys: Iterable[OffloadKey]) -> None:
+        """Refresh cached states after an authoritative successful store.
+
+        A failed load marks an entry absent so the request can recompute it.
+        Overlapping requests may keep that shared state alive after the
+        recomputed block has been stored again, so waiting for cleanup would
+        leave a stale miss until all of them finish. Only update existing
+        states; a key nobody has looked up does not need a cache entry.
+        """
+        for key in keys:
+            state = self._lookup_state.get(key)
+            if state is not None:
+                state.result = True
+
     def cleanup(self, req_id: str) -> None:
         """Remove entries no longer needed by any active request.
 

--- a/vllm/v1/kv_offload/tiering/async_lookup.py
+++ b/vllm/v1/kv_offload/tiering/async_lookup.py
@@ -45,6 +45,7 @@ logger = init_logger(__name__)
 
 @dataclass(slots=True)
 class LookupState:
+    generation: int
     result: bool | None = None  # True (found), False (not found), None
     request_ids: set[str] = field(default_factory=set)  # requests asking for the lookup
 
@@ -78,21 +79,24 @@ class AsyncLookupManager(ABC):
         self._lookup_state: dict[OffloadKey, LookupState] = {}
         # req_id → keys looked up by that request (reverse index for cleanup).
         self._req_keys: dict[str, set[OffloadKey]] = {}
+        # Results from an older state must not be applied after cleanup removes
+        # and recreates a key.
+        self._next_generation = 0
 
-        # Accumulates (key, req_context) pairs during lookup() calls.
+        # Accumulates (key, req_context, generation) triples during lookup().
         # Flushed as one queue item per step by flush().
-        self._lookup_batch: list[tuple[OffloadKey, ReqContext]] = []
+        self._lookup_batch: list[tuple[OffloadKey, ReqContext, int]] = []
 
         # Scheduler → worker: one full step's batch per item.
         # None is used as a shutdown sentinel.
         self._lookup_queue: queue.SimpleQueue[
-            list[tuple[OffloadKey, ReqContext]] | None
+            list[tuple[OffloadKey, ReqContext, int]] | None
         ] = queue.SimpleQueue()
 
         # Worker → scheduler: completed result batches.
-        # Each item is a list of (key, found) pairs.
+        # Each item is a list of (key, generation, found) triples.
         # SimpleQueue is explicitly thread-safe for one writer / one reader.
-        self._pending_results: queue.SimpleQueue[list[tuple[OffloadKey, bool]]] = (
+        self._pending_results: queue.SimpleQueue[list[tuple[OffloadKey, int, bool]]] = (
             queue.SimpleQueue()
         )
         self._need_to_drain: bool = False
@@ -137,9 +141,10 @@ class AsyncLookupManager(ABC):
         req_id = req_context.req_id
         state = self._lookup_state.get(key)
         if state is None:
-            state = LookupState()
+            state = LookupState(generation=self._next_generation)
+            self._next_generation += 1
             self._lookup_state[key] = state
-            self._lookup_batch.append((key, req_context))
+            self._lookup_batch.append((key, req_context, state.generation))
         state.request_ids.add(req_id)
         self._req_keys.setdefault(req_id, set()).add(key)
         return state.result
@@ -167,19 +172,19 @@ class AsyncLookupManager(ABC):
                 batch = self._pending_results.get_nowait()
             except queue.Empty:
                 break
-            for key, result in batch:
+            for key, generation, result in batch:
                 state = self._lookup_state.get(key)
-                if state is not None:
-                    # A key is enqueued for probing exactly once, so a decided
-                    # verdict must never receive a second result. Enforcing it
-                    # keeps a late/duplicate result from resurrecting a stale
-                    # True and reopening the failed-load livelock.
-                    assert state.result is None, (
-                        "cached key received a second lookup result; the "
-                        "enqueue-once invariant is broken and could reopen the "
-                        "failed-load livelock"
-                    )
-                    state.result = result
+                if state is None or state.generation != generation:
+                    continue
+                # Each lookup generation is enqueued exactly once. A matching
+                # generation must not receive a second result; stale
+                # generations were discarded above.
+                assert state.result is None, (
+                    "cached key received a second lookup result; the "
+                    "enqueue-once invariant is broken and could reopen the "
+                    "failed-load livelock"
+                )
+                state.result = result
 
     def mark_miss(self, keys: Collection[OffloadKey]) -> None:
         """Force the cached verdict for ``keys`` to False after a failed load, so
@@ -232,18 +237,19 @@ class AsyncLookupManager(ABC):
                 break
 
             # Group by req_id.
-            batches: dict[str, tuple[ReqContext, list[OffloadKey]]] = {}
-            for key, req_context in pending:
+            batches: dict[str, tuple[ReqContext, list[tuple[OffloadKey, int]]]] = {}
+            for key, req_context, generation in pending:
                 req_id = req_context.req_id
                 if req_id not in batches:
                     batches[req_id] = (req_context, [])
-                batches[req_id][1].append(key)
+                batches[req_id][1].append((key, generation))
 
             if not batches:
                 continue
 
-            results: list[tuple[OffloadKey, bool]] = []
-            for req_context, keys in batches.values():
+            results: list[tuple[OffloadKey, int, bool]] = []
+            for req_context, entries in batches.values():
+                keys = [key for key, _ in entries]
                 try:
                     hits = self.batch_lookup(keys, req_context)
                 except Exception as exc:
@@ -255,8 +261,8 @@ class AsyncLookupManager(ABC):
                     )
                     hits = (False for _ in keys)
 
-                for key, hit in zip(keys, hits):
-                    results.append((key, hit))
+                for (key, generation), hit in zip(entries, hits):
+                    results.append((key, generation, hit))
 
             # Post the entire batch as one item — no lock needed.
             if results:

--- a/vllm/v1/kv_offload/tiering/async_lookup.py
+++ b/vllm/v1/kv_offload/tiering/async_lookup.py
@@ -196,17 +196,24 @@ class AsyncLookupManager(ABC):
                 state.result = False
 
     def mark_present(self, keys: Iterable[OffloadKey]) -> None:
-        """Refresh cached states after an authoritative successful store.
+        """Replace cached verdicts after an authoritative successful store.
 
         A failed load marks an entry absent so the request can recompute it.
         Overlapping requests may keep that shared state alive after the
         recomputed block has been stored again, so waiting for cleanup would
-        leave a stale miss until all of them finish. Only update existing
-        states; a key nobody has looked up does not need a cache entry.
+        leave a stale miss until all of them finish.
+
+        A store can also finish while the first existence probe is in flight.
+        Advancing that state's generation makes the older probe result stale,
+        so it cannot overwrite the store's authoritative presence verdict.
+        Keys without lookup state do not need a cache entry.
         """
         for key in keys:
             state = self._lookup_state.get(key)
             if state is not None:
+                if state.result is None:
+                    state.generation = self._next_generation
+                    self._next_generation += 1
                 state.result = True
 
     def cleanup(self, req_id: str) -> None:

--- a/vllm/v1/kv_offload/tiering/fs/gc_manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/gc_manager.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Garbage collection for the fs secondary tier.
+
+The fs tier keeps no index of its own -- the filesystem *is* the index, since
+`lookup()` is a plain existence check -- so out of the box it has neither a
+capacity limit nor eviction, and grows until the filesystem fills.
+
+`FsGCManager` adds both, using file mtime as the single source of truth for
+recency:
+
+  - `touch()` stamps mtime when the scheduler marks a block recently used.
+    `TieringOffloadingManager` calls this on every secondary tier, including
+    for blocks served from the DRAM primary tier -- which never read this
+    tier's files and would otherwise age out while still hot. Reads cannot
+    supply this signal on their own: `store_block` sets mtime once at write
+    time, reads never update file metadata, and `load_block` opens O_DIRECT so
+    a read need not touch the device at all.
+  - A background sweep walks the tree, and when the total exceeds `max_bytes`
+    unlinks in mtime order until it is back under the low watermark.
+
+Keeping recency on disk rather than in a private dict means the ordering
+survives a restart (the fs tier's contents are reusable across runs when
+PYTHONHASHSEED is pinned), the accounting cannot drift from reality since every
+sweep re-measures it, and external tooling (`du`, `find -newermt`, a separate
+reaper) sees the same truth.
+
+Both `touch()` and the sweep run off the scheduler thread. `touch()` is called
+once per request per scheduling attempt with *all* of the request's offload keys
+(~1.9k keys for a 200k-token context), so stamping inline would cost
+milliseconds of syscalls per call and dirty thousands of inodes; instead a key
+is stamped at most once per `stamp_interval_s` and the `os.utime` calls happen
+on a daemon thread.
+
+Deleting a file that a promotion is about to read is not a correctness problem
+-- the failed promotion frees the DRAM block and the tokens get recomputed --
+but it wastes work and silently drops the block from disk, so the sweep protects
+any key with an in-flight job (`protect`/`release`) and any file whose mtime is
+within `grace_s`. Because `stamp_interval_s < grace_s`, every key used within
+`grace_s - stamp_interval_s` is guaranteed to have a protected mtime. That
+margin is eroded by clock skew wherever mtimes are not set by this host's
+clock -- on NFS or a network PVC the server stamps them while the sweep cutoff
+comes from local `time.time()` -- so on shared storage keep it well above the
+sweep duration rather than tightening the two intervals toward each other.
+
+Known limitation: sweeps do not emit KV events. When the owning tier publishes
+BlockStored events (enable_kv_events), a sweep's unlinks have no removed=True
+counterpart, so an external consumer of the event stream can believe evicted
+blocks still exist. Emitting removals would require reconstructing OffloadKeys
+from the swept paths and handing them across threads to the scheduler-owned
+events list -- and the stream would still be incomplete, because failed-load
+unlinks, peer instances sharing root_dir, and external reapers also remove
+files without events. MEDIUM_FS presence events are best-effort by design;
+consumers must tolerate a BlockStored block that is no longer there. This
+instance's own scheduler already does: a failed load invalidates its cached
+lookup and the tokens are recomputed.
+"""
+
+import os
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Collection, Iterator
+
+from vllm.logger import init_logger
+from vllm.v1.kv_offload.base import OffloadKey
+from vllm.v1.kv_offload.file_mapper import FileMapper
+
+logger = init_logger(__name__)
+
+# Bound the wait so shutdown() stays responsive when no work arrives.
+_WAKE_TIMEOUT_S = 1.0
+
+# Only block files are candidates. In particular `store_block` writes to
+# "<dest>.tmp" before os.replace, and config.json must never be removed. A
+# writer killed mid-store therefore leaks a .tmp that no sweep counts or
+# reaps; the window is one block write wide, so this is bounded in practice.
+_BLOCK_SUFFIX = ".bin"
+
+
+class FsGCManager:
+    """Bounds the fs tier's on-disk size, evicting least-recently-used blocks."""
+
+    def __init__(
+        self,
+        file_mapper: FileMapper,
+        max_bytes: int,
+        low_watermark: float = 0.9,
+        interval_s: float = 60.0,
+        stamp_interval_s: float = 60.0,
+        grace_s: float = 300.0,
+        max_tracked: int = 200_000,
+    ) -> None:
+        if not 0.0 < low_watermark <= 1.0:
+            raise ValueError(f"low_watermark must be in (0, 1], got {low_watermark}")
+        if grace_s <= stamp_interval_s:
+            raise ValueError(
+                f"grace_s ({grace_s}) must exceed stamp_interval_s "
+                f"({stamp_interval_s}), otherwise a block in active use can "
+                f"have an mtime old enough to be swept"
+            )
+
+        self.file_mapper = file_mapper
+        self.max_bytes = max_bytes
+        self.target_bytes = int(max_bytes * low_watermark)
+        self.interval_s = interval_s
+        self.stamp_interval_s = stamp_interval_s
+        self.grace_s = grace_s
+        self.max_tracked = max_tracked
+
+        # Blocks live under a per-rank sibling of the digest directory.
+        self.block_root = f"{file_mapper.base_path}_r{file_mapper.rank}"
+
+        # key -> monotonic time of last stamp, in LRU order so it can be
+        # trimmed. Losing an entry only costs one redundant utime later.
+        self._last_stamped: OrderedDict[OffloadKey, float] = OrderedDict()
+        # Dedup set of keys awaiting a stamp; dict preserves insertion order.
+        self._pending_stamps: dict[OffloadKey, None] = {}
+        # Keys with in-flight store/load jobs, which must not be unlinked.
+        self._protected: dict[OffloadKey, int] = {}
+
+        self._lock = threading.Lock()
+        self._wake = threading.Event()
+        self._stopping = False
+        self._stamped = 0
+        self._stamp_errors = 0
+
+        self._thread = threading.Thread(
+            target=self._run, name="vllm_kv_fs_gc", daemon=True
+        )
+        self._thread.start()
+        logger.info(
+            "fs tier GC enabled: cap %.1f GiB, sweeping to %.1f GiB every %gs "
+            "(mtime tracks last use, so eviction is LRU and survives restarts)",
+            max_bytes / 2**30,
+            self.target_bytes / 2**30,
+            interval_s,
+        )
+
+    # ------------------------------------------------------------------
+    # Scheduler-thread entry points
+    # ------------------------------------------------------------------
+
+    def touch(self, keys: Collection[OffloadKey]) -> None:
+        """Record keys as recently used. Cheap: one dict lookup per key."""
+        now = time.monotonic()
+        with self._lock:
+            if self._stopping:
+                return
+            for key in keys:
+                last = self._last_stamped.get(key)
+                if last is not None and now - last < self.stamp_interval_s:
+                    continue
+                self._last_stamped[key] = now
+                self._last_stamped.move_to_end(key)
+                self._pending_stamps[key] = None
+            while len(self._last_stamped) > self.max_tracked:
+                self._last_stamped.popitem(last=False)
+            has_work = bool(self._pending_stamps)
+        if has_work:
+            self._wake.set()
+
+    def protect(self, keys: Collection[OffloadKey]) -> None:
+        """Pin keys with an in-flight job so the sweep cannot unlink them."""
+        with self._lock:
+            for key in keys:
+                self._protected[key] = self._protected.get(key, 0) + 1
+
+    def release(self, keys: Collection[OffloadKey]) -> None:
+        """Undo one `protect` for each key."""
+        with self._lock:
+            for key in keys:
+                count = self._protected.get(key)
+                if count is None:
+                    continue
+                if count <= 1:
+                    del self._protected[key]
+                else:
+                    self._protected[key] = count - 1
+
+    # ------------------------------------------------------------------
+    # Background thread
+    # ------------------------------------------------------------------
+
+    def _run(self) -> None:
+        next_sweep = time.monotonic() + self.interval_s
+        while True:
+            self._wake.wait(_WAKE_TIMEOUT_S)
+            self._wake.clear()
+
+            with self._lock:
+                stopping = self._stopping
+                batch = list(self._pending_stamps)
+                self._pending_stamps.clear()
+            try:
+                self._stamp(batch)
+            except Exception:
+                # _stamp handles the expected per-key OSError itself; anything
+                # else escaping here would kill this daemon thread and
+                # silently un-bound the tier again, with no signal beyond the
+                # absence of sweep logs.
+                logger.exception("fs tier GC stamping failed")
+
+            if stopping:
+                return
+            now = time.monotonic()
+            if now >= next_sweep:
+                next_sweep = now + self.interval_s
+                try:
+                    self.sweep()
+                except Exception:
+                    logger.exception("fs tier GC sweep failed")
+
+    def _stamp(self, keys: list[OffloadKey]) -> None:
+        for key in keys:
+            # A key legitimately may have no file: the block can live only in
+            # the DRAM primary tier, or its cascade may have failed.
+            try:
+                os.utime(self.file_mapper.get_file_name(key), None)
+                self._stamped += 1
+            except OSError:
+                self._stamp_errors += 1
+
+    def _iter_blocks(self, path: str) -> Iterator[tuple[str, int, float]]:
+        """Yield (path, size, mtime) for every block file under `path`."""
+        try:
+            entries = list(os.scandir(path))
+        except FileNotFoundError:
+            return
+        for entry in entries:
+            try:
+                if entry.is_dir(follow_symlinks=False):
+                    yield from self._iter_blocks(entry.path)
+                elif entry.name.endswith(_BLOCK_SUFFIX):
+                    stat = entry.stat(follow_symlinks=False)
+                    yield entry.path, stat.st_size, stat.st_mtime
+            except OSError:
+                # Raced with a store or another sweep; skip it.
+                continue
+
+    def sweep(self) -> int:
+        """Unlink LRU blocks until under the low watermark. Returns bytes freed."""
+        started = time.monotonic()
+        blocks = list(self._iter_blocks(self.block_root))
+        total = sum(size for _, size, _ in blocks)
+        if total <= self.max_bytes:
+            logger.debug(
+                "fs tier GC: %.2f GiB in %d blocks, under the %.2f GiB cap",
+                total / 2**30,
+                len(blocks),
+                self.max_bytes / 2**30,
+            )
+            return 0
+
+        with self._lock:
+            protected_paths = {
+                self.file_mapper.get_file_name(key) for key in self._protected
+            }
+        cutoff = time.time() - self.grace_s
+
+        blocks.sort(key=lambda block: block[2])
+        freed = 0
+        removed = 0
+        in_flight = 0
+        within_grace = 0
+        for path, size, mtime in blocks:
+            if total - freed <= self.target_bytes:
+                break
+            # Check protection before recency: a block with an in-flight job must
+            # survive however old its mtime is, and the two reasons are worth
+            # telling apart. in_flight > 0 means the grace window alone was not
+            # enough and protect() is doing real work; within_grace > 0 means the
+            # working set itself is at least as large as the cap.
+            if path in protected_paths:
+                in_flight += 1
+                continue
+            if mtime > cutoff:
+                within_grace += 1
+                continue
+            try:
+                os.unlink(path)
+            except OSError:
+                continue
+            freed += size
+            removed += 1
+
+        logger.info(
+            "fs tier GC: %.2f GiB over the %.2f GiB cap, freed %.2f GiB in %d "
+            "blocks, kept %d with jobs in flight and %d used within the %gs "
+            "grace window, now %.2f GiB, took %.2fs",
+            total / 2**30,
+            self.max_bytes / 2**30,
+            freed / 2**30,
+            removed,
+            in_flight,
+            within_grace,
+            self.grace_s,
+            (total - freed) / 2**30,
+            time.monotonic() - started,
+        )
+        return freed
+
+    def shutdown(self) -> None:
+        """Stop the sweep thread. Best-effort, and nothing depends on it.
+
+        The engine reaches this through scheduler -> connector -> tier only if
+        it gets that far: EngineCore.shutdown() tears the executor down first,
+        and the API server's SIGTERM path force-kills the engine core with
+        timeout=0s, so in practice this often does not run at all. That is
+        safe -- the thread is a daemon, mtimes are already committed on disk
+        and sweeps are idempotent -- but it means queued stamps can be dropped
+        (costing at most `stamp_interval_s` of recency) and the summary below
+        should not be relied on as a shutdown signal.
+        """
+        with self._lock:
+            self._stopping = True
+        self._wake.set()
+        self._thread.join(timeout=5.0)
+        logger.info(
+            "fs tier GC stopped (%d mtime stamps, %d failed)",
+            self._stamped,
+            self._stamp_errors,
+        )

--- a/vllm/v1/kv_offload/tiering/fs/gc_manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/gc_manager.py
@@ -4,8 +4,8 @@
 Garbage collection for the fs secondary tier.
 
 The fs tier keeps no index of its own -- the filesystem *is* the index, since
-`lookup()` is a plain existence check -- so out of the box it has neither a
-capacity limit nor eviction, and grows until the filesystem fills.
+`lookup()` is a plain existence check. Without an `FsGCManager`, the tier has
+no capacity limit or eviction and grows until the filesystem fills.
 
 `FsGCManager` adds both, using file mtime as the single source of truth for
 recency:
@@ -92,14 +92,24 @@ class FsGCManager:
         grace_s: float = 300.0,
         max_tracked: int = 200_000,
     ) -> None:
+        if max_bytes <= 0:
+            raise ValueError(f"max_bytes must be positive, got {max_bytes}")
         if not 0.0 < low_watermark <= 1.0:
             raise ValueError(f"low_watermark must be in (0, 1], got {low_watermark}")
+        if interval_s <= 0:
+            raise ValueError(f"interval_s must be positive, got {interval_s}")
+        if stamp_interval_s <= 0:
+            raise ValueError(
+                f"stamp_interval_s must be positive, got {stamp_interval_s}"
+            )
         if grace_s <= stamp_interval_s:
             raise ValueError(
                 f"grace_s ({grace_s}) must exceed stamp_interval_s "
                 f"({stamp_interval_s}), otherwise a block in active use can "
                 f"have an mtime old enough to be swept"
             )
+        if max_tracked <= 0:
+            raise ValueError(f"max_tracked must be positive, got {max_tracked}")
 
         self.file_mapper = file_mapper
         self.max_bytes = max_bytes

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -139,8 +139,8 @@ class FileSystemTierManager(SecondaryTierManager):
                 cache events are enabled globally (kv_events_config).
             locality: Whether this tier's storage is LOCAL or REMOTE relative
                 to the publishing vLLM instance.
-            gc_max_size_gb: On-disk budget for this tier, in GiB. None (the
-                default) leaves the tier unbounded, as before. When set, a
+            gc_max_size_gb: On-disk budget for this tier, in GiB. None leaves
+                the tier unbounded. When set, a
                 background sweep evicts least-recently-used blocks to stay under
                 it; see FsGCManager. The budget is per engine rather than per
                 rank: the tier is constructed once on the scheduler side

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -176,7 +176,8 @@ class FileSystemTierManager(SecondaryTierManager):
                     "emit events.",
                     tier_type,
                 )
-        # Keys of in-flight store jobs, tracked only when events are enabled.
+        # Keys of in-flight stores, used to refresh lookup state on success and
+        # to emit events when enabled.
         self._store_job_keys: dict[JobId, list[OffloadKey]] = {}
         # Keys of in-flight load (promotion) jobs, so a failed load can mark
         # its own cached lookup verdicts False (see get_finished_jobs).
@@ -259,8 +260,7 @@ class FileSystemTierManager(SecondaryTierManager):
     @override
     def submit_store(self, job_metadata: TransferJob) -> None:
         keys = list(job_metadata.keys)
-        if self.events is not None:
-            self._store_job_keys[job_metadata.job_id] = keys
+        self._store_job_keys[job_metadata.job_id] = keys
         self._gc_protect(job_metadata)
         task = functools.partial(
             batch_store_block,
@@ -322,12 +322,13 @@ class FileSystemTierManager(SecondaryTierManager):
                 keys = self._gc_job_keys.pop(job_id, None)
                 if keys is not None:
                     self._gc_manager.release(keys)
-            if self.events is not None:
-                keys = self._store_job_keys.pop(job_id, None)
-                if success and keys:
+            store_keys = self._store_job_keys.pop(job_id, None)
+            if success and store_keys:
+                self._lookup_manager.mark_present(store_keys)
+                if self.events is not None:
                     self.events.append(
                         OffloadingEvent(
-                            keys=keys,
+                            keys=store_keys,
                             medium=self.medium,
                             removed=False,
                             locality=self.locality,

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -49,12 +49,12 @@ from vllm.v1.kv_offload.tiering.base import (
     SecondaryTierManager,
     TransferJob,
 )
+from vllm.v1.kv_offload.tiering.fs.gc_manager import FsGCManager
 from vllm.v1.kv_offload.tiering.fs.io import (
     batch_load_block,
     batch_store_block,
     probe_o_direct,
 )
-from vllm.v1.kv_offload.tiering.fs.gc_manager import FsGCManager
 from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
 
 if TYPE_CHECKING:

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -18,7 +18,7 @@ File naming:  <base_path>_r<rank>/<hhh>/<hh>_g<group_idx>/<hash_hex>.bin
 import functools
 import json
 import os
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable
 from typing import TYPE_CHECKING, ClassVar
 
 try:
@@ -54,6 +54,7 @@ from vllm.v1.kv_offload.tiering.fs.io import (
     batch_store_block,
     probe_o_direct,
 )
+from vllm.v1.kv_offload.tiering.fs.gc_manager import FsGCManager
 from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
 
 if TYPE_CHECKING:
@@ -117,6 +118,12 @@ class FileSystemTierManager(SecondaryTierManager):
         n_write_threads: int = 16,
         enable_kv_events: bool = False,
         locality: str | None = None,
+        gc_max_size_gb: float | None = None,
+        gc_low_watermark: float = 0.9,
+        gc_interval_s: float = 60.0,
+        gc_stamp_interval_s: float = 60.0,
+        gc_grace_s: float = 300.0,
+        gc_max_tracked: int = 200_000,
     ):
         """
         Args:
@@ -132,6 +139,28 @@ class FileSystemTierManager(SecondaryTierManager):
                 cache events are enabled globally (kv_events_config).
             locality: Whether this tier's storage is LOCAL or REMOTE relative
                 to the publishing vLLM instance.
+            gc_max_size_gb: On-disk budget for this tier, in GiB. None (the
+                default) leaves the tier unbounded, as before. When set, a
+                background sweep evicts least-recently-used blocks to stay under
+                it; see FsGCManager. The budget is per engine rather than per
+                rank: the tier is constructed once on the scheduler side
+                (get_manager), so TP and PP ranks share a single
+                <base_path>_r<rank> subtree and a single budget. Engines sharing
+                a root_dir enforce the budget independently over the same
+                subtree and so evict each other's blocks, and blocks written
+                under a different layout fingerprint (a different <base_path>)
+                are never swept at all. Note that sweeps emit no removed=True KV
+                events (see FsGCManager for why), so with enable_kv_events an
+                external consumer must treat BlockStored as best-effort.
+            gc_low_watermark: Fraction of gc_max_size_gb a sweep evicts down to,
+                so eviction is batched rather than continuous.
+            gc_interval_s: Seconds between sweeps.
+            gc_stamp_interval_s: Minimum seconds between mtime stamps of the
+                same block. Must be less than gc_grace_s.
+            gc_grace_s: Blocks used within this many seconds are never swept,
+                which keeps a sweep from racing a promotion that is about to
+                read the file.
+            gc_max_tracked: Cap on keys tracked for the stamp rate limit.
         """
         super().__init__(offloading_spec, primary_kv_view, tier_type)
         self.locality = Locality(locality) if locality is not None else None
@@ -203,6 +232,19 @@ class FileSystemTierManager(SecondaryTierManager):
 
         self._lookup_manager = FsAsyncLookupManager(tier=self, tier_type=self.tier_type)
 
+        self._gc_manager: FsGCManager | None = None
+        self._gc_job_keys: dict[JobId, list[OffloadKey]] = {}
+        if gc_max_size_gb is not None:
+            self._gc_manager = FsGCManager(
+                self.file_mapper,
+                max_bytes=int(gc_max_size_gb * 2**30),
+                low_watermark=gc_low_watermark,
+                interval_s=gc_interval_s,
+                stamp_interval_s=gc_stamp_interval_s,
+                grace_s=gc_grace_s,
+                max_tracked=gc_max_tracked,
+            )
+
     @override
     def on_new_request(self, req_context: ReqContext) -> RequestOffloadingContext:
         return RequestOffloadingContext()
@@ -219,6 +261,7 @@ class FileSystemTierManager(SecondaryTierManager):
         keys = list(job_metadata.keys)
         if self.events is not None:
             self._store_job_keys[job_metadata.job_id] = keys
+        self._gc_protect(job_metadata)
         task = functools.partial(
             batch_store_block,
             [self.file_mapper.get_file_name(key) for key in keys],
@@ -236,6 +279,7 @@ class FileSystemTierManager(SecondaryTierManager):
         # keys as a miss (see get_finished_jobs).
         keys = list(job_metadata.keys)
         self._load_job_keys[job_id] = keys
+        self._gc_protect(job_metadata)
         paths = [self.file_mapper.get_file_name(key) for key in keys]
         offsets = [int(bid) * self._block_size for bid in job_metadata.block_ids]
 
@@ -274,6 +318,10 @@ class FileSystemTierManager(SecondaryTierManager):
         as a miss here (scheduler thread)."""
         results = []
         for job_id, success, transfer_time in self._pool.get_finished():
+            if self._gc_manager is not None:
+                keys = self._gc_job_keys.pop(job_id, None)
+                if keys is not None:
+                    self._gc_manager.release(keys)
             if self.events is not None:
                 keys = self._store_job_keys.pop(job_id, None)
                 if success and keys:
@@ -332,6 +380,26 @@ class FileSystemTierManager(SecondaryTierManager):
         self._lookup_manager.flush()
 
     @override
+    def touch(self, keys: Collection[OffloadKey], req_context: ReqContext) -> None:
+        """Refresh on-disk recency so GC evicts least-recently-used blocks.
+
+        Called by TieringOffloadingManager for every tier whenever the scheduler
+        matches a request's blocks -- including blocks served from the DRAM
+        primary tier, which never read this tier's files and would otherwise age
+        out while still hot. No-op unless a GC budget is configured.
+        """
+        if self._gc_manager is not None:
+            self._gc_manager.touch(keys)
+
+    def _gc_protect(self, job_metadata: TransferJob) -> None:
+        """Pin a job's keys for as long as its transfers are in flight."""
+        if self._gc_manager is None:
+            return
+        keys = list(job_metadata.keys)
+        self._gc_job_keys[job_metadata.job_id] = keys
+        self._gc_manager.protect(keys)
+
+    @override
     def shutdown(self) -> None:
         """
         Release resources held by this tier.
@@ -339,5 +407,7 @@ class FileSystemTierManager(SecondaryTierManager):
         Shuts down the lookup manager and the thread pool,
         clearing pending tasks and waiting for active threads to complete.
         """
+        if self._gc_manager is not None:
+            self._gc_manager.shutdown()
         self._lookup_manager.shutdown()
         self._pool.shutdown(wait=True)

--- a/vllm/v1/kv_offload/tiering/obj/manager.py
+++ b/vllm/v1/kv_offload/tiering/obj/manager.py
@@ -139,7 +139,8 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
                     "emit events.",
                     tier_type,
                 )
-        # Keys of in-flight store jobs, tracked only when events are enabled.
+        # Keys of in-flight stores, used to refresh lookup state on success and
+        # to emit events when enabled.
         self._store_job_keys: dict[JobId, list[OffloadKey]] = {}
         # Keys of in-flight load (promotion) jobs, so a failed download can
         # mark its own cached lookup verdicts False (see get_finished_jobs).
@@ -280,8 +281,7 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
         return LookupResult.HIT if result else LookupResult.MISS
 
     def submit_store(self, job_metadata: TransferJob) -> None:
-        if self.events is not None:
-            self._store_job_keys[job_metadata.job_id] = list(job_metadata.keys)
+        self._store_job_keys[job_metadata.job_id] = list(job_metadata.keys)
         obj_keys = (self._file_mapper.get_file_name(k) for k in job_metadata.keys)
         self._submit_transfer(
             job_metadata.job_id, job_metadata.block_ids, obj_keys, NIXL_WRITE
@@ -365,12 +365,13 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
         results = self._pending_results
         self._pending_results = []
         for result in results:
-            if self.events is not None:
-                keys = self._store_job_keys.pop(result.job_id, None)
-                if result.success and keys:
+            store_keys = self._store_job_keys.pop(result.job_id, None)
+            if result.success and store_keys:
+                self._lookup_manager.mark_present(store_keys)
+                if self.events is not None:
                     self.events.append(
                         OffloadingEvent(
-                            keys=keys,
+                            keys=store_keys,
                             medium=self.medium,
                             removed=False,
                             locality=self.locality,


### PR DESCRIPTION
## Purpose

Enable a bounded native filesystem KV offload tier on `dev/jovian-judgement` while preserving the branch's batched C I/O, partial-load recovery, and default unbounded behavior.

A deployment can set `gc_max_size_gb` on an `fs` secondary tier. The scheduler records block use through persisted file mtimes, and a background worker evicts least-recently-used block files to a configurable low watermark. In-flight stores and promotions are protected from eviction. The feature is disabled when `gc_max_size_gb` is absent.

The same integration makes successful secondary-tier stores authoritative in the asynchronous lookup cache. A per-key generation prevents a late existence probe from overwriting a completed store with a stale absence result.

## Technical reason

`serve-ds4-flash.sh` maps `NATIVE_L2_GB` to the filesystem tier's `gc_max_size_gb` constructor argument. `dev/jovian-judgement` did not implement that argument, so a configured native L2 tier failed during engine construction. An unbounded filesystem tier can also consume all available backing storage.

Successful recomputation after a failed promotion creates a second lifecycle edge: an overlapping request can retain the cached miss while the block is stored again. The positive store result must update that state, and any older probe result must be rejected.

## Source relationship and duplicate-work check

- local-inference-lab/vllm#254 contains the qualified Gilded Gnosis implementation, but its merge commit is not an ancestor of `dev/jovian-judgement`. This PR ports only the filesystem capacity and store-revalidation contracts while retaining Jovian Judgement I/O behavior.
- vllm-project/vllm#54872 is the merged upstream generation-tagging fix. Commit `35faf957d65acdfc0b19f7cd4e4a2d50d7d73a1b` is preserved here with original authorship and extended so an authoritative store invalidates an in-flight probe generation.
- vllm-project/vllm#54327 and RFC #54779 propose a broader draft design with SQLite metadata, prefix-aware W-TinyLFU admission, namespace quotas, metrics, and DMA staging. This branch integration implements the RFC's independently useful `capacity + LRU` subset and does not duplicate that larger policy implementation.

## Compatibility

- No `gc_max_size_gb`: filesystem behavior remains unbounded.
- Positive capacity: mtime-based LRU collection runs off the scheduler thread.
- Nonpositive capacity and timing limits fail during configuration instead of creating an ineffective or continuously running collector.
- Filesystem eviction events are not emitted. KV event consumers must treat stored-block presence as best-effort because external deletion and failed-load cleanup are also not represented by removal events.
- Model computation, sampling, and cache tensor contents are unchanged.

## Validation

CUDA 13.3 / PyTorch 2.13 release environment:

```text
ruff check (7 changed/related files): passed
ruff format --check (7 changed/related files): passed
git diff --check: passed
pytest tests/v1/kv_offload/tiering: 375 passed, 11 skipped
focused fs/obj/lookup/GC tests: 104 passed, 11 skipped
```

The full tiering suite covers LRU order, low-watermark eviction, grace windows, in-flight protection, persisted recency, malformed limits, failed-load invalidation, successful-store revalidation, stale generation rejection, and object/filesystem tier lifecycle behavior.

Live DS4 TP2 native-L2 qualification will be added after the source-locked release image is rebuilt from this PR head.

## AI assistance

AI assistance was used for branch comparison, implementation adaptation, tests, and PR preparation. The submitter reviewed the changed behavior and test evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional filesystem-tier garbage collection to enforce disk usage limits, reclaim older blocks, and protect recently used or active files.
  * Added configurable cleanup thresholds, intervals, grace periods, and tracking limits.
* **Bug Fixes**
  * Prevented stale asynchronous lookup results from overriding newer key states.
  * Successful stores now reliably refresh lookup results, including after failed loads or cached misses.
* **Tests**
  * Added coverage for filesystem garbage collection, lookup generation handling, key reuse, cache revalidation, and storage-tier behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->