### PR TITLE
prefix cache: fine-grained hits for sliding-window groups; decouple GLM-5.3 target and recurrent blocks

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -1937,6 +1937,63 @@ def test_sliding_window_eagle_margin_is_one_hash_unit_under_partial_hits():
     assert 42 in seen_max_lengths
 
 
+def _cached_mamba_boundaries(manager, group_id: int = 1) -> list[int]:
+    return sorted(
+        {
+            block.block_hash_num_tokens
+            for block in manager.block_pool.blocks
+            if block.block_hash is not None
+            and block.block_hash_num_tokens
+            and get_group_id(block.block_hash) == group_id
+        }
+    )
+
+
+@pytest.mark.parametrize("prefill_chunk", [2, 16])
+def test_fine_grained_retention_keeps_scheduler_aligned_fallback(prefill_chunk: int):
+    """Sparse retention (interval 0) under fine-grained hits must keep the
+    scheduler-aligned recurrent state and its EAGLE predecessor next to the
+    fine replay boundary. With prefill in scheduler-sized steps the recurrent
+    state is only materialized at step ends, so the fine boundary alone would
+    retain nothing and a repeat request would resume from zero."""
+    hash_block_size = 2
+    attn_block_size = 16  # also the scheduler block (LCM with the mamba block)
+    manager = make_kv_cache_manager(
+        kv_cache_config=_make_hybrid_swa_eagle_config(
+            hash_block_size=hash_block_size,
+            attn_block_size=attn_block_size,
+            mamba_block_size=hash_block_size,
+            sliding_window=attn_block_size,
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        use_eagle=True,
+        retention_interval=0,
+    )
+    assert manager.coordinator.enable_partial_hash_hits
+    base = list(range(1000, 1045))  # replay boundary 44; scheduler-aligned 32
+    _prefill_and_free(
+        manager, make_request("0", base, hash_block_size, sha256), prefill_chunk
+    )
+
+    retained = _cached_mamba_boundaries(manager)
+    # Scheduler-aligned fallback (32) and its predecessor (16) are always kept.
+    assert {16, 32} <= set(retained)
+    if prefill_chunk == hash_block_size:
+        # Fine states exist: the replay boundary (44) and its EAGLE predecessor (42).
+        assert {42, 44} <= set(retained)
+        expected_repeat_hit = 42
+    else:
+        # Only step-end states exist; the fine boundary retains nothing extra.
+        assert retained == [16, 32]
+        expected_repeat_hit = 32
+    repeat = _prefill_and_free(
+        manager, make_request("1", base, hash_block_size, sha256), prefill_chunk
+    )
+    assert repeat == expected_repeat_hit
+
+
 @pytest.mark.parametrize("num_prompt_tokens", [13, 45, 48])
 def test_hybrid_decoupled_blocks_keep_fine_grained_reuse(num_prompt_tokens: int):
     """Large attention/draft blocks (page parity with the recurrent state)

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -1846,6 +1846,97 @@ def test_sliding_window_fine_grained_reachable_mask():
     )
 
 
+def test_attention_only_hybrid_keeps_block_aligned_hits():
+    """Without a recurrent group, hashing finer than an attention block does
+    not turn partial hits on: attention-only hybrids keep the block-aligned
+    behaviour they had before sliding-window groups learned fine-grained
+    lookups."""
+    hash_block_size = 2
+    kv_cache_config = KVCacheConfig(
+        num_blocks=64,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=2 * hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["swa"],
+                SlidingWindowSpec(
+                    block_size=4 * hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=4 * hash_block_size,
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    coordinator = manager.coordinator
+    assert not coordinator.enable_partial_hash_hits
+    assert all(
+        m.hit_alignment_tokens == coordinator.scheduler_block_size
+        for m in coordinator.single_type_managers
+    )
+
+
+def test_sliding_window_eagle_margin_is_one_hash_unit_under_partial_hits():
+    """With partial hits on, the coordinator hands the EAGLE sliding-window
+    group a one-hash-unit lookahead margin (not a whole draft block) and the
+    reconciled hit lands back on the candidate length."""
+    hash_block_size = 2
+    manager = make_kv_cache_manager(
+        kv_cache_config=_make_hybrid_swa_eagle_config(
+            hash_block_size=hash_block_size,
+            attn_block_size=16,
+            mamba_block_size=hash_block_size,
+            sliding_window=16,
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        use_eagle=True,
+    )
+    coordinator = manager.coordinator
+    assert coordinator.enable_partial_hash_hits
+    base = list(range(1000, 1045))
+    _prefill_and_free(manager, make_request("0", base, hash_block_size, sha256), 2)
+
+    seen_max_lengths: list[int] = []
+    swa_manager = coordinator.single_type_managers[2]
+    original = type(swa_manager).find_longest_cache_hit
+
+    def spy(cls, *args, **kwargs):
+        seen_max_lengths.append(kwargs["max_length"])
+        return original(*args, **kwargs)
+
+    type(swa_manager).find_longest_cache_hit = classmethod(spy)
+    try:
+        req = make_request("1", base, hash_block_size, sha256)
+        _, hit_length, _ = coordinator.find_longest_cache_hit(
+            req.block_hashes, len(base) - 1
+        )
+    finally:
+        type(swa_manager).find_longest_cache_hit = original
+    # Candidate 44 (the tail): the draft is asked for 44 + one hash unit
+    # (capped by max_length 44), rewinds to 42; the re-query asks for exactly
+    # the rewound length. Nothing is queried a whole draft block ahead.
+    assert hit_length == 42
+    assert seen_max_lengths and max(seen_max_lengths) <= 44
+    assert 42 in seen_max_lengths
+
+
 @pytest.mark.parametrize("num_prompt_tokens", [13, 45, 48])
 def test_hybrid_decoupled_blocks_keep_fine_grained_reuse(num_prompt_tokens: int):
     """Large attention/draft blocks (page parity with the recurrent state)

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -1569,7 +1569,85 @@ def test_hybrid_partial_hit_with_eagle_stays_within_group_blocks():
     assert manager.allocate_slots(req1, 4, num_computed, computed_blocks) is not None
 
 
-def test_hybrid_sliding_window_group_disables_partial_hash_hits():
+def _make_hybrid_swa_eagle_config(
+    hash_block_size: int,
+    attn_block_size: int,
+    mamba_block_size: int,
+    sliding_window: int,
+    num_blocks: int = 512,
+) -> KVCacheConfig:
+    """Full attention target + mamba "align" + an EAGLE sliding-window draft
+    group (window == draft block), the GLM-5.3 + DFlash topology."""
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=attn_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=mamba_block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["swa_draft"],
+                SlidingWindowSpec(
+                    block_size=attn_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=sliding_window,
+                ),
+                is_eagle_group=True,
+            ),
+        ],
+    )
+
+
+def _prefill_and_free(manager, request, chunk: int) -> int:
+    """Prefill ``request`` in ``chunk``-token steps (so the mamba group
+    checkpoints every block, as FlashKDA prefill checkpoints do), decode one
+    token, free it. Returns the prefix-cache hit it started from."""
+    num_tokens = len(request.prompt_token_ids)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(request)
+    done = num_computed
+    first = True
+    while done < num_tokens:
+        step = min(chunk, num_tokens - done)
+        if first:
+            result = manager.allocate_slots(
+                request, step, num_computed, computed_blocks
+            )
+            first = False
+        else:
+            result = manager.allocate_slots(request, step)
+        assert result is not None
+        done += step
+        request.num_computed_tokens = done
+        manager.new_step_starts()
+    assert manager.allocate_slots(request, 1) is not None
+    request.num_computed_tokens = done + 1
+    manager.new_step_starts()
+    manager.free(request)
+    manager.new_step_starts()
+    return num_computed
+
+
+def test_hybrid_sliding_window_group_enables_partial_hash_hits():
+    """A sliding-window draft group no longer forces block-aligned hits: with
+    the hash unit finer than the draft block, partial hash hits stay enabled
+    and the draft's EAGLE rewind is one hash unit, not one draft block."""
     hash_block_size = 2
     sliding_window_block_size = 2 * hash_block_size
     mamba_block_size = 2 * sliding_window_block_size
