### PR TITLE
Match Mooncake fine-hit eligibility and hash sequences to the engine

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -129,6 +129,7 @@ def test_mamba_align_split_partial_tail_schedule(dcp_world_size: int):
     scheduler_block_size = block_size * dcp_world_size
     hash_block_size = 32
     mock = SimpleNamespace(
+        drop_last_prefix_cache_block=False,
         cache_config=SimpleNamespace(block_size=block_size),
         max_num_scheduled_tokens=8192,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
@@ -177,6 +178,7 @@ def test_mamba_align_split_when_block_exceeds_scheduling_budget():
     token_budget = 8192
     prompt_length = 30000
     mock = SimpleNamespace(
+        drop_last_prefix_cache_block=False,
         cache_config=SimpleNamespace(block_size=block_size),
         max_num_scheduled_tokens=token_budget,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
@@ -214,6 +216,7 @@ def test_mamba_align_split_when_block_exceeds_long_prefill_threshold():
     long_prefill_threshold = 384
     prompt_length = 1300
     mock = SimpleNamespace(
+        drop_last_prefix_cache_block=False,
         cache_config=SimpleNamespace(block_size=block_size),
         max_num_scheduled_tokens=token_budget,
         scheduler_config=SimpleNamespace(

--- a/tests/v1/kv_connector/unit/test_mooncake_fine_hit_compatibility.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_fine_hit_compatibility.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import (
+    ExternalCachedBlockPool,
+    partial_hash_hits_enabled,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
+    BlobBlockHashes,
+)
+from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    FullAttentionSpec,
+    KVCacheGroupSpec,
+    MambaSpec,
+    SlidingWindowSpec,
+)
+
+
+def test_attention_can_need_fine_hits_when_mamba_matches_hash_size():
+    groups = [
+        KVCacheGroupSpec(
+            ["full"],
+            FullAttentionSpec(
+                block_size=2048, num_kv_heads=1, head_size=1, dtype=torch.float32
+            ),
+        ),
+        KVCacheGroupSpec(
+            ["mamba"],
+            MambaSpec(
+                block_size=256,
+                shapes=((1, 1),),
+                dtypes=(torch.float32,),
+                mamba_cache_mode="align",
+            ),
+        ),
+    ]
+    assert partial_hash_hits_enabled(groups, 256)
+    groups.append(
+        KVCacheGroupSpec(
+            ["chunked"],
+            ChunkedLocalAttentionSpec(
+                block_size=2048,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+                attention_chunk_size=2048,
+            ),
+        )
+    )
+    assert not partial_hash_hits_enabled(groups, 256)
+
+
+@pytest.mark.parametrize("present", [False, True])
+def test_swa_fine_lookup_accepts_external_hash_sequence(present):
+    hashes = BlobBlockHashes(memoryview(bytes(range(32)) * 8), 32)
+    pool = ExternalCachedBlockPool(32, None if present else set())
+    spec = SlidingWindowSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=128,
+    )
+    _, hit = SlidingWindowManager.find_longest_cache_hit(
+        hashes, 256, [0], pool, spec, False, alignment_tokens=32
+    )
+    assert hit == (256 if present else 0)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -20,6 +20,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheSpec,
     MambaSpec,
+    SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
@@ -404,9 +405,38 @@ def partial_hash_hits_enabled(
     (its dcp == 1 clause holds: the connector rejects hybrid + DCP/PCP > 1).
     Single copy on purpose — scheduler and coordinator must not disagree.
     """
-    return any(
+    has_partial_mamba_group = any(
         isinstance(spec := _unwrap_spec(g.kv_cache_spec), MambaSpec)
         and spec.mamba_cache_mode == "align"
         and spec.block_size > hash_block_size
         for g in kv_cache_groups
     )
+    has_mamba_align_group = any(
+        isinstance(spec := _unwrap_spec(g.kv_cache_spec), MambaSpec)
+        and spec.mamba_cache_mode == "align"
+        for g in kv_cache_groups
+    )
+    has_partial_attention_group = has_mamba_align_group and any(
+        isinstance(
+            spec := _unwrap_spec(g.kv_cache_spec),
+            FullAttentionSpec | SlidingWindowSpec,
+        )
+        and spec.block_size > hash_block_size
+        and (manager := KVCacheSpecRegistry.get_manager_class(spec)) is not None
+        and manager.supports_fine_grained_hash_lookup
+        for g in kv_cache_groups
+    )
+    if not (has_partial_mamba_group or has_partial_attention_group):
+        return False
+
+    for group in kv_cache_groups:
+        spec = _unwrap_spec(group.kv_cache_spec)
+        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        if manager_cls is None:
+            return False
+        if (
+            not manager_cls.supports_fine_grained_hash_lookup
+            and spec.block_size != hash_block_size
+        ):
+            return False
+    return True

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -990,7 +990,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             # Fine-grained mode (alignment_tokens == hash_block_size <
             # block_size): resolve_block_hashes kept the raw hash-granularity
             # list so hits can land on boundaries inside a cache block.
-            assert isinstance(block_hashes, list)
+            assert isinstance(block_hashes, Sequence)
             return cls._find_longest_fine_grained_cache_hit(
                 block_hashes=block_hashes,
                 max_length=max_length,
@@ -1085,7 +1085,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
     @classmethod
     def _find_longest_fine_grained_cache_hit(
         cls,
-        block_hashes: list[BlockHash],
+        block_hashes: Sequence[BlockHash],
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,


### PR DESCRIPTION
Keep Mooncake fine-hit eligibility consistent with the engine when attention blocks are larger than the hash unit but recurrent blocks already match that unit. For target2048 / recurrent256 / hash256, the engine previously enabled fine hits while Mooncake disabled them. Unsupported coarse chunked-local groups still disable fine lookup.

The same path exposes `BlobBlockHashes`, a lazy `Sequence`, to sliding-window lookup. Accept that existing hash representation instead of asserting that it is a list.

This follow-up is stacked on #646. It contains two runtime corrections and focused regressions. It also initializes the scheduler's existing `drop_last_prefix_cache_block` flag in three old mock fixtures so the full targeted suite runs.

Validation:
- All three new cases fail on the unmodified #646 head, covering the geometry gate and both hit/miss sequence paths.
- 81 targeted Mooncake coordinator, fine-hit, and partial-prefix tests pass after the changes. Ruff passes.
- The equivalent runtime corrections are included in the reviewed LP27 stock-r26 image, which passed 886 installed-image tests and the four-GPU VRAM-cache campaign, including 491520-token retrieval and 64 exact agent turns. Live external-store GPU transfers are outside that campaign.

Prepared with AI assistance and independent AI review. The LP27 release composition also includes #643/#645/#655/#656 and the exact-state store dependencies #557/#657. Merge #646 first and retarget this follow-up to its integration branch.

### Superseded

Superseded by #669, now merged on dev/jovian-judgement. The coordinated port preserves endpoint checkpoint guards and includes the cache, scheduler, connector and event repairs from this earlier branch. The combined release passed full MTP3 and DFlash2 serving qualification and was promoted, with zero preemptions and all LP26 5% performance gates satisfied. Closing this older proposal to avoid duplicate integration.
