### PR TITLE
Snapshot scheduled requests when connector stores need no allocation

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_snapshot.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_snapshot.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.v1.core.utils import create_requests, create_scheduler, mock_kv
+from tests.v1.kv_connector.unit.test_mooncake_store_scheduler import (
+    _make_bare_scheduler,
+)
+from vllm.v1.outputs import ModelRunnerOutput
+
+
+@pytest.mark.parametrize(
+    "batch_tokens,save_decode_cache,steps", [(8, False, 3), (8192, True, 18)]
+)
+def test_store_has_current_snapshot_without_new_allocation(
+    tmp_path, batch_tokens, save_decode_cache, steps
+):
+    (tmp_path / "config.json").write_text(
+        '{"architectures":["OPTForCausalLM"],"model_type":"opt","max_position_embeddings":32768}'
+    )
+    core = create_scheduler(
+        model=str(tmp_path),
+        skip_tokenizer_init=True,
+        enable_prefix_caching=True,
+        block_size=16,
+        max_num_seqs=2,
+        max_model_len=32768,
+        max_num_batched_tokens=batch_tokens,
+        use_kv_connector=mock_kv(0, False),
+        kv_role="kv_both",
+    )
+    mooncake = _make_bare_scheduler(
+        kv_role="kv_both", save_decode_cache=save_decode_cache
+    )
+    mooncake._gpu_block_pool = core.kv_cache_manager.block_pool
+    mooncake._boundary_state_group_ids = frozenset()
+    mooncake.client = MagicMock()
+    core.connector.update_state_after_alloc = mooncake.update_state_after_alloc
+    captured = []
+
+    def build(output):
+        captured.append(
+            (
+                dict(output.num_scheduled_tokens),
+                dict(output.kv_connector_block_state.block_ids),
+                list(output.scheduled_cached_reqs.new_block_ids),
+            )
+        )
+        print("snapshot", captured[-1])
+        return mooncake.build_connector_meta(output)
+
+    core.connector.build_connector_meta = build
+    (request,) = create_requests(
+        1, num_tokens=32, block_size=16, max_tokens=32, req_ids=["req-0"]
+    )
+    core.add_request(request)
+    for step in range(steps):
+        output = core.schedule()
+        req_ids = list(output.num_scheduled_tokens)
+        core.update_from_output(
+            output,
+            ModelRunnerOutput(
+                req_ids=req_ids,
+                req_id_to_index={req_id: i for i, req_id in enumerate(req_ids)},
+                sampled_token_ids=[
+                    [] if core.requests[req_id].is_prefill_chunk else [0]
+                    for req_id in req_ids
+                ],
+                logprobs=None,
+                prompt_logprobs_dict={},
+                pooler_output=[],
+            ),
+        )
+    assert any(
+        any(ids is None for ids in new_blocks) and "req-0" in snapshots
+        for _, snapshots, new_blocks in captured
+    )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1331,16 +1331,8 @@ class Scheduler(SchedulerInterface):
 
         kv_connector_block_state = None
         if self.connector is not None:
-            snapshot_req_ids = {req.req_id for req in new_reqs_data}
-            snapshot_req_ids.update(
-                req_id
-                for req_id, block_ids in zip(
-                    cached_reqs_data.req_ids,
-                    cached_reqs_data.new_block_ids,
-                    strict=True,
-                )
-                if block_ids
-            )
+            # Completing an existing block can create a store without allocation.
+            snapshot_req_ids = set(num_scheduled_tokens)
             snapshot_req_ids.update(
                 req_id for req_id in boundary_state_offloads if req_id in self.requests
             )


### PR DESCRIPTION
A connector store can become ready when a step finishes an existing block without allocating another. The scheduler previously omitted that request from `KVConnectorBlockState`, so Mooncake could fail to build store metadata even though the request was scheduled.

Snapshot every scheduled request, while retaining explicit boundary-state offers for other active requests. This changes snapshot coverage only. It does not infer recurrent-state validity from allocation.

This is a small follow-up stacked on #557. Merge #557 first, then retarget this PR to the same integration branch. It is part of the LP27 stock-r26 integration, alongside #643/#645/#646/#655/#656.

Validation:
- Both real-scheduler regressions fail before this change: chunked prefill with decode saving disabled, and decode saving enabled.
- 41 targeted Mooncake, snapshot, and connector override tests pass after the change.
- The equivalent integrated change passed the LP27 image's 886-test suite and the four-GPU GLM-5.3-Flash campaign, including 491520-token retrieval and 64 exact agent turns. That GPU campaign used VRAM cache; it does not establish live external-store transport correctness.

Prepared with AI assistance and independent AI review. Kept in draft for maintainer review of the dependency stack.

### Superseded

Superseded by #669, now merged on dev/jovian-judgement. The coordinated port preserves endpoint checkpoint guards and includes the cache, scheduler, connector and event repairs from this earlier branch. The combined release passed full MTP3 and DFlash2 serving qualification and was promoted, with zero preemptions and all LP26 5% performance gates satisfied. Closing this older proposal to avoid duplicate integration.
