### PR TITLE
[BugFix] Preserve sparse hybrid replay boundaries under EAGLE/MTP

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3492,7 +3492,10 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     assert [len(blocks) for blocks in computed_blocks.blocks] == [3, 12]
 
 
-def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
+@pytest.mark.parametrize("annotate_eagle_groups", [None, "full_only", "both"])
+def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop(
+    annotate_eagle_groups,
+):
     """Verify Mamba latest-only retention serves an MTP/EAGLE lookup.
 
     The full-attention EAGLE lookup drops one block below what it matched, so
@@ -3502,8 +3505,18 @@ def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
     boundary state leaves every retained state one block above every reachable
     candidate, and the reconciled hit is always zero (found live on
     GLM-5.3-Flash MTP: 0 hits across 16,897 queries).
+
+    Parametrized over how the groups are annotated, because the three cases
+    reach the manager's ``use_eagle`` bit by different routes and only one of
+    them is what production hits today: ``None`` is the coordinator's flag-all
+    fallback (no model annotator exists for glm5_next, so this is the live
+    path), ``full_only`` is a single annotated group (what a future annotator
+    would produce), and ``both`` is the hand-flagged case.
     """
     block_size = 32
+    num_spec = 3
+    full_is_eagle = annotate_eagle_groups in ("full_only", "both")
+    mamba_is_eagle = annotate_eagle_groups == "both"
     kv_cache_config = KVCacheConfig(
         num_blocks=100,
         kv_cache_tensors=[],
@@ -3516,7 +3529,7 @@ def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
                     head_size=1,
                     dtype=torch.float16,
                 ),
-                is_eagle_group=True,
+                is_eagle_group=full_is_eagle,
             ),
             KVCacheGroupSpec(
                 ["mamba_mtp"],
@@ -3525,8 +3538,9 @@ def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
                     shapes=((1, 1),),
                     dtypes=(torch.float32,),
                     mamba_cache_mode="align",
+                    num_speculative_blocks=num_spec,
                 ),
-                is_eagle_group=True,
+                is_eagle_group=mamba_is_eagle,
             ),
         ],
     )
@@ -3553,6 +3567,7 @@ def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
             chunk_end - req0.num_computed_tokens,
             num_computed_tokens,
             computed_blocks,
+            num_lookahead_tokens=num_spec,
         )
         assert blocks is not None
         req0.num_computed_tokens = chunk_end
@@ -3576,6 +3591,92 @@ def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
     computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
     assert num_computed_tokens == 2 * block_size
     assert [len(blocks) for blocks in computed_blocks.blocks] == [2, 2]
