### PR TITLE
fix(router): preserve FP32 gate outputs on SM120

### DIFF
--- a/tests/kernels/test_gate_linear_rocm_dispatch.py
+++ b/tests/kernels/test_gate_linear_rocm_dispatch.py
@@ -108,7 +108,7 @@ def test_rocm_set_out_dtype_respects_bias_guard(monkeypatch):
     assert not gate.allow_cublas_router_gemm
 
 
-def test_sm120_enables_only_ll_bf16_router(monkeypatch):
+def test_sm120_enables_bf16_fp32_paths_without_datacenter_kernels(monkeypatch):
     gate = _make_gate(
         monkeypatch,
         is_rocm=False,
@@ -119,7 +119,7 @@ def test_sm120_enables_only_ll_bf16_router(monkeypatch):
     assert gate.allow_ll_bf16_gemm
     assert not gate.allow_specialized_router_gemm
     assert not gate.allow_dsv3_router_gemm
-    assert not gate.allow_cublas_router_gemm
+    assert gate.allow_cublas_router_gemm
 
 
 def test_sm120_ll_bf16_respects_bias(monkeypatch):
@@ -132,6 +132,7 @@ def test_sm120_ll_bf16_respects_bias(monkeypatch):
     )
 
     assert not gate.allow_ll_bf16_gemm
+    assert not gate.allow_cublas_router_gemm
 
 
 def test_sm120_force_fp32_compute_preserves_fp32_weight_contract(monkeypatch):
@@ -145,6 +146,7 @@ def test_sm120_force_fp32_compute_preserves_fp32_weight_contract(monkeypatch):
 
     assert gate.weight.dtype == torch.float32
     assert not gate.allow_ll_bf16_gemm
+    assert not gate.allow_cublas_router_gemm
 
 
 def test_sm120_set_out_dtype_enables_ll_bf16(monkeypatch):
@@ -157,5 +159,19 @@ def test_sm120_set_out_dtype_enables_ll_bf16(monkeypatch):
     )
 
     assert not gate.allow_ll_bf16_gemm
+    assert not gate.allow_cublas_router_gemm
     gate.set_out_dtype(torch.float32)
     assert gate.allow_ll_bf16_gemm
+    assert gate.allow_cublas_router_gemm
+
+
+def test_sm120_bf16_output_does_not_enable_fp32_gemm(monkeypatch):
+    gate = _make_gate(
+        monkeypatch,
+        is_rocm=False,
+        is_cuda=True,
+        device_capability=(12, 0),
+        out_dtype=torch.bfloat16,
+    )
+    assert not gate.allow_ll_bf16_gemm
+    assert not gate.allow_cublas_router_gemm

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -123,14 +123,15 @@ class GateLinear(ReplicatedLinear):
         # Fused bf16 x bf16 -> fp32 GEMM eligibility. torch.mm's out_dtype
         # epilogue folds the fp32 cast into the GEMM, removing the standalone
         # bf16->fp32 copy kernel that otherwise runs before grouped_topk.
-        # cuBLAS on CUDA (SM90+, via allow_specialized_router_gemm); hipBLASLt on
-        # ROCm, which supports the same out_dtype epilogue.
+        # SM120 supports this cuBLAS epilogue, but not the datacenter-only
+        # specialized router kernels above. Preserve FP32 logits when M>16
+        # falls through the low-latency BF16 kernel's range.
         self._router_gemm_no_bias = not bias
+        self._can_use_cublas_bf16_fp32 = self._can_use_ll_bf16 or (
+            current_platform.is_rocm() and self._router_gemm_no_bias
+        )
         self.allow_cublas_router_gemm = (
-            (
-                self.allow_specialized_router_gemm
-                or (current_platform.is_rocm() and self._router_gemm_no_bias)
-            )
+            self._can_use_cublas_bf16_fp32
             and self.weight.dtype == torch.bfloat16
             and self.out_dtype == torch.float32
         )
@@ -162,10 +163,7 @@ class GateLinear(ReplicatedLinear):
 
         if (
             not self.allow_cublas_router_gemm
-            and (
-                self.allow_specialized_router_gemm
-                or (current_platform.is_rocm() and self._router_gemm_no_bias)
-            )
+            and self._can_use_cublas_bf16_fp32
             and out_dtype == torch.float32
         ):
             self.allow_cublas_router_gemm = self.weight.dtype == torch.bfloat16


### PR DESCRIPTION
**Ready for review/testing. Validation on the exact refreshed PR head is pending.**

## Why this matters

The router chooses which expert networks handle each token. On SM120, one
fallback rounded its scores to BF16 before returning them as FP32. That
unnecessary rounding could change which experts were selected.

This uses the existing FP32-output cuBLAS path instead. It keeps the BF16
weights, small-batch fast path and bias safeguards unchanged.

## How we proved it

Using the same real GLM layer-9 weights and seeded inputs, we compared expert
choices with a higher-precision FP64 calculation:

| Prior R25 test | Before | After |
|---|---:|---:|
| Expert-choice disagreements, 32 inputs | 2/32 | 0/32 |
| Expert-choice disagreements, 4096 inputs | 104/4096 | 1/4096 |
| Dispatch regression tests | 10 pass, 2 fail | 12 pass |

GPU graph replay also passed with changed inputs. **The extra rounding is
proven; a universal model-quality improvement is not.** One disagreement
remains, so this is not exact FP64 routing.

[Raw logs, runnable probe, full configuration and model/performance results](https://gist.github.com/MadeBy561/90b728c7b6b329895719a1e812d36534).

## Scope and testing

Prior rig: **GLM-5.3-Flash-NVFP4, TP4/DCP1, Marlin MTP3; 4× RTX PRO 6000
Blackwell Max-Q, 300 W/card, +6000 memory OC, zero core OC.**

The combined router + sampling fix passed Estonia 30/30, LAVD 30/30 and
GSM8K 64/64 with normal thinking; MMLU-Pro 49/64 and tools 8/16 remain imperfect.
These are **combined**, exploratory R25 results, not this PR in isolation.
Warm verifier speed was approximately unchanged, but warm C1 output was
4.3% lower and Sieve median 3.9% lower. No speedup claim.

Current-head pre-commit and diff checks passed. **Pending:** GPU and
normal-thinking model/performance tests on this exact PR head, plus isolated
router evaluation. Production was untouched.

<details>
<summary>Technical reproduction, base and attribution</summary>

Base: `dev/jovian-judgement` at `f564dffe9`; commit `d512eeb71`.
The changed source/test files match the audited R25 versions.
Correction: enable `allow_cublas_router_gemm` for eligible SM120 gates at
construction and `set_out_dtype`. No new kernel or flag.

```bash
.venv/bin/python -m pytest -q -p no:cacheprovider \
  tests/kernels/test_gate_linear_rocm_dispatch.py
pre-commit run --hook-stage pre-commit
git diff --check
```

Duplicate checks found no equivalent open JJ fix. Upstream #44343 targets
a different FP32-weight kernel; this fixes BF16-weight dispatch.
Companions: #653 and [B12X #317](https://github.com/local-inference-lab/b12x/pull/317).

AI assistance: OpenAI Codex under MadeBy561's direction. Human line-by-line
review remains pending.

</details>
