### PR TITLE
fix(parser): keep GLM tool delimiters inside argument values

### DIFF
--- a/tests/parser/engine/test_glm47_moe.py
+++ b/tests/parser/engine/test_glm47_moe.py
@@ -90,7 +90,7 @@ def parser(mock_tokenizer, tools):
 
 
 def _tag_chunks(output: str) -> list[str]:
-    """Split output so every tag is its own chunk, like GLM's tokenizer."""
+    """Split output at every GLM tag boundary."""
     chunks: list[str] = []
     offset = 0
     while offset < len(output):

--- a/tests/parser/engine/test_glm47_moe.py
+++ b/tests/parser/engine/test_glm47_moe.py
@@ -1,13 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""GLM-4.7 parser tests for tool delimiters that appear inside argument values.
-
-GLM tokenizes a literal ``</tool_call>`` or ``</arg_value>`` inside an
-argument value to the same token ID as the structural tag, so the parser
-can only tell them apart by position: ``</tool_call>`` is structural only
-between arguments, and ``</arg_value>`` is structural only when the next
-non-whitespace text is ``<arg_key>`` or ``</tool_call>``.
-"""
+"""Regression tests for GLM delimiters inside argument values."""
 
 import json
 

--- a/tests/parser/engine/test_glm47_moe.py
+++ b/tests/parser/engine/test_glm47_moe.py
@@ -144,6 +144,25 @@ class TestNonStreaming:
         assert json.loads(result.tool_calls[0].function.arguments) == EXPECTED_ARGS
         assert result.content is None
 
+    def test_missing_arg_value_end_keeps_tool_end_as_data(
+        self, parser, mock_request, tools
+    ):
+        mock_request.tools = tools
+        output = (
+            f"{THINK_END}{TOOL_CALL_START}record_value"
+            f"{ARG_KEY_START}value{ARG_KEY_END}{ARG_VALUE_START}unterminated"
+            f"{TOOL_CALL_END}after"
+        )
+
+        result = parser.extract_tool_calls(output, mock_request)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert json.loads(result.tool_calls[0].function.arguments) == {
+            "value": f"unterminated{TOOL_CALL_END}after"
+        }
+        assert result.content is None
+
 
 class TestStreaming:
     @pytest.mark.parametrize("split", ["tags", "chars"])

--- a/tests/parser/engine/test_glm47_moe.py
+++ b/tests/parser/engine/test_glm47_moe.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GLM-4.7 parser tests for tool delimiters that appear inside argument values.
+
+GLM tokenizes a literal ``</tool_call>`` or ``</arg_value>`` inside an
+argument value to the same token ID as the structural tag, so the parser
+can only tell them apart by position: ``</tool_call>`` is structural only
+between arguments, and ``</arg_value>`` is structural only when the next
+non-whitespace text is ``<arg_key>`` or ``</tool_call>``.
+"""
+
+import json
+
+import pytest
+
+from tests.parser.engine.conftest import make_mock_tokenizer
+from tests.parser.engine.streaming_helpers import (
+    collect_content,
+    collect_function_name,
+    collect_tool_arguments,
+    simulate_tool_streaming,
+)
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionToolsParam,
+    FunctionDefinition,
+)
+from vllm.parser.glm47_moe import (
+    ARG_KEY_END,
+    ARG_KEY_START,
+    ARG_VALUE_END,
+    ARG_VALUE_START,
+    THINK_END,
+    TOOL_CALL_END,
+    TOOL_CALL_START,
+    Glm47MoeParser,
+    _glm47_arg_converter,
+)
+
+TAGS = (
+    ARG_VALUE_END,
+    ARG_VALUE_START,
+    ARG_KEY_END,
+    ARG_KEY_START,
+    TOOL_CALL_END,
+    TOOL_CALL_START,
+    THINK_END,
+)
+
+VALUE = "left </arg_value> then </tool_call> as data <tool_call> more"
+OUTPUT = (
+    f"{THINK_END}{TOOL_CALL_START}record_value"
+    f"{ARG_KEY_START}value{ARG_KEY_END}{ARG_VALUE_START}{VALUE}{ARG_VALUE_END}"
+    f"{ARG_KEY_START}path{ARG_KEY_END}{ARG_VALUE_START}/tmp/x{ARG_VALUE_END}"
+    f"{TOOL_CALL_END}"
+)
+EXPECTED_ARGS = {"value": VALUE, "path": "/tmp/x"}
+
+
+@pytest.fixture
+def mock_tokenizer():
+    return make_mock_tokenizer(
+        {
+            "<think>": 154841,
+            THINK_END: 154842,
+            TOOL_CALL_START: 154843,
+            TOOL_CALL_END: 154844,
+            ARG_KEY_START: 154847,
+            ARG_KEY_END: 154848,
+            ARG_VALUE_START: 154849,
+            ARG_VALUE_END: 154850,
+            "<|observation|>": 154829,
+        }
+    )
+
+
+@pytest.fixture
+def tools():
+    return [
+        ChatCompletionToolsParam(
+            function=FunctionDefinition(
+                name="record_value",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "string"},
+                        "path": {"type": "string"},
+                    },
+                },
+            ),
+        )
+    ]
+
+
+@pytest.fixture
+def parser(mock_tokenizer, tools):
+    return Glm47MoeParser(mock_tokenizer, tools=tools)
+
+
+def _tag_chunks(output: str) -> list[str]:
+    """Split output so every tag is its own chunk, like GLM's tokenizer."""
+    chunks: list[str] = []
+    offset = 0
+    while offset < len(output):
+        tag = next((t for t in TAGS if output.startswith(t, offset)), None)
+        if tag is not None:
+            chunks.append(tag)
+            offset += len(tag)
+            continue
+        ends = [p for t in TAGS if (p := output.find(t, offset + 1)) >= 0]
+        end = min(ends, default=len(output))
+        chunks.append(output[offset:end])
+        offset = end
+    return chunks
+
+
+class TestConverter:
+    def test_literal_arg_value_end_inside_value(self):
+        raw = (
+            "<arg_key>a</arg_key><arg_value>x</arg_value>y</arg_value>"
+            "<arg_key>b</arg_key><arg_value>2</arg_value>"
+        )
+        assert json.loads(_glm47_arg_converter(raw, False)) == {
+            "a": "x</arg_value>y",
+            "b": "2",
+        }
+
+    def test_partial_holds_back_final_arg_value_end(self):
+        raw = "<arg_key>a</arg_key><arg_value>x</arg_value>"
+        assert json.loads(_glm47_arg_converter(raw, True)) == {"a": "x"}
+        raw += "y"
+        assert json.loads(_glm47_arg_converter(raw, True)) == {"a": "x"}
+        raw += "</arg_value>"
+        assert json.loads(_glm47_arg_converter(raw, True)) == {"a": "x</arg_value>y"}
+
+    def test_whitespace_between_args_still_accepted(self):
+        raw = (
+            "<arg_key>a</arg_key>\n<arg_value>1</arg_value>\n"
+            "<arg_key>b</arg_key>\n<arg_value>2</arg_value>\n"
+        )
+        assert json.loads(_glm47_arg_converter(raw, False)) == {"a": "1", "b": "2"}
+
+
+class TestNonStreaming:
+    def test_delimiters_inside_value(self, parser, mock_request, tools):
+        mock_request.tools = tools
+        result = parser.extract_tool_calls(OUTPUT, mock_request)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "record_value"
+        assert json.loads(result.tool_calls[0].function.arguments) == EXPECTED_ARGS
+        assert result.content is None
+
+
+class TestStreaming:
+    @pytest.mark.parametrize("split", ["tags", "chars"])
+    def test_delimiters_inside_value(self, parser, mock_request, tools, split):
+        mock_request.tools = tools
+        chunks = _tag_chunks(OUTPUT) if split == "tags" else list(OUTPUT)
+        results = simulate_tool_streaming(parser, mock_request, chunks)
+        finish = parser.finish_streaming()
+        if finish is not None:
+            results.append((finish, OUTPUT))
+
+        assert collect_function_name(results) == "record_value"
+        assert json.loads(collect_tool_arguments(results)) == EXPECTED_ARGS
+        assert collect_content(results) == ""
+
+    def test_stop_token_id_without_text_in_final_delta(self, mock_request, tools):
+        """Speculative decoding can deliver the whole call plus the stop
+        token in one step; serving strips the stop text but keeps its ID.
+        Literal tags inside the value carry the same IDs as real ones."""
+        tokens = [
+            (154842, THINK_END),
+            (154843, TOOL_CALL_START),
+            (400, "record_value"),
+            (154847, ARG_KEY_START),
+            (401, "value"),
+            (154848, ARG_KEY_END),
+            (154849, ARG_VALUE_START),
+            (154844, TOOL_CALL_END),
+            (402, " and "),
+            (154843, TOOL_CALL_START),
+            (154850, ARG_VALUE_END),
+            (154844, TOOL_CALL_END),
+            (154829, ""),
+        ]
+        vocab = {text: tid for tid, text in tokens if text}
+        vocab["<think>"] = 154841
+        vocab["<|observation|>"] = 154829
+        tokenizer = make_mock_tokenizer(
+            vocab,
+            special_tokens=[
+                t for t in vocab if t not in ("record_value", "value", " and ")
+            ],
+        )
+        parser = Glm47MoeParser(tokenizer, tools=tools)
+        mock_request.tools = tools
+        text = "".join(t for _, t in tokens)
+        ids = tuple(tid for tid, _ in tokens)
+
+        delta = parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text=text,
+            delta_text=text,
+            previous_token_ids=(),
+            current_token_ids=ids,
+            delta_token_ids=ids,
+            request=mock_request,
+        )
+        results = [(delta, text), (parser.finish_streaming(), text)]
+
+        assert collect_function_name(results) == "record_value"
+        assert json.loads(collect_tool_arguments(results)) == {
+            "value": "</tool_call> and <tool_call>"
+        }
+        assert collect_content(results) == ""