@@ -1615,29 +1693,212 @@ def test_hybrid_sliding_window_group_disables_partial_hash_hits():
         hash_block_size=hash_block_size,
         use_eagle=True,
     )
+    coordinator = manager.coordinator
+    assert coordinator.enable_partial_hash_hits
+    assert all(
+        m.hit_alignment_tokens == hash_block_size
+        for m in coordinator.single_type_managers
+    )
 
     tokens = list(range(3 * sliding_window_block_size))
     request = make_request("0", tokens, hash_block_size, sha256)
-    computed_blocks, num_computed, _ = manager.get_computed_blocks(request)
-    assert not manager.coordinator.enable_partial_hash_hits
-    assert (
-        manager.allocate_slots(request, mamba_block_size, num_computed, computed_blocks)
-        is not None
-    )
-    request.num_computed_tokens = mamba_block_size
-    manager.new_step_starts()
-    assert manager.allocate_slots(request, len(tokens) - mamba_block_size) is not None
-    request.num_computed_tokens = len(tokens)
-    manager.free(request)
-    manager.new_step_starts()
+    # Prefill in mamba-block steps, as the aligned scheduler split does.
+    assert _prefill_and_free(manager, request, mamba_block_size) == 0
 
     cached_request = make_request(
         "1", tokens + [len(tokens), len(tokens) + 1], hash_block_size, sha256
     )
     computed_blocks, num_computed, _ = manager.get_computed_blocks(cached_request)
-
+    # The mamba state at the last block boundary (8) is retained; the draft
+    # matches one hash unit past it (10, inside its cached block 2) and
+    # rewinds by that unit instead of by a whole draft block.
     assert num_computed == mamba_block_size
     assert len(computed_blocks.blocks[0]) * hash_block_size == num_computed
