### PR TITLE
[BugFix] Publish truthful sparse KV cache events

### DIFF
--- a/tests/distributed/test_kv_cache_events.py
+++ b/tests/distributed/test_kv_cache_events.py
@@ -50,6 +50,9 @@ def _make_block_stored(
     group_idx: int | None = None,
     kv_cache_spec_sliding_window: int | None = None,
     locality: str | None = None,
+    skipped_parent_block_hash: bytes | None = None,
+    skipped_token_ids: list[int] | None = None,
+    skipped_extra_keys: list[tuple[Any, ...] | None] | None = None,
 ) -> BlockStored:
     return BlockStored(
         block_hashes=[_FAKE_HASH],
@@ -59,6 +62,9 @@ def _make_block_stored(
         lora_id=None,
         medium="GPU",
         lora_name=None,
+        skipped_parent_block_hash=skipped_parent_block_hash,
+        skipped_token_ids=skipped_token_ids,
+        skipped_extra_keys=skipped_extra_keys,
         group_idx=group_idx,
         kv_cache_spec_sliding_window=kv_cache_spec_sliding_window,
         locality=locality,
@@ -103,6 +109,12 @@ def test_block_stored_hash_same_for_equal_group_idx():
     event_a = _make_block_stored(group_idx=1)
     event_b = _make_block_stored(group_idx=1)
     assert hash(event_a) == hash(event_b)
+
+
+def test_block_stored_hash_differs_by_skipped_context():
+    event_a = _make_block_stored(skipped_token_ids=[1, 2, 3, 4])
+    event_b = _make_block_stored(skipped_token_ids=[5, 6, 7, 8])
+    assert hash(event_a) != hash(event_b)
 
 
 @pytest.mark.parametrize("group_idx", [1, 2, 3])
@@ -160,19 +172,31 @@ def test_block_stored_locality_is_wire_compatible():
         kv_cache_spec_sliding_window=128,
     )
     legacy_payload = msgspec.msgpack.encode(legacy)
-    assert (
-        msgspec.msgpack.encode(
-            _make_block_stored(
-                group_idx=2,
-                kv_cache_spec_sliding_window=128,
-            )
-        )
-        == legacy_payload
-    )
-    assert msgspec.msgpack.decode(legacy_payload, type=BlockStored).locality is None
+    decoded_legacy = msgspec.msgpack.decode(legacy_payload, type=BlockStored)
+    assert decoded_legacy.locality is None
+    assert decoded_legacy.skipped_parent_block_hash is None
+    assert decoded_legacy.skipped_token_ids is None
+    assert decoded_legacy.skipped_extra_keys is None
+
     new_payload = msgspec.msgpack.encode(_make_block_stored(locality="LOCAL"))
     assert msgspec.msgpack.decode(new_payload)["locality"] == "LOCAL"
-    assert msgspec.msgpack.decode(new_payload, type=_LegacyBlockStored).medium == "GPU"
+    decoded_new = msgspec.msgpack.decode(new_payload, type=_LegacyBlockStored)
+    assert decoded_new.medium == "GPU"
+    assert decoded_new.group_idx is None
+
+
+def test_block_stored_skipped_context_is_wire_compatible():
+    event = _make_block_stored(
+        skipped_parent_block_hash=_FAKE_HASH,
+        skipped_token_ids=[5, 6, 7, 8],
+        skipped_extra_keys=[("salt",)],
+    )
+    payload = msgspec.msgpack.encode(event)
+    decoded = msgspec.msgpack.decode(payload)
+    assert decoded["skipped_parent_block_hash"] == _FAKE_HASH
+    assert decoded["skipped_token_ids"] == [5, 6, 7, 8]
+    assert decoded["skipped_extra_keys"] == [["salt"]]
+    assert msgspec.msgpack.decode(payload, type=_LegacyBlockStored).medium == "GPU"
 
 
 def test_block_removed_locality_is_wire_compatible():

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -78,6 +78,7 @@ def make_full_mamba_manager(
     num_blocks: int = 32,
     use_eagle: bool = False,
     num_prefill_checkpoint_blocks: int = 0,
+    enable_kv_cache_events: bool = False,
 ):
     kv_cache_config = KVCacheConfig(
         num_blocks=num_blocks,
@@ -116,6 +117,7 @@ def make_full_mamba_manager(
         scheduler_block_size=scheduler_block_size,
         hash_block_size=hash_block_size,
         use_eagle=use_eagle,
+        enable_kv_cache_events=enable_kv_cache_events,
     )
 
 
@@ -1786,3 +1788,62 @@ def test_dcp_partial_hit_with_eagle_rewinds_one_hash_unit():
     assert num_computed == 4
     assert [len(group) for group in computed_blocks.blocks] == [1, 1]
     assert manager.allocate_slots(req1, 4, num_computed, computed_blocks) is not None
+
+
+@pytest.mark.parametrize("dcp_world_size", [1, 2])
+@pytest.mark.parametrize("events_enabled", [True, False])
+def test_full_replay_reports_fine_hit(dcp_world_size, events_enabled):
+    from vllm.distributed.kv_events import BlockStored
+    from vllm.v1.core.kv_cache_utils import maybe_convert_block_hash
+
+    manager = make_full_mamba_manager(
+        dcp_world_size=dcp_world_size,
+        full_block_size=4,
+        mamba_block_size=16,
+        enable_kv_cache_events=events_enabled,
+    )
+    req = make_request("fine-replay", list(range(49)), 2, sha256)
+    req.kv_cache_report_mode = "full"
+    pool = manager.block_pool
+    hit_tokens = 46
+    for group_idx, single in enumerate(manager.coordinator.single_type_managers):
+        size = single.block_size
+        count = hit_tokens // size
+        blocks = pool.get_new_blocks(count + 1)
+        if group_idx == 0:
+            pool.cache_full_blocks(req, blocks, 0, count, size, group_idx)
+        pool.cache_partial_block(req, blocks[-1], hit_tokens, group_idx, size)
+    pool.take_events()
+    before = [(b.block_hash, b.block_hash_num_tokens, b.ref_cnt) for b in pool.blocks]
+    aliases = {
+        key: set(value) for key, value in pool.cached_block_hashes_by_block.items()
+    }
+    computed, hit, _ = manager.get_computed_blocks(req)
+    assert hit == hit_tokens
+    assert computed.blocks[1][0].is_null
+    events = manager.take_events()
+    assert [
+        (b.block_hash, b.block_hash_num_tokens, b.ref_cnt) for b in pool.blocks
+    ] == before
+    assert pool.cached_block_hashes_by_block == aliases
+    if not events_enabled:
+        assert events == []
+        return
+    assert len(events) == 3
+    assert all(isinstance(event, BlockStored) for event in events)
+    full, full_tail, mamba_tail = events
+    size = 4 * dcp_world_size
+    end = hit_tokens // size * size
+    assert full.block_size == size
+    assert full.token_ids == list(range(end))
+    assert full.block_hashes == [
+        maybe_convert_block_hash(req.block_hashes[i])
+        for i in range(size // 2 - 1, end // 2, size // 2)
+    ]
+    for event, group in [(full_tail, 0), (mamba_tail, 1)]:
+        assert event.group_idx == group
+        assert event.block_hashes == [maybe_convert_block_hash(req.block_hashes[22])]
+        assert event.parent_block_hash == maybe_convert_block_hash(req.block_hashes[21])
+        assert event.token_ids == [44, 45]
+        assert event.block_size == 2
+        assert event.extra_keys == [None]

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
@@ -460,3 +460,64 @@ def test_partial_block_promotes_to_direct_full_block_hash(dcp_world_size: int):
     )
     assert pool.get_cached_block(promoted_full_hash, [kv_cache_group_id]) == [blocks[1]]
     assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None
+
+
+@pytest.mark.parametrize("tail", ["alias", "unregistered", "null"])
+def test_replay_preserves_partial_alias_residency(tail):
+    req = make_request("alias-replay", list(range(16)), 2, sha256)
+    pool = BlockPool(3, True, 2, True)
+    blocks = pool.get_new_blocks(2)
+    pool.cache_full_blocks(req, blocks, 0, 2, 8, 0)
+    if tail == "alias":
+        pool.cache_partial_block(req, blocks[1], 10, 0, 8)
+    pool.take_events()
+    primary_hash = blocks[1].block_hash
+    aliases = {
+        key: set(value) for key, value in pool.cached_block_hashes_by_block.items()
+    }
+    returned = [blocks[0], pool.null_block if tail == "null" else blocks[1]]
+    pool.emit_cached_block_events(req, returned, 10, 8, 0)
+    events = pool.take_events()
+    assert len(events) == (2 if tail == "alias" else 1)
+    assert events[0].token_ids == list(range(8))
+    if tail == "alias":
+        assert events[1].block_hashes == [
+            kv_cache_utils.maybe_convert_block_hash(req.block_hashes[4])
+        ]
+        assert events[1].parent_block_hash == kv_cache_utils.maybe_convert_block_hash(
+            req.block_hashes[3]
+        )
+        assert events[1].token_ids == [8, 9]
+        assert events[1].block_size == 2
+    assert blocks[1].block_hash == primary_hash
+    assert pool.cached_block_hashes_by_block == aliases
+
+
+def test_sparse_promotion_removes_aliases_before_stored_runs():
+    req = make_request("promotion-runs", list(range(24)), 2, sha256)
+    pool = BlockPool(4, True, 2, True)
+    blocks = pool.get_new_blocks(3)
+    pool.cache_partial_block(req, blocks[0], 6, 0, 8)
+    pool.cache_partial_block(req, blocks[2], 22, 0, 8)
+    pool.take_events()
+    pool.cache_full_blocks(req, blocks, 0, 3, 8, 0, [True, False, True])
+    events = pool.take_events()
+    assert [type(event) for event in events] == [
+        BlockRemoved,
+        BlockRemoved,
+        BlockStored,
+        BlockStored,
+    ]
+    assert [event.block_hashes for event in events] == [
+        [kv_cache_utils.maybe_convert_block_hash(req.block_hashes[i])]
+        for i in (2, 10, 3, 11)
+    ]
+    pool.free_blocks(blocks)
+    assert pool.take_events() == []
+    pool.get_new_blocks(3)
+    removed = pool.take_events()
+    assert len(removed) == 2
+    assert all(isinstance(event, BlockRemoved) for event in removed)
+    assert {h for event in removed for h in event.block_hashes} == {
+        kv_cache_utils.maybe_convert_block_hash(req.block_hashes[i]) for i in (3, 11)
+    }

--- a/tests/v1/core/prefix_cache/test_sparse_event_context.py
+++ b/tests/v1/core/prefix_cache/test_sparse_event_context.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from tests.v1.core.test_prefix_caching import make_request
+from vllm.distributed.kv_events import BlockStored
+from vllm.multimodal.inputs import PlaceholderRange
+from vllm.utils.hashing import sha256
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import init_none_hash, maybe_convert_block_hash
+
+
+@pytest.fixture(autouse=True)
+def init_hash():
+    init_none_hash(sha256)
+
+
+@pytest.mark.parametrize("retain_first", [False, True])
+def test_context_survives_chunk_gap(retain_first):
+    req = make_request("chunks", list(range(16)), 4, sha256)
+    pool = BlockPool(5, True, 4, True)
+    blocks = pool.get_new_blocks(4)
+    pool.cache_full_blocks(req, blocks, 0, 2, 4, 0, [retain_first, False])
+    first = pool.take_events()
+    assert len(first) == int(retain_first)
+    pool.cache_full_blocks(req, blocks, 2, 4, 4, 0, [False, True])
+    (event,) = pool.take_events()
+    start = 4 if retain_first else 0
+    assert event.token_ids == list(range(12, 16))
+    assert event.skipped_token_ids == list(range(start, 12))
+    assert event.skipped_extra_keys == [None] * ((12 - start) // 4)
+    expected_parent = maybe_convert_block_hash(req.block_hashes[0]) if start else None
+    assert event.skipped_parent_block_hash == expected_parent
+    assert event.block_hashes == [maybe_convert_block_hash(req.block_hashes[3])]
+
+
+@pytest.mark.parametrize("retain_full", [False, True])
+def test_partial_replay_supplies_context(retain_full):
+    req = make_request(
+        "partial",
+        list(range(16)),
+        2,
+        sha256,
+        mm_positions=[PlaceholderRange(offset=8, length=2)],
+        mm_hashes=["image"],
+        cache_salt="tenant",
+    )
+    pool = BlockPool(3, True, 2, True)
+    blocks = pool.get_new_blocks(2)
+    if retain_full:
+        pool.cache_full_blocks(req, blocks, 0, 1, 8, 0)
+    pool.cache_partial_block(req, blocks[1], 14, 0, 8)
+    pool.take_events()
+    returned = [blocks[0] if retain_full else pool.null_block, blocks[1]]
+    before = [(b.block_hash, b.block_hash_num_tokens, b.ref_cnt) for b in blocks]
+    pool.emit_cached_block_events(req, returned, 14, 8, 0)
+    events = pool.take_events()
+    assert len(events) == 1 + int(retain_full)
+    event = events[-1]
+    start = 8 if retain_full else 0
+    assert isinstance(event, BlockStored)
+    assert event.token_ids == [12, 13]
+    assert event.block_size == 2
+    assert event.skipped_token_ids == list(range(start, 12))
+    keys = [("tenant",), None, None, None, (("image", 0),), None]
+    assert event.skipped_extra_keys == keys[start // 2 :]
+    expected_parent = maybe_convert_block_hash(req.block_hashes[3]) if start else None
+    assert event.skipped_parent_block_hash == expected_parent
+    assert event.parent_block_hash == maybe_convert_block_hash(req.block_hashes[5])
+    assert event.block_hashes == [maybe_convert_block_hash(req.block_hashes[6])]
+    assert [
+        (b.block_hash, b.block_hash_num_tokens, b.ref_cnt) for b in blocks
+    ] == before
+
+
+@pytest.mark.parametrize("boundary", ["group", "request", "reset"])
+def test_context_stays_with_its_request_group_and_cache(boundary):
+    req = make_request("reused-id", list(range(8)), 4, sha256)
+    pool = BlockPool(5, True, 4, True)
+    first = pool.get_new_blocks(1)
+    pool.cache_full_blocks(req, first, 0, 1, 4, 0)
+    pool.take_events()
+    group = int(boundary == "group")
+    if boundary == "request":
+        req = make_request("reused-id", list(range(8)), 4, sha256)
+    if boundary == "reset":
+        pool.free_blocks(first)
+        assert pool.reset_prefix_cache()
+        pool.take_events()
+    tail = pool.get_new_blocks(1)[0]
+    pool.cache_full_blocks(req, [pool.null_block, tail], 1, 2, 4, group)
+    (event,) = pool.take_events()
+    assert event.skipped_parent_block_hash is None
+    assert event.skipped_token_ids == list(range(4))
+
+
+def test_partial_store_supplies_context():
+    req = make_request("partial-store", list(range(16)), 2, sha256)
+    pool = BlockPool(2, True, 2, True)
+    block = pool.get_new_blocks(1)[0]
+    pool.cache_partial_block(req, block, 14, 0, 8)
+    (event,) = pool.take_events()
+    assert event.token_ids == [12, 13]
+    assert event.skipped_parent_block_hash is None
+    assert event.skipped_token_ids == list(range(12))
+    assert event.skipped_extra_keys == [None] * 6
+
+
+def test_stale_anchor_restarts_context_from_root():
+    req = make_request("stale-anchor", list(range(16)), 4, sha256)
+    pool = BlockPool(5, True, 4, True)
+    blocks = pool.get_new_blocks(4)
+    pool.cache_full_blocks(req, blocks, 0, 2, 4, 0)
+    pool.take_events()
+    # Streaming updates truncate a session in place and rebuild its hash
+    # chain (scheduler._update_request_as_session), which can change the
+    # request's block hashes under a saved anchor. A stale anchor must not
+    # suppress skipped context, so validation restarts from the root.
+    req._all_token_ids[1] = 999
+    req.block_hashes = []
+    req.update_block_hashes()
+    pool.cache_full_blocks(req, blocks, 2, 4, 4, 0, [False, True])
+    (event,) = pool.take_events()
+    assert event.skipped_parent_block_hash is None
+    assert event.skipped_token_ids == req.all_token_ids[:12]
+    assert event.skipped_extra_keys == [None] * 3
+    assert event.block_hashes == [maybe_convert_block_hash(req.block_hashes[3])]
+
+
+def test_partial_only_replay_ignores_saved_anchor():
+    req = make_request("partial-only-replay", list(range(16)), 2, sha256)
+    pool = BlockPool(3, True, 2, True)
+    full_block, partial_block = pool.get_new_blocks(2)
+    pool.cache_full_blocks(req, [full_block], 0, 1, 8, 0)
+    pool.cache_partial_block(req, partial_block, 14, 0, 8)
+    pool.take_events()
+
+    pool.emit_cached_block_events(req, [pool.null_block, partial_block], 14, 8, 0)
+    (event,) = pool.take_events()
+    assert event.token_ids == [12, 13]
+    assert event.skipped_token_ids == list(range(12))
+    assert event.skipped_parent_block_hash is None
+    assert event.skipped_extra_keys == [None] * 6
+
+
+@pytest.mark.parametrize("continuation", ["full", "partial"])
+def test_full_replay_advances_incremental_context(continuation):
+    producer = make_request("producer", list(range(32)), 2, sha256)
+    req = make_request("replay-continuation", list(range(32)), 2, sha256)
+    pool = BlockPool(4, True, 2, True)
+    full_block, partial_block, tail = pool.get_new_blocks(3)
+    pool.cache_full_blocks(producer, [full_block], 0, 1, 8, 0)
+    pool.take_events()
+
+    pool.emit_cached_block_events(req, [full_block], 8, 8, 0)
+    (replay,) = pool.take_events()
+    assert replay.token_ids == list(range(8))
+    assert replay.skipped_token_ids is None
+    if continuation == "partial":
+        pool.cache_partial_block(req, partial_block, 14, 0, 8)
+        (partial,) = pool.take_events()
+        assert partial.token_ids == [12, 13]
+        assert partial.skipped_token_ids == list(range(8, 12))
+        assert partial.skipped_extra_keys == [None] * 2
+        assert partial.skipped_parent_block_hash == maybe_convert_block_hash(
+            req.block_hashes[3]
+        )
+
+    pool.cache_full_blocks(
+        req, [full_block, pool.null_block, pool.null_block, tail], 1, 4, 8, 0
+    )
+    (event,) = pool.take_events()
+    assert event.token_ids == list(range(24, 32))
+    assert event.skipped_token_ids == list(range(8, 24))
+    assert event.skipped_extra_keys == [None] * 2
+    assert event.skipped_parent_block_hash == maybe_convert_block_hash(
+        req.block_hashes[3]
+    )

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3492,7 +3492,10 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     assert [len(blocks) for blocks in computed_blocks.blocks] == [3, 12]
 
 
-def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
+@pytest.mark.parametrize("annotate_eagle_groups", [None, "full_only", "both"])
+def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop(
+    annotate_eagle_groups,
+):
     """Verify Mamba latest-only retention serves an MTP/EAGLE lookup.
 
     The full-attention EAGLE lookup drops one block below what it matched, so
@@ -3502,8 +3505,18 @@ def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
     boundary state leaves every retained state one block above every reachable
     candidate, and the reconciled hit is always zero (found live on
     GLM-5.3-Flash MTP: 0 hits across 16,897 queries).
+
+    Parametrized over how the groups are annotated, because the three cases
+    reach the manager's ``use_eagle`` bit by different routes and only one of
+    them is what production hits today: ``None`` is the coordinator's flag-all
+    fallback (no model annotator exists for glm5_next, so this is the live
+    path), ``full_only`` is a single annotated group (what a future annotator
+    would produce), and ``both`` is the hand-flagged case.
     """
     block_size = 32
+    num_spec = 3
+    full_is_eagle = annotate_eagle_groups in ("full_only", "both")
+    mamba_is_eagle = annotate_eagle_groups == "both"
     kv_cache_config = KVCacheConfig(
         num_blocks=100,
         kv_cache_tensors=[],
@@ -3516,7 +3529,7 @@ def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
                     head_size=1,
                     dtype=torch.float16,
                 ),
-                is_eagle_group=True,
+                is_eagle_group=full_is_eagle,
             ),
             KVCacheGroupSpec(
                 ["mamba_mtp"],
@@ -3525,8 +3538,9 @@ def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
                     shapes=((1, 1),),
                     dtypes=(torch.float32,),
                     mamba_cache_mode="align",
+                    num_speculative_blocks=num_spec,
                 ),
-                is_eagle_group=True,
+                is_eagle_group=mamba_is_eagle,
             ),
         ],
     )
