### PR TITLE
logits: gather top-k values and ids in one exchange

### DIFF
--- a/tests/v1/sample/test_top_k_tokens.py
+++ b/tests/v1/sample/test_top_k_tokens.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the vocab-parallel top-k reduction of ``LogitsProcessor``."""
+
+import types
+from unittest import mock
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+
+_ALL_GATHER = (
+    "vllm.model_executor.layers.logits_processor.tensor_model_parallel_all_gather"
+)
+
+
+class _PlainLinear:
+    """A platform-independent stand-in for the lm_head's quant method."""
+
+    def apply(self, layer, x: torch.Tensor, bias: torch.Tensor | None = None):
+        return torch.nn.functional.linear(x, layer.weight, bias)
+
+
+class _FakeShardHead:
+    """One vocab shard of an lm_head, as ``get_top_k_tokens`` sees it."""
+
+    def __init__(self, weight: torch.Tensor, vocab_start: int, tp_size: int):
+        self.weight = weight
+        self.quant_method = _PlainLinear()
+        self.shard_indices = types.SimpleNamespace(
+            num_org_vocab_padding=0, org_vocab_start_index=vocab_start
+        )
+        self.tp_size = tp_size
+
+
+def _shard_heads(weight: torch.Tensor, tp_size: int) -> list[_FakeShardHead]:
+    shard = weight.shape[0] // tp_size
+    return [
+        _FakeShardHead(weight[r * shard : (r + 1) * shard], r * shard, tp_size)
+        for r in range(tp_size)
+    ]
+
+
+def _assert_top_k(
+    ids: torch.Tensor,
+    values: torch.Tensor,
+    full: torch.Tensor,
+    k: int,
+    transform=lambda v: v.float(),
+) -> None:
+    """``(ids, values)`` is a top-k of ``full``; ties may order differently."""
+    expected_values, _ = torch.topk(full, k, dim=-1)
+    assert ids.dtype == torch.int64
+    assert ids.shape == values.shape == (full.shape[0], k)
+    for row in ids:
+        assert len(set(row.tolist())) == k, "duplicate ids in one row"
+    torch.testing.assert_close(values, transform(expected_values))
+    torch.testing.assert_close(values, transform(full.gather(-1, ids)))
+
+
+def _simulate_tp(
+    lp: LogitsProcessor,
+    heads: list[_FakeShardHead],
+    hidden_states: torch.Tensor,
+    k: int,
+) -> tuple[list[tuple[torch.Tensor, torch.Tensor]], list[torch.Tensor]]:
+    """Run ``get_top_k_tokens`` on every rank with a simulated all-gather.
+
+    The first pass records each rank's gather input; the second pass answers
+    every rank with the concatenation of all recorded inputs, exactly as the
+    collective would.  Returns the per-rank results and the recorded inputs.
+    """
+
+    inputs: list[torch.Tensor] = []
+
+    def record(inp: torch.Tensor, dim: int = -1) -> torch.Tensor:
+        assert dim == -1
+        inputs.append(inp.clone())
+        return torch.cat([inp] * len(heads), dim=-1)
+
+    with mock.patch(_ALL_GATHER, side_effect=record):
+        for head in heads:
+            lp.get_top_k_tokens(head, hidden_states, k)
+    assert len(inputs) == len(heads), "one all-gather per rank"
+
+    def answer(inp: torch.Tensor, dim: int = -1) -> torch.Tensor:
+        assert dim == -1
+        assert any(torch.equal(inp, seen) for seen in inputs)
+        return torch.cat(inputs, dim=-1)
+
+    results = []
+    with mock.patch(_ALL_GATHER, side_effect=answer):
+        for head in heads:
+            results.append(lp.get_top_k_tokens(head, hidden_states, k))
+    return results, inputs
+
+
+@pytest.mark.parametrize("tp_size", [2, 4])
+@pytest.mark.parametrize("k", [16, 7])
+def test_top_k_tokens_single_packed_gather(default_vllm_config, tp_size, k):
+    """Values and ids travel in one fp32 exchange and reduce to the global top-k."""
+    torch.manual_seed(0)
+    vocab_size, hidden_size, batch = 256, 32, 5
+    hidden_states = torch.randn(batch, hidden_size, dtype=torch.bfloat16)
+    weight = torch.randn(vocab_size, hidden_size, dtype=torch.bfloat16)
+    lp = LogitsProcessor(vocab_size)
+
+    results, inputs = _simulate_tp(lp, _shard_heads(weight, tp_size), hidden_states, k)
+
+    for inp in inputs:
+        assert inp.dtype == torch.float32
+        assert inp.shape == (batch, 2 * k)
+        # ids ride along bit-exact as int32 in the second half of the row
+        ids = inp[:, k:].contiguous().view(torch.int32)
+        assert ids.min() >= 0 and ids.max() < vocab_size
+
+    full = torch.nn.functional.linear(hidden_states, weight)
+    for ids, values in results:
+        _assert_top_k(ids, values, full, k)
+
+
+def test_top_k_tokens_applies_scale_and_soft_cap_after_reduction(default_vllm_config):
+    torch.manual_seed(1)
+    vocab_size, hidden_size, batch, k, tp_size = 128, 16, 3, 4, 2
+    hidden_states = torch.randn(batch, hidden_size, dtype=torch.bfloat16)
+    weight = torch.randn(vocab_size, hidden_size, dtype=torch.bfloat16)
+    lp = LogitsProcessor(vocab_size, scale=0.5, soft_cap=2.0)
+
+    results, _ = _simulate_tp(lp, _shard_heads(weight, tp_size), hidden_states, k)
+
+    full = torch.nn.functional.linear(hidden_states, weight)
+    for ids, values in results:
+        _assert_top_k(
+            ids, values, full, k, lambda v: torch.tanh(v.float() * 0.5 / 2.0) * 2.0
+        )
+
+
+def test_top_k_tokens_tp1_skips_the_gather(default_vllm_config):
+    torch.manual_seed(2)
+    vocab_size, hidden_size, batch, k = 64, 16, 2, 8
+    hidden_states = torch.randn(batch, hidden_size, dtype=torch.bfloat16)
+    weight = torch.randn(vocab_size, hidden_size, dtype=torch.bfloat16)
+    lp = LogitsProcessor(vocab_size)
+    head = _FakeShardHead(weight, 0, tp_size=1)
+
+    with mock.patch(_ALL_GATHER) as all_gather:
+        ids, values = lp.get_top_k_tokens(head, hidden_states, k)
+    all_gather.assert_not_called()
+
+    full = torch.nn.functional.linear(hidden_states, weight)
+    _assert_top_k(ids, values, full, k)

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -354,10 +354,23 @@ class LogitsProcessor(PluggableLayer):
         ids = ids.to(torch.int64) + lm_head.shard_indices.org_vocab_start_index
 
         if lm_head.tp_size > 1:
-            values = tensor_model_parallel_all_gather(values, dim=-1)
-            ids = tensor_model_parallel_all_gather(ids, dim=-1)
+            # One exchange carries both the values and the ids: the fp32
+            # values and the int32 ids (bit-cast, not converted) share a
+            # [..., 2k] fp32 row per rank.  One collective instead of two,
+            # 8 bytes per candidate instead of 10, and for even k the rows are
+            # 16-byte multiples, which the RoCE all-gather writes in place.
+            # Vocab ids fit in int32 and the values are widened to fp32 for
+            # the final scaling anyway, so nothing is lost in the packing.
+            batch_shape = values.shape[:-1]
+            packed = torch.cat(
+                [values.float(), ids.to(torch.int32).view(torch.float32)], dim=-1
+            )
+            gathered = tensor_model_parallel_all_gather(packed, dim=-1)
+            gathered = gathered.view(*batch_shape, lm_head.tp_size, 2 * k)
+            values = gathered[..., :k].reshape(*batch_shape, -1)
+            ids = gathered[..., k:].reshape(*batch_shape, -1).view(torch.int32)
             values, selected = _topk(values, k)
-            ids = ids.gather(-1, selected)
+            ids = ids.gather(-1, selected).to(torch.int64)
 
         values = values.float()
         if self.scale != 1.0:


### PR DESCRIPTION
## TL;DR

The vocab-parallel top-k reduction ran **two** all-gathers per call, one for the selected values and one for the int64 ids. With DFlash candidate selection that is two small collectives on every draft step. This packs both into one exchange.