+
+
+def test_sliding_window_fine_grained_hits():
+    """Manager-level: hits on hash boundaries inside a draft block, the
+    window-coverage requirement, the EAGLE rewind by one hash unit, and a
+    covering entry registered further along the tail block."""
+    from vllm.v1.core.block_pool import BlockPool
+    from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
+
+    hash_block_size = 2
+    block_size = 8
+    spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=block_size,
+    )
+    pool = BlockPool(
+        num_gpu_blocks=16, enable_caching=True, hash_block_size=hash_block_size
+    )
+    req = make_request("0", list(range(100, 116)), hash_block_size, sha256)
+
+    def find(max_length, drop_eagle_block):
+        return SlidingWindowManager.find_longest_cache_hit(
+            block_hashes=req.block_hashes,
+            max_length=max_length,
+            kv_cache_group_ids=[0],
+            block_pool=pool,
+            kv_cache_spec=spec,
+            drop_eagle_block=drop_eagle_block,
+            alignment_tokens=hash_block_size,
+        )
+
+    blocks = pool.get_new_blocks(2)
+    # Block 0 fully cached (8 tokens); block 1 holds a partial entry at 14.
+    pool.cache_full_blocks(
+        request=req,
+        blocks=blocks[:1],
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=block_size,
+        kv_cache_group_id=0,
+    )
+    assert (
+        pool.cache_partial_block(
+            request=req,
+            block=blocks[1],
+            num_tokens=14,
+            kv_cache_group_id=0,
+            block_size=block_size,
+        )
+        is not None
+    )
+
+    # Hit at the registered partial boundary; window [7, 14) needs block 0.
+    hit_blocks, hit_length = find(16, drop_eagle_block=False)
+    assert (hit_length, [b.block_id for b in hit_blocks[0]]) == (
+        14,
+        [blocks[0].block_id, blocks[1].block_id],
+    )
+    # EAGLE rewinds one hash unit; the tail block still covers 12.
+    hit_blocks, hit_length = find(16, drop_eagle_block=True)
+    assert (hit_length, len(hit_blocks[0])) == (12, 2)
+    # A re-query at the rewound length (no entry at 12) is served by the
+    # covering entry at 14 of the same append-only tail block.
+    hit_blocks, hit_length = find(12, drop_eagle_block=False)
+    assert (hit_length, len(hit_blocks[0])) == (12, 2)
+    # Block-aligned boundary: the full block 0 is the tail.
+    hit_blocks, hit_length = find(8, drop_eagle_block=False)
+    assert (hit_length, [b.block_id for b in hit_blocks[0]]) == (
+        8,
+        [blocks[0].block_id],
+    )
+    # Window coverage: with only the partial tail cached (no block 0), the
+    # tail alone cannot serve 14 since its window reaches into block 0.
+    pool = BlockPool(
+        num_gpu_blocks=16, enable_caching=True, hash_block_size=hash_block_size
+    )
+    blocks = pool.get_new_blocks(2)
+    assert (
+        pool.cache_partial_block(
+            request=req,
+            block=blocks[1],
+            num_tokens=14,
+            kv_cache_group_id=0,
+            block_size=block_size,
+        )
+        is not None
+    )
+    hit_blocks, hit_length = find(16, drop_eagle_block=False)
+    assert hit_length == 0
+
+
+def test_sliding_window_fine_grained_reachable_mask():
+    """Sparse retention keeps the full blocks a fine-grained hit at each
+    reachable boundary needs; dense retention keeps everything."""
+    from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
+
+    spec = SlidingWindowSpec(
+        block_size=8,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=8,
+    )
+    mask = SlidingWindowManager.reachable_block_mask(
+        start_block=0,
+        end_block=4,
+        alignment_tokens=2,
+        kv_cache_spec=spec,
+        use_eagle=True,
+        retention_interval=0,
+        reachable_boundaries=[27],  # aligned to 26, inside block 3
+    )
+    # Window (+1 EAGLE unit) before 26 spans [17, 26): blocks 2 and 3 (a
+    # fully cached block 3 covers the boundary inside it), blocks 0-1 not.
+    assert mask == [False, False, True, True]
+    assert (
+        SlidingWindowManager.reachable_block_mask(
+            start_block=0,
+            end_block=4,
+            alignment_tokens=2,
+            kv_cache_spec=spec,
+            use_eagle=True,
+            retention_interval=None,
+            reachable_boundaries=[27],
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("num_prompt_tokens", [13, 45, 48])
+def test_hybrid_decoupled_blocks_keep_fine_grained_reuse(num_prompt_tokens: int):
+    """Large attention/draft blocks (page parity with the recurrent state)
+    with a fine recurrent block and hash unit reuse prefixes exactly like an
+    all-fine-block layout: a repeat or a shared-prefix request resumes from
+    the last recurrent checkpoint before the prompt tail, minus the draft's
+    EAGLE unit, and once the shared prefix is registered the next request
+    resumes from the tail itself."""
+    hash_block_size = 2
+
+    def hits(attn_block_size: int, mamba_block_size: int) -> tuple[int, int, int]:
+        manager = make_kv_cache_manager(
+            kv_cache_config=_make_hybrid_swa_eagle_config(
+                hash_block_size=hash_block_size,
+                attn_block_size=attn_block_size,
+                mamba_block_size=mamba_block_size,
+                sliding_window=attn_block_size,
+            ),
+            max_model_len=8192,
+            enable_caching=True,
+            hash_block_size=hash_block_size,
+            use_eagle=True,
+        )
+        base = list(range(1000, 1000 + num_prompt_tokens))
+        _prefill_and_free(
+            manager, make_request("0", base, hash_block_size, sha256), mamba_block_size
+        )
+        identical = _prefill_and_free(
+            manager, make_request("1", base, hash_block_size, sha256), mamba_block_size
+        )
+        suffix = _prefill_and_free(
+            manager,
+            make_request("2", base + [7, 7], hash_block_size, sha256),
+            mamba_block_size,
+        )
+        suffix_again = _prefill_and_free(
+            manager,
+            make_request("3", base + [7, 7], hash_block_size, sha256),
+            mamba_block_size,
+        )
+        return identical, suffix, suffix_again
+
+    fine = hits(attn_block_size=2, mamba_block_size=2)
+    decoupled = hits(attn_block_size=16, mamba_block_size=2)
+    # A repeat may hit up to num_prompt - 1; a longer request up to the whole
+    # shared prompt. Either way the draft's EAGLE unit comes off the tail.
+    repeat_tail = (num_prompt_tokens - 1) // hash_block_size * hash_block_size
+    shared_tail = num_prompt_tokens // hash_block_size * hash_block_size
+    assert fine[:2] == (
+        repeat_tail - hash_block_size,
+        shared_tail - hash_block_size,
+    )
+    assert decoupled == fine
 
 
 @pytest.mark.parametrize("dcp_world_size", [1, 2, 4])

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -860,10 +860,14 @@ class Platform:
                     "VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE must be a positive "
                     "multiple of 64 after automatic resolution."
                 )
-            if mamba_block_size <= 0 or mamba_block_size % target_block_size != 0:
+            if mamba_block_size <= 0 or (
+                mamba_block_size % target_block_size != 0
+                and target_block_size % mamba_block_size != 0
+            ):
                 raise ValueError(
-                    "VLLM_GLM53_SPLIT_MAMBA_BLOCK_SIZE must be a positive "
-                    "multiple of VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE."
+                    "VLLM_GLM53_SPLIT_MAMBA_BLOCK_SIZE must be positive and "
+                    "either a multiple or a divisor of "
+                    "VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE."
                 )
             if cache_config.mamba_cache_mode != "align":
                 raise ValueError(
@@ -872,8 +876,12 @@ class Platform:
                 )
 
             # The target MLA cache and recurrent-state cache use independent
-            # physical pages. Their token block sizes remain scheduler-visible,
-            # so the recurrent block must be a multiple of the target block.
+            # physical pages. Their token block sizes remain scheduler-visible
+            # (the scheduler block is their LCM), so one must be a multiple of
+            # the other. A recurrent block finer than the target block keeps
+            # recurrent checkpoints (and so prefix-cache reuse, with
+            # ``prefix_match_unit`` set to the recurrent block) fine-grained
+            # while the target page grows to match the recurrent page.
             cache_config.block_size = target_block_size
             cache_config.mamba_block_size = mamba_block_size
             cache_config.mamba_page_size_padded = None

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -678,6 +678,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 )
         for manager in self.single_type_managers:
             manager.hit_alignment_tokens = self._cache_hit_alignment_tokens
+            manager.retention_eagle_rewind = bool(self.eagle_group_ids)
         self.verify_and_split_kv_cache_groups()
 
     @property

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -14,7 +14,9 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     CrossAttentionManager,
+    FullAttentionManager,
     SingleTypeKVCacheManager,
+    SlidingWindowManager,
     get_manager_for_kv_cache_spec,
 )
 from vllm.v1.kv_cache_interface import (
@@ -641,7 +643,25 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             )
             for g in kv_cache_config.kv_cache_groups
         )