@@ -3553,6 +3567,7 @@ def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
             chunk_end - req0.num_computed_tokens,
             num_computed_tokens,
             computed_blocks,
+            num_lookahead_tokens=num_spec,
         )
         assert blocks is not None
         req0.num_computed_tokens = chunk_end
@@ -3576,6 +3591,92 @@ def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
     computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
     assert num_computed_tokens == 2 * block_size
     assert [len(blocks) for blocks in computed_blocks.blocks] == [2, 2]
+
+
+def test_hybrid_mamba_retention_eagle_backoff_is_one_alignment_unit():
+    """The EAGLE back-off is one ALIGNMENT unit, which is not one Mamba block.
+
+    When the groups' block sizes differ, the scheduler alignment is their LCM,
+    and the full-attention finder subtracts ``min(alignment, its block_size)``
+    and re-floors -- landing one alignment unit below the boundary regardless.
+    Backing off one Mamba block instead retains a state at the wrong offset:
+    Mamba's own finder then rejects it (its hit must be alignment-aligned) and
+    the reconciled hit stays 0, so the extra block is dead weight.
+
+    Here alignment is 64 and the Mamba block is 32, so the reachable position
+    is two Mamba blocks below the boundary, not one.
+    """
+    mamba_block = 32
+    full_block = 64  # scheduler alignment = lcm(64, 32) = 64 = 2 mamba blocks
+    kv_cache_config = KVCacheConfig(
+        num_blocks=200,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=full_block,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                ),
+                is_eagle_group=True,
+            ),
+            KVCacheGroupSpec(
+                ["mamba_mtp"],
+                MambaSpec(
+                    block_size=mamba_block,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+                is_eagle_group=True,
+            ),
+        ],
+    )
+    # hash_block_size must divide every group's block size, so it is the
+    # smaller (Mamba) block; the scheduler alignment is still the LCM, 64.
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=mamba_block,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    # 255 tokens: replay boundary floor(254 / 64) * 64 = 192. In Mamba blocks
+    # that is index 5; the EAGLE-reachable position 192 - 64 = 128 is index 3.
+    token_ids = [i for i in range(7) for _ in range(mamba_block)] + [7] * 31
+    req0 = make_request("0", token_ids, mamba_block, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    for chunk_end in (64, 128, 192, 255):
+        blocks = manager.allocate_slots(
+            req0,
+            chunk_end - req0.num_computed_tokens,
+            num_computed_tokens,
+            computed_blocks,
+        )
+        assert blocks is not None
+        req0.num_computed_tokens = chunk_end
+
+    pool = manager.block_pool
+    cached_mamba = {
+        i
+        for i in range(len(req0.block_hashes))
+        if pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
+        is not None
+    }
+    # Index 3 is the one a post-drop lookup can ask for; index 4 (one block
+    # below the boundary) is what a block-sized back-off would have kept.
+    assert 3 in cached_mamba, f"reachable state missing; cached={sorted(cached_mamba)}"
+    assert 4 not in cached_mamba, "one-block back-off retained an unreachable state"
+
+    manager.free(req0)
+    req1 = make_request("1", token_ids, mamba_block, sha256)
+    _, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    assert num_computed_tokens == 128
 
 
 def test_block_lookup_cache_single_block_per_key():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3492,6 +3492,92 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     assert [len(blocks) for blocks in computed_blocks.blocks] == [3, 12]
 
 
+def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop():
+    """Verify Mamba latest-only retention serves an MTP/EAGLE lookup.
+
+    The full-attention EAGLE lookup drops one block below what it matched, so
+    until a request decodes past the block boundary after its prompt, the only
+    candidate the coordinator can offer the Mamba group is one block below the
+    replay boundary. Mamba retention must keep that state too; keeping only the
+    boundary state leaves every retained state one block above every reachable
+    candidate, and the reconciled hit is always zero (found live on
+    GLM-5.3-Flash MTP: 0 hits across 16,897 queries).
+    """
+    block_size = 32
+    kv_cache_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                ),
+                is_eagle_group=True,
+            ),
+            KVCacheGroupSpec(
+                ["mamba_mtp"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+                is_eagle_group=True,
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    # 127 tokens: replay boundary floor(126 / 32) * 32 = 96, i.e. block 2's end.
+    # Prefill in block-aligned chunks the way the align-mode scheduler does:
+    # the state one block below the boundary only materializes as a chunk's
+    # running-state block, so a single-shot prefill could not retain it.
+    token_ids = [i for i in range(3) for _ in range(block_size)] + [3] * 31
+    req0 = make_request("0", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    for chunk_end in (32, 64, 96, 127):
+        blocks = manager.allocate_slots(
+            req0,
+            chunk_end - req0.num_computed_tokens,
+            num_computed_tokens,
+            computed_blocks,
+        )
+        assert blocks is not None
+        req0.num_computed_tokens = chunk_end
+
+    # Mamba keeps the boundary state (block 2) plus the state one block below
+    # (block 1) -- the only position an EAGLE-dropped lookup can reach while
+    # the request has not decoded past the next block boundary.
+    pool = manager.block_pool
+    expected_mamba_cached = {1, 2}
+    for i in range(3):
+        cached = pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
+        if i in expected_mamba_cached:
+            assert cached is not None, f"mamba hash {i} should be cached"
+        else:
+            assert cached is None, f"mamba hash {i} should not be cached"
+    manager.free(req0)
+
+    # Identical resend: full attention matches blocks 0-2 (96 tokens) and the
+    # EAGLE drop caps the candidate at 64; the retained state at 64 serves it.
+    req1 = make_request("1", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    assert num_computed_tokens == 2 * block_size
+    assert [len(blocks) for blocks in computed_blocks.blocks] == [2, 2]
+
+
 def test_block_lookup_cache_single_block_per_key():
     cache = BlockHashToBlockMap()
     key0 = BlockHashWithGroupId(b"hash0")

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -731,7 +731,10 @@ def _test_partial_request_hit(
 
 
 def _make_hybrid_kv_cache_config(
-    block_size: int, num_blocks: int, spec_types: list[str]
+    block_size: int,
+    num_blocks: int,
+    spec_types: list[str],
+    eagle_group_ids: set[int] | None = None,
 ) -> KVCacheConfig:
     """
     Create a KVCacheConfig with the specified spec types.
@@ -744,6 +747,7 @@ def _make_hybrid_kv_cache_config(
             - "sliding_window": SlidingWindowSpec with window=2*block_size
             - "sliding_window_large": SlidingWindowSpec with window=4*block_size
             - "mamba": MambaSpec
+        eagle_group_ids: Group indices explicitly marked for EAGLE/MTP.
     """
     spec_map = {
         "full": lambda: FullAttentionSpec(
@@ -779,8 +783,13 @@ def _make_hybrid_kv_cache_config(
         ),
     }
 
+    eagle_group_ids = eagle_group_ids or set()
     kv_cache_groups = [
-        KVCacheGroupSpec([f"layer{i}"], spec_map[spec_type]())
+        KVCacheGroupSpec(
+            [f"layer{i}"],
+            spec_map[spec_type](),
+            is_eagle_group=i in eagle_group_ids,
+        )
         for i, spec_type in enumerate(spec_types)
     ]
 
@@ -3461,8 +3470,8 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     )
 
     # 127 tokens: latest replay boundary is floor((127 - 1) / 32) * 32 = 96.
-    # The EAGLE/MTP SWA lookup group must cache the local tail ending at
-    # 104 tokens, and that tail is two 8-token blocks wide: hashes 11 and 12.
+    # The EAGLE/MTP SWA lookup group must cache two-block proof tails ending
+    # at 104 tokens and at the reachable predecessor after 64 tokens.
     token_ids = [i for i in range(15) for _ in range(block_size)] + [15] * 7
     req0 = make_request("0", token_ids, block_size, sha256)
     computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
@@ -3476,7 +3485,7 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     assert blocks is not None
 
     pool = manager.block_pool
-    expected_swa_cached = {11, 12}
+    expected_swa_cached = {7, 8, 11, 12}
     for i in range(15):
         cached = pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
         if i in expected_swa_cached:
@@ -3693,12 +3702,23 @@ def _cache_in_chunks(manager, request, chunk_ends, num_lookahead_tokens=0):
         request.num_computed_tokens = chunk_end
 
 
-def test_hybrid_swa_retention_keeps_eagle_reachable_predecessor():
+@pytest.mark.parametrize(
+    "eagle_group_ids",
+    [
+        pytest.param(None, id="fallback"),
+        pytest.param({0}, id="full_only"),
+        pytest.param({0, 1, 2}, id="all_groups"),
+    ],
+)
+def test_hybrid_swa_retention_keeps_eagle_reachable_predecessor(eagle_group_ids):
     """SWA and Mamba must retain the same post-drop replay boundary."""
     block_size = 32
     manager = make_kv_cache_manager(
         kv_cache_config=_make_hybrid_kv_cache_config(
-            block_size, 300, ["full", "mamba_align", "sliding_window"]
+            block_size,
+            300,
+            ["full", "mamba_align", "sliding_window"],
+            eagle_group_ids=eagle_group_ids,
         ),
         max_model_len=8192,
         enable_caching=True,
@@ -3716,6 +3736,39 @@ def test_hybrid_swa_retention_keeps_eagle_reachable_predecessor():
     computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
     assert num_computed_tokens == 2 * block_size
     assert [len(blocks) for blocks in computed_blocks.blocks] == [2, 2, 2]
+
+
+def test_hybrid_mamba_retention_follows_swa_eagle_drop():
+    """Mamba must retain a boundary lowered by another sparse group."""
+    block_size = 32
+    manager = make_kv_cache_manager(
+        kv_cache_config=_make_hybrid_kv_cache_config(
+            block_size,
+            300,
+            ["sliding_window", "mamba_align"],
+            eagle_group_ids={0},
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    token_ids = [i for i in range(8) for _ in range(block_size)] + [8] * 31
+    req0 = make_request("0", token_ids, block_size, sha256)
+    _cache_in_chunks(
+        manager,
+        req0,
+        (32, 64, 96, 128, 160, 192, 224, 256, 287),
+        num_lookahead_tokens=3,
+    )
+    manager.free(req0)
+
+    req1 = make_request("1", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    assert num_computed_tokens == 7 * block_size
+    assert [len(blocks) for blocks in computed_blocks.blocks] == [7, 7]
 
 
 def test_hybrid_sparse_retention_uses_fine_hit_alignment(monkeypatch):
@@ -4299,6 +4352,30 @@ def test_pure_swa_retention_latest_only():
     replay = make_request("1", token_ids, block_size, sha256)
     _, num_computed, _ = manager.get_computed_blocks(replay)
     assert num_computed == 240
+
+
+def test_pure_swa_eagle_retention_keeps_reachable_predecessor():
+    block_size = 32
+    manager = _make_pure_swa_manager(
+        block_size,
+        sliding_window=2 * block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    token_ids = [i for i in range(8) for _ in range(block_size)] + [8] * 31
+    request = make_request("0", token_ids, block_size, sha256)
+    _cache_in_chunks(
+        manager,
+        request,
+        (32, 64, 96, 128, 160, 192, 224, 256, 287),
+        num_lookahead_tokens=3,
+    )
+    manager.free(request)
+
+    replay = make_request("1", token_ids, block_size, sha256)
+    _, num_computed, _ = manager.get_computed_blocks(replay)
+    assert num_computed == 7 * block_size
 
 
 def test_pure_swa_dense_retention_caches_all():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -2509,21 +2509,28 @@ def test_emit_cached_block_events():
     )
     assert len(req.block_hashes) >= num_cached_blocks
 
+    blocks = pool.get_new_blocks(num_cached_blocks)
+    pool.cache_full_blocks(
+        req, blocks, 0, num_cached_blocks, block_size, kv_cache_group_id
+    )
+    pool.take_events()
+    before = [(block.block_hash, block.ref_cnt) for block in blocks]
     # Snapshot block state to prove emit_cached_block_events does not mutate it.
     free_before = pool.get_num_free_blocks()
-    assert len(pool.cached_block_hash_to_block) == 0
+    assert len(pool.cached_block_hash_to_block) == num_cached_blocks
 
     pool.emit_cached_block_events(
         request=req,
-        num_cached_blocks=num_cached_blocks,
+        blocks=blocks,
+        num_cached_tokens=num_cached_blocks * block_size,
         block_size=block_size,
         kv_cache_group_id=kv_cache_group_id,
     )
 
-    # No block-state mutation: nothing allocated, nothing inserted into the
-    # prefix-cache map.
+    assert [(block.block_hash, block.ref_cnt) for block in blocks] == before
+    # Replay does not allocate blocks or change cache membership.
     assert pool.get_num_free_blocks() == free_before
-    assert len(pool.cached_block_hash_to_block) == 0
+    assert len(pool.cached_block_hash_to_block) == num_cached_blocks
 
     events = pool.take_events()
     assert len(events) == 1
@@ -2563,7 +2570,8 @@ def test_emit_cached_block_events_disabled():
 
     pool.emit_cached_block_events(
         request=req,
-        num_cached_blocks=3,
+        blocks=pool.get_new_blocks(3),
+        num_cached_tokens=3 * block_size,
         block_size=block_size,
         kv_cache_group_id=0,
     )
@@ -2572,7 +2580,7 @@ def test_emit_cached_block_events_disabled():
 
 
 def test_emit_cached_block_events_zero_cached():
-    """No events are emitted when num_cached_blocks == 0."""
+    """No events are emitted when no blocks were reused."""
     block_size = 4
     pool = BlockPool(
         num_gpu_blocks=8,
@@ -2589,7 +2597,8 @@ def test_emit_cached_block_events_zero_cached():
 
     pool.emit_cached_block_events(
         request=req,
-        num_cached_blocks=0,
+        blocks=[],
+        num_cached_tokens=0,
         block_size=block_size,
         kv_cache_group_id=0,
     )
@@ -4924,3 +4933,82 @@ def test_sparse_block_stored_manager_masks(kind):
         assert event.parent_block_hash == kv_cache_utils.maybe_convert_block_hash(
             req.block_hashes[lo - 1]
         )
+
+
+@pytest.mark.parametrize("kind", ["swa", "mamba", "full"])
+@pytest.mark.parametrize("events_enabled", [True, False])
+def test_full_replay_reports_retained_blocks(kind, events_enabled):
+    block_size = 16
+    full_spec = FullAttentionSpec(
+        block_size=block_size, num_kv_heads=1, head_size=1, dtype=torch.float32
+    )
+    if kind == "mamba":
+        spec = MambaSpec(
+            block_size=block_size,
+            shapes=((1, 1),),
+            dtypes=(torch.float32,),
+            mamba_cache_mode="align",
+        )
+        retained = [5]
+    elif kind == "swa":
+        spec = SlidingWindowSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=32,
+        )
+        retained = [4, 5]
+    else:
+        spec = full_spec
+        retained = list(range(6))
+    manager = make_kv_cache_manager(
+        KVCacheConfig(
+            num_blocks=32,
+            kv_cache_tensors=[],
+            kv_cache_groups=[KVCacheGroupSpec(["layer"], spec)],
+        ),
+        max_model_len=256,
+        enable_caching=True,
+        enable_kv_cache_events=events_enabled,
+        hash_block_size=block_size,
+    )
+    req = make_request(
+        "replay", list(range(97)), block_size, sha256, cache_salt="tenant"
+    )
+    req.kv_cache_report_mode = "full"
+    pool = manager.block_pool
+    blocks = pool.get_new_blocks(6)
+    pool.cache_full_blocks(
+        req, blocks, 0, 6, block_size, 0, [i in retained for i in range(6)]
+    )
+    pool.take_events()
+    before = [(b.block_hash, b.ref_cnt) for b in blocks]
+    cache_size = len(pool.cached_block_hash_to_block)
+    computed, hit, _ = manager.get_computed_blocks(req)
+    assert hit == 96
+    assert [i for i, b in enumerate(computed.blocks[0]) if not b.is_null] == retained
+    events = manager.take_events()
+    assert [(b.block_hash, b.ref_cnt) for b in blocks] == before
+    assert len(pool.cached_block_hash_to_block) == cache_size
+    if not events_enabled:
+        assert events == []
+        return
+    assert len(events) == 1
+    event = events[0]
+    assert isinstance(event, BlockStored)
+    assert event.block_hashes == [
+        kv_cache_utils.maybe_convert_block_hash(req.block_hashes[i]) for i in retained
+    ]
+    assert event.token_ids == list(range(retained[0] * block_size, 96))
+    assert event.parent_block_hash == (
+        kv_cache_utils.maybe_convert_block_hash(req.block_hashes[retained[0] - 1])
+        if retained[0]
+        else None
+    )
+    assert event.extra_keys == (
+        [None] * len(retained) if retained[0] else [("tenant",)] + [None] * 5
+    )
+    assert event.kv_cache_spec_kind == kind.replace("full", "full_attention").replace(
+        "swa", "sliding_window"
+    )

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3501,6 +3501,61 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     assert [len(blocks) for blocks in computed_blocks.blocks] == [3, 12]
 
 
+def test_hybrid_local_kv_retention_mtp_reuses_exact_boundary():
+    """An unavailable SWA proof block must fall back one aligned boundary."""
+    block_size = 8
+    kv_cache_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=4 * block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["swa_mtp"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=block_size,
+                ),
+                is_eagle_group=True,
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    token_ids = [i // block_size for i in range(129)]
+    request = make_request("0", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(request)
+    blocks = manager.allocate_slots(
+        request,
+        len(token_ids),
+        num_computed_tokens,
+        computed_blocks,
+    )
+    assert blocks is not None
+    manager.free(request)
+
+    replay = make_request("1", token_ids, block_size, sha256)
+    _, num_computed_tokens, _ = manager.get_computed_blocks(replay)
+    assert num_computed_tokens == 12 * block_size
+
+
 @pytest.mark.parametrize("annotate_eagle_groups", [None, "full_only", "both"])
 def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop(
     annotate_eagle_groups,

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3863,6 +3863,71 @@ def test_hybrid_sparse_retention_uses_fine_hit_alignment(monkeypatch):
     assert set(observed_alignments) == {hash_block_size}
 
 
+def test_hybrid_fine_hit_retention_preserves_materialized_fallback():
+    """A fine boundary without a state must not displace a usable snapshot."""
+    full = lambda size: FullAttentionSpec(
+        block_size=size, num_kv_heads=1, head_size=1, dtype=torch.float32
+    )
+    config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["full128"], full(128)),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=64,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+            KVCacheGroupSpec(["full32"], full(32)),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=32,
+        retention_interval=0,
+    )
+    assert manager.coordinator._cache_hit_alignment_tokens == 32
+    request = make_request("producer", list(range(480)), 32, sha256)
+    scheduler = SimpleNamespace(
+        # EngineCore uses the smallest group block size here, not the LCM.
+        cache_config=SimpleNamespace(
+            block_size=min(g.kv_cache_spec.block_size for g in config.kv_cache_groups)
+        ),
+        use_eagle=False,
+        max_num_scheduled_tokens=384,
+        scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+        mamba_partial_cache_hit=True,
+        hash_block_size=32,
+        mamba_has_prefill_checkpoint_blocks=False,
+    )
+    chunk_ends = []
+    while request.num_computed_tokens < request.num_tokens:
+        num_new_tokens = Scheduler._mamba_block_aligned_split(
+            scheduler,
+            request,
+            min(384, request.num_tokens - request.num_computed_tokens),
+        )
+        assert num_new_tokens > 0
+        assert manager.allocate_slots(request, num_new_tokens) is not None
+        request.num_computed_tokens += num_new_tokens
+        chunk_ends.append(request.num_computed_tokens)
+    assert chunk_ends == [384, 480]
+    # No chunk materialized state@448. State@480 exceeds replay's 479-token cap.
+    mamba = manager.coordinator.single_type_managers[1]
+    assert mamba.req_to_blocks[request.request_id][6].is_null
+    manager.free(request)
+
+    replay = make_request("replay", list(range(480)), 32, sha256)
+    _, hit_tokens, _ = manager.get_computed_blocks(replay)
+    assert hit_tokens == 384
+
+
 def test_block_lookup_cache_single_block_per_key():
     cache = BlockHashToBlockMap()
     key0 = BlockHashWithGroupId(b"hash0")

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -4856,6 +4856,15 @@ def test_sparse_block_stored_runs(start, mask, null_indices, runs, events_enable
         assert cached == ([blocks[i]] if i in retained else None)
     events = pool.take_events()
     assert len(events) == (len(runs) if events_enabled else 0)
+    expected_keys = [
+        ("tenant",),
+        (("first-image", 0),),
+        None,
+        None,
+        (("second-image", 0),),
+        None,
+    ]
+    previous_end = start
     for event, (lo, hi) in zip(events, runs):
         assert isinstance(event, BlockStored)
         assert event.block_hashes == [
@@ -4867,19 +4876,28 @@ def test_sparse_block_stored_runs(start, mask, null_indices, runs, events_enable
             if lo
             else None
         )
-        expected_keys = [
-            ("tenant",),
-            (("first-image", 0),),
-            None,
-            None,
-            (("second-image", 0),),
-            None,
-        ][lo:hi]
-        assert event.extra_keys == expected_keys
+        assert event.extra_keys == expected_keys[lo:hi]
+        if lo > previous_end:
+            assert event.skipped_parent_block_hash == (
+                kv_cache_utils.maybe_convert_block_hash(
+                    req.block_hashes[previous_end - 1]
+                )
+                if previous_end
+                else None
+            )
+            assert event.skipped_token_ids == list(
+                range(previous_end * block_size, lo * block_size)
+            )
+            assert event.skipped_extra_keys == expected_keys[previous_end:lo]
+        else:
+            assert event.skipped_parent_block_hash is None
+            assert event.skipped_token_ids is None
+            assert event.skipped_extra_keys is None
         assert event.block_size == block_size
         assert event.group_idx == 2
         assert event.medium == MEDIUM_GPU
         assert len(event.token_ids) == block_size * len(event.block_hashes)
+        previous_end = hi
     batch = KVEventBatch(ts=0.0, events=events)
     encoded = msgspec.msgpack.encode(batch)
     assert (

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -4864,7 +4864,9 @@ def test_sparse_block_stored_runs(start, mask, null_indices, runs, events_enable
         (("second-image", 0),),
         None,
     ]
-    previous_end = start
+    # Nothing was published before this call, so the first run's skipped
+    # context starts at the root even when the caller's offset is nonzero.
+    previous_end = 0
     for event, (lo, hi) in zip(events, runs):
         assert isinstance(event, BlockStored)
         assert event.block_hashes == [

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3679,6 +3679,82 @@ def test_hybrid_mamba_retention_eagle_backoff_is_one_alignment_unit():
     assert num_computed_tokens == 128
 
 
+def _cache_in_chunks(manager, request, chunk_ends, num_lookahead_tokens=0):
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(request)
+    for chunk_end in chunk_ends:
+        blocks = manager.allocate_slots(
+            request,
+            chunk_end - request.num_computed_tokens,
+            num_computed_tokens,
+            computed_blocks,
+            num_lookahead_tokens=num_lookahead_tokens,
+        )
+        assert blocks is not None
+        request.num_computed_tokens = chunk_end
+
+
+def test_hybrid_swa_retention_keeps_eagle_reachable_predecessor():
+    """SWA and Mamba must retain the same post-drop replay boundary."""
+    block_size = 32
+    manager = make_kv_cache_manager(
+        kv_cache_config=_make_hybrid_kv_cache_config(
+            block_size, 300, ["full", "mamba_align", "sliding_window"]
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    token_ids = [i for i in range(3) for _ in range(block_size)] + [3] * 31
+    req0 = make_request("0", token_ids, block_size, sha256)
+    _cache_in_chunks(manager, req0, (32, 64, 96, 127), num_lookahead_tokens=3)
+    manager.free(req0)
+
+    req1 = make_request("1", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    assert num_computed_tokens == 2 * block_size
+    assert [len(blocks) for blocks in computed_blocks.blocks] == [2, 2, 2]
+
+
+def test_hybrid_sparse_retention_uses_fine_hit_alignment(monkeypatch):
+    """Sparse retention must use the same fine alignment as cache lookup."""
+    hash_block_size = 32
+    cache_block_size = 64
+    manager = make_kv_cache_manager(
+        kv_cache_config=_make_hybrid_kv_cache_config(
+            cache_block_size, 300, ["full", "mamba_align"]
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+    assert manager.coordinator._cache_hit_alignment_tokens == hash_block_size
+
+    mamba_manager = manager.coordinator.single_type_managers[1]
+    original_mask = type(mamba_manager).reachable_block_mask
+    observed_alignments = []
+
+    def record_alignment(cls, **kwargs):
+        observed_alignments.append(kwargs["alignment_tokens"])
+        return original_mask(**kwargs)
+
+    monkeypatch.setattr(
+        type(mamba_manager),
+        "reachable_block_mask",
+        classmethod(record_alignment),
+    )
+
+    token_ids = [i for i in range(3) for _ in range(hash_block_size)] + [3] * 31
+    req0 = make_request("0", token_ids, hash_block_size, sha256)
+    _cache_in_chunks(manager, req0, (64, 127), num_lookahead_tokens=3)
+    assert observed_alignments
+    assert set(observed_alignments) == {hash_block_size}
+
+
 def test_block_lookup_cache_single_block_per_key():
     cache = BlockHashToBlockMap()
     key0 = BlockHashWithGroupId(b"hash0")

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -4794,3 +4794,133 @@ def test_swa_shared_prefix_reuse_under_zero_retention():
     assert last_req_hit(retention=0, pin=False) == 0
     # retention=0 with the pin keeps the junction window -> reuse restored.
     assert last_req_hit(retention=0, pin=True) == 4 * block_size
+
+
+@pytest.mark.parametrize(
+    "start,mask,null_indices,runs",
+    [
+        pytest.param(
+            0,
+            [False, True, True, False, True, True],
+            (),
+            [(1, 3), (4, 6)],
+            id="leading-and-interior-mask",
+        ),
+        pytest.param(0, None, (2,), [(0, 2), (3, 6)], id="interior-null"),
+        pytest.param(0, None, (0,), [(1, 6)], id="leading-null"),
+        pytest.param(0, [False] * 6, (), [], id="all-masked"),
+        pytest.param(0, None, tuple(range(6)), [], id="all-null"),
+        pytest.param(
+            2, [False, True, False, True], (), [(3, 4), (5, 6)], id="cached-offset"
+        ),
+        pytest.param(5, [False], (), [], id="masked-decode"),
+        pytest.param(0, None, (), [(0, 6)], id="dense"),
+    ],
+)
+@pytest.mark.parametrize("events_enabled", [True, False])
+def test_sparse_block_stored_runs(start, mask, null_indices, runs, events_enabled):
+    import msgspec
+
+    from vllm.distributed.kv_events import KVEventBatch
+
+    block_size = 4
+    pool = BlockPool(16, True, block_size, events_enabled)
+    req = make_request(
+        "sparse-events",
+        list(range(24)),
+        block_size,
+        sha256,
+        mm_positions=[
+            PlaceholderRange(offset=4, length=4),
+            PlaceholderRange(offset=16, length=4),
+        ],
+        mm_hashes=["first-image", "second-image"],
+        cache_salt="tenant",
+    )
+    blocks = pool.get_new_blocks(6)
+    for i in null_indices:
+        blocks[i] = pool.null_block
+    pool.cache_full_blocks(req, blocks, start, 6, block_size, 2, mask)
+    retained = {i for lo, hi in runs for i in range(lo, hi)}
+    for i, block_hash in enumerate(req.block_hashes):
+        cached = pool.get_cached_block(block_hash, [2])
+        assert cached == ([blocks[i]] if i in retained else None)
+    events = pool.take_events()
+    assert len(events) == (len(runs) if events_enabled else 0)
+    for event, (lo, hi) in zip(events, runs):
+        assert isinstance(event, BlockStored)
+        assert event.block_hashes == [
+            kv_cache_utils.maybe_convert_block_hash(h) for h in req.block_hashes[lo:hi]
+        ]
+        assert event.token_ids == list(range(lo * block_size, hi * block_size))
+        assert event.parent_block_hash == (
+            kv_cache_utils.maybe_convert_block_hash(req.block_hashes[lo - 1])
+            if lo
+            else None
+        )
+        expected_keys = [
+            ("tenant",),
+            (("first-image", 0),),
+            None,
+            None,
+            (("second-image", 0),),
+            None,
+        ][lo:hi]
+        assert event.extra_keys == expected_keys
+        assert event.block_size == block_size
+        assert event.group_idx == 2
+        assert event.medium == MEDIUM_GPU
+        assert len(event.token_ids) == block_size * len(event.block_hashes)
+    batch = KVEventBatch(ts=0.0, events=events)
+    encoded = msgspec.msgpack.encode(batch)
+    assert (
+        msgspec.msgpack.encode(msgspec.msgpack.decode(encoded, type=KVEventBatch))
+        == encoded
+    )
+
+
+@pytest.mark.parametrize("kind", ["swa", "mamba"])
+def test_sparse_block_stored_manager_masks(kind):
+    from vllm.v1.core.single_type_kv_cache_manager import (
+        MambaManager,
+        SlidingWindowManager,
+    )
+
+    if kind == "swa":
+        spec = SlidingWindowSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=32,
+        )
+        mask = SlidingWindowManager.reachable_block_mask(0, 64, 512, spec, False)
+        runs = [(30, 32), (62, 64)]
+        count = 64
+    else:
+        spec = MambaSpec(
+            block_size=16,
+            shapes=((1, 1),),
+            dtypes=(torch.float32,),
+            mamba_cache_mode="align",
+        )
+        mask = MambaManager.reachable_block_mask(0, 8, 32, spec, True, 0, (127,))
+        runs = [(3, 4), (5, 6)]
+        count = 8
+    assert mask is not None
+    assert [i for i, keep in enumerate(mask) if keep] == [
+        i for lo, hi in runs for i in range(lo, hi)
+    ]
+    pool = BlockPool(count + 1, True, 16, True)
+    req = make_request("mask-events", list(range(count * 16)), 16, sha256)
+    pool.cache_full_blocks(req, pool.get_new_blocks(count), 0, count, 16, 0, mask)
+    events = pool.take_events()
+    assert len(events) == len(runs)
+    for event, (lo, hi) in zip(events, runs):
+        assert event.token_ids == list(range(lo * 16, hi * 16))
+        assert event.block_hashes == [
+            kv_cache_utils.maybe_convert_block_hash(h) for h in req.block_hashes[lo:hi]
+        ]
+        assert event.parent_block_hash == kv_cache_utils.maybe_convert_block_hash(
+            req.block_hashes[lo - 1]
+        )

--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -3,6 +3,7 @@
 
 from math import lcm
 
+import pytest
 import torch
 
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import (  # noqa: E501
@@ -480,7 +481,29 @@ def test_store_mask_uses_fine_hit_alignment():
 
     masks = coord.store_mask(512, num_prompt_tokens=501)
     assert masks[0] is None
-    assert masks[1] == [i == 6 for i in range(8)]
+    assert masks[1] == [i in (5, 6) for i in range(8)]
+
+
+@pytest.mark.parametrize("use_eagle, retained", [(False, {5, 6}), (True, {3, 5, 6})])
+def test_store_mask_preserves_fine_and_materialized_boundaries(use_eagle, retained):
+    groups = [
+        KVCacheGroupSpec(["full128"], _full(128)),
+        KVCacheGroupSpec(["mamba"], _mamba_align(64)),
+        KVCacheGroupSpec(["full32"], _full(32)),
+    ]
+    coord = _make_coord(
+        groups, hash_block_size=32, use_eagle=use_eagle, retention_interval=0
+    )
+    assert coord.enable_partial_hash_hits
+    # Fine replay positions: 448 (and 416 under EAGLE).
+    # Materialized fallback positions: 384 (and 256 under EAGLE).
+    assert coord.store_mask(480, num_prompt_tokens=480)[1] == [
+        i in retained for i in range(7)
+    ]
+    assert coord.store_mask(384, num_prompt_tokens=480)[1] == [
+        i in retained for i in range(6)
+    ]
+    assert coord.store_mask(480, start_token=384, num_prompt_tokens=480)[1] == [True]
 
 
 def test_store_mask_disables_fine_hits_for_incompatible_swa():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -451,6 +451,38 @@ def test_store_mask_retention_prefix_stable_as_aligned_length_grows():
     assert longer[: len(shorter)] == shorter
 
 
+def test_store_mask_retains_shared_eagle_predecessor():
+    groups = [
+        KVCacheGroupSpec(["full"], _full(32), is_eagle_group=True),
+        KVCacheGroupSpec(["mamba"], _mamba_align(32)),
+        KVCacheGroupSpec(["swa"], _swa(32, 64)),
+    ]
+    coord = _make_coord(
+        groups,
+        hash_block_size=32,
+        use_eagle=True,
+        retention_interval=0,
+    )
+
+    masks = coord.store_mask(288, num_prompt_tokens=287)
+    assert masks[0] is None
+    assert masks[1] == [i in (6, 7) for i in range(9)]
+    assert masks[2] == [i in (5, 6, 7) for i in range(9)]
+
+
+def test_store_mask_uses_fine_hit_alignment():
+    groups = [
+        KVCacheGroupSpec(["full"], _full(128)),
+        KVCacheGroupSpec(["mamba"], _mamba_align(64)),
+    ]
+    coord = _make_coord(groups, hash_block_size=32, retention_interval=0)
+    assert coord.enable_partial_hash_hits
+
+    masks = coord.store_mask(512, num_prompt_tokens=501)
+    assert masks[0] is None
+    assert masks[1] == [i == 6 for i in range(8)]
+
+
 # ----- Eagle / MTP interaction with load_mask -----
 
 

--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -483,6 +483,26 @@ def test_store_mask_uses_fine_hit_alignment():
     assert masks[1] == [i == 6 for i in range(8)]
 
 
+def test_store_mask_disables_fine_hits_for_incompatible_swa():
+    groups = [
+        KVCacheGroupSpec(["full"], _full(32), is_eagle_group=True),
+        KVCacheGroupSpec(["mamba"], _mamba_align(64)),
+        KVCacheGroupSpec(["swa"], _swa(64, 128)),
+    ]
+    coord = _make_coord(
+        groups,
+        hash_block_size=32,
+        use_eagle=True,
+        retention_interval=0,
+    )
+
+    assert not coord.enable_partial_hash_hits
+    masks = coord.store_mask(384, num_prompt_tokens=383)
+    assert masks[0] is None
+    assert masks[1] is not None
+    assert masks[2] is not None
+
+
 # ----- Eagle / MTP interaction with load_mask -----
 
 

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -76,6 +76,15 @@ class BlockStored(KVCacheEvent):
     locality: str | None = None
     """LOCAL or REMOTE relative to the publisher; None means unspecified."""
 
+    skipped_parent_block_hash: ExternalBlockHash | None = None
+    """Parent hash for skipped token context preceding this store event."""
+
+    skipped_token_ids: list[int] | None = None
+    """Logical token span for skipped blocks preceding this store event."""
+
+    skipped_extra_keys: list[tuple[Any, ...] | None] | None = None
+    """Extra keys for skipped_token_ids, one entry per skipped block."""
+
     def __hash__(self) -> int:
         return hash(
             (
@@ -90,6 +99,9 @@ class BlockStored(KVCacheEvent):
                 self.kv_cache_spec_kind,
                 self.kv_cache_spec_sliding_window,
                 self.locality,
+                self.skipped_parent_block_hash,
+                tuple(self.skipped_token_ids) if self.skipped_token_ids else None,
+                tuple(self.skipped_extra_keys) if self.skipped_extra_keys else None,
             )
         )
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -15,6 +15,9 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
 )
+from vllm.v1.core.single_type_kv_cache_manager import (
+    resolve_sparse_retention_inputs,
+)
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheGroupSpec,
@@ -133,6 +136,10 @@ class MooncakeStoreCoordinator:
         self.eagle_group_ids = {
             gid for g in attention_groups if g.use_eagle for gid in g.group_ids
         }
+        self.lookup_drops_eagle_block = any(
+            group.use_eagle and group.manager_cls.drops_eagle_block
+            for group in attention_groups
+        )
 
     def find_longest_cache_hit(
         self,
@@ -248,13 +255,20 @@ class MooncakeStoreCoordinator:
             manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
             assert manager_cls is not None
             use_eagle = g_idx in self.eagle_group_ids
-            reachable_boundaries = (
+            reachable_boundaries: Sequence[int] = (
                 () if num_prompt_tokens is None else (num_prompt_tokens - 1,)
+            )
+            use_eagle, reachable_boundaries = resolve_sparse_retention_inputs(
+                spec,
+                use_eagle,
+                self.lookup_drops_eagle_block,
+                mask_alignment,
+                reachable_boundaries,
             )
             mask = manager_cls.reachable_block_mask(
                 start_block=start_chunk,
                 end_block=end_chunk,
-                alignment_tokens=self.lcm_block_size,
+                alignment_tokens=mask_alignment,
                 kv_cache_spec=spec,
                 use_eagle=use_eagle,
                 retention_interval=retention_interval,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -351,10 +351,10 @@ class MooncakeStoreCoordinator:
                     apply_eagle and group_eagle and idx not in eagle_verified
                 )
                 _max_length = curr_hit_length
-                # No eagle peek margin for a recurrent (Mamba) group: its finder
-                # never drops a block, so a widened bound would match past the
-                # attention-verified hit and resume from speculative state (#43559).
-                if drop_eagle_block and not isinstance(spec, MambaSpec):
+                # Only managers whose finder drops a block receive a peek
+                # margin. Otherwise a widened bound can resume past the
+                # attention-verified hit (#43559).
+                if drop_eagle_block and manager_cls.drops_eagle_block:
                     eagle_margin = (
                         self.hash_block_size
                         if self.enable_partial_hash_hits
@@ -418,9 +418,23 @@ def partial_hash_hits_enabled(
     (its dcp == 1 clause holds: the connector rejects hybrid + DCP/PCP > 1).
     Single copy on purpose — scheduler and coordinator must not disagree.
     """
-    return any(
+    has_partial_mamba_group = any(
         isinstance(spec := _unwrap_spec(g.kv_cache_spec), MambaSpec)
         and spec.mamba_cache_mode == "align"
         and spec.block_size > hash_block_size
         for g in kv_cache_groups
     )
+    if not has_partial_mamba_group:
+        return False
+
+    for group in kv_cache_groups:
+        spec = _unwrap_spec(group.kv_cache_spec)
+        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        if manager_cls is None:
+            return False
+        if (
+            not manager_cls.supports_fine_grained_hash_lookup
+            and spec.block_size != hash_block_size
+        ):
+            return False
+    return True

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -262,8 +262,9 @@ class MooncakeStoreCoordinator:
                 spec,
                 use_eagle,
                 self.lookup_drops_eagle_block,
-                mask_alignment,
                 reachable_boundaries,
+                lookup_alignment_tokens=mask_alignment,
+                state_materialization_alignment_tokens=self.lcm_block_size,
             )
             mask = manager_cls.reachable_block_mask(
                 start_block=start_chunk,

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -348,7 +348,7 @@ class BlockPool:
     def _build_block_stored_event(
         self,
         request: Request,
-        block_hashes: list[ExternalBlockHash] | None,
+        block_hashes: list[ExternalBlockHash],
         parent_block_hash: ExternalBlockHash | None,
         start_token_idx: int,
         end_token_idx: int,
@@ -377,72 +377,71 @@ class BlockPool:
     def emit_cached_block_events(
         self,
         request: Request,
-        num_cached_blocks: int,
+        blocks: Sequence[KVCacheBlock],
+        num_cached_tokens: int,
         block_size: int,
         kv_cache_group_id: int,
     ) -> None:
-        """Generate BlockStored events for blocks reused from prefix cache.
+        """Publish retained entries returned by lookup without changing block state.
 
-        Unlike cache_full_blocks(), this does NOT modify block state —
-        the blocks are already cached. It only generates events so that
-        external consumers (e.g. gateway) can learn about reused blocks.
-
-        Args:
-            request: The request whose prefix cache blocks were reused.
-            num_cached_blocks: Number of blocks that were cache hits.
-            block_size: Number of tokens per block.
-            kv_cache_group_id: The KV cache group ID.
+        ``blocks`` includes sparse null placeholders. ``num_cached_tokens`` is
+        the reconciled hit length, which may end inside the last physical block.
+        Only registered hashes owned by the returned blocks are advertised.
         """
-        if not self.enable_kv_cache_events or num_cached_blocks == 0:
+        if not self.enable_kv_cache_events or not blocks or num_cached_tokens == 0:
             return
 
         block_hashes = resolve_block_hashes(
             request.block_hashes, self.hash_block_size, block_size
         )
-
-        # Collect external hashes and extra_keys for cached blocks.
-        cached_hashes: list[ExternalBlockHash] = []
-        extra_keys_list: list[tuple[Any, ...] | None] = []
-        curr_mm_idx = 0
-        for i in range(num_cached_blocks):
-            block_start = i * block_size
-            block_end = block_start + block_size
-            cached_hashes.append(maybe_convert_block_hash(block_hashes[i]))
-            extra_keys, curr_mm_idx = generate_block_hash_extra_keys(
-                request, block_start, block_end, curr_mm_idx
+        num_full_blocks = num_cached_tokens // block_size
+        stored_indices = [
+            i
+            for i, block in enumerate(blocks[:num_full_blocks])
+            if not block.is_null
+            and self.cached_block_hash_to_block.contain(
+                make_block_hash_with_group_id(block_hashes[i], kv_cache_group_id),
+                block.block_id,
             )
-            extra_keys_list.append(extra_keys)
+        ]
+        if stored_indices:
+            self._emit_stored_block_runs(
+                request, stored_indices, block_size, kv_cache_group_id
+            )
 
-        if not cached_hashes:
+        if num_cached_tokens % block_size == 0 or num_full_blocks >= len(blocks):
             return
-
-        # Prefix-cache hits always form a contiguous prefix starting at block 0,
-        # so the first (and thus the whole group's) parent block hash is None.
-        parent_block_hash: ExternalBlockHash | None = None
-        start_token_idx = 0
-        end_token_idx = num_cached_blocks * block_size
-
-        logger.debug(
-            "EmitCachedBlock event: block_size=%d, "
-            "num_cached_blocks=%d, parent_block_hash=%s, "
-            "token_ids_len=%d, group_idx=%s",
-            block_size,
-            num_cached_blocks,
-            parent_block_hash,
-            len(request.all_token_ids[start_token_idx:end_token_idx]),
-            kv_cache_group_id,
+        block = blocks[num_full_blocks]
+        if block.is_null:
+            return
+        partial_hash = self._get_partial_block_hash(request, num_cached_tokens)
+        if not self.cached_block_hash_to_block.contain(
+            make_block_hash_with_group_id(partial_hash, kv_cache_group_id),
+            block.block_id,
+        ):
+            # A longer group's hit can be truncated inside a full block during
+            # reconciliation. Do not invent a partial entry for that boundary.
+            return
+        parent_hash, start = self._get_partial_block_parent_hash_and_start(
+            request, num_cached_tokens
         )
-
+        extra_keys, _ = generate_block_hash_extra_keys(
+            request, start, num_cached_tokens, 0
+        )
         self.kv_event_queue.append(
             self._build_block_stored_event(
                 request,
-                block_hashes=cached_hashes,
-                parent_block_hash=parent_block_hash,
-                start_token_idx=start_token_idx,
-                end_token_idx=end_token_idx,
-                block_size=block_size,
+                block_hashes=[maybe_convert_block_hash(partial_hash)],
+                parent_block_hash=(
+                    maybe_convert_block_hash(parent_hash)
+                    if parent_hash is not None
+                    else None
+                ),
+                start_token_idx=start,
+                end_token_idx=num_cached_tokens,
+                block_size=num_cached_tokens - start,
                 kv_cache_group_id=kv_cache_group_id,
-                extra_keys_list=extra_keys_list,
+                extra_keys_list=[extra_keys],
             )
         )
 

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Iterable, Sequence
+from itertools import groupby
 from typing import Any
 
 from vllm.distributed.kv_events import (
@@ -265,9 +266,7 @@ class BlockPool:
         )
 
         new_block_hashes = block_hashes[num_cached_blocks:]
-        new_hashes: list[ExternalBlockHash] | None = (
-            [] if self.enable_kv_cache_events else None
-        )
+        stored_indices: list[int] | None = [] if self.enable_kv_cache_events else None
         for i, blk in enumerate(new_full_blocks):
             # Some blocks may be null or masked out when enabling sparse attention
             # like sliding window attention, or Mamba models with prefix-caching
@@ -295,46 +294,51 @@ class BlockPool:
                 blk,
                 num_tokens=num_hash_tokens,
             )
-            if new_hashes is not None:
-                new_hashes.append(maybe_convert_block_hash(block_hash))
+            if stored_indices is not None:
+                stored_indices.append(num_cached_blocks + i)
 
-        if self.enable_kv_cache_events:
-            if num_cached_blocks == 0:
-                parent_block_hash: ExternalBlockHash | None = None
-            else:
-                parent_block_hash = maybe_convert_block_hash(
-                    block_hashes[num_cached_blocks - 1]
-                )
+        # Publish after all insertions and promotion removals, as for dense stores.
+        if stored_indices:
+            self._emit_stored_block_runs(
+                request, stored_indices, block_size, kv_cache_group_id
+            )
 
-            # Calculate token range for the blocks being cached
-            start_token_idx = num_cached_blocks * block_size
-            end_token_idx = num_full_blocks * block_size
-
-            # Generate extra keys for each block individually.
-            # Each block may have different extra_keys (e.g., different MM
-            # features, or cache_salt only for the first block).
-            # Skip null/masked-out blocks to match the length of new_hashes.
+    def _emit_stored_block_runs(
+        self,
+        request: Request,
+        block_indices: list[int],
+        block_size: int,
+        kv_cache_group_id: int,
+    ) -> None:
+        """Publish maximal contiguous runs of sorted retained block indices."""
+        block_hashes = resolve_block_hashes(
+            request.block_hashes, self.hash_block_size, block_size
+        )
+        curr_mm_idx = 0
+        for _, run in groupby(
+            enumerate(block_indices), key=lambda pair: pair[1] - pair[0]
+        ):
+            indices = [index for _, index in run]
+            start, end = indices[0], indices[-1] + 1
             extra_keys_list: list[tuple[Any, ...] | None] = []
-            curr_mm_idx = 0
-            for i in range(num_cached_blocks, num_full_blocks):
-                if blocks[i].is_null:
-                    continue
-                if block_mask is not None and not block_mask[i - num_cached_blocks]:
-                    continue
-                block_start = i * block_size
-                block_end = block_start + block_size
+            for i in indices:
                 extra_keys, curr_mm_idx = generate_block_hash_extra_keys(
-                    request, block_start, block_end, curr_mm_idx
+                    request, i * block_size, (i + 1) * block_size, curr_mm_idx
                 )
                 extra_keys_list.append(extra_keys)
-
             self.kv_event_queue.append(
                 self._build_block_stored_event(
                     request,
-                    block_hashes=new_hashes,
-                    parent_block_hash=parent_block_hash,
-                    start_token_idx=start_token_idx,
-                    end_token_idx=end_token_idx,
+                    block_hashes=[
+                        maybe_convert_block_hash(block_hashes[i]) for i in indices
+                    ],
+                    parent_block_hash=(
+                        maybe_convert_block_hash(block_hashes[start - 1])
+                        if start
+                        else None
+                    ),
+                    start_token_idx=start * block_size,
+                    end_token_idx=end * block_size,
                     block_size=block_size,
                     kv_cache_group_id=kv_cache_group_id,
                     extra_keys_list=extra_keys_list,

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -300,7 +300,11 @@ class BlockPool:
         # Publish after all insertions and promotion removals, as for dense stores.
         if stored_indices:
             self._emit_stored_block_runs(
-                request, stored_indices, block_size, kv_cache_group_id
+                request,
+                stored_indices,
+                block_size,
+                kv_cache_group_id,
+                context_start_block_idx=num_cached_blocks,
             )
 
     def _emit_stored_block_runs(
@@ -309,23 +313,37 @@ class BlockPool:
         block_indices: list[int],
         block_size: int,
         kv_cache_group_id: int,
+        context_start_block_idx: int = 0,
     ) -> None:
         """Publish maximal contiguous runs of sorted retained block indices."""
         block_hashes = resolve_block_hashes(
             request.block_hashes, self.hash_block_size, block_size
         )
-        curr_mm_idx = 0
+        previous_end = context_start_block_idx
         for _, run in groupby(
             enumerate(block_indices), key=lambda pair: pair[1] - pair[0]
         ):
             indices = [index for _, index in run]
             start, end = indices[0], indices[-1] + 1
-            extra_keys_list: list[tuple[Any, ...] | None] = []
-            for i in indices:
-                extra_keys, curr_mm_idx = generate_block_hash_extra_keys(
-                    request, i * block_size, (i + 1) * block_size, curr_mm_idx
+            extra_keys_list = self._generate_block_extra_keys(
+                request, start, end, block_size
+            )
+            if start > previous_end:
+                skipped_parent_block_hash = (
+                    maybe_convert_block_hash(block_hashes[previous_end - 1])
+                    if previous_end
+                    else None
                 )
-                extra_keys_list.append(extra_keys)
+                skipped_start_token_idx = previous_end * block_size
+                skipped_end_token_idx = start * block_size
+                skipped_extra_keys = self._generate_block_extra_keys(
+                    request, previous_end, start, block_size
+                )
+            else:
+                skipped_parent_block_hash = None
+                skipped_start_token_idx = None
+                skipped_end_token_idx = None
+                skipped_extra_keys = None
             self.kv_event_queue.append(
                 self._build_block_stored_event(
                     request,
@@ -342,8 +360,29 @@ class BlockPool:
                     block_size=block_size,
                     kv_cache_group_id=kv_cache_group_id,
                     extra_keys_list=extra_keys_list,
+                    skipped_parent_block_hash=skipped_parent_block_hash,
+                    skipped_start_token_idx=skipped_start_token_idx,
+                    skipped_end_token_idx=skipped_end_token_idx,
+                    skipped_extra_keys=skipped_extra_keys,
                 )
             )
+            previous_end = end
+
+    @staticmethod
+    def _generate_block_extra_keys(
+        request: Request,
+        start_block_idx: int,
+        end_block_idx: int,
+        block_size: int,
+    ) -> list[tuple[Any, ...] | None]:
+        extra_keys_list: list[tuple[Any, ...] | None] = []
+        curr_mm_idx = 0
+        for i in range(start_block_idx, end_block_idx):
+            extra_keys, curr_mm_idx = generate_block_hash_extra_keys(
+                request, i * block_size, (i + 1) * block_size, curr_mm_idx
+            )
+            extra_keys_list.append(extra_keys)
+        return extra_keys_list
 
     def _build_block_stored_event(
         self,
@@ -355,6 +394,10 @@ class BlockPool:
         block_size: int,
         kv_cache_group_id: int,
         extra_keys_list: list[tuple[Any, ...] | None],
+        skipped_parent_block_hash: ExternalBlockHash | None = None,
+        skipped_start_token_idx: int | None = None,
+        skipped_end_token_idx: int | None = None,
+        skipped_extra_keys: list[tuple[Any, ...] | None] | None = None,
     ) -> BlockStored:
         """Build a ``BlockStored`` KV event for ``request``.
 
@@ -371,6 +414,14 @@ class BlockPool:
             medium=MEDIUM_GPU,
             lora_name=request.lora_request.name if request.lora_request else None,
             extra_keys=extra_keys_list if extra_keys_list else None,
+            skipped_parent_block_hash=skipped_parent_block_hash,
+            skipped_token_ids=(
+                request.all_token_ids[skipped_start_token_idx:skipped_end_token_idx]
+                if skipped_start_token_idx is not None
+                and skipped_end_token_idx is not None
+                else None
+            ),
+            skipped_extra_keys=skipped_extra_keys,
             group_idx=kv_cache_group_id,
         )
 

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import weakref
 from collections.abc import Iterable, Sequence
 from itertools import groupby
 from typing import Any
@@ -194,6 +195,16 @@ class BlockPool:
         self.enable_kv_cache_events = enable_kv_cache_events
         self.kv_event_queue: list[KVCacheEvent] = []
 
+        # Last published full-block endpoint per request and cache group, so a
+        # later publication reports only the unannounced span as skipped
+        # context instead of re-announcing blocks consumers already hold.
+        # Entries map the cache group id to (endpoint, last published block
+        # hash), where the endpoint counts full blocks in the group's block
+        # size. Weak keys let completed requests release their bookkeeping.
+        self.published_full_block_anchors: weakref.WeakKeyDictionary[
+            Request, dict[int, tuple[int, BlockHash]]
+        ] = weakref.WeakKeyDictionary()
+
         self.metrics_collector = metrics_collector
 
     def get_cached_block(
@@ -297,14 +308,19 @@ class BlockPool:
             if stored_indices is not None:
                 stored_indices.append(num_cached_blocks + i)
 
-        # Publish after all insertions and promotion removals, as for dense stores.
+        # Publish after all insertions and promotion removals, as for dense
+        # stores. Skipped context chains from the last published full-block
+        # endpoint, not from ``num_cached_blocks``: the caller's counter
+        # advances over masked and null blocks that were never announced.
         if stored_indices:
             self._emit_stored_block_runs(
                 request,
                 stored_indices,
                 block_size,
                 kv_cache_group_id,
-                context_start_block_idx=num_cached_blocks,
+                context_start_block_idx=self._published_full_block_context_start(
+                    request, block_size, kv_cache_group_id
+                ),
             )
 
     def _emit_stored_block_runs(
@@ -328,22 +344,17 @@ class BlockPool:
             extra_keys_list = self._generate_block_extra_keys(
                 request, start, end, block_size
             )
-            if start > previous_end:
-                skipped_parent_block_hash = (
-                    maybe_convert_block_hash(block_hashes[previous_end - 1])
-                    if previous_end
-                    else None
-                )
-                skipped_start_token_idx = previous_end * block_size
-                skipped_end_token_idx = start * block_size
-                skipped_extra_keys = self._generate_block_extra_keys(
-                    request, previous_end, start, block_size
-                )
-            else:
-                skipped_parent_block_hash = None
-                skipped_start_token_idx = None
-                skipped_end_token_idx = None
-                skipped_extra_keys = None
+            (
+                skipped_parent_block_hash,
+                skipped_start_token_idx,
+                skipped_end_token_idx,
+                skipped_extra_keys,
+            ) = self._get_skipped_context(
+                request,
+                previous_end * block_size,
+                start * block_size,
+                block_size,
+            )
             self.kv_event_queue.append(
                 self._build_block_stored_event(
                     request,
@@ -366,6 +377,10 @@ class BlockPool:
                     skipped_extra_keys=skipped_extra_keys,
                 )
             )
+            # Stores and full replays both advance publication context.
+            self._advance_full_block_anchor(
+                request, end, block_hashes[end - 1], kv_cache_group_id
+            )
             previous_end = end
 
     @staticmethod
@@ -383,6 +398,105 @@ class BlockPool:
             )
             extra_keys_list.append(extra_keys)
         return extra_keys_list
+
+    def _get_skipped_context(
+        self,
+        request: Request,
+        context_start_token_idx: int,
+        end_token_idx: int,
+        extra_keys_block_size: int,
+    ) -> tuple[
+        ExternalBlockHash | None,
+        int | None,
+        int | None,
+        list[tuple[Any, ...] | None] | None,
+    ]:
+        """Build the skipped-context fields for an unannounced token span.
+
+        The span ``[context_start_token_idx, end_token_idx)`` covers tokens
+        that no published event announced for this request yet.
+        ``context_start_token_idx`` is the boundary up to which consumers
+        already hold context (0 at the root). Returns
+        ``(skipped_parent_block_hash, skipped_start_token_idx,
+        skipped_end_token_idx, skipped_extra_keys)``, all ``None`` when the
+        span is empty. The parent hash is the prefix-chain hash at the span's
+        start boundary; extra keys are generated per ``extra_keys_block_size``,
+        which is the group's block size for full-block events and
+        ``self.hash_block_size`` for partial events.
+        """
+        if context_start_token_idx >= end_token_idx:
+            return None, None, None, None
+        assert context_start_token_idx % self.hash_block_size == 0
+        num_hash_blocks = context_start_token_idx // self.hash_block_size
+        skipped_parent_block_hash = (
+            maybe_convert_block_hash(request.block_hashes[num_hash_blocks - 1])
+            if num_hash_blocks
+            else None
+        )
+        skipped_extra_keys = self._generate_block_extra_keys(
+            request,
+            context_start_token_idx // extra_keys_block_size,
+            end_token_idx // extra_keys_block_size,
+            extra_keys_block_size,
+        )
+        return (
+            skipped_parent_block_hash,
+            context_start_token_idx,
+            end_token_idx,
+            skipped_extra_keys,
+        )
+
+    def _published_full_block_context_start(
+        self,
+        request: Request,
+        block_size: int,
+        kv_cache_group_id: int,
+    ) -> int:
+        """Return the validated published endpoint for this request and group.
+
+        The endpoint counts the full blocks whose publication already reached
+        the event queue for this request in this cache group, so the next
+        publication can report only tokens beyond it as skipped context.
+        Streaming updates truncate and re-extend a request in place and
+        recompute its block hashes, so the saved hash is validated before the
+        anchor is reused; an invalid or missing anchor starts at the root.
+        """
+        anchors = self.published_full_block_anchors.get(request)
+        if anchors is None:
+            return 0
+        anchor = anchors.get(kv_cache_group_id)
+        if anchor is None:
+            return 0
+        endpoint, published_hash = anchor
+        block_hashes = resolve_block_hashes(
+            request.block_hashes, self.hash_block_size, block_size
+        )
+        if (
+            endpoint <= 0
+            or endpoint > len(block_hashes)
+            or block_hashes[endpoint - 1] != published_hash
+        ):
+            # The request's prefix changed under the anchor: restart from the
+            # root and drop the stale entry.
+            del anchors[kv_cache_group_id]
+            if not anchors:
+                del self.published_full_block_anchors[request]
+            return 0
+        return endpoint
+
+    def _advance_full_block_anchor(
+        self,
+        request: Request,
+        endpoint: int,
+        last_block_hash: BlockHash,
+        kv_cache_group_id: int,
+    ) -> None:
+        """Record the last published full-block endpoint for request and group."""
+        anchors = self.published_full_block_anchors.get(request)
+        if anchors is None:
+            anchors = {}
+            self.published_full_block_anchors[request] = anchors
+        anchors[kv_cache_group_id] = (endpoint, last_block_hash)
 
     def _build_block_stored_event(
         self,
@@ -459,6 +573,12 @@ class BlockPool:
             self._emit_stored_block_runs(
                 request, stored_indices, block_size, kv_cache_group_id
             )
+            # A full replay re-announces from the root, so a partial event in
+            # the same replay chains from the run just published.
+            partial_context_start = (stored_indices[-1] + 1) * block_size
+        else:
+            # A full replay without a full run still starts at the root.
+            partial_context_start = 0
 
         if num_cached_tokens % block_size == 0 or num_full_blocks >= len(blocks):
             return
@@ -479,6 +599,14 @@ class BlockPool:
         extra_keys, _ = generate_block_hash_extra_keys(
             request, start, num_cached_tokens, 0
         )
+        (
+            skipped_parent_block_hash,
+            skipped_start_token_idx,
+            skipped_end_token_idx,
+            skipped_extra_keys,
+        ) = self._get_skipped_context(
+            request, partial_context_start, start, self.hash_block_size
+        )
         self.kv_event_queue.append(
             self._build_block_stored_event(
                 request,
@@ -493,6 +621,10 @@ class BlockPool:
                 block_size=num_cached_tokens - start,
                 kv_cache_group_id=kv_cache_group_id,
                 extra_keys_list=[extra_keys],
+                skipped_parent_block_hash=skipped_parent_block_hash,
+                skipped_start_token_idx=skipped_start_token_idx,
+                skipped_end_token_idx=skipped_end_token_idx,
+                skipped_extra_keys=skipped_extra_keys,
             )
         )
 
@@ -578,21 +710,34 @@ class BlockPool:
             extra_keys, _ = generate_block_hash_extra_keys(
                 request, block_start, block_end, curr_mm_idx
             )
+            (
+                skipped_parent_block_hash,
+                skipped_start_token_idx,
+                skipped_end_token_idx,
+                skipped_extra_keys,
+            ) = self._get_skipped_context(
+                request,
+                self._published_full_block_context_start(
+                    request, block_size, kv_cache_group_id
+                )
+                * block_size,
+                block_start,
+                self.hash_block_size,
+            )
             self.kv_event_queue.append(
-                BlockStored(
+                self._build_block_stored_event(
+                    request,
                     block_hashes=[maybe_convert_block_hash(block_hash)],
                     parent_block_hash=parent_block_hash,
-                    token_ids=request.all_token_ids[block_start:block_end],
+                    start_token_idx=block_start,
+                    end_token_idx=block_end,
                     block_size=block_end - block_start,
-                    lora_id=request.lora_request.adapter_id
-                    if request.lora_request
-                    else None,
-                    medium=MEDIUM_GPU,
-                    lora_name=request.lora_request.name
-                    if request.lora_request
-                    else None,
-                    extra_keys=[extra_keys],
-                    group_idx=kv_cache_group_id,
+                    kv_cache_group_id=kv_cache_group_id,
+                    extra_keys_list=[extra_keys],
+                    skipped_parent_block_hash=skipped_parent_block_hash,
+                    skipped_start_token_idx=skipped_start_token_idx,
+                    skipped_end_token_idx=skipped_end_token_idx,
+                    skipped_extra_keys=skipped_extra_keys,
                 )
             )
         return block_hash_with_group_id
@@ -847,6 +992,9 @@ class BlockPool:
         logger.info("Successfully reset prefix cache")
 
         if self.enable_kv_cache_events:
+            # Cached blocks are no longer reachable, so a kept anchor would
+            # wrongly suppress skipped context after the reset.
+            self.published_full_block_anchors.clear()
             self.kv_event_queue.append(AllBlocksCleared())
 
         return True

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -149,6 +149,14 @@ class KVCacheCoordinator(ABC):
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
 
+        # Sparse retention must key off "some group's lookup applies the EAGLE
+        # drop", not "this group holds draft layers": the coordinator reconciles
+        # every group to ONE hit length, so a drop anywhere shortens the
+        # candidate offered to all of them. A group that kept only its own
+        # boundary state would then sit above every reachable candidate.
+        for manager in self.single_type_managers:
+            manager.lookup_drops_eagle_block = bool(self.eagle_group_ids)
+
         # A positive retention interval must be a multiple of the base hit granularity
         # (``scheduler_block_size``) to land on real cache-hit boundaries.
         # 0 = keep only the latest replay boundary; None = dense;

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -846,12 +846,11 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 drop_eagle_block = use_eagle and idx not in eagle_verified
 
                 _max_length = curr_hit_length
-                # Eagle matches one extra drop unit (one hash unit for
+                # EAGLE matches one extra drop unit (one hash unit for
                 # fine-grained managers, else one cache block) and then drops
-                # it, landing back at the candidate length. No margin for
-                # mamba: its finder never drops (draft models have no mamba
-                # layers), so the hit would grow past the candidate.
-                if drop_eagle_block and not isinstance(spec, MambaSpec):
+                # it, landing back at the candidate length. Managers whose
+                # finder does not drop receive no margin.
+                if drop_eagle_block and manager_cls.drops_eagle_block:
                     eagle_margin = (
                         self.hash_block_size
                         if self.enable_partial_hash_hits

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -149,14 +149,9 @@ class KVCacheCoordinator(ABC):
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
 
-        # Sparse retention must account for a full-attention EAGLE drop because
-        # the coordinator reconciles every group to one hit length. A sparse
-        # group that kept only its own boundary would then sit above the shared
-        # candidate.
         lookup_drops_eagle_block = any(
-            i in self.eagle_group_ids
-            and isinstance(group.kv_cache_spec, FullAttentionSpec)
-            for i, group in enumerate(self.kv_cache_config.kv_cache_groups)
+            i in self.eagle_group_ids and manager.drops_eagle_block
+            for i, manager in enumerate(self.single_type_managers)
         )
         for manager in self.single_type_managers:
             manager.lookup_drops_eagle_block = lookup_drops_eagle_block

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -149,13 +149,17 @@ class KVCacheCoordinator(ABC):
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
 
-        # Sparse retention must key off "some group's lookup applies the EAGLE
-        # drop", not "this group holds draft layers": the coordinator reconciles
-        # every group to ONE hit length, so a drop anywhere shortens the
-        # candidate offered to all of them. A group that kept only its own
-        # boundary state would then sit above every reachable candidate.
+        # Sparse retention must account for a full-attention EAGLE drop because
+        # the coordinator reconciles every group to one hit length. A sparse
+        # group that kept only its own boundary would then sit above the shared
+        # candidate.
+        lookup_drops_eagle_block = any(
+            i in self.eagle_group_ids
+            and isinstance(group.kv_cache_spec, FullAttentionSpec)
+            for i, group in enumerate(self.kv_cache_config.kv_cache_groups)
+        )
         for manager in self.single_type_managers:
-            manager.lookup_drops_eagle_block = bool(self.eagle_group_ids)
+            manager.lookup_drops_eagle_block = lookup_drops_eagle_block
 
         # A positive retention interval must be a multiple of the base hit granularity
         # (``scheduler_block_size``) to land on real cache-hit boundaries.
@@ -779,6 +783,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 request,
                 num_tokens_to_cache,
                 retention_interval=self.retention_interval,
+                alignment_tokens=self._cache_hit_alignment_tokens,
             )
 
     def find_longest_cache_hit(

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -275,16 +275,14 @@ class KVCacheManager:
             and getattr(request, "kv_cache_report_mode", "incremental") == "full"
         ):
             for group_idx, group_blocks in enumerate(computed_blocks):
-                num_blocks = len(group_blocks)
-                if num_blocks > 0:
-                    group = self.kv_cache_config.kv_cache_groups[group_idx]
-                    block_size = group.kv_cache_spec.block_size
-                    self.block_pool.emit_cached_block_events(
-                        request,
-                        num_blocks,
-                        block_size,
-                        group_idx,
-                    )
+                manager = self.coordinator.single_type_managers[group_idx]
+                self.block_pool.emit_cached_block_events(
+                    request,
+                    group_blocks,
+                    num_new_computed_tokens,
+                    manager.block_size,
+                    group_idx,
+                )
 
         # The junction to pin is where the lagging sparse-retention group stops
         # (``num_new_computed_tokens``) plus the uncached shared prefix -- i.e.

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -33,6 +33,32 @@ from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
 
 
+def reachable_hit_positions(
+    boundary_tokens: int,
+    alignment_tokens: int,
+    use_eagle: bool,
+) -> tuple[int, ...]:
+    """Token positions a cache hit can land on for one reachable boundary.
+
+    A lookup floors the boundary to ``alignment_tokens``. Under EAGLE the
+    full-attention finder additionally subtracts ``min(alignment_tokens,
+    its own block_size)`` and re-floors to the alignment, which lands on
+    exactly one alignment unit below the boundary either way. That lower
+    position is the ONLY one this group can be asked for until the request
+    decodes past the next boundary, so sparse-retention masks must treat both
+    as reachable: retaining only the boundary leaves every kept state above
+    every candidate a lookup can produce, and the reconciled hit is always 0.
+
+    Expressing the back-off in tokens rather than blocks is what makes this
+    correct when a group's block size differs from the alignment: one block is
+    the right step only when they are equal.
+    """
+    aligned = boundary_tokens // alignment_tokens * alignment_tokens
+    if not use_eagle:
+        return (aligned,)
+    return (aligned, max(aligned - alignment_tokens, 0))
+
+
 class SingleTypeKVCacheManager(ABC):
     """
     An abstract base class for a manager that handle the kv cache management
@@ -102,11 +128,16 @@ class SingleTypeKVCacheManager(ABC):
         self.kv_cache_group_id = kv_cache_group_id
         self._null_block = block_pool.null_block
 
-        # Whether this group's prefix-cache hits drop the EAGLE/MTP lookahead
-        # block. Only consulted by managers whose hit logic is sparse within an
-        # aligned segment (SWA). Initialized lazily by the coordinator after
+        # Whether THIS group's own prefix-cache lookup drops the EAGLE/MTP
+        # lookahead block. Initialized lazily by the coordinator after
         # determining the attention groups.
         self.use_eagle = False
+
+        # Whether ANY group's lookup applies that drop, which is what sparse
+        # retention must key off: the coordinator reconciles every group to one
+        # hit length, so a drop anywhere shortens the candidate offered here.
+        # See ``reachable_hit_positions``. Set by the coordinator.
+        self.lookup_drops_eagle_block = False
 
         # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
         # managers (full attention, mamba "align"); harmlessly empty elsewhere.
@@ -457,7 +488,8 @@ class SingleTypeKVCacheManager(ABC):
             end_block=num_full_blocks,
             alignment_tokens=self.scheduler_block_size,
             kv_cache_spec=self.kv_cache_spec,
-            use_eagle=self.use_eagle,
+            # Retention, unlike lookup, cares whether the drop happens anywhere.
+            use_eagle=self.use_eagle or self.lookup_drops_eagle_block,
             retention_interval=retention_interval,
             reachable_boundaries=reachable_boundaries,
         )
@@ -1428,25 +1460,15 @@ class MambaManager(SingleTypeKVCacheManager):
         # (2) Reachable-boundary states: the replay boundary (``num_prompt - 1``,
         # capped by ``get_computed_blocks``) and any shared-prefix junction, both
         # of which segments would otherwise skip under sparse retention. A Mamba
-        # hit needs exactly the single state block ending on the boundary.
-        #
-        # Under EAGLE/MTP the full-attention lookup drops one block below what
-        # it matched, so until the request decodes past the block boundary
-        # after ``boundary_tokens`` the only candidate the coordinator can
-        # offer this group is one block below the boundary. Keep that state
-        # too; keeping only the boundary state leaves every retained state one
-        # block above every reachable candidate, and the reconciled hit is
-        # always zero.
+        # hit needs exactly the single state block ending on the reachable
+        # position, so retain one block per position rather than a run.
         for boundary_tokens in reachable_boundaries:
-            aligned = boundary_tokens // alignment_tokens * alignment_tokens
-            boundary_block = aligned // block_size - 1
-            for kept in (
-                (boundary_block, boundary_block - 1)
-                if use_eagle
-                else (boundary_block,)
+            for position in reachable_hit_positions(
+                boundary_tokens, alignment_tokens, use_eagle
             ):
-                if start_block <= kept < end_block:
-                    mask[kept - start_block] = True
+                boundary_block = position // block_size - 1
+                if start_block <= boundary_block < end_block:
+                    mask[boundary_block - start_block] = True
 
         return mask
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1408,9 +1408,11 @@ class MambaManager(SingleTypeKVCacheManager):
         mask = [False] * (end_block - start_block)
 
         # (1) Segment-boundary states. A Mamba hit needs exactly the single
-        # state block ending on the boundary (no window, and draft models have
-        # no mamba layers, so no eagle shift). Block ``i`` ends at token
-        # ``(i + 1) * block_size``.
+        # state block ending on the boundary (no window). Segment tails get no
+        # EAGLE shift: under the EAGLE drop the fixed point settles on the next
+        # lower tail, costing at most one segment of hit length, unlike the
+        # reachable boundaries below where the unshifted state is the only one.
+        # Block ``i`` ends at token ``(i + 1) * block_size``.
         segment_tokens = None if retention_interval == 0 else retention_interval
         if segment_tokens is not None:
             per_segment = segment_tokens // block_size
@@ -1427,11 +1429,24 @@ class MambaManager(SingleTypeKVCacheManager):
         # capped by ``get_computed_blocks``) and any shared-prefix junction, both
         # of which segments would otherwise skip under sparse retention. A Mamba
         # hit needs exactly the single state block ending on the boundary.
+        #
+        # Under EAGLE/MTP the full-attention lookup drops one block below what
+        # it matched, so until the request decodes past the block boundary
+        # after ``boundary_tokens`` the only candidate the coordinator can
+        # offer this group is one block below the boundary. Keep that state
+        # too; keeping only the boundary state leaves every retained state one
+        # block above every reachable candidate, and the reconciled hit is
+        # always zero.
         for boundary_tokens in reachable_boundaries:
             aligned = boundary_tokens // alignment_tokens * alignment_tokens
             boundary_block = aligned // block_size - 1
-            if start_block <= boundary_block < end_block:
-                mask[boundary_block - start_block] = True
+            for kept in (
+                (boundary_block, boundary_block - 1)
+                if use_eagle
+                else (boundary_block,)
+            ):
+                if start_block <= kept < end_block:
+                    mask[kept - start_block] = True
 
         return mask
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -133,10 +133,10 @@ class SingleTypeKVCacheManager(ABC):
         # determining the attention groups.
         self.use_eagle = False
 
-        # Whether ANY group's lookup applies that drop, which is what sparse
-        # retention must key off: the coordinator reconciles every group to one
-        # hit length, so a drop anywhere shortens the candidate offered here.
-        # See ``reachable_hit_positions``. Set by the coordinator.
+        # Whether a full-attention lookup applies that drop. Sparse retention
+        # must account for it because the coordinator reconciles every group to
+        # one hit length. See ``reachable_hit_positions``. Set by the
+        # coordinator.
         self.lookup_drops_eagle_block = False
 
         # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
@@ -457,6 +457,7 @@ class SingleTypeKVCacheManager(ABC):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        alignment_tokens: int | None = None,
     ) -> None:
         """
         Cache the blocks for the request.
@@ -469,12 +470,18 @@ class SingleTypeKVCacheManager(ABC):
                 keeps dense checkpointing; ``0`` keeps only the latest replay
                 boundary; a positive multiple of ``scheduler_block_size`` keeps
                 a tail once per that-sized segment. Only SWA acts on it.
+            alignment_tokens: Cache-hit alignment. Defaults to the scheduler
+                block size for non-hybrid coordinators.
         """
         num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
         num_full_blocks = num_tokens // self.block_size
 
         if num_cached_blocks >= num_full_blocks:
             return
+
+        mask_alignment_tokens = (
+            self.scheduler_block_size if alignment_tokens is None else alignment_tokens
+        )
 
         # Token boundaries whose reachable tail must be retained under sparse
         # retention: the replay boundary (``num_prompt - 1``, capped by
@@ -483,13 +490,26 @@ class SingleTypeKVCacheManager(ABC):
         if request.shared_prefix_boundary:
             reachable_boundaries.append(request.shared_prefix_boundary)
 
+        retention_use_eagle = self.use_eagle
+        if self.lookup_drops_eagle_block:
+            if isinstance(self.kv_cache_spec, MambaSpec):
+                retention_use_eagle = True
+            elif isinstance(self.kv_cache_spec, SlidingWindowSpec):
+                reachable_boundaries = [
+                    position
+                    for boundary in reachable_boundaries
+                    for position in reachable_hit_positions(
+                        boundary, mask_alignment_tokens, True
+                    )
+                    if position > 0
+                ]
+
         block_mask = self.reachable_block_mask(
             start_block=num_cached_blocks,
             end_block=num_full_blocks,
-            alignment_tokens=self.scheduler_block_size,
+            alignment_tokens=mask_alignment_tokens,
             kv_cache_spec=self.kv_cache_spec,
-            # Retention, unlike lookup, cares whether the drop happens anywhere.
-            use_eagle=self.use_eagle or self.lookup_drops_eagle_block,
+            use_eagle=retention_use_eagle,
             retention_interval=retention_interval,
             reachable_boundaries=reachable_boundaries,
         )
@@ -815,8 +835,14 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        alignment_tokens: int | None = None,
     ) -> None:
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            alignment_tokens=alignment_tokens,
+        )
         hash_block_size = self.block_pool.hash_block_size
         if self.block_size == hash_block_size:
             return
@@ -1753,9 +1779,15 @@ class MambaManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        alignment_tokens: int | None = None,
     ) -> None:
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            alignment_tokens=alignment_tokens,
+        )
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
         if self.mamba_cache_mode == "align":
             partial_hash = self._cache_partial_tail_block(request, num_tokens)
@@ -1848,6 +1880,7 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        alignment_tokens: int | None = None,
     ) -> None:
         # We do not cache blocks for cross-attention to be shared between
         # requests, so this method is not relevant.

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -40,14 +40,11 @@ def reachable_hit_positions(
 ) -> tuple[int, ...]:
     """Token positions a cache hit can land on for one reachable boundary.
 
-    A lookup floors the boundary to ``alignment_tokens``. Under EAGLE the
-    full-attention finder additionally subtracts ``min(alignment_tokens,
-    its own block_size)`` and re-floors to the alignment, which lands on
-    exactly one alignment unit below the boundary either way. That lower
-    position is the ONLY one this group can be asked for until the request
-    decodes past the next boundary, so sparse-retention masks must treat both
-    as reachable: retaining only the boundary leaves every kept state above
-    every candidate a lookup can produce, and the reconciled hit is always 0.
+    A lookup floors the boundary to ``alignment_tokens``. Under EAGLE an
+    attention finder removes its lookahead block and re-floors to the
+    alignment. The result is either the aligned boundary or one alignment unit
+    below it, depending on the finder's block size. Sparse-retention masks must
+    treat both as reachable.
 
     Expressing the back-off in tokens rather than blocks is what makes this
     correct when a group's block size differs from the alignment: one block is
@@ -59,6 +56,29 @@ def reachable_hit_positions(
     return (aligned, max(aligned - alignment_tokens, 0))
 
 
+def resolve_sparse_retention_inputs(
+    kv_cache_spec: KVCacheSpec,
+    use_eagle: bool,
+    lookup_drops_eagle_block: bool,
+    alignment_tokens: int,
+    reachable_boundaries: Sequence[int],
+) -> tuple[bool, tuple[int, ...]]:
+    """Account for an EAGLE-reduced shared hit boundary."""
+    boundaries = tuple(reachable_boundaries)
+    if not lookup_drops_eagle_block:
+        return use_eagle, boundaries
+    if isinstance(kv_cache_spec, MambaSpec):
+        return True, boundaries
+    if isinstance(kv_cache_spec, SlidingWindowSpec):
+        boundaries = tuple(
+            position
+            for boundary in boundaries
+            for position in reachable_hit_positions(boundary, alignment_tokens, True)
+            if position > 0
+        )
+    return use_eagle, boundaries
+
+
 class SingleTypeKVCacheManager(ABC):
     """
     An abstract base class for a manager that handle the kv cache management
@@ -66,6 +86,7 @@ class SingleTypeKVCacheManager(ABC):
     """
 
     supports_fine_grained_hash_lookup: ClassVar[bool] = False
+    drops_eagle_block: ClassVar[bool] = False
 
     def __init__(
         self,
@@ -133,10 +154,9 @@ class SingleTypeKVCacheManager(ABC):
         # determining the attention groups.
         self.use_eagle = False
 
-        # Whether a full-attention lookup applies that drop. Sparse retention
+        # Whether an attention-group lookup applies that drop. Sparse retention
         # must account for it because the coordinator reconciles every group to
-        # one hit length. See ``reachable_hit_positions``. Set by the
-        # coordinator.
+        # one hit length. Set by the coordinator.
         self.lookup_drops_eagle_block = False
 
         # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
@@ -486,23 +506,20 @@ class SingleTypeKVCacheManager(ABC):
         # Token boundaries whose reachable tail must be retained under sparse
         # retention: the replay boundary (``num_prompt - 1``, capped by
         # ``get_computed_blocks``) and any detected shared-prefix junction.
-        reachable_boundaries = [request.num_prompt_tokens - 1]
+        reachable_boundaries: Sequence[int] = (request.num_prompt_tokens - 1,)
         if request.shared_prefix_boundary:
-            reachable_boundaries.append(request.shared_prefix_boundary)
+            reachable_boundaries = (
+                *reachable_boundaries,
+                request.shared_prefix_boundary,
+            )
 
-        retention_use_eagle = self.use_eagle
-        if self.lookup_drops_eagle_block:
-            if isinstance(self.kv_cache_spec, MambaSpec):
-                retention_use_eagle = True
-            elif isinstance(self.kv_cache_spec, SlidingWindowSpec):
-                reachable_boundaries = [
-                    position
-                    for boundary in reachable_boundaries
-                    for position in reachable_hit_positions(
-                        boundary, mask_alignment_tokens, True
-                    )
-                    if position > 0
-                ]
+        retention_use_eagle, reachable_boundaries = resolve_sparse_retention_inputs(
+            self.kv_cache_spec,
+            self.use_eagle,
+            self.lookup_drops_eagle_block,
+            mask_alignment_tokens,
+            reachable_boundaries,
+        )
 
         block_mask = self.reachable_block_mask(
             start_block=num_cached_blocks,
@@ -731,6 +748,7 @@ class SingleTypeKVCacheManager(ABC):
 
 class FullAttentionManager(SingleTypeKVCacheManager):
     supports_fine_grained_hash_lookup: ClassVar[bool] = True
+    drops_eagle_block: ClassVar[bool] = True
 
     @classmethod
     def find_longest_cache_hit(
@@ -936,6 +954,8 @@ class RSWAManager(FullAttentionManager):
 
 
 class SlidingWindowManager(SingleTypeKVCacheManager):
+    drops_eagle_block: ClassVar[bool] = True
+
     def __init__(self, kv_cache_spec: SlidingWindowSpec, **kwargs) -> None:
         super().__init__(kv_cache_spec, **kwargs)
         self.sliding_window = kv_cache_spec.sliding_window

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -60,20 +60,44 @@ def resolve_sparse_retention_inputs(
     kv_cache_spec: KVCacheSpec,
     use_eagle: bool,
     lookup_drops_eagle_block: bool,
-    alignment_tokens: int,
     reachable_boundaries: Sequence[int],
+    *,
+    lookup_alignment_tokens: int,
+    state_materialization_alignment_tokens: int,
 ) -> tuple[bool, tuple[int, ...]]:
-    """Account for an EAGLE-reduced shared hit boundary."""
+    """Resolve the mask's EAGLE flag and retained token boundaries.
+
+    Lookup alignment can be finer than the scheduler alignment used to
+    materialize recurrent states. Keep both sets of Mamba positions so a
+    missing fine state does not displace a usable scheduler-aligned fallback.
+    """
     boundaries = tuple(reachable_boundaries)
+    if isinstance(kv_cache_spec, MambaSpec):
+        alignments = dict.fromkeys(
+            (lookup_alignment_tokens, state_materialization_alignment_tokens)
+        )
+        positions = tuple(
+            dict.fromkeys(
+                position
+                for boundary in boundaries
+                for alignment in alignments
+                for position in reachable_hit_positions(
+                    boundary, alignment, use_eagle or lookup_drops_eagle_block
+                )
+            )
+        )
+        # Each alignment's EAGLE predecessor is already included. The mask
+        # must not apply another lookup-sized drop to materialized positions.
+        return False, positions
     if not lookup_drops_eagle_block:
         return use_eagle, boundaries
-    if isinstance(kv_cache_spec, MambaSpec):
-        return True, boundaries
     if isinstance(kv_cache_spec, SlidingWindowSpec):
         boundaries = tuple(
             position
             for boundary in boundaries
-            for position in reachable_hit_positions(boundary, alignment_tokens, True)
+            for position in reachable_hit_positions(
+                boundary, lookup_alignment_tokens, True
+            )
             if position > 0
         )
     return use_eagle, boundaries
@@ -517,8 +541,9 @@ class SingleTypeKVCacheManager(ABC):
             self.kv_cache_spec,
             self.use_eagle,
             self.lookup_drops_eagle_block,
-            mask_alignment_tokens,
             reachable_boundaries,
+            lookup_alignment_tokens=mask_alignment_tokens,
+            state_materialization_alignment_tokens=self.scheduler_block_size,
         )
 
         block_mask = self.reachable_block_mask(


### PR DESCRIPTION
## Purpose

Sparse `BlockStored` events can claim missing blocks or omit the context needed
to reconstruct a retained block after a gap. This change emits contiguous runs
of retained blocks and adopts the skipped-context fields from
vllm-project/vllm#44488, while fixing full cached-prefix replay in this fork.

This draft is stacked on local-inference-lab/vllm#643 and must not merge first.
Its event-specific commits are isolated in the
[stack comparison](https://github.com/logprobz/vllm/compare/fix/hybrid-sparse-retention-boundaries...fix/sparse-blockstored-events).

- Store publication emits nothing for an empty selection. Each retained run
  carries its exact hashes, tokens, extra keys, and immediate logical parent.
- Sparse runs include optional `skipped_parent_block_hash`, `skipped_token_ids`,
  and `skipped_extra_keys`, allowing consumers to reconstruct omitted context.
- Full replay advertises only registered entries owned by returned blocks. It
  respects the reconciled hit length, DCP-effective block sizes, and registered
  partial aliases. Every full replay starts at root, including partial-only
  replay when a saved publication anchor exists.
- Weak per-Request, per-cache-group anchors preserve missing context across
  prefill chunks. Saved hashes are validated before reuse, anchors clear on a
  successful cache reset, and bookkeeping never retains Request objects strongly.
- Shared skipped-context generation covers full runs, partial stores, and
  partial replay. Published full runs update the anchor; partial events do not
  advance the full-block anchor. Partial context uses hash-block granularity.
  Stored hashes, ownership checks, and reconciled lengths are preserved.

The event-specific diff changes metadata publication and the public event
schema. It does not change KV tensors, insertion, eviction, or scheduling.
The underlying cache-retention changes belong to #643. The context-anchor
fix preserves the BlockStored schema introduced by the earlier event adaptation.

## Compatibility and attribution

Credit @Li-brua (Librua) for vllm-project/vllm#44488. Its skipped-context design
is adapted here with co-author attribution in the commit. The fork-specific
replay correction remains necessary because that upstream PR does not repair
full cached-prefix replay. Credit @glaziermag for the report in
vllm-project/vllm#44451.

The optional fields follow the fork's existing fields. Tests verify old and
new payloads decode compatibly when the new fields are unset. MsgPack bytes
are not identical: msgspec may select `map16` instead of `fixmap` for the
larger struct. Consumers that compare encoded bytes must account for this.

The DCP-effective replay sizing overlaps with @jperezdealgaba's
vllm-project/vllm#50118. The event-kind markers in vllm-project/vllm#51699
remain a separate change.

## Validation

The original eight acceptance cases failed before implementation. A stale-anchor
case and three parent-review cases bring focused coverage to twelve cases, all
passing. The three parent-review cases also failed before their corrections.
They cover partial-only replay with a saved anchor and full replay followed by
incremental full or partial publication, including preservation of the full-block
anchor after partial events. The parent reran the exact g1 acceptance command
successfully: 12 passed.

Seven regression suites passed 443 tests: prefix caching, the prefix-cache test
directory, Mamba chunk alignment, Mooncake store coordinator, worker and scheduler,
and distributed KV-cache events. Coverage includes sparse gaps, request and group
isolation, reset and stale anchors, replay ownership, partial aliases, skipped
tokens and extra keys, hashing, and legacy decoding.

Repository-pinned changed-file pre-commit hooks, manual mypy-3.12,
`git diff --check`, and Python compilation passed. Commands and local receipts
are recorded in `/tmp/pr645-context-checks/review-validation.md`, with the parent
acceptance rerun in `parent-goal.log`, regressions in `regression-review.log`,
hooks in `hooks-review-final.log`, and mypy in `mypy312-review.log`.

These are CPU tests with the PR source mounted read-only into the pinned LP26
test container (`sha256:da3588b2adf80999c20cfc254a98cbcc8807a8f3ab357ea769279597df66edb5`).
They are not GPU model qualification or a rebuilt LP26 integration. No additional
test-container runs were made for publication.

The earlier skipped-context adaptation passed 201 prefix-cache and KV-event
tests in the digest-pinned r25 container. That earlier source was also included
in the local LP26 integration based on
`voipmonitor/vllm@sha256:89376e9aa49442a90754662ca1bb281bffbeca29bb7393e6e8281506e5ac4804`.
That integration retains r25's exact Mamba block-ID handoffs and adjusts test
fixtures for r25's scheduler. Its results are separate from this PR's head;
this update does not rebuild or change that integration.

The runtime was untouched. No new model evaluation was run for these changes.
The cache-retention changes in #643 still require GPU qualification, and this
draft must not merge before #643.

## AI assistance

GPT-6 Astra implemented and reviewed the initial event adaptation. OpenAI
Codex assisted with the skipped-context follow-up, integration, and validation.
For the context-anchor fix, LOCAL/glm-5.3-flash-local-lab-nvfp4-dflash2
provided the initial implementation, OpenAI Codex handled parent orchestration,
and GPT-6 Astra performed corrections, review, and validation. The draft remains
subject to the submitting human's review.

### Superseded

Superseded by #669, now merged on dev/jovian-judgement. The coordinated port preserves endpoint checkpoint guards and includes the cache, scheduler, connector and event repairs from this earlier branch. The combined release passed full MTP3 and DFlash2 serving qualification and was promoted, with zero preemptions and all LP26 5% performance gates satisfied. Closing this older proposal to avoid duplicate integration.
