### PR TITLE
fix(parser): keep anchors when a stop token's text is stripped

### DIFF
--- a/tests/parser/engine/test_token_id_scanner.py
+++ b/tests/parser/engine/test_token_id_scanner.py
@@ -199,6 +199,18 @@ class TestHoldbackTextRecovery:
         assert isinstance(result[1], PreLexedTerminal)
         assert result[1].terminal == "THINK_START"
 
+    def test_reconstructed_text_matches_suffix(self, scanner):
+        result = scanner.scan(
+            delta_text=f"regular{CHANNEL_END} held regular{CHANNEL_END}",
+            delta_token_ids=[REGULAR_TOKEN_ID, CHANNEL_END_ID],
+        )
+
+        assert result == [
+            TextChunk(f"regular{CHANNEL_END} held "),
+            TextChunk("regular", ("regular",), 1),
+            PreLexedTerminal("THINK_END", CHANNEL_END_ID, CHANNEL_END),
+        ]
+
     def test_multi_token_batch_special_in_middle(self, scanner, tokenizer):
         """Multi-token batch with special token in the middle."""
         tok_a = 201

--- a/tests/parser/engine/test_token_id_scanner.py
+++ b/tests/parser/engine/test_token_id_scanner.py
@@ -1022,9 +1022,12 @@ class TestStopStrippedTrailingDrop:
     """Serving strips the stop token's text but keeps its ID in the delta."""
 
     DROP_TEXT = "<|observation|>"
+    DROP_TEXT_2 = "<|user|>"
     DROP_ID = 112
+    DROP_ID_2 = 113
     TEXT_ID = 201
     BODY_ID = 202