-        self.enable_partial_hash_hits = has_partial_mamba_group
+        # Recurrent hybrids may instead hash finer than their attention
+        # blocks (``prefix_match_unit`` at the recurrent block, attention
+        # pages grown to match the recurrent page): partial hits then keep
+        # prefix reuse at the recurrent checkpoint granularity. Attention-only
+        # hybrids keep block-aligned hits, as before.
+        has_mamba_align_group = any(
+            isinstance(g.kv_cache_spec, MambaSpec)
+            and g.kv_cache_spec.mamba_cache_mode == "align"
+            for g in kv_cache_config.kv_cache_groups
+        )
+        has_partial_attention_group = has_mamba_align_group and any(
+            isinstance(manager, (FullAttentionManager, SlidingWindowManager))
+            and manager.block_size > hash_block_size
+            and manager.supports_fine_grained_hash_lookup
+            for manager in self.single_type_managers
+        )
+        self.enable_partial_hash_hits = (
+            has_partial_mamba_group or has_partial_attention_group
+        )
         if self.enable_partial_hash_hits:
             unsupported_partial_hit_managers = {
                 type(manager).__name__
@@ -656,6 +676,8 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     "cache managers require block-aligned lookups: %s.",
                     ", ".join(sorted(unsupported_partial_hit_managers)),
                 )
+        for manager in self.single_type_managers:
+            manager.hit_alignment_tokens = self._cache_hit_alignment_tokens
         self.verify_and_split_kv_cache_groups()
 
     @property

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -77,6 +77,10 @@ class SingleTypeKVCacheManager(ABC):
         # fine-grained partial hash hits are enabled, so retention masks keep
         # the tails those finer hits need.
         self.hit_alignment_tokens = scheduler_block_size
+        # Whether any EAGLE/MTP group rewinds the reconciled hit by one hit
+        # alignment unit, so sparse retention must also keep the state one
+        # unit below each reachable boundary. Set by the coordinator.
+        self.retention_eagle_rewind = False
         # The block size for this manager; used for actual block allocation.
         self.block_size = kv_cache_spec.block_size
         self.dcp_world_size = dcp_world_size
@@ -488,6 +492,17 @@ class SingleTypeKVCacheManager(ABC):
         if request.shared_prefix_boundary:
             reachable_boundaries.append(request.shared_prefix_boundary)
 
+        if self.hit_alignment_tokens < self.scheduler_block_size:
+            # Fine-grained hits floor boundaries to the hash unit, but a
+            # recurrent state may only be materialized at scheduler-step ends
+            # (no per-block prefill checkpoints). Keep the scheduler-aligned
+            # fallback next to the fine boundary, and the position one unit
+            # below each when an EAGLE group rewinds the reconciled hit, so a
+            # mathematically valid fine boundary never displaces the only
+            # state that exists.
+            reachable_boundaries = self._expand_reachable_boundaries(
+                reachable_boundaries
+            )
         block_mask = self.reachable_block_mask(
             start_block=num_cached_blocks,
             end_block=num_full_blocks,
@@ -508,6 +523,20 @@ class SingleTypeKVCacheManager(ABC):
         )
 
         self.num_cached_block[request.request_id] = num_full_blocks