--- a/tests/parser/engine/test_glm47_moe.py
+++ b/tests/parser/engine/test_glm47_moe.py
@@ -163,6 +163,25 @@ class TestNonStreaming:
         }
         assert result.content is None
 
+    def test_last_arg_value_end_drops_trailing_malformed_text(
+        self, parser, mock_request, tools
+    ):
+        mock_request.tools = tools
+        output = (
+            f"{THINK_END}{TOOL_CALL_START}record_value"
+            f"{ARG_KEY_START}value{ARG_KEY_END}{ARG_VALUE_START}Beijing"
+            f"{ARG_VALUE_END} stray {TOOL_CALL_END}after"
+        )
+
+        result = parser.extract_tool_calls(output, mock_request)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert json.loads(result.tool_calls[0].function.arguments) == {
+            "value": "Beijing"
+        }
+        assert result.content is None
+
 
 class TestStreaming:
     @pytest.mark.parametrize("split", ["tags", "chars"])

--- a/vllm/parser/engine/parser_engine_config.py
+++ b/vllm/parser/engine/parser_engine_config.py
@@ -11,6 +11,8 @@ Each model format is described by a :class:`ParserEngineConfig` that specifies:
 * **transitions** – a state machine mapping
   ``(state, terminal) → (new_state, events_to_emit)`` that drives semantic
   event generation during streaming.
