### PR TITLE
[BugFix] Materialize retained hybrid replay checkpoints during prefill

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -4,6 +4,8 @@
 "align") models: scheduler chunk splitting, partial tail registration, CoW
 on partial hits, and same-step deferral."""
 
+import unittest
+from dataclasses import replace
 from math import lcm
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -133,6 +135,7 @@ def test_mamba_align_split_partial_tail_schedule(dcp_world_size: int):
         max_num_scheduled_tokens=8192,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         use_eagle=False,
+        drop_last_prefix_cache_block=False,
         hash_block_size=hash_block_size,
         dcp_world_size=dcp_world_size,
         scheduler_block_size=scheduler_block_size,
@@ -181,6 +184,7 @@ def test_mamba_align_split_when_block_exceeds_scheduling_budget():
         max_num_scheduled_tokens=token_budget,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         use_eagle=False,
+        drop_last_prefix_cache_block=False,
         hash_block_size=32,
         mamba_partial_cache_hit=False,
         mamba_has_prefill_checkpoint_blocks=False,
@@ -220,6 +224,7 @@ def test_mamba_align_split_when_block_exceeds_long_prefill_threshold():
             long_prefill_token_threshold=long_prefill_threshold
         ),
         use_eagle=False,
+        drop_last_prefix_cache_block=False,
         hash_block_size=32,
         mamba_partial_cache_hit=False,
         mamba_has_prefill_checkpoint_blocks=False,
@@ -2195,3 +2200,133 @@ def test_dcp_partial_hit_with_eagle_rewinds_one_hash_unit():
     assert num_computed == 4
     assert [len(group) for group in computed_blocks.blocks] == [1, 1]
     assert manager.allocate_slots(req1, 4, num_computed, computed_blocks) is not None
+
+
+class TestSemanticReplayCheckpoints(unittest.TestCase):
+    def manager(self, block, draft):
+        config = _make_hybrid_swa_eagle_config(
+            block, 2048, block, 2048, num_blocks=4096
+        )
+        config.kv_cache_groups[1].kv_cache_spec = replace(
+            config.kv_cache_groups[1].kv_cache_spec, num_prefill_checkpoint_blocks=1
+        )
+        if draft == "mtp":
+            config.kv_cache_groups[2].kv_cache_spec = FullAttentionSpec(
+                block_size=2048, num_kv_heads=1, head_size=1, dtype=torch.float32
+            )
+        return make_kv_cache_manager(
+            config,
+            max_model_len=524288,
+            enable_caching=True,
+            hash_block_size=block,
+            use_eagle=True,
+            retention_interval=0,
+        )
+
+    def test_large_chunk_materializes_a_reusable_replay_state(self):
+        manager = self.manager(256, "mtp")
+        scheduler = SimpleNamespace(
+            cache_config=SimpleNamespace(
+                block_size=2048,
+                prefix_cache_retention_interval=0,
+                mamba_cache_mode="align",
+            ),
+            kv_cache_manager=manager,
+            block_size=2048,
+            scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+            drop_last_prefix_cache_block=True,
+            mamba_has_prefill_checkpoint_blocks=True,
+            use_eagle=True,
+            max_num_scheduled_tokens=8192,
+            hash_block_size=256,
+            mamba_partial_cache_hit=True,
+        )
+        request = make_request("cold", list(range(65536)), 256, sha256)
+        steps = 0
+        while request.num_computed_tokens < request.num_prompt_tokens:
+            budget = min(8192, request.num_prompt_tokens - request.num_computed_tokens)
+            step = Scheduler._mamba_block_aligned_split(scheduler, request, budget)
+            self.assertGreater(step, 0)
+            self.assertLessEqual(step, budget)
+            self.assertIsNotNone(manager.allocate_slots(request, step))
+            request.num_computed_tokens += step
+            manager.new_step_starts()
+            steps += 1
+            self.assertLessEqual(steps, 16)
+        self.assertIsNotNone(manager.allocate_slots(request, 1))
+        request.num_computed_tokens += 1
+        manager.new_step_starts()
+        manager.free(request)
+        manager.new_step_starts()
+        _, hit, _ = manager.get_computed_blocks(
+            make_request("repeat", list(range(65536)), 256, sha256)
+        )
+        self.assertGreaterEqual(hit, 65024)
+
+    def test_swa_preserves_the_materialized_recurrent_fallback(self):
+        manager = self.manager(256, "dflash")
+        _prefill_and_free(
+            manager, make_request("cold", list(range(65536)), 256, sha256), 4096
+        )
+        retained = {
+            b.block_hash_num_tokens
+            for b in manager.block_pool.blocks
+            if b.block_hash and get_group_id(b.block_hash) == 1
+        }
+        self.assertIn(61440, retained)
+        _, hit, _ = manager.get_computed_blocks(
+            make_request("repeat", list(range(65536)), 256, sha256)
+        )
+        self.assertGreaterEqual(hit, 61440)
+
+    def test_fine_checkpoint_keeps_the_rewind_stop(self):
+        manager = self.manager(256, "mtp")
+        scheduler = SimpleNamespace(
+            cache_config=SimpleNamespace(
+                block_size=2048, prefix_cache_retention_interval=0
+            ),
+            kv_cache_manager=manager,
+            block_size=2048,
+            scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+            drop_last_prefix_cache_block=True,
+            mamba_has_prefill_checkpoint_blocks=True,
+            use_eagle=True,
+            max_num_scheduled_tokens=4096,
+            hash_block_size=256,
+            mamba_partial_cache_hit=True,
+        )
+        request = make_request("tail", list(range(8449)), 256, sha256)
+        request.num_computed_tokens = 6144
+        # The worker captures 8448 internally. Lookup also needs 8192.
+        step = Scheduler._mamba_block_aligned_split(scheduler, request, 2305)
+        self.assertEqual(step, 2048)
+
+
+def test_semantic_checkpoints_support_unitary_recurrent_coordinator():
+    config = _make_hybrid_swa_eagle_config(2048, 2048, 2048, 2048, num_blocks=128)
+    config.kv_cache_groups = [config.kv_cache_groups[1]]
+    manager = make_kv_cache_manager(
+        config,
+        max_model_len=524288,
+        enable_caching=True,
+        hash_block_size=2048,
+        retention_interval=0,
+    )
+    assert not hasattr(manager.coordinator, "_cache_hit_alignment_tokens")
+    scheduler = SimpleNamespace(
+        cache_config=SimpleNamespace(
+            block_size=2048, prefix_cache_retention_interval=0
+        ),
+        kv_cache_manager=manager,
+        block_size=2048,
+        scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+        drop_last_prefix_cache_block=False,
+        mamba_has_prefill_checkpoint_blocks=True,
+        use_eagle=False,
+        max_num_scheduled_tokens=8192,
+        hash_block_size=2048,
+        mamba_partial_cache_hit=False,
+    )
+    request = make_request("unitary-tail", list(range(65536)), 2048, sha256)
+    request.num_computed_tokens = 61440
+    assert Scheduler._mamba_block_aligned_split(scheduler, request, 4096) == 2048

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1087,6 +1087,7 @@ def test_hybrid_cache_mamba_align_shared_prefix_detection():
         max_num_scheduled_tokens=3 * block_size,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         use_eagle=False,
+        drop_last_prefix_cache_block=False,
         hash_block_size=block_size,
         mamba_partial_cache_hit=False,
         mamba_has_prefill_checkpoint_blocks=False,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -611,6 +611,36 @@ class Scheduler(SchedulerInterface):
             if start < request.shared_prefix_boundary < end
             else 0,
         )
+        if getattr(self.cache_config, "prefix_cache_retention_interval", None) == 0:
+            # Retention cannot preserve a recurrent state that prefill skipped.
+            # Use the same fine and coarse replay positions as the cache masks.
+            managers = [
+                manager
+                for manager in self.kv_cache_manager.coordinator.single_type_managers
+                if isinstance(manager.kv_cache_spec, MambaSpec)
+            ]
+            boundaries = [request.num_prompt_tokens - 1]
+            if request.shared_prefix_boundary:
+                boundaries.append(request.shared_prefix_boundary)
+            reuse_stops = {
+                position
+                for manager in managers
+                for position in manager._expand_reachable_boundaries(boundaries)
+                if start < position < end
+            }
+            if use_internal_checkpoint:
+                # The worker's checkpoint grid belongs to each recurrent group.
+                internal_positions = {
+                    end // manager.block_size * manager.block_size
+                    if end % manager.block_size
+                    else None
+                    for manager in managers
+                }
+                if len(internal_positions) == 1:
+                    internal = internal_positions.pop()
+                    if internal is not None and internal > start:
+                        reuse_stops.discard(internal)
+            stops = (*stops, *reuse_stops)
         # Stop at the earliest mandatory position strictly inside the chunk.
         end = min((s for s in stops if start < s < end), default=end)
         return max(end - start, 0)


### PR DESCRIPTION
Large prefill chunks can skip the recurrent states required by a subsequent prefix-cache lookup. With target block2048, recurrent block256, hash unit256, and semantic retention, the included 65536-token replay reproducer returns zero cached tokens on the current #646 head. This change schedules the missing checkpoints and restores at least 65024 reusable tokens.

## Scope and merge order

This draft targets the head branch of #646 (`prefix-cache/swa-fine-grained-hits`) so its diff contains only the follow-up. Merge it into that branch before merging #646, or retarget after #646 lands.

The latest #646 already fixes coarse fallback retention. Its window-retention regression passes before this change, so this PR does not copy that fix. Existing #643 remains responsible for the broader coarse-retention and connector changes; #645 remains the separate event-publication PR. #463 addresses worker resume indexing on Infernal Invocation, while this change addresses scheduler checkpoint materialization on Jovian Judgement.

## Changes

- Under semantic retention, materialize fine/coarse replay and shared-prefix checkpoints using the same boundary expansion as the cache masks.
- Treat an internal checkpoint as covering a stop only when all recurrent groups agree on that position, using each group's block size.
- Avoid the hybrid-only `_cache_hit_alignment_tokens` property. A real single-group recurrent coordinator is covered.
- Repair five stale dense-mode scheduler test cases by supplying their existing `drop_last_prefix_cache_block=False` fixture field. Their assertions are unchanged.

Chunk stops remain bounded by the requested budget. This does not change KV tensor layout, sampling, model weights, or the default scheduler policy. It does not force every prefill chunk to stop at each 256-token page.

## Validation

The final tests were run against the unchanged #646 scheduler first: three failures and one pass. The failures cover large-chunk cache reuse, the fine-checkpoint rewind stop, and single-group checkpoint materialization. The already-fixed window-retention case passes on both versions.

CPU commands in the LP26 runtime dependency environment, with this source checkout mounted and no GPU devices:

```text
pytest tests/v1/core/prefix_cache tests/v1/core/test_mamba_align_chunk_split.py tests/v1/core/test_prefix_caching.py -q
```

190 passed. No tests were skipped to accommodate this change.

Ruff check, Ruff format, and git diff whitespace checks pass for the changed files.

The prior local r25 implementation of these checkpoint invariants was GPU-qualified on 4x RTX PRO 6000 Blackwell, GLM-5.3-Flash NVFP4, DFlash2 K3, Marlin, TP4/DCP1, FP8 KV, and 524288 context:

- 64k warm replay reused 65280 tokens and reduced TTFT from 6.373s cold to 0.200s warm.
- 491520-token retrieval passed cold and warm, with 491264 reused tokens and identical prompt hashes.
- Required/streamed tools, literal-delimiter parser safety, one/four-image inputs, and all 64 turns in a 16-agent continuation test passed.
- No preemptions, restarts, or fatal CUDA errors were observed during accepted qualification.

Those GPU results establish evidence for the earlier local implementation. This new port onto the current #646 source has CPU regression validation, not a new full-image GPU qualification. Keep the PR draft until the final combined source is reviewed and GPU-replayed. Full-stack throughput gains also included scheduling, model/template revision, and runtime changes; they are not attributed to this patch alone.

AI assistance: OpenAI Codex prepared this extraction and ran the recorded checks at the submitter's request. Human line-by-line review is pending before marking the draft ready.

### Superseded

Superseded by #669, now merged on dev/jovian-judgement. The coordinated port preserves endpoint checkpoint guards and includes the cache, scheduler, connector and event repairs from this earlier branch. The combined release passed full MTP3 and DFlash2 serving qualification and was promoted, with zero preemptions and all LP26 5% performance gates satisfied. Closing this older proposal to avoid duplicate integration.