For GLM-5.3-Flash (DFlash2, `selector_top_k=16`) at a decode batch of 80 rows on a four-node TP4 cluster:

| | Before | After |
|---|---|---|
| Collectives per draft step | 2 | **1** |
| Bytes on the wire | 2,560 B (bf16 values) + 10,240 B (int64 ids) = 12,800 B | **10,240 B** |
| Bytes per candidate | 10 (2 + 8) | **8** (4 + 4) |

## What

Pack the fp32 values and the ids (as int32, **bit-cast rather than converted**) into one `[..., 2k]` fp32 row per rank, gather that once, then split it back before the final `_topk` + `gather`. Vocab ids fit in int32 (154,880 for this model, and `torch.int32` covers any vocab vLLM supports) and the values are widened to fp32 for the final scale/soft-cap anyway, so nothing is lost in the packing.

For even `k` the packed rows are 16-byte multiples, which matters for backends that write the concatenated layout directly; for odd `k` the row is 8-byte aligned and the collective takes whichever fallback the backend already has. Both are covered by tests.

## Measured

Graph-captured all-gather latency on the target fabric (four-node DGX Spark TP4, GB10, dual-rail ConnectX-7 RoCE, cross-rank median-of-slowest, `benchmarks/benchmark_roce_oneshot.py` from b12x, bit-exactness gated before and after timing):

| shard | latency |
|---|---|
| 1 KB | 14.9 us |
| 4 KB | 16.1 us |
| 8 KB | 17.1 us |

The two gathers this replaces are a 2.5 KB one and a 10 KB one, so roughly **32 us -> 17 us** per draft step by interpolation on that curve. (Derived from the size sweep, not a directly instrumented draft step.) Paired with local-inference-lab/b12x#315, which sizes the all-gather grid to the message, the single 10 KB gather drops further to ~12.5 us.

**End-to-end this is not visible.** Against a 59-210 ms inter-token latency, ~15 us per draft step is under 0.03%, and the decode matrix (c=1,2,4,8,16 x 0/16k/32k) and GSM8K-100 (95/100 vs 96/100) came back at parity with the build without this change; the per-cell spread between those two runs is run-to-run noise. The motivation is halving the collective count on the draft path and shrinking the message, not a throughput claim.

## Numerics

One deliberate difference: the cross-rank selection now compares fp32 values where it previously compared the values in the head's dtype (bf16 here). The `.float()` happened immediately after the reduction before, so the returned values are unchanged; the only effect is that near-ties between shards are resolved at higher precision. Ids are bit-cast, never converted, so no id can be perturbed by a float round-trip.

## Testing

- `tests/v1/sample/test_top_k_tokens.py` (new, CPU, no GPU required): simulates the tensor-parallel exchange by recording each rank's gather input and answering every rank with the concatenation, for tp 2 and 4 and even (16) and odd (7) `k`. Asserts the exchange is a single fp32 `[batch, 2k]` tensor, that the ids survive the bit-cast in range, that the result is a genuine top-k of the full unsharded logits (tie-tolerant: distinct ids, values matching both `topk` and a `gather` at the returned ids), that scale and soft cap are applied after the reduction, and that tp 1 does not gather at all.
- Serving: four-node DGX Spark TP4, GLM-5.3-Flash NVFP4 + DFlash2 draft (k=5), fp8 KV, 8192-token chunks. The engine's first routed gather goes from `(80, 16) bfloat16` to `(80, 32) float32`, confirming the packed path is live; decode matrix and GSM8K as above, 0 engine errors.

## Related

- local-inference-lab/b12x#315 sizes the RoCE all-gather grid to the message; the two together take the draft-step gather from two full-grid collectives to one one-to-two-block collective. They are independent -- either can land first.
- Built and tested together on `dev/jovian-judgement@5c90fc8b9`; this branch is rebased onto `f564dffe9`.

## Conventions

`ruff check`, `ruff format --check` and pre-commit pass (mypy hook skipped, as elsewhere in this repo's flow). Commit is DCO signed.

## AI assistance

The change, the tests and the cluster measurements were produced with AI assistance (Claude); the submitter reviewed the changed lines and ran the tests on our cluster.