+
+    def _expand_reachable_boundaries(self, boundaries: Sequence[int]) -> list[int]:
+        """Token boundaries to retain for ``boundaries`` when hits align to
+        a hash unit finer than the scheduler block: each boundary floored to
+        the hit alignment and to the scheduler block, plus the position one
+        alignment unit below each when an EAGLE group rewinds the hit."""
+        retained: set[int] = set()
+        for boundary in boundaries:
+            for alignment in (self.hit_alignment_tokens, self.scheduler_block_size):
+                aligned = boundary // alignment * alignment
+                retained.add(aligned)
+                if self.retention_eagle_rewind:
+                    retained.add(max(aligned - alignment, 0))
+        return sorted(retained)
 
     @classmethod
     def reachable_block_mask(

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -9,6 +9,7 @@ from typing import ClassVar
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
     BlockHashList,
     BlockHashListWithBlockSize,
     BlockHashWithGroupId,
@@ -71,6 +72,11 @@ class SingleTypeKVCacheManager(ABC):
                 block until the request finishes.
         """
         self.scheduler_block_size = scheduler_block_size
+        # Token alignment of prefix-cache hits for this manager. Defaults to
+        # the scheduler block; the coordinator lowers it to the hash block when
+        # fine-grained partial hash hits are enabled, so retention masks keep
+        # the tails those finer hits need.
+        self.hit_alignment_tokens = scheduler_block_size
         # The block size for this manager; used for actual block allocation.
         self.block_size = kv_cache_spec.block_size
         self.dcp_world_size = dcp_world_size
@@ -399,6 +405,36 @@ class SingleTypeKVCacheManager(ABC):
         self._pending_partial_tail_offloads = []
         return pending
 
+    def _cache_partial_tail_block(
+        self,
+        request: Request,
+        num_tokens: int,
+    ) -> BlockHashWithGroupId | None:
+        """Cache the prompt tail when it ends inside a cache block.
+
+        Only the final prompt hash boundary is registered as a partial
+        prefix-cache entry; intermediate hash boundaries inside the same cache
+        block are intentionally skipped.
+        """
+        hash_block_size = self.block_pool.hash_block_size
+        boundary_tokens = request.num_prompt_tokens // hash_block_size * hash_block_size
+        if boundary_tokens == 0 or boundary_tokens > num_tokens:
+            return None
+        if boundary_tokens % self.block_size == 0:
+            return None
+
+        blocks = self.req_to_blocks[request.request_id]
+        block_idx = boundary_tokens // self.block_size
+        if block_idx >= len(blocks):
+            return None
+        return self.block_pool.cache_partial_block(
+            request=request,
+            block=blocks[block_idx],
+            num_tokens=boundary_tokens,
+            kv_cache_group_id=self.kv_cache_group_id,
+            block_size=self.block_size,
+        )
+
     def _apply_cow(
         self,
         request_id: str,
@@ -455,7 +491,7 @@ class SingleTypeKVCacheManager(ABC):
         block_mask = self.reachable_block_mask(
             start_block=num_cached_blocks,
             end_block=num_full_blocks,
-            alignment_tokens=self.scheduler_block_size,
+            alignment_tokens=self.hit_alignment_tokens,
             kv_cache_spec=self.kv_cache_spec,
             use_eagle=self.use_eagle,
             retention_interval=retention_interval,
@@ -752,16 +788,34 @@ class FullAttentionManager(SingleTypeKVCacheManager):
                 max_length // alignment_tokens,
                 len(block_hashes),
             )
-            for fine_idx in range(max_partial_idx - 1, first_partial_idx - 1, -1):
-                cached_tail = block_pool.get_cached_block(
-                    block_hashes[fine_idx], kv_cache_group_ids
+            # A block's KV is append-only, so a fully cached block also covers
+            # every interior boundary below ``max_length`` (e.g. a re-query at
+            # a rewound length inside the block); the tail is then a partial
+            # hit that the consumer CoW-redirects.
+            partial_block_idx = len(computed_blocks[0])
+            if (
+                max_partial_idx > first_partial_idx
+                and (partial_block_idx + 1) * scale_factor <= len(block_hashes)
+                and (
+                    cached_full := block_pool.get_cached_block(
+                        full_block_hashes[partial_block_idx], kv_cache_group_ids
+                    )
                 )
-                if not cached_tail:
-                    continue
-                for computed, cached in zip(computed_blocks, cached_tail):
+            ):
+                for computed, cached in zip(computed_blocks, cached_full):
                     computed.append(cached)
-                hit_length = (fine_idx + 1) * alignment_tokens
-                break
+                hit_length = max_partial_idx * alignment_tokens
+            else:
+                for fine_idx in range(max_partial_idx - 1, first_partial_idx - 1, -1):
+                    cached_tail = block_pool.get_cached_block(
+                        block_hashes[fine_idx], kv_cache_group_ids
+                    )
+                    if not cached_tail:
+                        continue
+                    for computed, cached in zip(computed_blocks, cached_tail):
+                        computed.append(cached)
+                    hit_length = (fine_idx + 1) * alignment_tokens
+                    break
 
         # Eagle needs the tokens right before the generation point recomputed:
         # drop one hash unit when fine-grained (the tail block's KV is
@@ -789,36 +843,6 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         if self.block_size == hash_block_size:
             return
         self._cache_partial_tail_block(request, num_tokens)
-
-    def _cache_partial_tail_block(
-        self,
-        request: Request,
-        num_tokens: int,
-    ) -> None:
-        """Cache the prompt tail when it ends inside a cache block.
-
-        Only the final prompt hash boundary is registered as a partial
-        prefix-cache entry; intermediate hash boundaries inside the same cache
-        block are intentionally skipped.
-        """
-        hash_block_size = self.block_pool.hash_block_size
-        boundary_tokens = request.num_prompt_tokens // hash_block_size * hash_block_size
-        if boundary_tokens == 0 or boundary_tokens > num_tokens:
-            return
-        if boundary_tokens % self.block_size == 0:
-            return
-
-        blocks = self.req_to_blocks[request.request_id]
-        block_idx = boundary_tokens // self.block_size
-        if block_idx >= len(blocks):
-            return
-        self.block_pool.cache_partial_block(
-            request=request,
-            block=blocks[block_idx],
-            num_tokens=boundary_tokens,
-            kv_cache_group_id=self.kv_cache_group_id,
-            block_size=self.block_size,
-        )
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         blocks = self.req_to_blocks[running_request_id]
@@ -878,6 +902,8 @@ class RSWAManager(FullAttentionManager):
 
 
 class SlidingWindowManager(SingleTypeKVCacheManager):
+    supports_fine_grained_hash_lookup: ClassVar[bool] = True
+
     def __init__(self, kv_cache_spec: SlidingWindowSpec, **kwargs) -> None:
         super().__init__(kv_cache_spec, **kwargs)
         self.sliding_window = kv_cache_spec.sliding_window
@@ -921,12 +947,6 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         assert pcp_world_size == 1 or kv_cache_spec.dcp_replicated, (
             "PCP only supports sliding-window KV when it is replicated."
         )
-        # Fine-grained partial hits are not supported for sliding window now.
-        # Fall back to block-aligned hits instead of crashing the engine when
-        # the coordinator alignment is finer than this group's block size
-        # (e.g. a hybrid mamba target with a finer `prefix_match_unit`).
-        if alignment_tokens % kv_cache_spec.block_size != 0:
-            alignment_tokens = kv_cache_spec.block_size
         block_hashes = resolve_block_hashes(
             block_hashes,
             block_pool.hash_block_size,
@@ -934,6 +954,24 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
             alignment_tokens=alignment_tokens,
         )
+        if (
+            alignment_tokens < kv_cache_spec.block_size
+            and kv_cache_spec.block_size % alignment_tokens == 0
+        ):
+            # Fine-grained mode (alignment_tokens == hash_block_size <
+            # block_size): resolve_block_hashes kept the raw hash-granularity
+            # list so hits can land on boundaries inside a cache block.
+            assert isinstance(block_hashes, list)
+            return cls._find_longest_fine_grained_cache_hit(
+                block_hashes=block_hashes,
+                max_length=max_length,
+                kv_cache_group_ids=kv_cache_group_ids,
+                block_pool=block_pool,
+                kv_cache_spec=kv_cache_spec,
+                drop_eagle_block=drop_eagle_block,
+                alignment_tokens=alignment_tokens,
+            )
+        assert alignment_tokens % kv_cache_spec.block_size == 0
 
         # The number of contiguous blocks needed for a prefix cache hit.
         sliding_window_contiguous_blocks = cls._contiguous_blocks_for_hit(
@@ -1005,6 +1043,163 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         return computed_blocks, hit_length
 
     @classmethod
+    def _fine_grained_need_tokens(
+        cls, window_size: int, alignment_tokens: int, use_eagle: bool
+    ) -> int:
+        """Cached tokens a fine-grained hit ending at a hash boundary needs
+        before that boundary: the sliding window of the next token, plus one
+        hash unit when EAGLE rewinds the hit by that unit (the rewound window
+        starts one unit earlier, so the cached run must reach one unit further
+        back)."""
+        return window_size - 1 + (alignment_tokens if use_eagle else 0)
+
+    @classmethod
+    def _find_longest_fine_grained_cache_hit(
+        cls,
+        block_hashes: list[BlockHash],
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: SlidingWindowSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        """Fine-grained (partial) hit search for sliding window layers.
+
+        Candidates are hash boundaries, probed high-to-low. Boundary ``L``
+        hits when the cache block ending at ``L`` is cached (a full block when
+        ``L`` is block-aligned, else a partial entry keyed by the hash at
+        ``L``) and every full block covering the window before ``L`` is cached
+        too. As in ``FullAttentionManager``, EAGLE rewinds the hit by one hash
+        unit: the required run is one unit longer so the rewound window stays
+        covered, and blocks past the rewound length are trimmed. Blocks before
+        the window are null, as in the block-aligned path.
+        """
+        block_size = kv_cache_spec.block_size
+        num_groups = len(kv_cache_group_ids)
+        scale_factor = block_size // alignment_tokens
+        full_block_hashes = BlockHashListWithBlockSize(
+            block_hashes, alignment_tokens, block_size
+        )
+        need_tokens = cls._fine_grained_need_tokens(
+            kv_cache_spec.sliding_window, alignment_tokens, drop_eagle_block
+        )
+        max_units = min(max_length // alignment_tokens, len(block_hashes))
+        # Per tail block: the highest registered boundary found so far and how
+        # far down the block has been scanned. A block's KV is append-only, so
+        # an entry registered at a higher boundary of the same block covers
+        # every lower boundary (the tail is then a partial hit, CoW-redirected
+        # by the consumer); this is what lets a re-query at a rewound length
+        # land inside a block whose only entry sits further along.
+        tail_found: dict[int, list[KVCacheBlock] | None] = {}
+        tail_scanned_to: dict[int, int] = {}
+        for unit_idx in range(max_units - 1, -1, -1):
+            hit_tokens = (unit_idx + 1) * alignment_tokens
+            tail_block_idx = (hit_tokens - 1) // block_size
+            tail_blocks = tail_found.get(tail_block_idx)
+            if tail_blocks is None:
+                top_unit = min((tail_block_idx + 1) * scale_factor, len(block_hashes))
+                scan_from = tail_scanned_to.get(tail_block_idx, top_unit) - 1
+                for probe_unit in range(scan_from, unit_idx - 1, -1):
+                    probe_tokens = (probe_unit + 1) * alignment_tokens
+                    probe_hash = (
+                        full_block_hashes[tail_block_idx]
+                        if probe_tokens % block_size == 0
+                        else block_hashes[probe_unit]
+                    )
+                    tail_blocks = block_pool.get_cached_block(
+                        probe_hash, kv_cache_group_ids
+                    )
+                    if tail_blocks:
+                        tail_found[tail_block_idx] = tail_blocks
+                        break
+                tail_scanned_to[tail_block_idx] = unit_idx
+            if not tail_blocks:
+                continue
+            first_block_idx = max(0, (hit_tokens - need_tokens) // block_size)
+            run: list[list[KVCacheBlock]] = [[] for _ in range(num_groups)]
+            for block_idx in range(first_block_idx, tail_block_idx):
+                cached = block_pool.get_cached_block(
+                    full_block_hashes[block_idx], kv_cache_group_ids
+                )
+                if not cached:
+                    break
+                for per_group, block in zip(run, cached):
+                    per_group.append(block)
+            else:
+                hit_length = hit_tokens
+                if drop_eagle_block:
+                    hit_length -= alignment_tokens
+                num_blocks = cdiv(hit_length, block_size)
+                computed_blocks = tuple(
+                    [block_pool.null_block] * first_block_idx + per_group + [tail]
+                    for per_group, tail in zip(run, tail_blocks)
+                )
+                for computed in computed_blocks:
+                    del computed[num_blocks:]
+                return computed_blocks, hit_length
+        return tuple([] for _ in range(num_groups)), 0
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+    ) -> None:
+        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        if self.hit_alignment_tokens < self.block_size:
+            # Fine-grained hits may land inside the tail block: register the
+            # prompt's last hash boundary as a partial entry, as full
+            # attention does.
+            self._cache_partial_tail_block(request, num_tokens)
+
+    @classmethod
+    def _fine_grained_reachable_block_mask(
+        cls,
+        start_block: int,
+        end_block: int,
+        alignment_tokens: int,
+        kv_cache_spec: SlidingWindowSpec,
+        use_eagle: bool,
+        retention_interval: int | None,
+        reachable_boundaries: Sequence[int],
+    ) -> list[bool] | None:
+        """Retention mask when hits align to hash units inside a block.
+
+        A hit at hash boundary ``B`` needs the full blocks covering
+        ``[B - need_tokens, B)``; the tail block itself is registered as a
+        partial entry separately. Segment boundaries (``retention_interval``
+        > 0) and reachable boundaries keep exactly those blocks; ``None``
+        retention caches every block.
+        """
+        if retention_interval is None:
+            return None
+        block_size = kv_cache_spec.block_size
+        need_tokens = cls._fine_grained_need_tokens(
+            kv_cache_spec.sliding_window, alignment_tokens, use_eagle
+        )
+        mask = [False] * (end_block - start_block)
+
+        def keep_tail(boundary_tokens: int) -> None:
+            first = max(0, (boundary_tokens - need_tokens) // block_size)
+            last = cdiv(boundary_tokens, block_size)  # exclusive
+            for i in range(max(first, start_block), min(last, end_block)):
+                mask[i - start_block] = True
+
+        if retention_interval > 0:
+            segment = retention_interval
+            if need_tokens + block_size >= segment:
+                # Every block lies in some segment tail; keep them all.
+                return None
+            first_segment = (start_block * block_size) // segment * segment
+            last_token = end_block * block_size + need_tokens
+            for boundary in range(first_segment + segment, last_token + 1, segment):
+                keep_tail(boundary)
+        for boundary_tokens in reachable_boundaries:
+            keep_tail(boundary_tokens // alignment_tokens * alignment_tokens)
+        return mask
+
+    @classmethod
     def reachable_block_mask(
         cls,
         start_block: int,
@@ -1019,6 +1214,19 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         if alignment_tokens is None:
             # Fast path: when the coordinator imposes no alignment constraint.
             return None
+        if (
+            alignment_tokens < kv_cache_spec.block_size
+            and kv_cache_spec.block_size % alignment_tokens == 0
+        ):
+            return cls._fine_grained_reachable_block_mask(
+                start_block,
+                end_block,
+                alignment_tokens,
+                kv_cache_spec,
+                use_eagle,
+                retention_interval,
+                reachable_boundaries,
+            )
         assert alignment_tokens % kv_cache_spec.block_size == 0
 
         block_size = kv_cache_spec.block_size


### PR DESCRIPTION
## TL;DR

Tested with **GLM-5.3-Flash** (NVFP4 and NVFP4-Spark checkpoints, DFlash2 draft) on a four-node DGX Spark TP4 cluster. With `--block-size 2048 --mamba-block-size 256 --prefix-match-unit 256`:

| | Before (256-token pages) | After |
|---|---|---|
| KV cache pool at a 33 GB budget | 1.39M tokens, 5.3x concurrent 262k-token requests | 4.30M tokens, 16.4x |
| Same 5.3x concurrency needs | 33 GB | ~10.7 GB (22 GB per node freed) |
| Prefix-cache reuse granularity | 256 tokens | 256 tokens (unchanged) |
| Decode / prefill throughput | baseline | at parity (within a few %) |
| Long-context correctness (90k needle, estonia) | pass | pass |

Before this change, 2048-token pages were only reachable with 2048-token recurrent blocks, which coarsened prefix reuse to 2048 tokens and cost 8-38% on decode cells with 16k/32k contexts. Other models and attention-only hybrids are not affected by default.

## Baseline and what the numbers mean

The capacity figure is **3.08x** relative to 256-token target pages on the current `dev/jovian-judgement` head (1,394,714 -> 4,297,015 tokens at 33 GB). Upstream #603 now rebalances the split cache groups (`[9, 9, 8, 8, 11]` -> `[5, 5, 5, 5, 5, 5, 4, 11]`), which recovers part of the shared-pool stride waste on its own: the same 256/256 profile gave 791,273 tokens / 3.02x before that change, which is where an earlier 5.4x figure in this PR came from. Images whose split geometry already defaults to 2048-token target pages (e.g. the `auto` geometry, which pairs them with 2048-token recurrent blocks) already have the pool efficiency; against that configuration the contribution of this PR is recovering 256-token prefix reuse and DFlash fine-grained hits while keeping the large pages. The comparison on the same cluster, budget and matrix (decode tok/s per cell, 30 s cells); the 256/256 and 2048/256 rows are a same-image pair on the current head (`a8c796f3a` + b12x `b58f34e` + #667), the 2048/2048 row is from the earlier `a84f907` build:

| Geometry (target/recurrent/match unit) | KV pool @33 GB | c1 @32k | c4 @16k | c16 @32k |
|---|---:|---:|---:|---:|
| 256 / 256 / 256 (production, current head) | 1.39M tokens | 43.1 | 93.3 | 207.2 |
| 2048 / 2048 / 2048 (+ dense retention, a84f907 build) | 4.30M | 36.1 | 69.2 | 186.1 |
| 2048 / 256 / 256 (this PR, current head) | 4.30M | 42.6 | 84.3 | 203.3 |

Across the full 15-cell matrix the current-head pair is at parity: -15% to +12% per cell with no directional trend (2048/256 ahead at c1 and c4 with no context, behind at c4 with 16k/32k, within 6% everywhere at c8/c16), standalone prefill identical (2773/2888/2826 vs 2845/2899/2817 tok/s at 8k/32k/128k), GSM8K-100 96/100 vs 95/100.

The 16.4x "maximum concurrency" is the engine's KV-capacity estimate for 262k-token requests, not a demonstrated throughput at sixteen concurrent 262k requests; the measured cells go up to c16 at 32k context.

## What

Fine-grained prefix-cache hits for sliding-window KV cache groups, and the coordinator/platform changes that let a GLM-5.3-Flash deployment run 2048-token target pages next to 256-token recurrent pages without giving up 256-token prefix reuse.

Motivation: with the split GLM-5.3 cache pages (`VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE`), every cache group draws block ids from one pool whose stride is the largest group's bytes per block. That is a 9-layer GDN group at ~10.3 MB, while an 11-layer MLA group at 256 tokens needs 11 x 143,616 B, so each attention block uses ~15% of its slot. Growing the target block to 2048 tokens matches the pages (11 x 1,148,928 B vs 1,146,880 B) and gives 5.4x the KV capacity for the same budget. But the recurrent block had to be a multiple of the target block, so recurrent checkpoints and prefix hits coarsened to 2048 tokens, and the DFlash draft's sliding-window group made the coordinator disable fine-grained hits entirely (`Disabling fine-grained prefix-cache hits ... SlidingWindowManager`), so `--prefix-match-unit 256` had no effect.

## Details

- `SlidingWindowManager` gains `supports_fine_grained_hash_lookup`. In fine-grained mode a hit lands on a hash boundary `L` when the cache block ending at `L` is registered (a full block, or a partial entry at or beyond `L` in the same append-only block) and the full blocks covering the window before `L` are cached. EAGLE rewinds the hit by one hash unit, as `FullAttentionManager` does, with the covered run extended by that unit so the rewound window stays covered. The prompt's last hash boundary is registered as a partial tail, and the sparse retention mask keeps the window tails those hits need.
- The covering-entry rule matters for the coordinator's fixed-point loop: after the EAGLE rewind the group is re-queried at the rewound length with no margin, and the only registered entry may sit further along the tail block. Without it the reconciled hit cascades to 0 (observed).
- `FullAttentionManager`: a fully cached block also serves interior boundaries below `max_length`, so a re-query at a rewound length inside that block does not fall back a whole block.
- Managers carry `hit_alignment_tokens`; the coordinator sets it to the hash unit when partial hits are enabled so retention masks match hit granularity. `_cache_partial_tail_block` moves to the base class.
- Sparse retention keeps both boundaries: when the hit alignment is finer than the scheduler block, each reachable boundary is expanded to its hash-aligned and scheduler-aligned positions, plus the position one unit below each when an EAGLE group rewinds the reconciled hit. Without this, a recurrent state materialized only at a scheduler-step end was no longer retained and a repeat request resumed from zero (review finding; regression test `test_fine_grained_retention_keeps_scheduler_aligned_fallback`). #643 generalizes the same rule (and applies it to the Mooncake store); whichever lands first, the other rebases onto it.
- `KVCacheCoordinator` also enables partial hash hits for recurrent hybrids whose attention/sliding-window blocks are coarser than the hash unit (an explicit `prefix_match_unit` at the recurrent block). Attention-only hybrids keep block-aligned hits (test included).
- `VLLM_GLM53_SPLIT_MAMBA_BLOCK_SIZE` may now divide the target block instead of only being a multiple of it; the scheduler block is their LCM either way. This composes with the new `auto` split geometry (target block from the retention interval or scheduler budget): `auto` still defaults the recurrent block to the target block, so nothing changes unless a finer recurrent block is requested explicitly.

Serving geometry this was built and tested for (GLM-5.3-Flash only; other GLM-5.x variants were not tested): `--block-size 2048 --mamba-block-size 256 --prefix-match-unit 256` (i.e. `VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE=2048`, `VLLM_GLM53_SPLIT_MAMBA_BLOCK_SIZE=256`).

## Testing

Unit: `tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py` -- retention with prefill in scheduler-sized steps (no finer recurrent checkpoints) and with per-block checkpoints, manager-level fine-grained sliding-window hits (window coverage, EAGLE rewind, covering entry, retention mask), an enable test for the hybrid full-attention + mamba-align + EAGLE sliding-window topology, the EAGLE hash-unit margin under partial hits, attention-only hybrids unchanged, and a decoupled-geometry test asserting that target/draft 16 + recurrent 2 + hash 2 reproduces the all-fine (2/2/2) hit arithmetic exactly for repeat and shared-prefix requests at prompt lengths 13/45/48. `tests/v1/core/prefix_cache`, `test_single_type_kv_cache_manager.py`, `test_prefix_caching.py`, `test_mamba_align_chunk_split.py`: all pass on the rebased branch except four tests that fail identically on the untouched `dev/jovian-judgement` head (`test_mamba_align_split_*` x4: their fake scheduler lacks the `drop_last_prefix_cache_block` attribute a recent scheduler change reads; not touched here). On `f564dffe9` the suite is 54 passed / 4 pre-existing failures on this branch versus 45 passed / the same 4 on the untouched head. `test_hybrid_sliding_window_group_disables_partial_hash_hits` is replaced by the enable test.

Serving, four-node DGX Spark TP4 (GB10, sm_121a, CUDA 13.0, torch 2.13), GLM-5.3-Flash NVFP4 + DFlash2 draft (k=5), fp8 KV, RoCEnante on, 8192-token chunks, 33 GB KV budget. Latest validation: `dev/jovian-judgement@a8c796f3a` + b12x `master@b58f34e` + #667 with this branch's three commits (image `...-dd399e7-b58f34e`; the later rebase onto `b7e3d0336` changed no line of the three commits, `git range-diff` reports all identical). Note the current heads carry an intermittent DFlash speculative-acceptance collapse that is independent of this PR (it reproduces identically at 256/256) and is fixed by #667; the numbers below were taken with that fix applied:

- KV pool at 33 GB: 1,394,714 tokens / 5.32x @262k with 256-token pages on the current head -> 4,297,015 tokens / 16.39x with 2048/256/256 (791,273 / 3.02x for 256-token pages before upstream #603 rebalanced the split groups).
- Prefix reuse: a shared-prefix request to a 52k prompt hits `n//256*256 - 256` tokens (51,968 of 52,445) in 0.62 s, the same arithmetic as 256-token pages; with 2048/2048 (no fine-grained hits) the same request hit 45,056 in 1.4 s and 16k/32k-context decode cells lost 8-38% to prefill.
- `llm-inference-bench` decode matrix (c=1,2,4,8,16 x 0/16k/32k, 30 s cells) vs the 256-page profile, same image: -15% to +12% per cell with no directional trend; standalone cold prefill 8k/32k/128k within 3%; GSM8K-100 @c16 95/100 vs 96/100. The per-cell spread is run-to-run noise rather than a geometry effect: two builds that differ only by two unrelated collective commits reproduce the same matrix with up to 19% difference on the same cell (c2@16k), and the c2/c4 cells with context are the noisiest in both directions.
- Correctness with the Spark checkpoint (`GLM-5.3-Flash-NVFP4-Spark`): single-stream 90k needle 4/4 (temp 0), 4-stream needle 12/12, estonia c4 x 30 across four builds: 30/30 completed every time, 26-30/30 PASS, 0 DECOY (no run ever answered the planted wrong country; the misses are unparseable or "not stated" answers, which the quality bar counts against the run).
- Async scheduling on: a 2h11m 8-cycle soak (decode matrix + prefill sweep + GSM8K @c16 per cycle) with an engine-step stall monitor, 0 stalls, 0 engine errors. Note: on a build from 83cb22a + b12x 4152c5b the same geometry with async scheduling hung once on a decode step (all ranks stuck in a kernel launch, GPU at 96%); it did not reproduce on b12x >= 9ae41c5 (which includes "fix(gemm): wait for persistent epilogue stores"), so this change should ride on those heads.

### Independent validation on SM120

A reviewer applied these commits as a 3-way merge onto the community r25 image (vLLM `a4b04eea0` + baked patches) and ran them on 4x RTX PRO 6000 Blackwell WS with the official GLM-5.3-Flash-NVFP4 checkpoint, marlin MoE, MTP k=2, KV `nvfp4_ds_mla`, an LMCache sidecar (64G L1 + 128G L2 tmpfs), DCP=1, at target 2048 / recurrent 256 / match unit 256:

| Prefix reuse on that box | Before | After |
|---|---|---|
| Serial 25k prompt, cold -> hot TTFT | 3.68 s | 0.37 s |
| 16 streams sharing a 32k prefix, TTFT | - | 2.56 s (all) |
| Needle at 64k riding the shared prefix | 11.8 s | 2.3 s |
| Needle at ~620k riding the shared prefix | 99.5 s | 9.6 s |

Their GPU KV pool was 4.20M tokens (4.01x @ 1M `max_model_len`) versus 4.16M for their 2048/2048 baseline at the same 0.863 utilization: parity, because r25's `auto` geometry already resolves 2048-token target pages there. That is the same point as the baseline section above -- on a build that already runs large target pages this PR's contribution is the fine-grained hits, not the pool.

Not measured: other models (only GLM-5.3-Flash was tested), DCP/PCP > 1 (the mamba finder asserts DCP 1 as before), and hybrids where a sliding-window group is not the EAGLE group.

## Duplicate check

`gh pr list --state open --search "prefix_match_unit OR fine-grained OR SlidingWindowManager OR partial hash"` returns nothing related; #616/#622 touch the C4 indexer path, not the cache managers.

## Conventions

`ruff check` and `ruff format --check` (0.14.0, repo pyproject) pass; pre-commit hooks pass except the mypy hook, which was skipped for the commit (the two typing findings it raised were fixed: `BlockHash` list narrowing at the finder call site, and `_cache_partial_tail_block` returning `BlockHashWithGroupId | None` in the base class to match the mamba override). Commits are DCO signed.

## AI assistance

The analysis, the change, the tests and the cluster measurements were produced with AI assistance (Claude); the submitter reviewed the changed lines and ran the serving tests on our cluster.

## Assumptions to check in review

- The EAGLE margin for a fine-grained sliding-window group is one hash unit (`eagle_margin = hash_block_size` in the coordinator when the group's block is coarser than the hash unit); the finder extends the required cached run by that unit rather than by a block.
- Enabling partial hits for recurrent hybrids with coarse attention blocks is gated on a mamba-align group being present, so attention-only hybrids see no behaviour change. If a broader gate is preferred (any group coarser than the hash unit), the existing test_prefix_caching SWA/FA expectations would need to move with it.
- A recurrent block finer than the target block relies on the scheduler block being the LCM (2048 here) and the mamba group hitting at hash granularity; nothing else in the split path assumed the old ordering as far as the serving tests show.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved prefix-cache reuse for hybrid attention configurations, including sliding-window and EAGLE decoding.
  * Requests can now reuse cached prefixes at finer-grained boundaries, including portions of previously cached blocks.
  * Improved cache retention and reuse when attention windows or sparse cache layouts are involved.
  * Added support for more flexible cache block sizing in GLM-5.3 configurations.
* **Bug Fixes**
  * Corrected cache-hit alignment and EAGLE rewind behavior for hybrid decoding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
