### PR TITLE
perf(glm5next): add opt-in NVFP4 MTP proposal head

### DIFF
--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -23,6 +23,8 @@ from vllm.model_executor.models.glm4_1v import Glm4vForConditionalGeneration
 from vllm.model_executor.models.interfaces import supports_eagle3, supports_pp
 from vllm.models.glm5next.nvidia import attention as glm5next_attention
 from vllm.models.glm5next.nvidia import model as glm5next_model
+from vllm.models.glm5next.nvidia import mtp as glm5next_mtp
+from vllm.models.glm5next.nvidia import mtp_draft_head
 from vllm.models.glm5next.nvidia.kda import Glm5NextLinearAttention
 from vllm.models.glm5next.nvidia.model import (
     GLM5NEXT_PACKED_MODULES_MAPPING,
@@ -190,6 +192,41 @@ def test_glm5next_mtp_selects_only_draft_checkpoint_weights() -> None:
         "model.layers.45.",
         "layers.45.",
     )
+
+
+@pytest.mark.parametrize(
+    ("configured", "resolved"), (("bf16", "bf16"), ("NVFP4", "nvfp4"))
+)
+def test_glm5next_mtp_draft_head_mode(
+    monkeypatch, configured: str, resolved: str
+) -> None:
+    monkeypatch.setenv("VLLM_GLM53_MTP_DRAFT_HEAD", configured)
+
+    assert mtp_draft_head.configured_draft_head_mode() == resolved
+
+
+def test_glm5next_mtp_draft_head_rejects_unknown_mode(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_GLM53_MTP_DRAFT_HEAD", "int4")
+
+    with pytest.raises(ValueError, match="must be one of bf16, nvfp4"):
+        mtp_draft_head.configured_draft_head_mode()
+
+
+def test_glm5next_mtp_prepares_configured_draft_head(monkeypatch) -> None:
+    source_head = torch.nn.Linear(4, 8, bias=False)
+    quantized_head = torch.nn.Linear(4, 8, bias=False)
+    predictor = Glm5NextMultiTokenPredictor.__new__(Glm5NextMultiTokenPredictor)
+    torch.nn.Module.__init__(predictor)
+
+    monkeypatch.setattr(
+        glm5next_mtp,
+        "make_quantized_draft_head",
+        lambda actual_head: quantized_head if actual_head is source_head else None,
+    )
+
+    predictor.prepare_draft_lm_head(source_head)
+
+    assert predictor.quantized_draft_head is quantized_head
 
 
 def test_glm5next_mtp_preserves_position_zero_embedding() -> None:

--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -14,6 +14,8 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import (
     PLACEHOLDER_TOKEN_ID,
     RejectionSampler,
+    apply_sampling_constraints,
+    rejection_sample,
     sample_recovered_tokens,
 )
 from vllm.v1.sample.sampler import Sampler, SamplerOutput
@@ -127,6 +129,105 @@ def create_sampling_metadata(
         bad_words_token_ids={} if bad_words_token_ids is None else bad_words_token_ids,
         logitsprocs=LogitsProcessors(),
     )
+
+
+def test_apply_sampling_constraints_can_return_normalized_probabilities():
+    num_draft_tokens = 5
+    vocab_size = 257
+    generator = torch.Generator(device=DEVICE_TYPE).manual_seed(53)
+    logits = torch.randn(
+        num_draft_tokens,
+        vocab_size,
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+        generator=generator,
+    )
+    cu_num_draft_tokens = torch.tensor([3, 5], device=DEVICE_TYPE)
+    sampling_metadata = create_sampling_metadata(
+        all_greedy=False,
+        temperature=torch.tensor([0.7, 1.2], device=DEVICE_TYPE),
+        top_k=torch.tensor([19, 37], dtype=torch.int32, device=DEVICE_TYPE),
+        top_p=torch.tensor([0.6, 0.92], device=DEVICE_TYPE),
+    )
+
+    processed_logits = apply_sampling_constraints(
+        logits.clone(),
+        cu_num_draft_tokens,
+        sampling_metadata,
+    )
+    expected = processed_logits.softmax(dim=-1, dtype=torch.float32)
+    actual = apply_sampling_constraints(
+        logits.clone(),
+        cu_num_draft_tokens,
+        sampling_metadata,
+        return_probs=True,
+    )
+
+    assert torch.equal(actual != 0, expected != 0)
+    assert torch.allclose(actual, expected, atol=2e-7, rtol=2e-6)
+
+
+def test_rejection_sample_accepts_precomputed_target_probabilities():
+    batch_size = 2
+    max_spec_len = 3
+    vocab_size = 64
+    num_tokens = batch_size * max_spec_len
+    generator = torch.Generator(device=DEVICE_TYPE).manual_seed(59)
+    draft_logits = torch.randn(
+        num_tokens,
+        vocab_size,
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+        generator=generator,
+    )
+    target_logits = torch.randn(
+        num_tokens,
+        vocab_size,
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+        generator=generator,
+    )
+    draft_probs = draft_logits.softmax(dim=-1)
+    target_probs = target_logits.softmax(dim=-1)
+    draft_token_ids = draft_probs.argmax(dim=-1).to(torch.int32).contiguous()
+    bonus_token_ids = torch.tensor([[3], [7]], device=DEVICE_TYPE)
+    cu_num_draft_tokens = torch.tensor([3, 6], device=DEVICE_TYPE)
+
+    def make_metadata() -> SamplingMetadata:
+        return create_sampling_metadata(
+            all_greedy=False,
+            temperature=torch.ones(batch_size, device=DEVICE_TYPE),
+            generators={
+                request_id: torch.Generator(device=DEVICE_TYPE).manual_seed(
+                    67 + request_id
+                )
+                for request_id in range(batch_size)
+            },
+        )
+
+    from_logits = rejection_sample(
+        draft_token_ids,
+        [max_spec_len] * batch_size,
+        max_spec_len,
+        cu_num_draft_tokens,
+        draft_probs,
+        target_logits,
+        bonus_token_ids,
+        make_metadata(),
+    )
+    from_probs = rejection_sample(
+        draft_token_ids,
+        [max_spec_len] * batch_size,
+        max_spec_len,
+        cu_num_draft_tokens,
+        draft_probs,
+        target_probs,
+        bonus_token_ids,
+        make_metadata(),
+        target_is_probs=True,
+    )
+
+    assert torch.equal(from_probs, from_logits)
 
 
 ########################### Tests for Greedy Sampling ###################

--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -9,6 +9,8 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.sample.ops.topk_topp_sampler import (
+    apply_top_k_top_p,
+    apply_top_k_top_p_probs,
     apply_top_k_top_p_pytorch,
     random_sample,
 )
@@ -18,6 +20,46 @@ DEVICE_TYPE = current_platform.device_type
 
 BATCH_SIZE = 1024
 VOCAB_SIZE = 128 * 1024
+
+
+@pytest.mark.parametrize("batch_size", [1, 3, 7])
+@pytest.mark.parametrize("use_top_k", [False, True])
+def test_apply_top_k_top_p_probs_matches_processed_logits(
+    batch_size: int,
+    use_top_k: bool,
+):
+    vocab_size = 257
+    generator = torch.Generator(device=DEVICE_TYPE).manual_seed(41 + batch_size)
+    logits = torch.randn(
+        batch_size,
+        vocab_size,
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+        generator=generator,
+    )
+    top_k = (
+        torch.arange(17, 17 + batch_size, dtype=torch.int32, device=DEVICE_TYPE)
+        if use_top_k
+        else None
+    )
+    top_p = torch.linspace(0.55, 0.95, batch_size, device=DEVICE_TYPE)
+
+    expected = apply_top_k_top_p(logits.clone(), top_k, top_p).softmax(
+        dim=-1,
+        dtype=torch.float32,
+    )
+    input_buffer = logits.clone()
+    actual = apply_top_k_top_p_probs(input_buffer, top_k, top_p)
+
+    assert actual.data_ptr() == input_buffer.data_ptr()
+    assert torch.equal(actual != 0, expected != 0)
+    assert torch.allclose(actual, expected, atol=2e-7, rtol=2e-6)
+    assert torch.allclose(
+        actual.sum(dim=-1),
+        torch.ones(batch_size, device=DEVICE_TYPE),
+        atol=2e-7,
+        rtol=0,
+    )
 
 
 def _flashinfer_topk_topp_supported() -> bool:

--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -51,8 +51,10 @@ def test_apply_top_k_top_p_probs_matches_processed_logits(
     input_buffer = logits.clone()
     actual = apply_top_k_top_p_probs(input_buffer, top_k, top_p)
 
-    reuses_input = batch_size < 8 and (
-        batch_size == 1 or use_top_k or not FLASHINFER_TOPK_TOPP_SUPPORTED
+    reuses_input = (
+        not current_platform.is_cpu()
+        and batch_size < 8
+        and (batch_size == 1 or use_top_k or not FLASHINFER_TOPK_TOPP_SUPPORTED)
     )
     if reuses_input:
         assert actual.data_ptr() == input_buffer.data_ptr()

--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -22,7 +22,7 @@ BATCH_SIZE = 1024
 VOCAB_SIZE = 128 * 1024
 
 
-@pytest.mark.parametrize("batch_size", [1, 3, 7])
+@pytest.mark.parametrize("batch_size", [1, 3, 7, 8])
 @pytest.mark.parametrize("use_top_k", [False, True])
 def test_apply_top_k_top_p_probs_matches_processed_logits(
     batch_size: int,
@@ -51,13 +51,17 @@ def test_apply_top_k_top_p_probs_matches_processed_logits(
     input_buffer = logits.clone()
     actual = apply_top_k_top_p_probs(input_buffer, top_k, top_p)
 
-    assert actual.data_ptr() == input_buffer.data_ptr()
+    reuses_input = batch_size < 8 and (
+        batch_size == 1 or use_top_k or not FLASHINFER_TOPK_TOPP_SUPPORTED
+    )
+    if reuses_input:
+        assert actual.data_ptr() == input_buffer.data_ptr()
     assert torch.equal(actual != 0, expected != 0)
     assert torch.allclose(actual, expected, atol=2e-7, rtol=2e-6)
     assert torch.allclose(
         actual.sum(dim=-1),
         torch.ones(batch_size, device=DEVICE_TYPE),
-        atol=2e-7,
+        atol=3e-7,
         rtol=0,
     )
 
@@ -84,6 +88,90 @@ def _flashinfer_topk_topp_supported() -> bool:
 
 
 FLASHINFER_TOPK_TOPP_SUPPORTED = _flashinfer_topk_topp_supported()
+
+
+@pytest.mark.skipif(
+    not FLASHINFER_TOPK_TOPP_SUPPORTED,
+    reason="FlashInfer top-p renormalization requires a supported CUDA device",
+)
+@pytest.mark.parametrize("batch_size", [2, 7, 8, 64])
+def test_probability_helper_matches_flashinfer_target_distribution(
+    batch_size: int,
+):
+    """The rejection distribution must match the CUDA target sampler."""
+    from flashinfer.sampling import top_p_renorm_probs
+
+    device = torch.device(DEVICE_TYPE)
+    vocab_size = 154880
+    generator = torch.Generator(device=device).manual_seed(73 + batch_size)
+    logits = torch.randn(
+        batch_size,
+        vocab_size,
+        dtype=torch.float32,
+        device=device,
+        generator=generator,
+    )
+    top_p = torch.linspace(0.55, 0.95, batch_size, device=device)
+
+    expected = top_p_renorm_probs(
+        logits.softmax(dim=-1, dtype=torch.float32),
+        top_p,
+        is_deterministic=True,
+    )
+    actual = apply_top_k_top_p_probs(logits.clone(), None, top_p)
+    python_reference = apply_top_k_top_p_pytorch(logits.clone(), None, top_p).softmax(
+        dim=-1, dtype=torch.float32
+    )
+
+    assert torch.equal(actual, expected)
+    assert torch.allclose(
+        actual.sum(dim=-1),
+        torch.ones(batch_size, device=device),
+        atol=3e-7,
+        rtol=0,
+    )
+    total_variation = 0.5 * torch.abs(actual - python_reference).sum(dim=-1)
+    # FP32 cumulative sums can select an adjacent cutoff token. Bound the
+    # affected probability mass while requiring exact target-sampler parity.
+    assert total_variation.max() < 2e-5
+
+
+@pytest.mark.skipif(
+    not FLASHINFER_TOPK_TOPP_SUPPORTED,
+    reason="FlashInfer top-p renormalization requires a supported CUDA device",
+)
+def test_probability_helper_respects_flashinfer_sampler_disable(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The rejection path must honor the existing sampler feature gate."""
+    from vllm.v1.sample.ops import topk_topp_sampler as sampler_ops
+
+    device = torch.device(DEVICE_TYPE)
+    generator = torch.Generator(device=device).manual_seed(107)
+    logits = torch.randn(
+        7,
+        257,
+        dtype=torch.float32,
+        device=device,
+        generator=generator,
+    )
+    top_p = torch.linspace(0.55, 0.95, 7, device=device)
+    expected = apply_top_k_top_p_pytorch(logits.clone(), None, top_p).softmax(
+        dim=-1,
+        dtype=torch.float32,
+    )
+
+    monkeypatch.setenv("VLLM_USE_FLASHINFER_SAMPLER", "0")
+    sampler_ops._flashinfer_probability_renorm_supported.cache_clear()
+    try:
+        input_buffer = logits.clone()
+        actual = apply_top_k_top_p_probs(input_buffer, None, top_p)
+    finally:
+        sampler_ops._flashinfer_probability_renorm_supported.cache_clear()
+
+    assert actual.data_ptr() == input_buffer.data_ptr()
+    assert torch.equal(actual != 0, expected != 0)
+    assert torch.allclose(actual, expected, atol=2e-7, rtol=2e-6)
 
 
 def _seed_default_generator(seed: int) -> None:

--- a/tests/v1/spec_decode/test_llm_base_proposer_sampling.py
+++ b/tests/v1/spec_decode/test_llm_base_proposer_sampling.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import dataclasses
 from types import SimpleNamespace
 
 import pytest
@@ -10,6 +11,7 @@ from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
 from vllm.v1.spec_decode.llm_base_proposer import (
     SpecDecodeBaseProposer,
     compute_probs_and_sample_next_token,
@@ -72,6 +74,78 @@ def test_compute_probs_and_sample_next_token_uses_fp64_exponential_race():
 
     assert torch.equal(actual_ids, expected_ids)
     assert torch.allclose(actual_probs, probs)
+
+
+def test_compute_probs_and_sample_next_token_returns_constrained_distribution():
+    batch_size = 3
+    vocab_size = 32
+    generator = torch.Generator(device=DEVICE_TYPE).manual_seed(29)
+    logits = torch.randn(
+        batch_size,
+        vocab_size,
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+        generator=generator,
+    )
+    metadata = dataclasses.replace(
+        _make_sampling_metadata(batch_size),
+        temperature=torch.tensor([0.7, 1.0, 1.3], device=DEVICE_TYPE),
+        top_k=torch.tensor([5, 9, 17], dtype=torch.int32, device=DEVICE_TYPE),
+        top_p=torch.tensor([0.6, 0.8, 0.95], device=DEVICE_TYPE),
+    )
+
+    expanded_logits = logits / metadata.temperature.unsqueeze(-1)
+    expected_probs = apply_top_k_top_p(
+        expanded_logits,
+        metadata.top_k,
+        metadata.top_p,
+    ).softmax(dim=-1, dtype=torch.float32)
+
+    token_ids, actual_probs = compute_probs_and_sample_next_token(
+        logits.clone(),
+        metadata,
+    )
+
+    assert torch.equal(actual_probs != 0, expected_probs != 0)
+    assert torch.allclose(actual_probs, expected_probs)
+    assert torch.all(actual_probs.gather(1, token_ids.unsqueeze(-1)) > 0)
+
+
+def test_parallel_draft_sampling_repeats_request_constraints_in_request_order():
+    batch_size = 2
+    positions_per_request = 3
+    vocab_size = 32
+    generator = torch.Generator(device=DEVICE_TYPE).manual_seed(31)
+    logits = torch.randn(
+        batch_size * positions_per_request,
+        vocab_size,
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+        generator=generator,
+    )
+    metadata = dataclasses.replace(
+        _make_sampling_metadata(batch_size),
+        temperature=torch.tensor([0.7, 1.3], device=DEVICE_TYPE),
+        top_k=torch.tensor([5, 11], dtype=torch.int32, device=DEVICE_TYPE),
+        top_p=torch.tensor([0.65, 0.9], device=DEVICE_TYPE),
+    )
+    proposer = object.__new__(SpecDecodeBaseProposer)
+    proposer._enable_probabilistic_draft_probs = True
+    proposer.use_fp64_gumbel = False
+
+    token_ids, actual_probs = proposer._sample_from_logits(logits.clone(), metadata)
+
+    temperature = metadata.temperature.repeat_interleave(positions_per_request)
+    top_k = metadata.top_k.repeat_interleave(positions_per_request)
+    top_p = metadata.top_p.repeat_interleave(positions_per_request)
+    expected_probs = apply_top_k_top_p(
+        logits / temperature.unsqueeze(-1),
+        top_k,
+        top_p,
+    ).softmax(dim=-1, dtype=torch.float32)
+    assert torch.equal(actual_probs != 0, expected_probs != 0)
+    assert torch.allclose(actual_probs, expected_probs)
+    assert torch.all(actual_probs.gather(1, token_ids.unsqueeze(-1)) > 0)
 
 
 @pytest.mark.parametrize(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     VLLM_LOG_STATS_INTERVAL: float = 10.0
     VLLM_TRACE_FUNCTION: int = 0
     VLLM_USE_FLASHINFER_SAMPLER: bool = True
+    VLLM_GLM53_MTP_DRAFT_HEAD: Literal["bf16", "nvfp4"] = "bf16"
     VLLM_PP_LAYER_PARTITION: str | None = None
     VLLM_CPU_KVCACHE_SPACE: int | None = 0
     VLLM_CPU_OMP_THREADS_BIND: str = "auto"
@@ -869,6 +870,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
         bool(int(os.environ["VLLM_USE_FLASHINFER_SAMPLER"]))
         if "VLLM_USE_FLASHINFER_SAMPLER" in os.environ
         else True
+    ),
+    # Storage and compute format for the independent GLM-5.3 MTP proposal head.
+    # The target vocabulary head and verifier remain BF16 in every mode.
+    "VLLM_GLM53_MTP_DRAFT_HEAD": env_with_choices(
+        "VLLM_GLM53_MTP_DRAFT_HEAD",
+        "bf16",
+        ["bf16", "nvfp4"],
+        case_sensitive=False,
     ),
     # Pipeline stage partition strategy
     "VLLM_PP_LAYER_PARTITION": lambda: os.getenv("VLLM_PP_LAYER_PARTITION", None),

--- a/vllm/models/glm5next/nvidia/mtp.py
+++ b/vllm/models/glm5next/nvidia/mtp.py
@@ -33,6 +33,7 @@ from .model import (
     _try_load_mxfp8_bf16_attn_proj,
     get_spec_layer_idx_from_weight_name,
 )
+from .mtp_draft_head import QuantizedDraftHead, make_quantized_draft_head
 from .pooled_indexer import Glm5NextPooledIndexer
 
 
@@ -134,7 +135,12 @@ class Glm5NextMultiTokenPredictor(nn.Module):
         # string and hashes it on every draft step.
         self._mtp_layers = list(self.layers.values())
         self._prefill_output_indices: torch.Tensor | None = None
+        self.quantized_draft_head: QuantizedDraftHead | None = None
         self.logits_processor = LogitsProcessor(config.vocab_size)
+
+    def prepare_draft_lm_head(self, source_head: nn.Module) -> None:
+        """Create the configured draft-only head after target weights are loaded."""
+        self.quantized_draft_head = make_quantized_draft_head(source_head)
 
     def update_max_model_len(self, max_model_len: int) -> None:
         for module in self.modules():
@@ -212,7 +218,8 @@ class Glm5NextMultiTokenPredictor(nn.Module):
         # hidden_states is already post-final-norm (produced in the layer
         # forward and recycled as-is); apply the LM head only, without a
         # second RMSNorm.
-        return self.logits_processor(mtp_layer.shared_head.head, hidden_states)
+        head = self.quantized_draft_head or mtp_layer.shared_head.head
+        return self.logits_processor(head, hidden_states)
 
     def get_top_tokens(
         self,
@@ -227,9 +234,8 @@ class Glm5NextMultiTokenPredictor(nn.Module):
         # step. Tie-breaking matches the full argmax (shards are contiguous
         # and rank-ordered, so the lowest-rank winner is the lowest global
         # index), so greedy draft tokens are unchanged.
-        return self.logits_processor.get_top_tokens(
-            mtp_layer.shared_head.head, hidden_states
-        )
+        head = self.quantized_draft_head or mtp_layer.shared_head.head
+        return self.logits_processor.get_top_tokens(head, hidden_states)
 
 
 class Glm5NextMTP(nn.Module, DeepseekV2MixtureOfExperts):
@@ -285,6 +291,10 @@ class Glm5NextMTP(nn.Module, DeepseekV2MixtureOfExperts):
 
     def update_max_model_len(self, max_model_len: int) -> None:
         self.model.update_max_model_len(max_model_len)
+
+    def prepare_draft_lm_head(self, source_head: nn.Module) -> None:
+        """Create a draft-only quantized copy of the shared target head."""
+        self.model.prepare_draft_lm_head(source_head)
 
     def forward(
         self,

--- a/vllm/models/glm5next/nvidia/mtp_draft_head.py
+++ b/vllm/models/glm5next/nvidia/mtp_draft_head.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Quantized vocabulary-head copies for GLM-5.3 speculative proposals.
+
+``VLLM_GLM53_MTP_DRAFT_HEAD`` selects the weight used only to produce MTP
+draft logits:
+
+* ``bf16`` (default) shares the target model's unquantized head;
+* ``nvfp4`` creates an independent block-scaled NVFP4 copy and uses
+  FlashInfer's W4A16 CuTe-DSL GEMM.
+
+The target model retains its BF16 vocabulary head.  The verifier therefore
+keeps the target distribution unchanged; quantization can only change proposal
+acceptance and speculative-decoding efficiency.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_NVFP4_GLOBAL_MAX = 448.0 * 6.0
+_SUPPORTED_MODES = frozenset(("bf16", "nvfp4"))
+
+
+def configured_draft_head_mode() -> str:
+    """Return the validated GLM MTP draft-head storage mode."""
+    mode = os.getenv("VLLM_GLM53_MTP_DRAFT_HEAD", "bf16").strip().lower()
+    if mode not in _SUPPORTED_MODES:
+        choices = ", ".join(sorted(_SUPPORTED_MODES))
+        raise ValueError(
+            f"VLLM_GLM53_MTP_DRAFT_HEAD must be one of {choices}; got {mode!r}"
+        )
+    return mode
+
+
+class _DraftHeadQuantMethod:
+    """Adapt a quantized draft head to ``LogitsProcessor``'s linear contract."""
+
+    def apply(
+        self,
+        layer: QuantizedDraftHead,
+        hidden_states: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if bias is not None:
+            raise ValueError("quantized GLM MTP draft heads do not support bias")
+        return layer(hidden_states)
+
+
+class QuantizedDraftHead(nn.Module):
+    """Vocab-parallel NVFP4 copy of a BF16 vocabulary-head shard."""
+
+    quant_method = _DraftHeadQuantMethod()
+
+    def __init__(self, source_head: nn.Module, mode: str) -> None:
+        super().__init__()
+        if mode != "nvfp4":
+            raise ValueError(f"quantized draft-head mode must be nvfp4; got {mode!r}")
+        weight = getattr(source_head, "weight", None)
+        if not isinstance(weight, torch.Tensor):
+            raise TypeError("the shared target vocabulary head has no tensor weight")
+        if weight.ndim != 2 or weight.dtype != torch.bfloat16 or not weight.is_cuda:
+            raise ValueError(
+                "quantized GLM MTP draft heads require a two-dimensional CUDA "
+                f"BF16 weight; got shape={tuple(weight.shape)}, dtype={weight.dtype}, "
+                f"device={weight.device}"
+            )
+        if not weight.is_contiguous():
+            raise ValueError(
+                "the shared target vocabulary-head weight must be contiguous"
+            )
+
+        self.tp_size = int(getattr(source_head, "tp_size", 1))
+        self.shard_indices: Any = getattr(source_head, "shard_indices", None)
+        if self.shard_indices is None:
+            raise TypeError("the shared target vocabulary head has no shard metadata")
+
+        major, minor = torch.cuda.get_device_capability(weight.device)
+        if (major, minor) != (12, 0):
+            raise ValueError(
+                "the NVFP4 W4A16 draft vocabulary head requires CUDA capability "
+                f"12.0; got {major}.{minor}"
+            )
+        import flashinfer
+
+        weight_global_scale = (
+            _NVFP4_GLOBAL_MAX / weight.float().abs().nan_to_num().max()
+        )
+        weight_fp4, weight_sf = flashinfer.nvfp4_quantize(
+            weight,
+            weight_global_scale,
+            sfLayout=flashinfer.SfLayout.layout_128x4,
+            do_shuffle=False,
+            backend="cuda",
+        )
+        weight_fp4, weight_sf, output_scale = flashinfer.prepare_bf16_fp4_weights(
+            weight_fp4.view(torch.uint8),
+            weight_sf,
+            weight_global_scale.reciprocal().reshape(1),
+            backend="cute-dsl",
+        )
+        self.register_buffer("weight", weight_fp4, persistent=False)
+        self.register_buffer("weight_scale", weight_sf, persistent=False)
+        self.register_buffer("weight_global_scale", output_scale, persistent=False)
+
+    @property
+    def storage_bytes(self) -> int:
+        """Return bytes retained by the independent quantized weight copy."""
+        return sum(
+            tensor.numel() * tensor.element_size()
+            for tensor in self.buffers()
+            if tensor is not None
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        shape = hidden_states.shape
+        hidden = hidden_states.reshape(-1, shape[-1])
+        import flashinfer
+
+        logits = flashinfer.mm_bf16_fp4(
+            hidden,
+            self.weight,
+            self.weight_scale,
+            self.weight_global_scale,
+            backend="cute-dsl",
+            out_dtype=hidden.dtype,
+        )
+        return logits.reshape(*shape[:-1], -1)
+
+
+def make_quantized_draft_head(source_head: nn.Module) -> QuantizedDraftHead | None:
+    """Build the configured draft-only head copy after target weights load."""
+    mode = configured_draft_head_mode()
+    if mode == "bf16":
+        return None
+    result = QuantizedDraftHead(source_head, mode)
+    logger.info(
+        "Using a draft-only %s GLM MTP vocabulary head copy (%0.2f MiB per rank); "
+        "the target verifier vocabulary head remains BF16.",
+        mode.upper(),
+        result.storage_bytes / (1024 * 1024),
+    )
+    return result

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -374,6 +374,14 @@ def apply_top_k_top_p_probs(
     full-vocabulary softmax in callers that need probabilities rather than
     processed logits. ``logits`` may be reused as the output buffer when it is
     float32.
+
+    Args:
+        logits: Unnormalized token scores with shape ``[batch_size, vocab_size]``.
+        k: Per-row top-k limits, or ``None`` when top-k is disabled.
+        p: Per-row top-p thresholds, or ``None`` when top-p is disabled.
+
+    Returns:
+        Normalized constrained probabilities with the same shape as ``logits``.
     """
     if p is None:
         return apply_top_k_top_p(logits, k, p).softmax(dim=-1, dtype=torch.float32)

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -364,6 +364,44 @@ def apply_top_k_top_p(
     return apply_top_k_top_p_pytorch(logits, k, p)
 
 
+def apply_top_k_top_p_probs(
+    logits: torch.Tensor, k: torch.Tensor | None, p: torch.Tensor | None
+) -> torch.Tensor:
+    """Apply top-k/top-p and return normalized probabilities.
+
+    The small-batch PyTorch top-p path already computes probabilities to find
+    the nucleus cutoff. Returning those probabilities directly avoids a second
+    full-vocabulary softmax in callers that need probabilities rather than
+    processed logits. ``logits`` may be reused as the output buffer when it is
+    float32.
+    """
+    if p is None:
+        return apply_top_k_top_p(logits, k, p).softmax(dim=-1, dtype=torch.float32)
+
+    if current_platform.is_cpu() or (HAS_TRITON and logits.shape[0] >= 8):
+        return apply_top_k_top_p(logits, k, p).softmax(dim=-1, dtype=torch.float32)
+
+    logits_sort, logits_idx = logits.sort(dim=-1, descending=False)
+
+    if k is not None:
+        top_k_mask = logits_sort.size(1) - k.to(torch.long)
+        top_k_mask = logits_sort.gather(1, top_k_mask.unsqueeze(dim=1))
+        logits_sort.masked_fill_(logits_sort < top_k_mask, -float("inf"))
+
+    probs_sort = logits_sort.softmax(dim=-1, dtype=torch.float32)
+    probs_cumsum = probs_sort.cumsum(dim=-1)
+    top_p_mask = probs_cumsum <= 1 - p.unsqueeze(dim=1)
+    top_p_mask[:, -1] = False
+    probs_sort.masked_fill_(top_p_mask, 0.0)
+    probs_sort.div_(probs_sort.sum(dim=-1, keepdim=True))
+
+    if logits.dtype == torch.float32:
+        probs = logits.zero_()
+    else:
+        probs = torch.zeros_like(logits, dtype=torch.float32)
+    return probs.scatter_(dim=-1, index=logits_idx, src=probs_sort)
+
+
 def apply_top_k_top_p_pytorch(
     logits: torch.Tensor,
     k: torch.Tensor | None,

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -78,7 +78,11 @@ def flashinfer_sampler_supported() -> bool:
 
 @cache
 def _flashinfer_probability_renorm_supported() -> bool:
-    """Return the process-stable availability of FlashInfer renormalization."""
+    """Return the process-stable availability of FlashInfer renormalization.
+
+    Returns:
+        Whether the configured platform can use the FlashInfer sampler.
+    """
     return flashinfer_sampler_supported()
 
 

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+from functools import cache
+
 import torch
 import torch.nn as nn
 
@@ -72,6 +74,12 @@ def flashinfer_sampler_supported() -> bool:
         unsupported_reason,
     )
     return False
+
+
+@cache
+def _flashinfer_probability_renorm_supported() -> bool:
+    """Return the process-stable availability of FlashInfer renormalization."""
+    return flashinfer_sampler_supported()
 
 
 class TopKTopPSampler(nn.Module):
@@ -385,6 +393,18 @@ def apply_top_k_top_p_probs(
     """
     if p is None:
         return apply_top_k_top_p(logits, k, p).softmax(dim=-1, dtype=torch.float32)
+
+    # Standard rejection sampling needs the complete constrained probability
+    # distribution.  The target CUDA sampler already uses FlashInfer's
+    # deterministic top-p implementation, so the corresponding renormalizer
+    # both matches that distribution and avoids sorting the full vocabulary.
+    # One-row PyTorch sorting is marginally faster; top-k combinations retain
+    # the existing path until their FlashInfer ordering contract is qualified.
+    if k is None and logits.shape[0] > 1 and _flashinfer_probability_renorm_supported():
+        from flashinfer.sampling import top_p_renorm_probs
+
+        probs = logits.softmax(dim=-1, dtype=torch.float32)
+        return top_p_renorm_probs(probs, p, is_deterministic=True)
 
     if current_platform.is_cpu() or (HAS_TRITON and logits.shape[0] >= 8):
         return apply_top_k_top_p(logits, k, p).softmax(dim=-1, dtype=torch.float32)

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -536,6 +536,7 @@ def apply_sampling_constraints(
         cu_num_draft_tokens: Cumulative number of draft tokens.
         sampling_metadata: Metadata containing sampling parameters such as
             temperature and whether greedy sampling is used.
+        return_probs: Return normalized probabilities instead of processed logits.
 
     Returns:
         torch.Tensor: Processed logits, or normalized probabilities when

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -18,7 +18,10 @@ from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
 from vllm.v1.sample.ops.penalties import apply_all_penalties
-from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
+from vllm.v1.sample.ops.topk_topp_sampler import (
+    apply_top_k_top_p,
+    apply_top_k_top_p_probs,
+)
 from vllm.v1.sample.sampler import Sampler
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.spec_decode.utils import unconditional_to_conditional_rates
@@ -164,10 +167,12 @@ class RejectionSampler(nn.Module):
         # [num_tokens, vocab_size]
         # NOTE(woosuk): `target_logits` can be updated in place inside the
         # `apply_sampling_constraints` function.
+        target_is_probs = sampling_metadata.max_num_logprobs is None
         target_logits = apply_sampling_constraints(
             target_logits,
             metadata.cu_num_draft_tokens,
             sampling_metadata,
+            return_probs=target_is_probs,
         )
 
         output_token_ids = rejection_sample(
@@ -179,6 +184,7 @@ class RejectionSampler(nn.Module):
             target_logits,
             bonus_token_ids,
             sampling_metadata,
+            target_is_probs=target_is_probs,
             synthetic_mode=self.synthetic_mode,
             synthetic_conditional_rates=self.synthetic_conditional_rates,
             use_fp64_gumbel=self.use_fp64_gumbel,
@@ -406,6 +412,7 @@ def rejection_sample(
     # [batch_size, 1]
     bonus_token_ids: torch.Tensor,
     sampling_metadata: SamplingMetadata,
+    target_is_probs: bool = False,
     synthetic_mode: bool = False,
     synthetic_conditional_rates: torch.Tensor | None = None,
     use_fp64_gumbel: bool = False,
@@ -468,8 +475,13 @@ def rejection_sample(
         if sampling_metadata.all_greedy:
             return output_token_ids
 
-    # Compute probability distribution from target logits.
-    target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)
+    # The small-batch top-p fast path can pass normalized probabilities
+    # directly and avoid repeating a full-vocabulary softmax here.
+    target_probs = (
+        target_logits
+        if target_is_probs
+        else target_logits.softmax(dim=-1, dtype=torch.float32)
+    )
     assert target_probs.is_contiguous()
 
     # Sample recovered tokens for each position.
@@ -511,6 +523,7 @@ def apply_sampling_constraints(
     logits: torch.Tensor,  # [num_tokens, vocab_size]
     cu_num_draft_tokens: torch.Tensor,  # [batch_size]
     sampling_metadata: SamplingMetadata,
+    return_probs: bool = False,
 ) -> torch.Tensor:
     """Process logits based on sampling metadata.
 
@@ -525,8 +538,8 @@ def apply_sampling_constraints(
             temperature and whether greedy sampling is used.
 
     Returns:
-        torch.Tensor: Processed logits if non-greedy sampling is used,
-        otherwise returns the original logits.
+        torch.Tensor: Processed logits, or normalized probabilities when
+        ``return_probs`` is true. Greedy sampling returns the original logits.
     """
     assert logits.ndim == 2
     assert cu_num_draft_tokens.ndim == 1
@@ -562,6 +575,8 @@ def apply_sampling_constraints(
 
     # NOTE(woosuk): `apply_top_k_top_p` uses sorting to calculate the mask,
     # which is slow for large vocab sizes. This may cause performance issues.
+    if return_probs:
+        return apply_top_k_top_p_probs(logits, top_k, top_p)
     return apply_top_k_top_p(logits, top_k, top_p)
 
 

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -45,6 +45,7 @@ from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
 from vllm.v1.kv_cache_interface import KVCacheConfig, UniformTypeKVCacheSpecs
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.topk_topp_sampler import (
+    apply_top_k_top_p,
     empty_exponential_noise_like,
     sample_with_exponential_noise,
 )
@@ -467,6 +468,16 @@ class SpecDecodeBaseProposer:
             sampling_metadata = dataclasses.replace(
                 sampling_metadata,
                 temperature=temperature.repeat_interleave(factor, dim=0),
+                top_p=(
+                    None
+                    if sampling_metadata.top_p is None
+                    else sampling_metadata.top_p.repeat_interleave(factor, dim=0)
+                ),
+                top_k=(
+                    None
+                    if sampling_metadata.top_k is None
+                    else sampling_metadata.top_k.repeat_interleave(factor, dim=0)
+                ),
             )
 
         return compute_probs_and_sample_next_token(
@@ -1882,12 +1893,16 @@ def compute_probs_and_sample_next_token(
         is_greedy = temperature < _SAMPLING_EPS
         temperature = torch.where(is_greedy, 1.0, temperature)
     logits.div_(temperature.view(-1, 1))
+    logits = apply_top_k_top_p(
+        logits,
+        sampling_metadata.top_k,
+        sampling_metadata.top_p,
+    )
     probs = logits.softmax(dim=-1, dtype=torch.float32)
 
-    # NOTE(woosuk): Currently, we ignore most of the sampling parameters in
-    # generating the draft tokens. We only use the temperature. While this
-    # could degrade the acceptance rate, it does not affect the distribution
-    # of the generated tokens after rejection sampling.
+    # Logits processors that depend on request history remain target-only.
+    # Temperature, top-k, and top-p are position-local, so the drafter can
+    # match those constraints exactly and keep q closer to the verifier's p.
 
     # TODO(woosuk): Consider seeds.
     q = empty_exponential_noise_like(probs, use_fp64_gumbel)

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -45,7 +45,7 @@ from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
 from vllm.v1.kv_cache_interface import KVCacheConfig, UniformTypeKVCacheSpecs
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.topk_topp_sampler import (
-    apply_top_k_top_p,
+    apply_top_k_top_p_probs,
     empty_exponential_noise_like,
     sample_with_exponential_noise,
 )
@@ -1893,12 +1893,11 @@ def compute_probs_and_sample_next_token(
         is_greedy = temperature < _SAMPLING_EPS
         temperature = torch.where(is_greedy, 1.0, temperature)
     logits.div_(temperature.view(-1, 1))
-    logits = apply_top_k_top_p(
+    probs = apply_top_k_top_p_probs(
         logits,
         sampling_metadata.top_k,
         sampling_metadata.top_p,
     )
-    probs = logits.softmax(dim=-1, dtype=torch.float32)
 
     # Logits processors that depend on request history remain target-only.
     # Temperature, top-k, and top-p are position-local, so the drafter can

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1609,6 +1609,10 @@ class SpecDecodeBaseProposer:
                             "Shared target model lm_head with MTP shared_head.head."
                         )
 
+            prepare_draft_lm_head = getattr(self.model, "prepare_draft_lm_head", None)
+            if prepare_draft_lm_head is not None:
+                prepare_draft_lm_head(target_language_model.lm_head)
+
         if hasattr(target_language_model.model, "topk_indices_buffer"):
             target_buffer = target_language_model.model.topk_indices_buffer
             if hasattr(self.model.model, "topk_indices_buffer"):

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -123,6 +123,11 @@ def load_eagle_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mod
                     del sh.head
                     sh.head = target_lm_head
 
+    prepare_draft_lm_head = getattr(eagle_model, "prepare_draft_lm_head", None)
+    effective_draft_lm_head = getattr(eagle_model, "lm_head", None)
+    if prepare_draft_lm_head is not None and effective_draft_lm_head is not None:
+        prepare_draft_lm_head(effective_draft_lm_head)
+
     # MTP shares topk_indices_buffer with the target model. We update
     # every module in the draft that holds a buffer reference so that
     # the per-layer indexer and sparse-attention backends all point to


### PR DESCRIPTION
## Purpose

Provide an opt-in NVFP4 W4A16 vocabulary-head copy for GLM-5.3 MTP
proposals. The target model retains its BF16 vocabulary head, and standard
speculative rejection continues to verify every proposal against the target
distribution.

Set `VLLM_GLM53_MTP_DRAFT_HEAD=nvfp4` to enable the copy. The default
`bf16` mode retains the shared BF16 head and allocates no additional weight.

## Behavior and compatibility

- Each tensor-parallel rank quantizes its loaded BF16 vocabulary shard once
  after target-weight loading.
- FlashInfer's SM120 CuTe-DSL W4A16 GEMM evaluates proposal logits.
- The copy retains the target head's tensor-parallel shard indices and world
  size, so the existing vocabulary-parallel gather and global top-token
  selection remain authoritative.
- Only MTP proposal logits use the quantized copy. Target logits and target
  verification remain BF16.
- Unsupported CUDA capabilities, weight layouts, biases, and selector values
  fail explicitly.
- The independent `[38720, 4096]` shard consumes 85.08 MiB per rank.

Quantization can change proposal choices and therefore acceptance efficiency.
It cannot change the target distribution under standard rejection sampling.
The accelerated mode requires CUDA capability 12.0 and FlashInfer's CuTe-DSL
NVFP4 implementation.

## Non-duplication

vllm-project/vllm#54897 implements an approximate target-side hybrid vocabulary
projection with BF16 candidate refinement. vllm-project/vllm#54574 loads a
separately quantized MTP head supplied by a Nemotron checkpoint. Neither creates
a GLM-5.3 proposal-only copy from the loaded target head.

## Validation

Source validation against
`dev/jovian-judgement@5c90fc8b93c56e0bf355fbdfb7fc2facc2770f98`:

- `pytest tests/models/test_glm5next_model.py -q`: 59 passed and one
  device-specific test skipped;
- Ruff check and format validation passed for all six changed files;
- `git diff --check dev/jovian-judgement...HEAD` passed;
- server startup and full plus piecewise CUDA graph capture passed;
- direct graph replay passed for 1, 8, and 128 rows;
- six greedy serial and concurrent requests, including 32K-token prompts,
  produced identical BF16-head and NVFP4-head output tokens.

A matched performance A/B used four RTX PRO 6000 Blackwell Workstation Edition
GPUs at stock clocks, TP4/DCP1, MTP depth 3, a 4,096-token scheduler budget,
FlashInfer sampling, and full plus piecewise CUDA graphs. Each arm ran five
sequential 4,096-output-token requests after a separate warmup. The image,
launcher, prompt, and request parameters were identical; only
`VLLM_GLM53_MTP_DRAFT_HEAD` changed.

| Proposal head | Median verifier steps/s | Median output tok/s | Median accepted/draft |
|---|---:|---:|---:|
| BF16 | 100.032 | 292.634 | 1.933 |
| NVFP4 W4A16 | 103.963 | 307.613 | 1.965 |

The NVFP4 head improves verifier execution by 3.93%. Output throughput and
acceptance are reported together because the draft sampler does not honor the
per-request generator; their difference is stochastic and is not claimed as an
acceptance or quality gain. The underlying vocabulary projection measured
0.194 ms in BF16 and 0.047–0.063 ms in W4A16 for 1–32 rows.

Evidence is stored under
`results/glm53-mtp-draft-head-e2e-20260905` in the qualification workspace.

## AI assistance

AI assistance was used to implement and benchmark this change. The submitter
reviewed the source diff, operation contract, and validation evidence.