### PR TITLE
perf(qwen3.8): overlap independent GDN input projections

### DIFF
--- a/tests/kernels/mamba/test_gdn_fused_mtp.py
+++ b/tests/kernels/mamba/test_gdn_fused_mtp.py
@@ -248,7 +248,6 @@ def test_fused_forward_overlaps_b12x_mxfp8_input_projections() -> None:
     ba = torch.randn(num_tokens, 2 * HV, dtype=torch.bfloat16, device=device)
     qkvz_weight = object()
     ba_weight = object()
-    secondary_stream_handle = 1234
     layer = types.SimpleNamespace(
         prefix=PREFIX,
         enable_fused_gdn_decode=True,
@@ -260,7 +259,6 @@ def test_fused_forward_overlaps_b12x_mxfp8_input_projections() -> None:
         head_v_dim=V,
         in_proj_qkvz=types.SimpleNamespace(b12x_mxfp8_packed_weight=qkvz_weight),
         in_proj_ba=types.SimpleNamespace(b12x_mxfp8_packed_weight=ba_weight),
-        _b12x_mxfp8_pair_stream_handle=secondary_stream_handle,
         out_proj=lambda x: (x, None),
     )
     layer.forward_cuda = types.MethodType(
@@ -299,7 +297,6 @@ def test_fused_forward_overlaps_b12x_mxfp8_input_projections() -> None:
         ba_weight,
         expected_m=num_tokens,
         parallel_max_tokens=1023,
-        secondary_stream=secondary_stream_handle,
     )
     torch.testing.assert_close(output, torch.ones_like(output))
 

--- a/tests/kernels/mamba/test_gdn_fused_mtp.py
+++ b/tests/kernels/mamba/test_gdn_fused_mtp.py
@@ -236,6 +236,74 @@ def test_fused_forward_uses_packed_entrypoint() -> None:
     torch.testing.assert_close(output, torch.ones_like(output))
 
 
+@torch.inference_mode()
+def test_fused_forward_overlaps_b12x_mxfp8_input_projections() -> None:
+    """B12X-packed QKVZ and BA weights use the paired projection API."""
+    device = torch.device("cuda")
+    num_tokens = 4
+    hidden_states = torch.empty(num_tokens, 256, dtype=torch.bfloat16, device=device)
+    mixed_qkvz = torch.randn(
+        num_tokens, CONV_DIM + HV * V, dtype=torch.bfloat16, device=device
+    )
+    ba = torch.randn(num_tokens, 2 * HV, dtype=torch.bfloat16, device=device)
+    qkvz_weight = object()
+    ba_weight = object()
+    secondary_stream_handle = 1234
+    layer = types.SimpleNamespace(
+        prefix=PREFIX,
+        enable_fused_gdn_decode=True,
+        norm=types.SimpleNamespace(
+            weight=torch.empty(V, dtype=torch.bfloat16, device=device)
+        ),
+        num_v_heads=HV,
+        tp_size=1,
+        head_v_dim=V,
+        in_proj_qkvz=types.SimpleNamespace(b12x_mxfp8_packed_weight=qkvz_weight),
+        in_proj_ba=types.SimpleNamespace(b12x_mxfp8_packed_weight=ba_weight),
+        _b12x_mxfp8_pair_stream_handle=secondary_stream_handle,
+        out_proj=lambda x: (x, None),
+    )
+    layer.forward_cuda = types.MethodType(
+        QwenGatedDeltaNetAttention.forward_cuda, layer
+    )
+
+    def packed_op(
+        actual_qkvz: torch.Tensor,
+        actual_ba: torch.Tensor,
+        output: torch.Tensor,
+        *,
+        layer_name: str,
+    ) -> None:
+        assert actual_qkvz is mixed_qkvz
+        assert actual_ba is ba
+        assert layer_name == _encode_layer_name(PREFIX)
+        output.fill_(1)
+
+    with (
+        patch.object(
+            qwen_gdn_linear_attn,
+            "_b12x_mxfp8_pair",
+            return_value=(mixed_qkvz, ba),
+        ) as pair_mock,
+        patch.object(
+            torch.ops.vllm,
+            "qwen_gdn_attention_core_fused_norm_packed",
+            side_effect=packed_op,
+        ),
+    ):
+        output = layer.forward_cuda(hidden_states)
+
+    pair_mock.assert_called_once_with(
+        hidden_states,
+        qkvz_weight,
+        ba_weight,
+        expected_m=num_tokens,
+        parallel_max_tokens=1023,
+        secondary_stream=secondary_stream_handle,
+    )
+    torch.testing.assert_close(output, torch.ones_like(output))
+
+
 @pytest.mark.parametrize(
     "seq_lens,query_lens,draft_tokens,expected_fused_calls",
     [

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -68,7 +68,6 @@ from vllm.utils.torch_utils import (
     LayerNameType,
     _encode_layer_name,
     _resolve_layer_name,
-    aux_stream,
     direct_register_custom_op,
 )
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
@@ -462,11 +461,6 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             prefix=f"{prefix}.in_proj_ba",
         )
         self.disable_tp_for_ba_proj = self.maybe_disable_tp(self.quant_config)
-        pair_stream = aux_stream() if _b12x_mxfp8_pair is not None else None
-        self._b12x_mxfp8_pair_stream_handle = (
-            int(pair_stream.cuda_stream) if pair_stream is not None else None
-        )
-
         query_key_settings = (self.key_dim, 0, False)
         value_settings = (self.value_dim, 0, False)
 
@@ -1089,7 +1083,6 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 self.in_proj_ba.b12x_mxfp8_packed_weight,
                 expected_m=max(1, int(hidden_states.shape[0])),
                 parallel_max_tokens=1023,
-                secondary_stream=self._b12x_mxfp8_pair_stream_handle,
             )
         else:
             mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -59,11 +59,16 @@ from vllm.third_party.flash_linear_attention.ops.chunk import l2norm_fwd
 from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE
 from vllm.transformers_utils.configs.qwen3_next import Qwen3NextConfig
 from vllm.triton_utils import tl, triton