+
+
+def test_hybrid_mamba_retention_eagle_backoff_is_one_alignment_unit():
+    """The EAGLE back-off is one ALIGNMENT unit, which is not one Mamba block.
+
+    When the groups' block sizes differ, the scheduler alignment is their LCM,
+    and the full-attention finder subtracts ``min(alignment, its block_size)``
+    and re-floors -- landing one alignment unit below the boundary regardless.
+    Backing off one Mamba block instead retains a state at the wrong offset:
+    Mamba's own finder then rejects it (its hit must be alignment-aligned) and
+    the reconciled hit stays 0, so the extra block is dead weight.
+
+    Here alignment is 64 and the Mamba block is 32, so the reachable position
+    is two Mamba blocks below the boundary, not one.
+    """
+    mamba_block = 32
+    full_block = 64  # scheduler alignment = lcm(64, 32) = 64 = 2 mamba blocks
+    kv_cache_config = KVCacheConfig(
+        num_blocks=200,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=full_block,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                ),
+                is_eagle_group=True,
+            ),
+            KVCacheGroupSpec(
+                ["mamba_mtp"],
+                MambaSpec(
+                    block_size=mamba_block,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+                is_eagle_group=True,
+            ),
+        ],
+    )
+    # hash_block_size must divide every group's block size, so it is the
+    # smaller (Mamba) block; the scheduler alignment is still the LCM, 64.
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=mamba_block,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    # 255 tokens: replay boundary floor(254 / 64) * 64 = 192. In Mamba blocks
+    # that is index 5; the EAGLE-reachable position 192 - 64 = 128 is index 3.
+    token_ids = [i for i in range(7) for _ in range(mamba_block)] + [7] * 31
+    req0 = make_request("0", token_ids, mamba_block, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    for chunk_end in (64, 128, 192, 255):
+        blocks = manager.allocate_slots(
+            req0,
+            chunk_end - req0.num_computed_tokens,
+            num_computed_tokens,
+            computed_blocks,
+        )
+        assert blocks is not None
+        req0.num_computed_tokens = chunk_end
+
+    pool = manager.block_pool
+    cached_mamba = {
+        i
+        for i in range(len(req0.block_hashes))
+        if pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
+        is not None
+    }
+    # Index 3 is the one a post-drop lookup can ask for; index 4 (one block
+    # below the boundary) is what a block-sized back-off would have kept.
+    assert 3 in cached_mamba, f"reachable state missing; cached={sorted(cached_mamba)}"
+    assert 4 not in cached_mamba, "one-block back-off retained an unreachable state"
+
+    manager.free(req0)
+    req1 = make_request("1", token_ids, mamba_block, sha256)
+    _, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    assert num_computed_tokens == 128
 
 
 def test_block_lookup_cache_single_block_per_key():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3492,6 +3492,92 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     assert [len(blocks) for blocks in computed_blocks.blocks] == [3, 12]
 
 
+def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
+    """Verify Mamba latest-only retention serves an MTP/EAGLE lookup.
+
+    The full-attention EAGLE lookup drops one block below what it matched, so
+    until a request decodes past the block boundary after its prompt, the only
+    candidate the coordinator can offer the Mamba group is one block below the
+    replay boundary. Mamba retention must keep that state too; keeping only the
+    boundary state leaves every retained state one block above every reachable
+    candidate, and the reconciled hit is always zero (found live on
+    GLM-5.3-Flash MTP: 0 hits across 16,897 queries).
+    """
+    block_size = 32
+    kv_cache_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                ),
+                is_eagle_group=True,
+            ),
+            KVCacheGroupSpec(
+                ["mamba_mtp"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+                is_eagle_group=True,
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    # 127 tokens: replay boundary floor(126 / 32) * 32 = 96, i.e. block 2's end.
+    # Prefill in block-aligned chunks the way the align-mode scheduler does:
+    # the state one block below the boundary only materializes as a chunk's
+    # running-state block, so a single-shot prefill could not retain it.
+    token_ids = [i for i in range(3) for _ in range(block_size)] + [3] * 31
+    req0 = make_request("0", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    for chunk_end in (32, 64, 96, 127):
+        blocks = manager.allocate_slots(
+            req0,
+            chunk_end - req0.num_computed_tokens,
+            num_computed_tokens,
+            computed_blocks,
+        )
+        assert blocks is not None
+        req0.num_computed_tokens = chunk_end
+
+    # Mamba keeps the boundary state (block 2) plus the state one block below
+    # (block 1) -- the only position an EAGLE-dropped lookup can reach while
+    # the request has not decoded past the next block boundary.
+    pool = manager.block_pool
+    expected_mamba_cached = {1, 2}
+    for i in range(3):
+        cached = pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
+        if i in expected_mamba_cached:
+            assert cached is not None, f"mamba hash {i} should be cached"
+        else:
+            assert cached is None, f"mamba hash {i} should not be cached"
+    manager.free(req0)
+
+    # Identical resend: full attention matches blocks 0-2 (96 tokens) and the
+    # EAGLE drop caps the candidate at 64; the retained state at 64 serves it.
+    req1 = make_request("1", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    assert num_computed_tokens == 2 * block_size
+    assert [len(blocks) for blocks in computed_blocks.blocks] == [2, 2]
+
+
 def test_block_lookup_cache_single_block_per_key():
     cache = BlockHashToBlockMap()
     key0 = BlockHashWithGroupId(b"hash0")

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -731,7 +731,10 @@ def _test_partial_request_hit(
 
 
 def _make_hybrid_kv_cache_config(
-    block_size: int, num_blocks: int, spec_types: list[str]
+    block_size: int,
+    num_blocks: int,
+    spec_types: list[str],
+    eagle_group_ids: set[int] | None = None,
 ) -> KVCacheConfig:
     """
     Create a KVCacheConfig with the specified spec types.
@@ -744,6 +747,7 @@ def _make_hybrid_kv_cache_config(
             - "sliding_window": SlidingWindowSpec with window=2*block_size
             - "sliding_window_large": SlidingWindowSpec with window=4*block_size
             - "mamba": MambaSpec
+        eagle_group_ids: Group indices explicitly marked for EAGLE/MTP.
     """
     spec_map = {
         "full": lambda: FullAttentionSpec(
@@ -779,8 +783,13 @@ def _make_hybrid_kv_cache_config(
         ),
     }
 
+    eagle_group_ids = eagle_group_ids or set()
     kv_cache_groups = [
-        KVCacheGroupSpec([f"layer{i}"], spec_map[spec_type]())
+        KVCacheGroupSpec(
+            [f"layer{i}"],
+            spec_map[spec_type](),
+            is_eagle_group=i in eagle_group_ids,
+        )
         for i, spec_type in enumerate(spec_types)
     ]
 
@@ -3461,8 +3470,8 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     )
 
     # 127 tokens: latest replay boundary is floor((127 - 1) / 32) * 32 = 96.
-    # The EAGLE/MTP SWA lookup group must cache the local tail ending at
-    # 104 tokens, and that tail is two 8-token blocks wide: hashes 11 and 12.
+    # The EAGLE/MTP SWA lookup group must cache two-block proof tails ending
+    # at 104 tokens and at the reachable predecessor after 64 tokens.
     token_ids = [i for i in range(15) for _ in range(block_size)] + [15] * 7
     req0 = make_request("0", token_ids, block_size, sha256)
     computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
@@ -3476,7 +3485,7 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     assert blocks is not None
 
     pool = manager.block_pool
-    expected_swa_cached = {11, 12}
+    expected_swa_cached = {7, 8, 11, 12}
     for i in range(15):
         cached = pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
         if i in expected_swa_cached:
@@ -3693,12 +3702,23 @@ def _cache_in_chunks(manager, request, chunk_ends, num_lookahead_tokens=0):
         request.num_computed_tokens = chunk_end
 
 
-def test_hybrid_swa_retention_keeps_eagle_reachable_predecessor():
+@pytest.mark.parametrize(
+    "eagle_group_ids",
+    [
+        pytest.param(None, id="fallback"),
+        pytest.param({0}, id="full_only"),
+        pytest.param({0, 1, 2}, id="all_groups"),
+    ],
+)
+def test_hybrid_swa_retention_keeps_eagle_reachable_predecessor(eagle_group_ids):
     """SWA and Mamba must retain the same post-drop replay boundary."""
     block_size = 32
     manager = make_kv_cache_manager(
         kv_cache_config=_make_hybrid_kv_cache_config(
-            block_size, 300, ["full", "mamba_align", "sliding_window"]
+            block_size,
+            300,
+            ["full", "mamba_align", "sliding_window"],
+            eagle_group_ids=eagle_group_ids,
         ),
         max_model_len=8192,
         enable_caching=True,
@@ -3716,6 +3736,39 @@ def test_hybrid_swa_retention_keeps_eagle_reachable_predecessor():
     computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
     assert num_computed_tokens == 2 * block_size
     assert [len(blocks) for blocks in computed_blocks.blocks] == [2, 2, 2]
+
+
+def test_hybrid_mamba_retention_follows_swa_eagle_drop():
+    """Mamba must retain a boundary lowered by another sparse group."""
+    block_size = 32
+    manager = make_kv_cache_manager(
+        kv_cache_config=_make_hybrid_kv_cache_config(
+            block_size,
+            300,
+            ["sliding_window", "mamba_align"],
+            eagle_group_ids={0},
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    token_ids = [i for i in range(8) for _ in range(block_size)] + [8] * 31
+    req0 = make_request("0", token_ids, block_size, sha256)
+    _cache_in_chunks(
+        manager,
+        req0,
+        (32, 64, 96, 128, 160, 192, 224, 256, 287),
+        num_lookahead_tokens=3,
+    )
+    manager.free(req0)
+
+    req1 = make_request("1", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    assert num_computed_tokens == 7 * block_size
+    assert [len(blocks) for blocks in computed_blocks.blocks] == [7, 7]
 
 
 def test_hybrid_sparse_retention_uses_fine_hit_alignment(monkeypatch):
@@ -4299,6 +4352,30 @@ def test_pure_swa_retention_latest_only():
     replay = make_request("1", token_ids, block_size, sha256)
     _, num_computed, _ = manager.get_computed_blocks(replay)
     assert num_computed == 240
+
+
+def test_pure_swa_eagle_retention_keeps_reachable_predecessor():
+    block_size = 32
+    manager = _make_pure_swa_manager(
+        block_size,
+        sliding_window=2 * block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    token_ids = [i for i in range(8) for _ in range(block_size)] + [8] * 31
+    request = make_request("0", token_ids, block_size, sha256)
+    _cache_in_chunks(
+        manager,
+        request,
+        (32, 64, 96, 128, 160, 192, 224, 256, 287),
+        num_lookahead_tokens=3,
+    )
+    manager.free(request)
+
+    replay = make_request("1", token_ids, block_size, sha256)
+    _, num_computed, _ = manager.get_computed_blocks(replay)
+    assert num_computed == 7 * block_size
 
 
 def test_pure_swa_dense_retention_caches_all():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3501,6 +3501,61 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     assert [len(blocks) for blocks in computed_blocks.blocks] == [3, 12]
 
 
+def test_hybrid_local_kv_retention_mtp_reuses_exact_boundary():
+    """An unavailable SWA proof block must fall back one aligned boundary."""
+    block_size = 8
+    kv_cache_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=4 * block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["swa_mtp"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=block_size,
+                ),
+                is_eagle_group=True,
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    token_ids = [i // block_size for i in range(129)]
+    request = make_request("0", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(request)
+    blocks = manager.allocate_slots(
+        request,
+        len(token_ids),
+        num_computed_tokens,
+        computed_blocks,
+    )
+    assert blocks is not None
+    manager.free(request)
+
+    replay = make_request("1", token_ids, block_size, sha256)
+    _, num_computed_tokens, _ = manager.get_computed_blocks(replay)
+    assert num_computed_tokens == 12 * block_size
+
+
 @pytest.mark.parametrize("annotate_eagle_groups", [None, "full_only", "both"])
 def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop(
     annotate_eagle_groups,

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3863,6 +3863,71 @@ def test_hybrid_sparse_retention_uses_fine_hit_alignment(monkeypatch):
     assert set(observed_alignments) == {hash_block_size}
 
 
+def test_hybrid_fine_hit_retention_preserves_materialized_fallback():
+    """A fine boundary without a state must not displace a usable snapshot."""
+    full = lambda size: FullAttentionSpec(
+        block_size=size, num_kv_heads=1, head_size=1, dtype=torch.float32
+    )
+    config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["full128"], full(128)),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=64,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+            KVCacheGroupSpec(["full32"], full(32)),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=32,
+        retention_interval=0,
+    )
+    assert manager.coordinator._cache_hit_alignment_tokens == 32
+    request = make_request("producer", list(range(480)), 32, sha256)
+    scheduler = SimpleNamespace(
+        # EngineCore uses the smallest group block size here, not the LCM.
+        cache_config=SimpleNamespace(
+            block_size=min(g.kv_cache_spec.block_size for g in config.kv_cache_groups)
+        ),
+        use_eagle=False,
+        max_num_scheduled_tokens=384,
+        scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+        mamba_partial_cache_hit=True,
+        hash_block_size=32,
+        mamba_has_prefill_checkpoint_blocks=False,
+    )
+    chunk_ends = []
+    while request.num_computed_tokens < request.num_tokens:
+        num_new_tokens = Scheduler._mamba_block_aligned_split(
+            scheduler,
+            request,
+            min(384, request.num_tokens - request.num_computed_tokens),
+        )
+        assert num_new_tokens > 0
+        assert manager.allocate_slots(request, num_new_tokens) is not None
+        request.num_computed_tokens += num_new_tokens
+        chunk_ends.append(request.num_computed_tokens)
+    assert chunk_ends == [384, 480]
+    # No chunk materialized state@448. State@480 exceeds replay's 479-token cap.
+    mamba = manager.coordinator.single_type_managers[1]
+    assert mamba.req_to_blocks[request.request_id][6].is_null
+    manager.free(request)
+
+    replay = make_request("replay", list(range(480)), 32, sha256)
+    _, hit_tokens, _ = manager.get_computed_blocks(replay)
+    assert hit_tokens == 384
+
+
 def test_block_lookup_cache_single_block_per_key():
     cache = BlockHashToBlockMap()
     key0 = BlockHashWithGroupId(b"hash0")

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3679,6 +3679,82 @@ def test_hybrid_mamba_retention_eagle_backoff_is_one_alignment_unit():
     assert num_computed_tokens == 128
 
 
+def _cache_in_chunks(manager, request, chunk_ends, num_lookahead_tokens=0):
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(request)
+    for chunk_end in chunk_ends:
+        blocks = manager.allocate_slots(
+            request,
+            chunk_end - request.num_computed_tokens,
+            num_computed_tokens,
+            computed_blocks,
+            num_lookahead_tokens=num_lookahead_tokens,
+        )
+        assert blocks is not None
+        request.num_computed_tokens = chunk_end
+
+
+def test_hybrid_swa_retention_keeps_eagle_reachable_predecessor():
+    """SWA and Mamba must retain the same post-drop replay boundary."""
+    block_size = 32
+    manager = make_kv_cache_manager(
+        kv_cache_config=_make_hybrid_kv_cache_config(
+            block_size, 300, ["full", "mamba_align", "sliding_window"]
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    token_ids = [i for i in range(3) for _ in range(block_size)] + [3] * 31
+    req0 = make_request("0", token_ids, block_size, sha256)
+    _cache_in_chunks(manager, req0, (32, 64, 96, 127), num_lookahead_tokens=3)
+    manager.free(req0)
+
+    req1 = make_request("1", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    assert num_computed_tokens == 2 * block_size
+    assert [len(blocks) for blocks in computed_blocks.blocks] == [2, 2, 2]
+
+
+def test_hybrid_sparse_retention_uses_fine_hit_alignment(monkeypatch):
+    """Sparse retention must use the same fine alignment as cache lookup."""
+    hash_block_size = 32
+    cache_block_size = 64
+    manager = make_kv_cache_manager(
+        kv_cache_config=_make_hybrid_kv_cache_config(
+            cache_block_size, 300, ["full", "mamba_align"]
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+    assert manager.coordinator._cache_hit_alignment_tokens == hash_block_size
+
+    mamba_manager = manager.coordinator.single_type_managers[1]
+    original_mask = type(mamba_manager).reachable_block_mask
+    observed_alignments = []
+
+    def record_alignment(cls, **kwargs):
+        observed_alignments.append(kwargs["alignment_tokens"])
+        return original_mask(**kwargs)
+
+    monkeypatch.setattr(
+        type(mamba_manager),
+        "reachable_block_mask",
+        classmethod(record_alignment),
+    )
+
+    token_ids = [i for i in range(3) for _ in range(hash_block_size)] + [3] * 31
+    req0 = make_request("0", token_ids, hash_block_size, sha256)
+    _cache_in_chunks(manager, req0, (64, 127), num_lookahead_tokens=3)
+    assert observed_alignments
+    assert set(observed_alignments) == {hash_block_size}
+
+
 def test_block_lookup_cache_single_block_per_key():
     cache = BlockHashToBlockMap()
     key0 = BlockHashWithGroupId(b"hash0")

--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -3,6 +3,7 @@
 
 from math import lcm
 
+import pytest
 import torch
 
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import (  # noqa: E501
@@ -480,7 +481,29 @@ def test_store_mask_uses_fine_hit_alignment():
 
     masks = coord.store_mask(512, num_prompt_tokens=501)
     assert masks[0] is None
-    assert masks[1] == [i == 6 for i in range(8)]
+    assert masks[1] == [i in (5, 6) for i in range(8)]
+
+
+@pytest.mark.parametrize("use_eagle, retained", [(False, {5, 6}), (True, {3, 5, 6})])
+def test_store_mask_preserves_fine_and_materialized_boundaries(use_eagle, retained):
+    groups = [
+        KVCacheGroupSpec(["full128"], _full(128)),
+        KVCacheGroupSpec(["mamba"], _mamba_align(64)),
+        KVCacheGroupSpec(["full32"], _full(32)),
+    ]
+    coord = _make_coord(
+        groups, hash_block_size=32, use_eagle=use_eagle, retention_interval=0
+    )
+    assert coord.enable_partial_hash_hits
+    # Fine replay positions: 448 (and 416 under EAGLE).
+    # Materialized fallback positions: 384 (and 256 under EAGLE).
+    assert coord.store_mask(480, num_prompt_tokens=480)[1] == [
+        i in retained for i in range(7)
+    ]
+    assert coord.store_mask(384, num_prompt_tokens=480)[1] == [
+        i in retained for i in range(6)
+    ]
+    assert coord.store_mask(480, start_token=384, num_prompt_tokens=480)[1] == [True]
 
 
 def test_store_mask_disables_fine_hits_for_incompatible_swa():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -451,6 +451,38 @@ def test_store_mask_retention_prefix_stable_as_aligned_length_grows():
     assert longer[: len(shorter)] == shorter
 
 
+def test_store_mask_retains_shared_eagle_predecessor():
+    groups = [
+        KVCacheGroupSpec(["full"], _full(32), is_eagle_group=True),
+        KVCacheGroupSpec(["mamba"], _mamba_align(32)),
+        KVCacheGroupSpec(["swa"], _swa(32, 64)),
+    ]
+    coord = _make_coord(
+        groups,
+        hash_block_size=32,
+        use_eagle=True,
+        retention_interval=0,
+    )
+
+    masks = coord.store_mask(288, num_prompt_tokens=287)
+    assert masks[0] is None
+    assert masks[1] == [i in (6, 7) for i in range(9)]
+    assert masks[2] == [i in (5, 6, 7) for i in range(9)]
+
+
+def test_store_mask_uses_fine_hit_alignment():
+    groups = [
+        KVCacheGroupSpec(["full"], _full(128)),
+        KVCacheGroupSpec(["mamba"], _mamba_align(64)),
+    ]
+    coord = _make_coord(groups, hash_block_size=32, retention_interval=0)
+    assert coord.enable_partial_hash_hits
+
+    masks = coord.store_mask(512, num_prompt_tokens=501)
+    assert masks[0] is None
+    assert masks[1] == [i == 6 for i in range(8)]
+
+
 # ----- Eagle / MTP interaction with load_mask -----
 
 

--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -483,6 +483,26 @@ def test_store_mask_uses_fine_hit_alignment():
     assert masks[1] == [i == 6 for i in range(8)]
 
 
+def test_store_mask_disables_fine_hits_for_incompatible_swa():
+    groups = [
+        KVCacheGroupSpec(["full"], _full(32), is_eagle_group=True),
+        KVCacheGroupSpec(["mamba"], _mamba_align(64)),
+        KVCacheGroupSpec(["swa"], _swa(64, 128)),
+    ]
+    coord = _make_coord(
+        groups,
+        hash_block_size=32,
+        use_eagle=True,
+        retention_interval=0,
+    )
+
+    assert not coord.enable_partial_hash_hits
+    masks = coord.store_mask(384, num_prompt_tokens=383)
+    assert masks[0] is None
+    assert masks[1] is not None
+    assert masks[2] is not None
+
+
 # ----- Eagle / MTP interaction with load_mask -----
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -15,6 +15,9 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
 )
+from vllm.v1.core.single_type_kv_cache_manager import (
+    resolve_sparse_retention_inputs,
+)
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheGroupSpec,
@@ -133,6 +136,10 @@ class MooncakeStoreCoordinator:
         self.eagle_group_ids = {
             gid for g in attention_groups if g.use_eagle for gid in g.group_ids
         }
+        self.lookup_drops_eagle_block = any(
+            group.use_eagle and group.manager_cls.drops_eagle_block
+            for group in attention_groups
+        )
 
     def find_longest_cache_hit(
         self,
@@ -248,13 +255,20 @@ class MooncakeStoreCoordinator:
             manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
             assert manager_cls is not None
             use_eagle = g_idx in self.eagle_group_ids
-            reachable_boundaries = (
+            reachable_boundaries: Sequence[int] = (
                 () if num_prompt_tokens is None else (num_prompt_tokens - 1,)
+            )
+            use_eagle, reachable_boundaries = resolve_sparse_retention_inputs(
+                spec,
+                use_eagle,
+                self.lookup_drops_eagle_block,
+                mask_alignment,
+                reachable_boundaries,
             )
             mask = manager_cls.reachable_block_mask(
                 start_block=start_chunk,
                 end_block=end_chunk,
-                alignment_tokens=self.lcm_block_size,
+                alignment_tokens=mask_alignment,
                 kv_cache_spec=spec,
                 use_eagle=use_eagle,
                 retention_interval=retention_interval,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -351,10 +351,10 @@ class MooncakeStoreCoordinator:
                     apply_eagle and group_eagle and idx not in eagle_verified
                 )
                 _max_length = curr_hit_length
-                # No eagle peek margin for a recurrent (Mamba) group: its finder
-                # never drops a block, so a widened bound would match past the
-                # attention-verified hit and resume from speculative state (#43559).
-                if drop_eagle_block and not isinstance(spec, MambaSpec):
+                # Only managers whose finder drops a block receive a peek
+                # margin. Otherwise a widened bound can resume past the
+                # attention-verified hit (#43559).
+                if drop_eagle_block and manager_cls.drops_eagle_block:
                     eagle_margin = (
                         self.hash_block_size
                         if self.enable_partial_hash_hits
@@ -418,9 +418,23 @@ def partial_hash_hits_enabled(
     (its dcp == 1 clause holds: the connector rejects hybrid + DCP/PCP > 1).
     Single copy on purpose — scheduler and coordinator must not disagree.
     """
-    return any(
+    has_partial_mamba_group = any(
         isinstance(spec := _unwrap_spec(g.kv_cache_spec), MambaSpec)
         and spec.mamba_cache_mode == "align"
         and spec.block_size > hash_block_size
         for g in kv_cache_groups
     )
+    if not has_partial_mamba_group:
+        return False
+
+    for group in kv_cache_groups:
+        spec = _unwrap_spec(group.kv_cache_spec)
+        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        if manager_cls is None:
+            return False
+        if (
+            not manager_cls.supports_fine_grained_hash_lookup
+            and spec.block_size != hash_block_size
+        ):
+            return False
+    return True

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -262,8 +262,9 @@ class MooncakeStoreCoordinator:
                 spec,
                 use_eagle,
                 self.lookup_drops_eagle_block,
-                mask_alignment,
                 reachable_boundaries,
+                lookup_alignment_tokens=mask_alignment,
+                state_materialization_alignment_tokens=self.lcm_block_size,
             )
             mask = manager_cls.reachable_block_mask(
                 start_block=start_chunk,

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -149,6 +149,14 @@ class KVCacheCoordinator(ABC):
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
 
+        # Sparse retention must key off "some group's lookup applies the EAGLE
+        # drop", not "this group holds draft layers": the coordinator reconciles
+        # every group to ONE hit length, so a drop anywhere shortens the
+        # candidate offered to all of them. A group that kept only its own
+        # boundary state would then sit above every reachable candidate.
+        for manager in self.single_type_managers:
+            manager.lookup_drops_eagle_block = bool(self.eagle_group_ids)
+
         # A positive retention interval must be a multiple of the base hit granularity
         # (``scheduler_block_size``) to land on real cache-hit boundaries.
         # 0 = keep only the latest replay boundary; None = dense;

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -846,12 +846,11 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 drop_eagle_block = use_eagle and idx not in eagle_verified
 
                 _max_length = curr_hit_length
-                # Eagle matches one extra drop unit (one hash unit for
+                # EAGLE matches one extra drop unit (one hash unit for
                 # fine-grained managers, else one cache block) and then drops
-                # it, landing back at the candidate length. No margin for
-                # mamba: its finder never drops (draft models have no mamba
-                # layers), so the hit would grow past the candidate.
-                if drop_eagle_block and not isinstance(spec, MambaSpec):
+                # it, landing back at the candidate length. Managers whose
+                # finder does not drop receive no margin.
+                if drop_eagle_block and manager_cls.drops_eagle_block:
                     eagle_margin = (
                         self.hash_block_size
                         if self.enable_partial_hash_hits

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -149,14 +149,9 @@ class KVCacheCoordinator(ABC):
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
 
-        # Sparse retention must account for a full-attention EAGLE drop because
-        # the coordinator reconciles every group to one hit length. A sparse
-        # group that kept only its own boundary would then sit above the shared
-        # candidate.
         lookup_drops_eagle_block = any(
-            i in self.eagle_group_ids
-            and isinstance(group.kv_cache_spec, FullAttentionSpec)
-            for i, group in enumerate(self.kv_cache_config.kv_cache_groups)
+            i in self.eagle_group_ids and manager.drops_eagle_block
+            for i, manager in enumerate(self.single_type_managers)
         )
         for manager in self.single_type_managers:
             manager.lookup_drops_eagle_block = lookup_drops_eagle_block

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -149,13 +149,17 @@ class KVCacheCoordinator(ABC):
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
 
-        # Sparse retention must key off "some group's lookup applies the EAGLE
-        # drop", not "this group holds draft layers": the coordinator reconciles
-        # every group to ONE hit length, so a drop anywhere shortens the
-        # candidate offered to all of them. A group that kept only its own
-        # boundary state would then sit above every reachable candidate.
+        # Sparse retention must account for a full-attention EAGLE drop because
+        # the coordinator reconciles every group to one hit length. A sparse
+        # group that kept only its own boundary would then sit above the shared
+        # candidate.
+        lookup_drops_eagle_block = any(
+            i in self.eagle_group_ids
+            and isinstance(group.kv_cache_spec, FullAttentionSpec)
+            for i, group in enumerate(self.kv_cache_config.kv_cache_groups)
+        )
         for manager in self.single_type_managers:
-            manager.lookup_drops_eagle_block = bool(self.eagle_group_ids)
+            manager.lookup_drops_eagle_block = lookup_drops_eagle_block
 
         # A positive retention interval must be a multiple of the base hit granularity
         # (``scheduler_block_size``) to land on real cache-hit boundaries.
@@ -779,6 +783,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 request,
                 num_tokens_to_cache,
                 retention_interval=self.retention_interval,
+                alignment_tokens=self._cache_hit_alignment_tokens,
             )
 
     def find_longest_cache_hit(

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -33,6 +33,32 @@ from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
 
 
+def reachable_hit_positions(
+    boundary_tokens: int,
+    alignment_tokens: int,
+    use_eagle: bool,
+) -> tuple[int, ...]:
+    """Token positions a cache hit can land on for one reachable boundary.
+
+    A lookup floors the boundary to ``alignment_tokens``. Under EAGLE the
+    full-attention finder additionally subtracts ``min(alignment_tokens,
+    its own block_size)`` and re-floors to the alignment, which lands on
+    exactly one alignment unit below the boundary either way. That lower
+    position is the ONLY one this group can be asked for until the request
+    decodes past the next boundary, so sparse-retention masks must treat both
+    as reachable: retaining only the boundary leaves every kept state above
+    every candidate a lookup can produce, and the reconciled hit is always 0.
+
+    Expressing the back-off in tokens rather than blocks is what makes this
+    correct when a group's block size differs from the alignment: one block is
+    the right step only when they are equal.
+    """
+    aligned = boundary_tokens // alignment_tokens * alignment_tokens
+    if not use_eagle:
+        return (aligned,)
+    return (aligned, max(aligned - alignment_tokens, 0))
+
+
 class SingleTypeKVCacheManager(ABC):
     """
     An abstract base class for a manager that handle the kv cache management
@@ -102,11 +128,16 @@ class SingleTypeKVCacheManager(ABC):
         self.kv_cache_group_id = kv_cache_group_id
         self._null_block = block_pool.null_block
 
-        # Whether this group's prefix-cache hits drop the EAGLE/MTP lookahead
-        # block. Only consulted by managers whose hit logic is sparse within an
-        # aligned segment (SWA). Initialized lazily by the coordinator after
+        # Whether THIS group's own prefix-cache lookup drops the EAGLE/MTP
+        # lookahead block. Initialized lazily by the coordinator after
         # determining the attention groups.
         self.use_eagle = False
+
+        # Whether ANY group's lookup applies that drop, which is what sparse
+        # retention must key off: the coordinator reconciles every group to one
+        # hit length, so a drop anywhere shortens the candidate offered here.
+        # See ``reachable_hit_positions``. Set by the coordinator.
+        self.lookup_drops_eagle_block = False
 
         # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
         # managers (full attention, mamba "align"); harmlessly empty elsewhere.
@@ -457,7 +488,8 @@ class SingleTypeKVCacheManager(ABC):
             end_block=num_full_blocks,
             alignment_tokens=self.scheduler_block_size,
             kv_cache_spec=self.kv_cache_spec,
-            use_eagle=self.use_eagle,
+            # Retention, unlike lookup, cares whether the drop happens anywhere.
+            use_eagle=self.use_eagle or self.lookup_drops_eagle_block,
             retention_interval=retention_interval,
             reachable_boundaries=reachable_boundaries,
         )
@@ -1428,25 +1460,15 @@ class MambaManager(SingleTypeKVCacheManager):
         # (2) Reachable-boundary states: the replay boundary (``num_prompt - 1``,
         # capped by ``get_computed_blocks``) and any shared-prefix junction, both
         # of which segments would otherwise skip under sparse retention. A Mamba
-        # hit needs exactly the single state block ending on the boundary.
-        #
-        # Under EAGLE/MTP the full-attention lookup drops one block below what
-        # it matched, so until the request decodes past the block boundary
-        # after ``boundary_tokens`` the only candidate the coordinator can
-        # offer this group is one block below the boundary. Keep that state
-        # too; keeping only the boundary state leaves every retained state one
-        # block above every reachable candidate, and the reconciled hit is
-        # always zero.
+        # hit needs exactly the single state block ending on the reachable
+        # position, so retain one block per position rather than a run.
         for boundary_tokens in reachable_boundaries:
-            aligned = boundary_tokens // alignment_tokens * alignment_tokens
-            boundary_block = aligned // block_size - 1
-            for kept in (
-                (boundary_block, boundary_block - 1)
-                if use_eagle
-                else (boundary_block,)
+            for position in reachable_hit_positions(
+                boundary_tokens, alignment_tokens, use_eagle
             ):
-                if start_block <= kept < end_block:
-                    mask[kept - start_block] = True
+                boundary_block = position // block_size - 1
+                if start_block <= boundary_block < end_block:
+                    mask[boundary_block - start_block] = True
 
         return mask
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1408,9 +1408,11 @@ class MambaManager(SingleTypeKVCacheManager):
         mask = [False] * (end_block - start_block)
 
         # (1) Segment-boundary states. A Mamba hit needs exactly the single
-        # state block ending on the boundary (no window, and draft models have
-        # no mamba layers, so no eagle shift). Block ``i`` ends at token
-        # ``(i + 1) * block_size``.
+        # state block ending on the boundary (no window). Segment tails get no
+        # EAGLE shift: under the EAGLE drop the fixed point settles on the next
+        # lower tail, costing at most one segment of hit length, unlike the
+        # reachable boundaries below where the unshifted state is the only one.
+        # Block ``i`` ends at token ``(i + 1) * block_size``.
         segment_tokens = None if retention_interval == 0 else retention_interval
         if segment_tokens is not None:
             per_segment = segment_tokens // block_size
@@ -1427,11 +1429,24 @@ class MambaManager(SingleTypeKVCacheManager):
         # capped by ``get_computed_blocks``) and any shared-prefix junction, both
         # of which segments would otherwise skip under sparse retention. A Mamba
         # hit needs exactly the single state block ending on the boundary.
+        #
+        # Under EAGLE/MTP the full-attention lookup drops one block below what
+        # it matched, so until the request decodes past the block boundary
+        # after ``boundary_tokens`` the only candidate the coordinator can
+        # offer this group is one block below the boundary. Keep that state
+        # too; keeping only the boundary state leaves every retained state one
+        # block above every reachable candidate, and the reconciled hit is
+        # always zero.
         for boundary_tokens in reachable_boundaries:
             aligned = boundary_tokens // alignment_tokens * alignment_tokens
             boundary_block = aligned // block_size - 1
-            if start_block <= boundary_block < end_block:
-                mask[boundary_block - start_block] = True
+            for kept in (
+                (boundary_block, boundary_block - 1)
+                if use_eagle
+                else (boundary_block,)
+            ):
+                if start_block <= kept < end_block:
+                    mask[kept - start_block] = True
 
         return mask
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -133,10 +133,10 @@ class SingleTypeKVCacheManager(ABC):
         # determining the attention groups.
         self.use_eagle = False
 
-        # Whether ANY group's lookup applies that drop, which is what sparse
-        # retention must key off: the coordinator reconciles every group to one
-        # hit length, so a drop anywhere shortens the candidate offered here.
-        # See ``reachable_hit_positions``. Set by the coordinator.
+        # Whether a full-attention lookup applies that drop. Sparse retention
+        # must account for it because the coordinator reconciles every group to
+        # one hit length. See ``reachable_hit_positions``. Set by the
+        # coordinator.
         self.lookup_drops_eagle_block = False
 
         # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
@@ -457,6 +457,7 @@ class SingleTypeKVCacheManager(ABC):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        alignment_tokens: int | None = None,
     ) -> None:
         """
         Cache the blocks for the request.
@@ -469,12 +470,18 @@ class SingleTypeKVCacheManager(ABC):
                 keeps dense checkpointing; ``0`` keeps only the latest replay
                 boundary; a positive multiple of ``scheduler_block_size`` keeps
                 a tail once per that-sized segment. Only SWA acts on it.
+            alignment_tokens: Cache-hit alignment. Defaults to the scheduler
+                block size for non-hybrid coordinators.
         """
         num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
         num_full_blocks = num_tokens // self.block_size
 
         if num_cached_blocks >= num_full_blocks:
             return
+
+        mask_alignment_tokens = (
+            self.scheduler_block_size if alignment_tokens is None else alignment_tokens
+        )
 
         # Token boundaries whose reachable tail must be retained under sparse
         # retention: the replay boundary (``num_prompt - 1``, capped by
@@ -483,13 +490,26 @@ class SingleTypeKVCacheManager(ABC):
         if request.shared_prefix_boundary:
             reachable_boundaries.append(request.shared_prefix_boundary)
 
+        retention_use_eagle = self.use_eagle
+        if self.lookup_drops_eagle_block:
+            if isinstance(self.kv_cache_spec, MambaSpec):
+                retention_use_eagle = True
+            elif isinstance(self.kv_cache_spec, SlidingWindowSpec):
+                reachable_boundaries = [
+                    position
+                    for boundary in reachable_boundaries
+                    for position in reachable_hit_positions(
+                        boundary, mask_alignment_tokens, True
+                    )
+                    if position > 0
+                ]
+
         block_mask = self.reachable_block_mask(
             start_block=num_cached_blocks,
             end_block=num_full_blocks,
-            alignment_tokens=self.scheduler_block_size,
+            alignment_tokens=mask_alignment_tokens,
             kv_cache_spec=self.kv_cache_spec,
-            # Retention, unlike lookup, cares whether the drop happens anywhere.
-            use_eagle=self.use_eagle or self.lookup_drops_eagle_block,
+            use_eagle=retention_use_eagle,
             retention_interval=retention_interval,
             reachable_boundaries=reachable_boundaries,
         )
@@ -815,8 +835,14 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        alignment_tokens: int | None = None,
     ) -> None:
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            alignment_tokens=alignment_tokens,
+        )
         hash_block_size = self.block_pool.hash_block_size
         if self.block_size == hash_block_size:
             return
@@ -1753,9 +1779,15 @@ class MambaManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        alignment_tokens: int | None = None,
     ) -> None:
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            alignment_tokens=alignment_tokens,
+        )
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
         if self.mamba_cache_mode == "align":
             partial_hash = self._cache_partial_tail_block(request, num_tokens)
@@ -1848,6 +1880,7 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        alignment_tokens: int | None = None,
     ) -> None:
         # We do not cache blocks for cross-attention to be shared between
         # requests, so this method is not relevant.

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -40,14 +40,11 @@ def reachable_hit_positions(
 ) -> tuple[int, ...]:
     """Token positions a cache hit can land on for one reachable boundary.
 
-    A lookup floors the boundary to ``alignment_tokens``. Under EAGLE the
-    full-attention finder additionally subtracts ``min(alignment_tokens,
-    its own block_size)`` and re-floors to the alignment, which lands on
-    exactly one alignment unit below the boundary either way. That lower
-    position is the ONLY one this group can be asked for until the request
-    decodes past the next boundary, so sparse-retention masks must treat both
-    as reachable: retaining only the boundary leaves every kept state above
-    every candidate a lookup can produce, and the reconciled hit is always 0.
+    A lookup floors the boundary to ``alignment_tokens``. Under EAGLE an
+    attention finder removes its lookahead block and re-floors to the
+    alignment. The result is either the aligned boundary or one alignment unit
+    below it, depending on the finder's block size. Sparse-retention masks must
+    treat both as reachable.
 
     Expressing the back-off in tokens rather than blocks is what makes this
     correct when a group's block size differs from the alignment: one block is
@@ -59,6 +56,29 @@ def reachable_hit_positions(
     return (aligned, max(aligned - alignment_tokens, 0))
 
 
+def resolve_sparse_retention_inputs(
+    kv_cache_spec: KVCacheSpec,
+    use_eagle: bool,
+    lookup_drops_eagle_block: bool,
+    alignment_tokens: int,
+    reachable_boundaries: Sequence[int],
+) -> tuple[bool, tuple[int, ...]]:
+    """Account for an EAGLE-reduced shared hit boundary."""
+    boundaries = tuple(reachable_boundaries)
+    if not lookup_drops_eagle_block:
+        return use_eagle, boundaries
+    if isinstance(kv_cache_spec, MambaSpec):
+        return True, boundaries
+    if isinstance(kv_cache_spec, SlidingWindowSpec):
+        boundaries = tuple(
+            position
+            for boundary in boundaries
+            for position in reachable_hit_positions(boundary, alignment_tokens, True)
+            if position > 0
+        )
+    return use_eagle, boundaries
+
+
 class SingleTypeKVCacheManager(ABC):
     """
     An abstract base class for a manager that handle the kv cache management
@@ -66,6 +86,7 @@ class SingleTypeKVCacheManager(ABC):
     """
 
     supports_fine_grained_hash_lookup: ClassVar[bool] = False
+    drops_eagle_block: ClassVar[bool] = False
 
     def __init__(
         self,
@@ -133,10 +154,9 @@ class SingleTypeKVCacheManager(ABC):
         # determining the attention groups.
         self.use_eagle = False
 
-        # Whether a full-attention lookup applies that drop. Sparse retention
+        # Whether an attention-group lookup applies that drop. Sparse retention
         # must account for it because the coordinator reconciles every group to
-        # one hit length. See ``reachable_hit_positions``. Set by the
-        # coordinator.
+        # one hit length. Set by the coordinator.
         self.lookup_drops_eagle_block = False
 
         # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
@@ -486,23 +506,20 @@ class SingleTypeKVCacheManager(ABC):
         # Token boundaries whose reachable tail must be retained under sparse
         # retention: the replay boundary (``num_prompt - 1``, capped by
         # ``get_computed_blocks``) and any detected shared-prefix junction.
-        reachable_boundaries = [request.num_prompt_tokens - 1]
+        reachable_boundaries: Sequence[int] = (request.num_prompt_tokens - 1,)
         if request.shared_prefix_boundary:
-            reachable_boundaries.append(request.shared_prefix_boundary)
+            reachable_boundaries = (
+                *reachable_boundaries,
+                request.shared_prefix_boundary,
+            )
 
-        retention_use_eagle = self.use_eagle
-        if self.lookup_drops_eagle_block:
-            if isinstance(self.kv_cache_spec, MambaSpec):
-                retention_use_eagle = True
-            elif isinstance(self.kv_cache_spec, SlidingWindowSpec):
-                reachable_boundaries = [
-                    position
-                    for boundary in reachable_boundaries
-                    for position in reachable_hit_positions(
-                        boundary, mask_alignment_tokens, True
-                    )
-                    if position > 0
-                ]
+        retention_use_eagle, reachable_boundaries = resolve_sparse_retention_inputs(
+            self.kv_cache_spec,
+            self.use_eagle,
+            self.lookup_drops_eagle_block,
+            mask_alignment_tokens,
+            reachable_boundaries,
+        )
 
         block_mask = self.reachable_block_mask(
             start_block=num_cached_blocks,
@@ -731,6 +748,7 @@ class SingleTypeKVCacheManager(ABC):
 
 class FullAttentionManager(SingleTypeKVCacheManager):
     supports_fine_grained_hash_lookup: ClassVar[bool] = True
+    drops_eagle_block: ClassVar[bool] = True
 
     @classmethod
     def find_longest_cache_hit(
@@ -936,6 +954,8 @@ class RSWAManager(FullAttentionManager):
 
 
 class SlidingWindowManager(SingleTypeKVCacheManager):
+    drops_eagle_block: ClassVar[bool] = True
+
     def __init__(self, kv_cache_spec: SlidingWindowSpec, **kwargs) -> None:
         super().__init__(kv_cache_spec, **kwargs)
         self.sliding_window = kv_cache_spec.sliding_window

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -60,20 +60,44 @@ def resolve_sparse_retention_inputs(
     kv_cache_spec: KVCacheSpec,
     use_eagle: bool,
     lookup_drops_eagle_block: bool,
-    alignment_tokens: int,
     reachable_boundaries: Sequence[int],
+    *,
+    lookup_alignment_tokens: int,
+    state_materialization_alignment_tokens: int,
 ) -> tuple[bool, tuple[int, ...]]:
-    """Account for an EAGLE-reduced shared hit boundary."""
+    """Resolve the mask's EAGLE flag and retained token boundaries.
+
+    Lookup alignment can be finer than the scheduler alignment used to
+    materialize recurrent states. Keep both sets of Mamba positions so a
+    missing fine state does not displace a usable scheduler-aligned fallback.
+    """
     boundaries = tuple(reachable_boundaries)
+    if isinstance(kv_cache_spec, MambaSpec):
+        alignments = dict.fromkeys(
+            (lookup_alignment_tokens, state_materialization_alignment_tokens)
+        )
+        positions = tuple(
+            dict.fromkeys(
+                position
+                for boundary in boundaries
+                for alignment in alignments
+                for position in reachable_hit_positions(
+                    boundary, alignment, use_eagle or lookup_drops_eagle_block
+                )
+            )
+        )
+        # Each alignment's EAGLE predecessor is already included. The mask
+        # must not apply another lookup-sized drop to materialized positions.
+        return False, positions
     if not lookup_drops_eagle_block:
         return use_eagle, boundaries
-    if isinstance(kv_cache_spec, MambaSpec):
-        return True, boundaries
     if isinstance(kv_cache_spec, SlidingWindowSpec):
         boundaries = tuple(
             position
             for boundary in boundaries
-            for position in reachable_hit_positions(boundary, alignment_tokens, True)
+            for position in reachable_hit_positions(
+                boundary, lookup_alignment_tokens, True
+            )
             if position > 0
         )
     return use_eagle, boundaries
@@ -517,8 +541,9 @@ class SingleTypeKVCacheManager(ABC):
             self.kv_cache_spec,
             self.use_eagle,
             self.lookup_drops_eagle_block,
-            mask_alignment_tokens,
             reachable_boundaries,
+            lookup_alignment_tokens=mask_alignment_tokens,
+            state_materialization_alignment_tokens=self.scheduler_block_size,
         )
 
         block_mask = self.reachable_block_mask(


### PR DESCRIPTION
## Purpose

This draft builds directly on local-inference-lab/vllm#556. It preserves both
original commits unchanged, so @tobymao remains their author. Thank you to Toby
Mao for finding and implementing the original Mamba sparse-retention fix.

The follow-up implements findings from
[logprobz's review comment](https://github.com/local-inference-lab/vllm/pull/556#issuecomment-5517232206)
and two independent Claude Opus 5 reviews:

- Retain both positions an EAGLE/MTP attention lookup can make reachable: the
  aligned boundary and its predecessor. A manager capability now identifies
  lookups that actually drop a proof block, including full attention, MLA, and
  SWA, while excluding Mamba and unsupported local-attention managers. This
  refines the `bool(eagle_group_ids)` predicate introduced by #556.
- Pass the coordinator's `_cache_hit_alignment_tokens` into sparse-retention
  masks. For Mamba, retain both the fine lookup position and a
  scheduler-aligned state-materialization fallback, so a mathematically valid
  fine boundary does not displace the only state the scheduler produced.
- Apply the same boundary and alignment rules to Mooncake store masks. The
  connector now shares the engine's sparse-retention input resolver instead of
  offloading states that local lookup cannot consume. It also mirrors the
  engine's compatibility gate, so mixed SWA and Mamba layouts fall back to
  block-aligned hits instead of asserting during store.

The PR targets `dev/jovian-judgement`, so its diff contains Toby's two original
commits from #556 followed by four `logprobz` follow-up commits.

The `BlockStored` sparse-event concern from the linked review remains out of
scope because it changes connector event semantics. This PR does not file a
separate issue; that work remains tracked in the review comment pending an
independent issue or PR.

### Related work

- vllm-project/vllm#54713 is the upstream form of #556.
- vllm-project/vllm#53802 is related but not a duplicate. It approaches the
  symptom from registration: it floors the scheduler tail split and
  `_cache_partial_tail_block` from `num_tokens - 1`, and adds an SWA tail at the
  fine hash boundary inside `reachable_block_mask`. This draft leaves
  registration unchanged. It passes the coordinator's actual lookup alignment
  into `cache_blocks` and retains EAGLE-reachable positions consistently in the
  engine and Mooncake store masks.

## Test Plan

The pytest runs use the pinned r22 container's isolated `/opt/venv` after adding
the `tblib` test dependency, which the image does not include:

```bash
/opt/venv/bin/python -m pytest -q -p no:cacheprovider \
  tests/v1/core/test_prefix_caching.py \
  tests/v1/core/prefix_cache \
  tests/v1/core/test_mamba_align_chunk_split.py \
  tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py \
  tests/v1/kv_connector/unit/test_mooncake_store_worker.py \
  tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
```

The lint runs use an isolated `uv` environment and the repository's pinned hook
configuration:

```bash
pre-commit run --files \
  tests/v1/core/test_prefix_caching.py \
  tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py \
  vllm/v1/core/kv_cache_coordinator.py \
  vllm/v1/core/single_type_kv_cache_manager.py \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py

pre-commit run mypy-3.12 --hook-stage manual --files \
  tests/v1/core/test_prefix_caching.py \
  tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py \
  vllm/v1/core/kv_cache_coordinator.py \
  vllm/v1/core/single_type_kv_cache_manager.py \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
```

Container image:
`voipmonitor/vllm@sha256:284784e685aa0377f1cf63a312a364fc884b02beb98949d6886624edbddb3806`.

## Test Result

Baseline on the unchanged #556 head, with the first two follow-up tests
overlaid:

- SWA replay returned 0 cached tokens instead of the reachable 64-token prefix.
- Sparse retention received 64-token scheduler alignment instead of the
  32-token fine-hit alignment.
- Result: 2 failed, 95 deselected.

The Opus review added focused coverage against the prior PR head. Four cases
failed before the review fixes:

- SWA-driven hybrid replay returned 0 instead of 224 tokens for its Mamba group.
- Pure SWA under EAGLE returned 0 instead of 224 tokens on replay.
- Mooncake omitted the Mamba and SWA states at the EAGLE-reachable predecessor.
- Mooncake retained Mamba block 5 with coarse alignment instead of block 6 with
  fine-hit alignment.

A closure review then found that Mooncake enabled fine hits for a mixed SWA and
Mamba layout that the engine correctly rejects. The new regression test failed
before the compatibility fix on `assert not coord.enable_partial_hash_hits`.
Without that guard, `store_mask` reached the SWA alignment assertion.

A GPT-6 Astra review found that fine alignment could retain an unmaterialized
Mamba state while removing its usable scheduler-aligned fallback. In its
480-token reproduction, identical replay improved from 0 to 384 tokens after
retaining both positions. Engine and Mooncake regression tests cover this case.

Current head:

- 382 tests passed across the six suites in the pytest command.
- All focused EAGLE, SWA, Mamba, and Mooncake regressions passed, including
  three SWA annotation routes and the mixed-layout compatibility fallback.
- The complete changed-file hook set passed, including Ruff, typos, mypy 3.10,
  SPDX, import, configuration, and forbidden-API checks.
- The manual CI-style mypy 3.12 hook passed.
- `git diff --check` passed.

No GPU model evaluation was run for the follow-up commits. This PR remains a
draft because the repository requires a serving evaluation and human review
before it is ready. `logprobz` must review every changed line, run the relevant
tests, and add the GLM-5.3-Flash replay results before marking it ready.

## AI assistance

OpenAI Codex assisted with implementation, tests, and this description. Two
Claude Opus 5 agents independently reviewed the implementation and the PR's
guideline compliance. The original review posted by logprobz on #556 credits
Claude Fable 5.1. GPT-6 Astra independently reviewed the current PR and found
the fine-hit materialization regression described above.

The first Codex follow-up commit was already published without attribution and
sign-off trailers. It remains unamended to preserve published history without a
force-push. All three later follow-up commits include
`Assisted-by: OpenAI Codex` and `Signed-off-by: logprobz` trailers.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and distinction from related PRs are described above.
- [x] Test commands and current results are included.
- [ ] GLM-5.3-Flash model evaluation is pending while this remains a draft.
- [x] No documentation update is required for this internal cache correction.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>**

### Superseded

Superseded by #669, now merged on dev/jovian-judgement. The coordinated port preserves endpoint checkpoint guards and includes the cache, scheduler, connector and event repairs from this earlier branch. The combined release passed full MTP3 and DFlash2 serving qualification and was promoted, with zero preemptions and all LP26 5% performance gates satisfied. Closing this older proposal to avoid duplicate integration.
