### PR TITLE
fix(glm5next): bump FlashKDA to stable inverse

### DIFF
--- a/cmake/external_projects/flashkda.cmake
+++ b/cmake/external_projects/flashkda.cmake
@@ -13,7 +13,7 @@ else()
   FetchContent_Declare(
     flashkda
     GIT_REPOSITORY https://github.com/vllm-project/FlashKDA.git
-    GIT_TAG ee0be888cd0e972f9409bf53756f8c38c6652173
+    GIT_TAG 3b225bf26bb8e218928a1fe14751cb48cf31d11b
     GIT_PROGRESS TRUE
     GIT_SUBMODULES cutlass
   )

--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -1062,6 +1062,56 @@ def test_fused_kda_decode_rejects_speculative_conv_state():
 
 
 @torch.inference_mode()
+def test_flashkda_near_collinear_keys_remain_finite():
+    """Guard against unstable inversion of near-collinear key blocks."""
+    lower_bound = -5.0
+    if not is_flashkda_supported(128, torch.bfloat16, lower_bound):
+        pytest.skip("FlashKDA is not supported on this platform")
+
+    import vllm._flashkda_C  # noqa: F401
+
+    T, H, D = 16384, 1, 128
+    torch.manual_seed(0)
+    key = torch.randn(1, 1, H, D, dtype=torch.bfloat16, device=DEVICE)
+    qk = key.expand(1, T, H, D).contiguous()
+    value_block = torch.randn(1, 16, H, D, dtype=torch.bfloat16, device=DEVICE)
+    value = value_block.repeat(1, T // 16, 1, 1)
+    raw_gate = torch.full_like(qk, -12.0)
+    raw_beta = torch.full((1, T, H), 8.0, dtype=qk.dtype, device=DEVICE)
+    A_log = torch.zeros(H, dtype=torch.float32, device=DEVICE)
+    dt_bias = torch.zeros(H, D, dtype=torch.float32, device=DEVICE)
+    initial_state = torch.zeros(1, H, D, D, dtype=torch.float32, device=DEVICE)
+    final_state = torch.empty_like(initial_state)
+    output = torch.empty_like(value)
+    cu_seqlens = torch.tensor([0, T], dtype=torch.int32, device=DEVICE)
+    workspace = torch.empty(
+        torch.ops._flashkda_C.get_workspace_size(T, H, 1),
+        dtype=torch.uint8,
+        device=DEVICE,
+    )
+
+    torch.ops._flashkda_C.fwd(
+        qk,
+        qk,
+        value,
+        raw_gate,
+        raw_beta,
+        D**-0.5,
+        output,
+        workspace,
+        A_log,
+        dt_bias,
+        lower_bound,
+        initial_state,
+        final_state,
+        cu_seqlens,
+    )
+
+    assert torch.isfinite(output).all()
+    assert torch.isfinite(final_state).all()
+
+
+@torch.inference_mode()
 def test_flashkda_correctness():
     if not is_flashkda_supported(128, torch.bfloat16, -3.0):
         pytest.skip("FlashKDA is not supported on this platform")


### PR DESCRIPTION
## Summary

- Bump FlashKDA from `ee0be888cd0e972f9409bf53756f8c38c6652173` to `3b225bf26bb8e218928a1fe14751cb48cf31d11b`.
- Replace the numerically unstable FP16 Neumann-series inverse with FlashKDA's upstream mixed-precision stable inverse.
- Add the upstream near-collinear-key regression test.

Fixes #637.

Upstream references:

- https://github.com/vllm-project/FlashKDA/pull/10
- https://github.com/vllm-project/vllm/pull/54859

## Root cause

The FlashKDA revision pinned by r20 computes the triangular inverse using an
FP16 Neumann series:

`(I - L)(I + L²)(I + L⁴)(I + L⁸)`

For valid near-collinear KDA keys, intermediate powers can become large and
then require cancellation that FP16 cannot represent accurately. This can
produce non-finite FlashKDA output and recurrent state. Once written into the
model's recurrent cache, the invalid state manifests as corrupted answers or
long decoding runaways.

The corrected kernel performs the fragile 8×8 triangular solve using FP32
forward substitution. Its larger 16×16 merge remains BF16 tensor-core work;
the rest of FlashKDA is unchanged.

## Local reproduction

Exact base image:

`voipmonitor/vllm@sha256:d6ccc79f65e3b83896e7307afafc89146b2d116ef2e7166295e15bd362a5d340`

Configuration:

- GLM-5.3-Flash-NVFP4
- TP4 / DCP4
- MTP depth 3
- `fp8_ds_mla`
- 4,096 maximum batched tokens
- Four simultaneous unique 90K-token prefills

| Test | Result |
|---|---:|
| r20 FlashKDA end-to-end | 3 clean, 1 runaway |
| Same image with only Triton KDA selected | 12/12 clean |
| r20 FlashKDA near-collinear oracle | 55,264 non-finite output values; 16,000 non-finite state values |
| Corrected compiled kernel oracle | All finite; zero non-finite values |

## Performance

CN4 SM120 kernel microbenchmark at the relevant packed TP4/C4 shape:

- Shape: 4,096 total tokens, four sequences, 16 local heads, head dimension 128
- Five samples of 100 calls after warm-up

| Kernel | Median |
|---|---:|
| r20 FlashKDA | 105.03 µs |
| Corrected FlashKDA | 102.98 µs |
| Difference | -1.95% |

No regression was measured on our SM120 test. Upstream reported between 0.72%
and 1.99% kernel-level overhead on its tested hardware and no expected
measurable end-to-end regression.

## Scope

This PR contains only the upstream FlashKDA pin bump and its regression test.
It does not change scheduling, cache geometry, LMCache, speculative decoding,
or backend-selection policy.