+    AFTER_ID = 203
     BODY = (
         "record_value<arg_key>value</arg_key><arg_value>"
         "</tool_call> and <tool_call></arg_value>"
@@ -1035,15 +1038,18 @@ class TestStopStrippedTrailingDrop:
         tok.decode.side_effect = lambda ids: {
             self.TEXT_ID: "prefix",
             self.BODY_ID: self.BODY,
+            self.AFTER_ID: "after",
             TOOL_START_ID: TOOL_START,
             TOOL_END_ID: TOOL_END,
             self.DROP_ID: self.DROP_TEXT,
+            self.DROP_ID_2: self.DROP_TEXT_2,
         }[ids[0]]
         return TokenIDScanner(
             {
                 TOOL_START_ID: "TOOL_START",
                 TOOL_END_ID: "TOOL_END",
                 self.DROP_ID: DROP_TERMINAL,
+                self.DROP_ID_2: DROP_TERMINAL,
             },
             tok,
         )
@@ -1071,3 +1077,42 @@ class TestStopStrippedTrailingDrop:
         items = scanner.scan("prefix", [self.TEXT_ID, self.DROP_ID])
 
         assert items == [TextChunk("prefix", ("prefix",), 1)]
+
+    def test_holdback_prefix_is_preserved(self):
+        scanner = self._scanner()
+
+        items = scanner.scan("holdback prefix", [self.TEXT_ID, self.DROP_ID])
+
+        assert items == [
+            TextChunk("holdback "),
+            TextChunk("prefix", ("prefix",), 1),
+        ]
+        assert scanner.flush_pending() == [
+            PreLexedTerminal(DROP_TERMINAL, self.DROP_ID, self.DROP_TEXT)
+        ]
+
+    def test_multiple_drops_flush_in_order(self):
+        scanner = self._scanner()
+
+        items = scanner.scan(
+            "prefix",
+            [self.TEXT_ID, self.DROP_ID, self.DROP_ID_2],
+        )
+
+        assert items == [TextChunk("prefix", ("prefix",), 1)]
+        assert scanner.flush_pending() == [
+            PreLexedTerminal(DROP_TERMINAL, self.DROP_ID, self.DROP_TEXT),
+            PreLexedTerminal(DROP_TERMINAL, self.DROP_ID_2, self.DROP_TEXT_2),
+        ]
+
+    def test_deferred_drop_resolves_on_next_delta(self):
+        scanner = self._scanner()
+        scanner.scan("prefix", [self.TEXT_ID, self.DROP_ID])
+
+        items = scanner.scan(self.DROP_TEXT + "after", [self.AFTER_ID])
+
+        assert items == [
+            PreLexedTerminal(DROP_TERMINAL, self.DROP_ID, self.DROP_TEXT),
+            TextChunk("after", ("after",), 1),
+        ]
+        assert scanner._deferred_terminals == []

--- a/tests/parser/engine/test_token_id_scanner.py
+++ b/tests/parser/engine/test_token_id_scanner.py
@@ -9,6 +9,7 @@ import pytest
 from vllm.parser.engine.events import EventType
 from vllm.parser.engine.streaming_parser_engine import StreamingParserEngine
 from vllm.parser.engine.token_id_scanner import (
+    DROP_TERMINAL,
     PreLexedTerminal,
     TextChunk,
     TokenIDScanner,
@@ -1015,3 +1016,58 @@ class TestRebuildFromAnchorsCascadingDeferral:
         assert bare_scanner._deferred_post_text == "more"
         assert len(bare_scanner._deferred_terminals) == 1
         assert bare_scanner._deferred_terminals[0].terminal == "THINK_END"
+
+
+class TestStopStrippedTrailingDrop:
+    """Serving strips the stop token's text but keeps its ID in the delta."""
+
+    DROP_TEXT = "<|observation|>"
+    DROP_ID = 112
+    TEXT_ID = 201
+    BODY_ID = 202
+    BODY = (
+        "record_value<arg_key>value</arg_key><arg_value>"
+        "</tool_call> and <tool_call></arg_value>"
+    )
+
+    def _scanner(self) -> TokenIDScanner:
+        tok = MagicMock()
+        tok.decode.side_effect = lambda ids: {
+            self.TEXT_ID: "prefix",
+            self.BODY_ID: self.BODY,
+            TOOL_START_ID: TOOL_START,
+            TOOL_END_ID: TOOL_END,
+            self.DROP_ID: self.DROP_TEXT,
+        }[ids[0]]
+        return TokenIDScanner(
+            {
+                TOOL_START_ID: "TOOL_START",
+                TOOL_END_ID: "TOOL_END",
+                self.DROP_ID: DROP_TERMINAL,
+            },
+            tok,
+        )
+
+    def test_anchors_stay_on_structural_tokens(self):
+        scanner = self._scanner()
+        ids = [self.TEXT_ID, TOOL_START_ID, self.BODY_ID, TOOL_END_ID, self.DROP_ID]
+        text = f"prefix{TOOL_START}{self.BODY}{TOOL_END}"
+
+        items = scanner.scan(text, ids)
+
+        assert items == [
+            TextChunk("prefix", ("prefix",), 1),
+            PreLexedTerminal("TOOL_START", TOOL_START_ID, TOOL_START),
+            TextChunk(self.BODY, (self.BODY,), 1),
+            PreLexedTerminal("TOOL_END", TOOL_END_ID, TOOL_END),
+        ]
+        assert scanner.flush_pending() == [
+            PreLexedTerminal(DROP_TERMINAL, self.DROP_ID, self.DROP_TEXT)
+        ]
+
+    def test_text_token_count_is_kept(self):
+        scanner = self._scanner()
+
+        items = scanner.scan("prefix", [self.TEXT_ID, self.DROP_ID])
+
+        assert items == [TextChunk("prefix", ("prefix",), 1)]

--- a/vllm/parser/engine/token_id_scanner.py
+++ b/vllm/parser/engine/token_id_scanner.py
@@ -291,11 +291,30 @@ class TokenIDScanner:
         if not reconstructed:
             return [TextChunk(delta_text)] + results
 
-        pos = delta_text.find(reconstructed)
-        if pos > 0:
-            return [TextChunk(delta_text[:pos])] + results
-        if pos == 0:
-            return results
+        if delta_text.endswith(reconstructed):
+            holdback = delta_text[: -len(reconstructed)]
+            return [TextChunk(holdback)] + results if holdback else results
+
+        # Serving strips a trailing stop token's text from delta_text but
+        # keeps its ID. Match without the trailing DROP terminals before
+        # falling back to anchor rebuilding, which would rebind an anchor
+        # to a literal lookalike earlier in the text.
+        retained = list(results)
+        trailing_drops: list[PreLexedTerminal] = []
+        while (
+            retained
+            and isinstance(retained[-1], PreLexedTerminal)
+            and retained[-1].terminal == DROP_TERMINAL
+        ):
+            trailing_drops.insert(0, retained.pop())
+        if trailing_drops:
+            retained_text = self._join_decoded_text(retained)
+            if retained_text and delta_text.endswith(retained_text):
+                for drop in trailing_drops:
+                    self._deferred_terminals.append(drop)
+                    self._deferred_prefix_token_counts.append(0)
+                holdback = delta_text[: -len(retained_text)]
+                return [TextChunk(holdback)] + retained if holdback else retained
 
         # Fallback: SentencePiece context-dependent decoding mismatch.
         # Rebuild from delta_text using PreLexedTerminals as split anchors.


### PR DESCRIPTION
## Problem

Serving can strip a stop token's text from `delta_text` while retaining its ID in `delta_token_ids`. The non-streaming path likewise passes `output.text` together with `model_output_token_ids` to the parser.

When the retained stop ID is an auto-assigned `DROP_TERMINAL`, `TokenIDScanner._recover_holdback_text` cannot match the reconstructed text. Its fallback, `_rebuild_from_anchors`, resolves anchors right to left. A missing trailing DROP can therefore bind a structural anchor such as `<tool_call>` to a literal lookalike earlier in the text. With one text token followed by a stripped stop ID, the fallback can also lose the text token count.

## Fix

When reconstructed text does not match, `_recover_holdback_text` retries without trailing DROP terminals. If the retained items match the suffix of `delta_text`, it returns them unchanged and defers the DROPs with zero prefix token counts. A later `scan()` or `flush_pending()` still emits the deferred terminals.

The previous `find` check is replaced by `endswith`. Detokenizer holdback can only precede the current token reconstruction, so a valid reconstruction must be a suffix. A middle match now follows the existing anchor-rebuild path instead of silently discarding trailing text.

## Compatibility and side effects

- This is a generic `TokenIDScanner` change and affects every parser-engine configuration with auto-DROP special tokens.
- A stripped trailing DROP is now retained internally until the next `scan()` or `flush_pending()`. `StreamingParserEngine.finish()` always flushes scanner state.
- Direct internal scanner callers must also resolve or flush pending items. Existing callers and tests do so.
- Multiple trailing DROPs keep their original order, and retained text-token counts remain attached to the retained text chunks.
- This PR is recommended to land before or with #639. The combined parser-engine suite passes.

## Related work and duplicate check

This is the focused scanner portion split from closed PR #540. The GLM delimiter-state change is #639.

Open-PR searches found no upstream PR implementing the stripped trailing DROP recovery. This is not a duplicate of [vllm-project/vllm#54971](https://github.com/vllm-project/vllm/pull/54971), which changes GLM argument-key parsing and does not touch `TokenIDScanner`.

## Tests

Pytest validation used Python 3.12 in `/opt/venv` inside the existing `rtx-station/glm53-jovian:lp15` image. Source and temporary test dependencies were mounted read-only. Lint validation used the repository-pinned Ruff version through `uvx` on the host.

```bash
/opt/venv/bin/python -m pytest \
  tests/parser/engine/test_token_id_scanner.py::TestStopStrippedTrailingDrop -q
/opt/venv/bin/python -m pytest tests/parser/engine/test_token_id_scanner.py -q
/opt/venv/bin/python -m pytest tests/parser/engine -q
uvx ruff@0.14.0 check \
  tests/parser/engine/test_token_id_scanner.py \
  vllm/parser/engine/token_id_scanner.py
uvx ruff@0.14.0 format --check \
  tests/parser/engine/test_token_id_scanner.py \
  vllm/parser/engine/token_id_scanner.py
```

Results:

- Both original regression tests fail on the test-only commit and pass with the fix.
- Four review-added regressions cover holdback prefixes, multiple trailing DROPs, next-delta resolution, and suffix-only reconstruction.
- Complete token-scanner file: 36 passed.
- `tests/parser/engine`: 3,797 passed.
- Ruff lint, Ruff format, and `git diff --check`: passed.
- This PR and #639 combined: 3,806 parser-engine tests passed.

## Model and serving validation

No live model-generation evaluation was run. This is a deterministic scanner-level regression: `delta_text` omits the trailing stop text while `delta_token_ids` retains its ID. Unit and parser-engine tests cover that exact input shape and verify anchor ordering and token-count preservation.

## AI assistance and human review

Claude Code assisted with implementation and tests. OpenAI Codex performed an independent line-by-line diff review and validation. The human submitter reviewed and understands every changed line.