+* **non_whitespace_transitions** – optional state changes triggered by plain
+  content that contains a non-whitespace character.
 * **content_events** – what :class:`EventType` to emit for plain content
   (non-terminal text) in each state.
 """
@@ -33,6 +35,7 @@ class ParserState(Enum):
     TOOL_NAME = auto()
     TOOL_ARGS = auto()
     TOOL_BETWEEN = auto()
+    TOOL_ARG_END_PENDING = auto()
 
 
 @dataclass(frozen=True, slots=True)
@@ -95,6 +98,10 @@ class ParserEngineConfig:
 
     # Reject tool calls whose names are absent from the request tools.
     validate_tool_names: bool = False
+
+    non_whitespace_transitions: dict[ParserState, Transition] = field(
+        default_factory=dict,
+    )
 
     @cached_property
     def terminal_defs(self):

--- a/vllm/parser/engine/streaming_parser_engine.py
+++ b/vllm/parser/engine/streaming_parser_engine.py
@@ -300,6 +300,7 @@ class StreamingParserEngine:
             ParserState.TOOL_ARGS,
             ParserState.TOOL_NAME,
             ParserState.TOOL_BETWEEN,
+            ParserState.TOOL_ARG_END_PENDING,
         ):
             if self.tool_index >= 0:
                 events.append(
@@ -355,6 +356,7 @@ class StreamingParserEngine:
             ParserState.TOOL_NAME,
             ParserState.TOOL_ARGS,
             ParserState.TOOL_BETWEEN,
+            ParserState.TOOL_ARG_END_PENDING,
         }
     )
 
@@ -430,6 +432,9 @@ class StreamingParserEngine:
         return self._apply_transition(transition, value, token_count)
 
     def _emit_for_state(self, text: str, token_count: int = 0) -> list[SemanticEvent]:
+        transition = self.config.non_whitespace_transitions.get(self.state)
+        if transition is not None and text.strip():
+            return self._apply_transition(transition, text, token_count)
         if self.state == ParserState.MESSAGE_HEADER:
             self._message_header_buffer += text
             self._message_header_token_count += token_count

--- a/vllm/parser/glm47_moe.py
+++ b/vllm/parser/glm47_moe.py
@@ -8,6 +8,11 @@ GLM-4.7 uses XML-like tool calls::
 
 The function name can be followed directly by the first ``<arg_key>`` tag,
 and tool calls may have no arguments.
+
+A literal tag inside an argument value has the same token ID as the
+structural tag, so position is the only signal: ``</tool_call>`` is
+structural only between arguments, and ``</arg_value>`` is structural only
+when the next non-whitespace text is ``<arg_key>`` or ``</tool_call>``.
 """
 
 from __future__ import annotations