-from vllm.utils.b12x import get_b12x_gdn_decode, get_b12x_scratch_buffers
+from vllm.utils.b12x import (
+    get_b12x_gdn_decode,
+    get_b12x_mxfp8_linear,
+    get_b12x_scratch_buffers,
+)
 from vllm.utils.torch_utils import (
     LayerNameType,
     _encode_layer_name,
     _resolve_layer_name,
+    aux_stream,
     direct_register_custom_op,
 )
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
@@ -89,6 +94,10 @@ logger = init_logger(__name__)
 
 MAX_FUSED_GDN_MTP_TOKENS = 8
 FUSED_GDN_STATE_DTYPES = (torch.float32, torch.bfloat16)
+_b12x_mxfp8 = get_b12x_mxfp8_linear()
+_b12x_mxfp8_pair = (
+    getattr(_b12x_mxfp8, "mm_pair", None) if _b12x_mxfp8 is not None else None
+)
 
 
 def _resolve_gdn_decode_kernel(
@@ -453,6 +462,10 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             prefix=f"{prefix}.in_proj_ba",
         )
         self.disable_tp_for_ba_proj = self.maybe_disable_tp(self.quant_config)
+        pair_stream = aux_stream() if _b12x_mxfp8_pair is not None else None
+        self._b12x_mxfp8_pair_stream_handle = (
+            int(pair_stream.cuda_stream) if pair_stream is not None else None
+        )
 
         query_key_settings = (self.key_dim, 0, False)
         value_settings = (self.value_dim, 0, False)
@@ -1065,8 +1078,22 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # ============================================================
         # Part 1: Input Projection
         # ============================================================
-        mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
-        ba, _ = self.in_proj_ba(hidden_states)
+        if (
+            _b12x_mxfp8_pair is not None
+            and hasattr(self.in_proj_qkvz, "b12x_mxfp8_packed_weight")
+            and hasattr(self.in_proj_ba, "b12x_mxfp8_packed_weight")
+        ):
+            mixed_qkvz, ba = _b12x_mxfp8_pair(
+                hidden_states,
+                self.in_proj_qkvz.b12x_mxfp8_packed_weight,
+                self.in_proj_ba.b12x_mxfp8_packed_weight,
+                expected_m=max(1, int(hidden_states.shape[0])),
+                parallel_max_tokens=1023,
+                secondary_stream=self._b12x_mxfp8_pair_stream_handle,
+            )
+        else:
+            mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
+            ba, _ = self.in_proj_ba(hidden_states)
 
         use_fused_gdn_decode = (
             self.enable_fused_gdn_decode


### PR DESCRIPTION
## Behavior

Qwen3.8 Flash Next Gated DeltaNet layers use the paired B12X MXFP8 projection API when both QKVZ and BA projections carry packed B12X weights. The vLLM call contains no CUDA stream handle; B12X owns the per-process, per-device auxiliary stream and joins it before recurrent attention consumes either result.

Inputs with at most 1023 rows use the paired path. Inputs with 1024 or more rows execute serially. Quantization methods and linear backends without two packed B12X weights retain the existing projection calls.

Depends on local-inference-lab/b12x#307.

## Technical reason

QKVZ and BA consume the same hidden state and have no data dependency on each other. QKVZ does not occupy all RTX PRO 6000 Blackwell SM resources at bounded row counts, so the narrow BA projection can use otherwise idle capacity. Keeping CUDA stream creation inside B12X prevents a process-local handle from becoming a scalar constant in a serialized AOT graph.

## Validation

- Configuration: TP1, MTP3, BF16 activations, packed MXFP8 weights, and full-and-piecewise CUDA graphs.
- `tests/kernels/mamba/test_gdn_fused_mtp.py`: 13 passed.
- Model-path coverage verifies paired B12X routing, the 1023-row limit, expected output shapes, and unchanged fallback behavior for other linear backends.
- Generated AOT graphs contain `b12x::blockscaled_packed_mxfp8_pair` at Qwen Gated DeltaNet layers; replay does not fall back to Python projection dispatch.
- A same-GPU comparison with two warmups and five 4096-token samples measured 71.003 serial versus 72.760 paired verifier rounds/s, a 2.47% increase.
- A B12X CUDA graph microbenchmark measured row counts 1, 4, 16, 32, 64, 128, 256, 512, 768, and 1023. The paired interval was faster at every measured shape, with reductions from 9.36% to 39.42%; outputs were bit-identical.
- Restarting the engine against the same AOT compile cache completed CUDA graph capture and replay, confirming that no stale CUDA stream handle was loaded from the cached graph.
- A 32,768-token prefill request measured 17,144 engine input tok/s; its large projection batches select serial execution.

Output-token throughput is acceptance-dependent because the MTP draft sampler does not bind its randomness to the per-request generator. Verifier rounds/s is the stable decode execution metric used for the A/B conclusion.

## Compatibility

The optimization activates only when the optional B12X paired API and both packed weights are available. Other hardware, quantization methods, and linear backends retain existing behavior.