@@ -41,12 +46,15 @@ ARG_KEY_END = "</arg_key>"
 ARG_VALUE_START = "<arg_value>"
 ARG_VALUE_END = "</arg_value>"
 
+# A complete argument ends at the first ``</arg_value>`` that is followed
+# by the next ``<arg_key>`` or by the end of the arguments. Any other
+# ``</arg_value>`` is data inside the value.
 _ARG_RE = re.compile(
     r"<arg_key>(?P<key>.*?)</arg_key>\s*"
-    r"<arg_value>(?P<value>.*?)</arg_value>",
+    r"<arg_value>(?P<value>.*?)</arg_value>(?=\s*(?:<arg_key>|$))",
     re.DOTALL,
 )
-_PARTIAL_ARG_RE = re.compile(
+_TAIL_ARG_RE = re.compile(
     r"<arg_key>(?P<key>.*?)</arg_key>\s*"
     r"<arg_value>(?P<value>.*)$",
     re.DOTALL,
@@ -55,17 +63,25 @@ _PARTIAL_ARG_RE = re.compile(
 
 def _glm47_arg_converter(raw_args: str, partial: bool) -> str:
     params: dict[str, object] = {}
+    pos = 0
 
     for match in _ARG_RE.finditer(raw_args):
+        if partial and match.end() == len(raw_args.rstrip()):
+            # The final </arg_value> may still turn out to be data once
+            # more text arrives, so leave it to the tail below.
+            break
         params[match.group("key").strip()] = match.group("value")
+        pos = match.end()
 
-    if partial:
-        remaining = _ARG_RE.sub("", raw_args)
-        match = _PARTIAL_ARG_RE.search(remaining)
-        if match:
-            key = match.group("key").strip()
-            if key:
-                params[key] = match.group("value")
+    tail = _TAIL_ARG_RE.search(raw_args, pos)
+    if tail:
+        key = tail.group("key").strip()
+        value = tail.group("value")
+        last_end = value.rfind(ARG_VALUE_END)
+        if last_end >= 0:
+            value = value[:last_end]
+        if key:
+            params[key] = value
 
     return json.dumps(params, ensure_ascii=False)
 
@@ -73,16 +89,36 @@ def _glm47_arg_converter(raw_args: str, partial: bool) -> str:
 @functools.cache
 def glm47_moe_config(thinking: bool = True) -> ParserEngineConfig:
     arg_tag_transitions = {
-        (ParserState.TOOL_ARGS, terminal): Transition(
+        (ParserState.TOOL_NAME, "ARG_KEY_START"): Transition(
+            ParserState.TOOL_BETWEEN,
+            (EventType.ARG_VALUE_CHUNK,),
+        ),
+        (ParserState.TOOL_BETWEEN, "ARG_KEY_START"): Transition(
+            ParserState.TOOL_BETWEEN,
+            (EventType.ARG_VALUE_CHUNK,),
+        ),
+        (ParserState.TOOL_BETWEEN, "ARG_KEY_END"): Transition(
+            ParserState.TOOL_BETWEEN,
+            (EventType.ARG_VALUE_CHUNK,),
+        ),
+        (ParserState.TOOL_BETWEEN, "ARG_VALUE_START"): Transition(
             ParserState.TOOL_ARGS,
             (EventType.ARG_VALUE_CHUNK,),
-        )
-        for terminal in (
-            "ARG_KEY_START",
-            "ARG_KEY_END",
-            "ARG_VALUE_START",
-            "ARG_VALUE_END",
-        )
+        ),
+        # A </arg_value> is only structural if the next non-whitespace text
+        # is <arg_key> or </tool_call>; anything else means it was data.
+        (ParserState.TOOL_ARGS, "ARG_VALUE_END"): Transition(
+            ParserState.TOOL_ARG_END_PENDING,
+            (EventType.ARG_VALUE_CHUNK,),
+        ),
+        (ParserState.TOOL_ARG_END_PENDING, "ARG_VALUE_END"): Transition(
+            ParserState.TOOL_ARG_END_PENDING,
+            (EventType.ARG_VALUE_CHUNK,),
+        ),
+        (ParserState.TOOL_ARG_END_PENDING, "ARG_KEY_START"): Transition(
+            ParserState.TOOL_BETWEEN,
+            (EventType.ARG_VALUE_CHUNK,),
+        ),
     }
 
     reasoning_terminals = (
@@ -151,19 +187,33 @@ def glm47_moe_config(thinking: bool = True) -> ParserEngineConfig:
                 ParserState.TOOL_NAME,
                 (EventType.TOOL_CALL_START,),
             ),
-            (ParserState.TOOL_NAME, "ARG_KEY_START"): Transition(
-                ParserState.TOOL_ARGS,
-                (EventType.ARG_VALUE_CHUNK,),
-            ),
             (ParserState.TOOL_NAME, "TOOL_END"): Transition(
                 ParserState.CONTENT,
                 (EventType.TOOL_CALL_END,),
             ),
-            (ParserState.TOOL_ARGS, "TOOL_END"): Transition(
+            (ParserState.TOOL_BETWEEN, "TOOL_END"): Transition(
+                ParserState.CONTENT,
+                (EventType.TOOL_CALL_END,),
+            ),
+            (ParserState.TOOL_ARG_END_PENDING, "TOOL_END"): Transition(
                 ParserState.CONTENT,
                 (EventType.TOOL_CALL_END,),
             ),
             **arg_tag_transitions,
+        },
+        non_whitespace_transitions={
+            ParserState.TOOL_ARG_END_PENDING: Transition(
+                ParserState.TOOL_ARGS,
+                (EventType.ARG_VALUE_CHUNK,),
+            ),
+        },
+        content_events={
+            ParserState.CONTENT: EventType.TEXT_CHUNK,
+            ParserState.REASONING: EventType.REASONING_CHUNK,
+            ParserState.TOOL_NAME: EventType.TOOL_NAME,
+            ParserState.TOOL_ARGS: EventType.ARG_VALUE_CHUNK,
+            ParserState.TOOL_BETWEEN: EventType.ARG_VALUE_CHUNK,
+            ParserState.TOOL_ARG_END_PENDING: EventType.ARG_VALUE_CHUNK,
         },
         arg_converter=_glm47_arg_converter,
         stream_arg_deltas=True,

--- a/vllm/parser/glm47_moe.py
+++ b/vllm/parser/glm47_moe.py
@@ -11,8 +11,8 @@ and tool calls may have no arguments.
 
 A literal tag inside an argument value has the same token ID as the
 structural tag, so position is the only signal: ``</tool_call>`` is
-structural only between arguments, and ``</arg_value>`` is structural only
-when the next non-whitespace text is ``<arg_key>`` or ``</tool_call>``.
+structural only outside an argument value, and ``</arg_value>`` is structural
+only when the next non-whitespace text is ``<arg_key>`` or ``</tool_call>``.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Problem

GLM-4.7 and GLM-5.3 tokenize a literal `</tool_call>`, `</arg_value>`, or `<tool_call>` inside an argument value to the same token ID as the structural tag. When the model writes those strings as data, such as while editing parser or template code, the parser can close the tool call at the first `</tool_call>` and leak the rest of the value into content.

## Fix

Position is the only remaining signal, so the parser applies two rules:

- `</tool_call>` is structural only outside an argument value: before arguments, between arguments, or immediately after a candidate `</arg_value>`. The `(TOOL_ARGS, TOOL_END)` transition is removed from the GLM transition table.
- `</arg_value>` is structural only when the next non-whitespace text is `<arg_key>` or `</tool_call>`. A new `TOOL_ARG_END_PENDING` state holds that decision. Any other non-whitespace text returns the engine to `TOOL_ARGS`.

The second rule uses a small parser-engine hook, `ParserEngineConfig.non_whitespace_transitions`. Its default is empty, so existing parser configurations do not change. `_emit_for_state` applies the configured transition when plain content contains a non-whitespace character.

The argument converter uses `_ARG_RE` with a lookahead for the next `<arg_key>` or the end of the argument buffer, plus `_TAIL_ARG_RE` for the open final argument. In partial mode, a final `</arg_value>` is held until later text proves whether it is structural or data. This keeps streamed argument prefixes monotonic.

## Compatibility and failure behavior

- The shared `glm47_moe_config` is also used by the GLM-4.5 aliases and Ling3. Their existing parser tests pass.
- `non_whitespace_transitions` is opt-in and default-inert for every other parser configuration.
- The exact sequences `</arg_value><arg_key>` and `</arg_value></tool_call>` are necessarily structural. The token stream contains no information that could distinguish those boundaries from identical literal data.
- If a malformed call omits its closing `</arg_value>`, a later `</tool_call>` is treated as argument data and following text remains in the argument until `finish()`. This is the deliberate tradeoff for preserving literal tool delimiters inside values.
- At final conversion, if no confirmed boundary follows, the last `</arg_value>` candidate is used as the malformed fallback and later bytes are discarded.

## Related work and duplicate check

This is not a duplicate of [vllm-project/vllm#54971](https://github.com/vllm-project/vllm/pull/54971). That PR prevents stray `arg_key` tags from corrupting argument keys; this PR disambiguates delimiters inside argument values. Both edit the GLM argument regexes, so a future upstream rebase must compose its `_ARG_KEY` prefix with this PR's lookahead patterns.

This PR replaces the GLM delimiter portion of #540. The companion scanner correction is #640. Other parser-wide experiments from #540 are intentionally not included.

Open-PR searches found no other upstream or fork PR implementing this argument-value boundary behavior.

## Tests

Pytest validation used Python 3.12 in `/opt/venv` inside the existing `rtx-station/glm53-jovian:lp15` image. Source and temporary test dependencies were mounted read-only. Lint validation used the repository-pinned Ruff version through `uvx` on the host.

```bash
/opt/venv/bin/python -m pytest tests/parser/engine/test_glm47_moe.py -q
/opt/venv/bin/python -m pytest tests/parser/engine -q
/opt/venv/bin/python -m pytest tests/tool_parsers/test_glm47_moe_tool_parser.py -q
/opt/venv/bin/python -m pytest tests/reasoning/test_glm4_moe_reasoning_parser.py -q
/opt/venv/bin/python -m pytest \
  tests/tool_parsers/test_glm4_moe_tool_parser.py \
  tests/parser/engine/test_ling3.py -q
uvx ruff@0.14.0 check \
  tests/parser/engine/test_glm47_moe.py \
  vllm/parser/engine/parser_engine_config.py \
  vllm/parser/engine/streaming_parser_engine.py \
  vllm/parser/glm47_moe.py
uvx ruff@0.14.0 format --check \
  tests/parser/engine/test_glm47_moe.py \
  vllm/parser/engine/parser_engine_config.py \
  vllm/parser/engine/streaming_parser_engine.py \
  vllm/parser/glm47_moe.py
```

Results:

- The original regression file is 6 failed and 1 passed on the test-only commit, then 7 passed with the fix. Two review-added malformed-input regressions also pass, for 9 tests total.
- `tests/parser/engine`: 3,800 passed.
- Existing GLM-4.7 tool-parser tests: 13 passed.
- Existing GLM reasoning tests: 16 passed.
- GLM-4.5 and Ling3 compatibility tests: 12 passed.
- Ruff lint, Ruff format, and `git diff --check`: passed.
- Both this PR and #640 combined: 3,806 parser-engine tests passed.

## Model and serving validation

The cached GLM-5.3 tokenizer maps the relevant delimiters to IDs 154842, 154843, 154844, 154847, 154848, 154849, and 154850, with observation stop ID 154829. An independent token-by-token replay using the production incremental detokenizer passed with literal delimiters, Unicode data, and a stripped final observation token text.

No live model-generation or serving re-probe was run for this revision. The tests validate parser behavior for recorded and constructed token streams, not the model's likelihood of generating them.

## Out of scope

- A model escaping its own reasoning by writing a literal `</think>`. That token is byte-identical to the structural one, so mitigation belongs in the prompt or a logits processor.
- The generic `TokenIDScanner` case where a trailing stop token ID has no text in the delta. That is handled by #640.

## AI assistance and human review

Claude Code assisted with implementation and tests. OpenAI Codex performed an independent line-by-line diff review and validation. The human submitter reviewed and understands every changed line.
