### PR TITLE
perf(glm5next): use an NVFP4 MTP proposal head

### DIFF
--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -23,6 +23,8 @@ from vllm.model_executor.models.glm4_1v import Glm4vForConditionalGeneration
 from vllm.model_executor.models.interfaces import supports_eagle3, supports_pp
 from vllm.models.glm5next.nvidia import attention as glm5next_attention
 from vllm.models.glm5next.nvidia import model as glm5next_model
+from vllm.models.glm5next.nvidia import mtp as glm5next_mtp
+from vllm.models.glm5next.nvidia import mtp_draft_head
 from vllm.models.glm5next.nvidia.kda import Glm5NextLinearAttention
 from vllm.models.glm5next.nvidia.model import (
     GLM5NEXT_PACKED_MODULES_MAPPING,
@@ -262,6 +264,41 @@ def test_glm5next_mtp_requires_both_draft_layer_and_head_weights(
     match = "requires an unquantized" if missing_head else "layer 45 weights missing"
     with pytest.raises(ValueError, match=match):
         glm_mtp_head_loader.load_weights(weights)
+
+
+@pytest.mark.parametrize(
+    ("configured", "resolved"), (("bf16", "bf16"), ("NVFP4", "nvfp4"))
+)
+def test_glm5next_mtp_draft_head_mode(
+    monkeypatch, configured: str, resolved: str
+) -> None:
+    monkeypatch.setenv("VLLM_GLM53_MTP_DRAFT_HEAD", configured)
+
+    assert mtp_draft_head.configured_draft_head_mode() == resolved
+
+
+def test_glm5next_mtp_draft_head_rejects_unknown_mode(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_GLM53_MTP_DRAFT_HEAD", "int4")
+
+    with pytest.raises(ValueError, match="must be one of bf16, nvfp4"):
+        mtp_draft_head.configured_draft_head_mode()
+
+
+def test_glm5next_mtp_prepares_configured_draft_head(monkeypatch) -> None:
+    source_head = torch.nn.Linear(4, 8, bias=False)
+    quantized_head = torch.nn.Linear(4, 8, bias=False)
+    predictor = Glm5NextMultiTokenPredictor.__new__(Glm5NextMultiTokenPredictor)
+    torch.nn.Module.__init__(predictor)
+
+    monkeypatch.setattr(
+        glm5next_mtp,
+        "make_quantized_draft_head",
+        lambda actual_head: quantized_head if actual_head is source_head else None,
+    )
+
+    predictor.prepare_draft_lm_head(source_head)
+
+    assert predictor.quantized_draft_head is quantized_head
 
 
 def test_glm5next_mtp_preserves_position_zero_embedding() -> None:

--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -195,6 +195,26 @@ def test_glm5next_mtp_selects_only_draft_checkpoint_weights() -> None:
     )
 
 
+def test_glm5next_mtp_reuses_runtime_quantized_draft_head(monkeypatch) -> None:
+    source_head = SimpleNamespace(runtime_lm_head_quantization="nvfp4")
+    predictor = Glm5NextMultiTokenPredictor.__new__(Glm5NextMultiTokenPredictor)
+    torch.nn.Module.__init__(predictor)
+    predictor.quantized_draft_head = torch.nn.Linear(4, 8, bias=False)
+
+    def reject_duplicate_quantization(_source_head):
+        raise AssertionError("runtime-quantized draft head was quantized twice")
+
+    monkeypatch.setattr(
+        glm5next_mtp,
+        "make_quantized_draft_head",
+        reject_duplicate_quantization,
+    )
+
+    predictor.prepare_draft_lm_head(source_head)
+
+    assert predictor.quantized_draft_head is None
+
+
 @pytest.fixture
 def glm_mtp_head_loader(monkeypatch):
     from vllm.model_executor.model_loader.weight_utils import default_weight_loader

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     VLLM_LOG_STATS_INTERVAL: float = 10.0
     VLLM_TRACE_FUNCTION: int = 0
     VLLM_USE_FLASHINFER_SAMPLER: bool = True
+    VLLM_GLM53_MTP_DRAFT_HEAD: Literal["bf16", "nvfp4"] = "bf16"
     VLLM_PP_LAYER_PARTITION: str | None = None
     VLLM_CPU_KVCACHE_SPACE: int | None = 0
     VLLM_CPU_OMP_THREADS_BIND: str = "auto"
@@ -878,6 +879,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
         bool(int(os.environ["VLLM_USE_FLASHINFER_SAMPLER"]))
         if "VLLM_USE_FLASHINFER_SAMPLER" in os.environ
         else True
+    ),
+    # Storage and compute format for the independent GLM-5.3 MTP proposal head.
+    # The target vocabulary head and verifier remain BF16 in every mode.
+    "VLLM_GLM53_MTP_DRAFT_HEAD": env_with_choices(
+        "VLLM_GLM53_MTP_DRAFT_HEAD",
+        "bf16",
+        ["bf16", "nvfp4"],
+        case_sensitive=False,
     ),
     # Pipeline stage partition strategy
     "VLLM_PP_LAYER_PARTITION": lambda: os.getenv("VLLM_PP_LAYER_PARTITION", None),

--- a/vllm/models/glm5next/nvidia/mtp.py
+++ b/vllm/models/glm5next/nvidia/mtp.py
@@ -34,6 +34,7 @@ from .model import (
     _try_load_mxfp8_bf16_attn_proj,
     get_spec_layer_idx_from_weight_name,
 )
+from .mtp_draft_head import QuantizedDraftHead, make_quantized_draft_head
 from .pooled_indexer import Glm5NextPooledIndexer
 
 
@@ -138,7 +139,12 @@ class Glm5NextMultiTokenPredictor(nn.Module):
         # string and hashes it on every draft step.
         self._mtp_layers = list(self.layers.values())
         self._prefill_output_indices: torch.Tensor | None = None
+        self.quantized_draft_head: QuantizedDraftHead | None = None
         self.logits_processor = LogitsProcessor(config.vocab_size)
+
+    def prepare_draft_lm_head(self, source_head: nn.Module) -> None:
+        """Create the configured draft-only head after target weights are loaded."""
+        self.quantized_draft_head = make_quantized_draft_head(source_head)
 
     def update_max_model_len(self, max_model_len: int) -> None:
         for module in self.modules():
@@ -216,7 +222,8 @@ class Glm5NextMultiTokenPredictor(nn.Module):
         # hidden_states is already post-final-norm (produced in the layer
         # forward and recycled as-is); apply the LM head only, without a
         # second RMSNorm.
-        return self.logits_processor(mtp_layer.shared_head.head, hidden_states)
+        head = self.quantized_draft_head or mtp_layer.shared_head.head
+        return self.logits_processor(head, hidden_states)
 
     def get_top_tokens(
         self,
@@ -231,9 +238,8 @@ class Glm5NextMultiTokenPredictor(nn.Module):
         # step. Tie-breaking matches the full argmax (shards are contiguous
         # and rank-ordered, so the lowest-rank winner is the lowest global
         # index), so greedy draft tokens are unchanged.
-        return self.logits_processor.get_top_tokens(
-            mtp_layer.shared_head.head, hidden_states
-        )
+        head = self.quantized_draft_head or mtp_layer.shared_head.head
+        return self.logits_processor.get_top_tokens(head, hidden_states)
 
 
 class Glm5NextMTP(nn.Module, DeepseekV2MixtureOfExperts):
@@ -308,6 +314,10 @@ class Glm5NextMTP(nn.Module, DeepseekV2MixtureOfExperts):
 
     def update_max_model_len(self, max_model_len: int) -> None:
         self.model.update_max_model_len(max_model_len)
+
+    def prepare_draft_lm_head(self, source_head: nn.Module) -> None:
+        """Create a draft-only quantized copy of the shared target head."""
+        self.model.prepare_draft_lm_head(source_head)
 
     def forward(
         self,

--- a/vllm/models/glm5next/nvidia/mtp.py
+++ b/vllm/models/glm5next/nvidia/mtp.py
@@ -143,7 +143,16 @@ class Glm5NextMultiTokenPredictor(nn.Module):
         self.logits_processor = LogitsProcessor(config.vocab_size)
 
     def prepare_draft_lm_head(self, source_head: nn.Module) -> None:
-        """Create the configured draft-only head after target weights are loaded."""
+        """Resolve the draft-only head after its weights have loaded.
+
+        A runtime-quantized MTP head already owns its packed vocabulary
+        projection and must not be quantized again from that packed tensor.
+        Otherwise, create the GLM-specific copy selected by
+        ``VLLM_GLM53_MTP_DRAFT_HEAD`` from an unquantized target head.
+        """
+        if getattr(source_head, "runtime_lm_head_quantization", None) == "nvfp4":
+            self.quantized_draft_head = None
+            return
         self.quantized_draft_head = make_quantized_draft_head(source_head)
 
     def update_max_model_len(self, max_model_len: int) -> None:

--- a/vllm/models/glm5next/nvidia/mtp_draft_head.py
+++ b/vllm/models/glm5next/nvidia/mtp_draft_head.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Quantized vocabulary-head copies for GLM-5.3 speculative proposals.
+
+``VLLM_GLM53_MTP_DRAFT_HEAD`` selects the weight used only to produce MTP
+draft logits:
+
+* ``bf16`` (default) shares the target model's unquantized head;
+* ``nvfp4`` creates an independent block-scaled NVFP4 copy and uses
+  FlashInfer's W4A16 CuTe-DSL GEMM.
+
+The target model retains its BF16 vocabulary head.  The verifier therefore
+keeps the target distribution unchanged; quantization can only change proposal
+acceptance and speculative-decoding efficiency.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_NVFP4_GLOBAL_MAX = 448.0 * 6.0
+_SUPPORTED_MODES = frozenset(("bf16", "nvfp4"))
+
+
+def configured_draft_head_mode() -> str:
+    """Return the validated GLM MTP draft-head storage mode."""
+    mode = os.getenv("VLLM_GLM53_MTP_DRAFT_HEAD", "bf16").strip().lower()
+    if mode not in _SUPPORTED_MODES:
+        choices = ", ".join(sorted(_SUPPORTED_MODES))
+        raise ValueError(
+            f"VLLM_GLM53_MTP_DRAFT_HEAD must be one of {choices}; got {mode!r}"
+        )
+    return mode
+
+
+class _DraftHeadQuantMethod:
+    """Adapt a quantized draft head to ``LogitsProcessor``'s linear contract."""
+
+    def apply(
+        self,
+        layer: QuantizedDraftHead,
+        hidden_states: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if bias is not None:
+            raise ValueError("quantized GLM MTP draft heads do not support bias")
+        return layer(hidden_states)
+
+
+class QuantizedDraftHead(nn.Module):
+    """Vocab-parallel NVFP4 copy of a BF16 vocabulary-head shard."""
+
+    quant_method = _DraftHeadQuantMethod()
+
+    def __init__(self, source_head: nn.Module, mode: str) -> None:
+        super().__init__()
+        if mode != "nvfp4":
+            raise ValueError(f"quantized draft-head mode must be nvfp4; got {mode!r}")
+        weight = getattr(source_head, "weight", None)
+        if not isinstance(weight, torch.Tensor):
+            raise TypeError("the shared target vocabulary head has no tensor weight")
+        if weight.ndim != 2 or weight.dtype != torch.bfloat16 or not weight.is_cuda:
+            raise ValueError(
+                "quantized GLM MTP draft heads require a two-dimensional CUDA "
+                f"BF16 weight; got shape={tuple(weight.shape)}, dtype={weight.dtype}, "
+                f"device={weight.device}"
+            )
+        if not weight.is_contiguous():
+            raise ValueError(
+                "the shared target vocabulary-head weight must be contiguous"
+            )
+
+        self.tp_size = int(getattr(source_head, "tp_size", 1))
+        self.shard_indices: Any = getattr(source_head, "shard_indices", None)
+        if self.shard_indices is None:
+            raise TypeError("the shared target vocabulary head has no shard metadata")
+
+        major, minor = torch.cuda.get_device_capability(weight.device)
+        if (major, minor) != (12, 0):
+            raise ValueError(
+                "the NVFP4 W4A16 draft vocabulary head requires CUDA capability "
+                f"12.0; got {major}.{minor}"
+            )
+        import flashinfer
+
+        weight_global_scale = (
+            _NVFP4_GLOBAL_MAX / weight.float().abs().nan_to_num().max()
+        )
+        weight_fp4, weight_sf = flashinfer.nvfp4_quantize(
+            weight,
+            weight_global_scale,
+            sfLayout=flashinfer.SfLayout.layout_128x4,
+            do_shuffle=False,
+            backend="cuda",
+        )
+        weight_fp4, weight_sf, output_scale = flashinfer.prepare_bf16_fp4_weights(
+            weight_fp4.view(torch.uint8),
+            weight_sf,
+            weight_global_scale.reciprocal().reshape(1),
+            backend="cute-dsl",
+        )
+        self.register_buffer("weight", weight_fp4, persistent=False)
+        self.register_buffer("weight_scale", weight_sf, persistent=False)
+        self.register_buffer("weight_global_scale", output_scale, persistent=False)
+
+    @property
+    def storage_bytes(self) -> int:
+        """Return bytes retained by the independent quantized weight copy."""
+        return sum(
+            tensor.numel() * tensor.element_size()
+            for tensor in self.buffers()
+            if tensor is not None
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        shape = hidden_states.shape
+        hidden = hidden_states.reshape(-1, shape[-1])
+        import flashinfer
+
+        logits = flashinfer.mm_bf16_fp4(
+            hidden,
+            self.weight,
+            self.weight_scale,
+            self.weight_global_scale,
+            backend="cute-dsl",
+            out_dtype=hidden.dtype,
+        )
+        return logits.reshape(*shape[:-1], -1)
+
+
+def make_quantized_draft_head(source_head: nn.Module) -> QuantizedDraftHead | None:
+    """Build the configured draft-only head copy after target weights load."""
+    mode = configured_draft_head_mode()
+    if mode == "bf16":
+        return None
+    result = QuantizedDraftHead(source_head, mode)
+    logger.info(
+        "Using a draft-only %s GLM MTP vocabulary head copy (%0.2f MiB per rank); "
+        "the target verifier vocabulary head remains BF16.",
+        mode.upper(),
+        result.storage_bytes / (1024 * 1024),
+    )
+    return result

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1598,6 +1598,10 @@ class SpecDecodeBaseProposer:
                             "Shared target model lm_head with MTP shared_head.head."
                         )
 
+            prepare_draft_lm_head = getattr(self.model, "prepare_draft_lm_head", None)
+            if prepare_draft_lm_head is not None:
+                prepare_draft_lm_head(target_language_model.lm_head)
+
         if hasattr(target_language_model.model, "topk_indices_buffer"):
             target_buffer = target_language_model.model.topk_indices_buffer
             if hasattr(self.model.model, "topk_indices_buffer"):

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -123,6 +123,11 @@ def load_eagle_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mod
                     del sh.head
                     sh.head = target_lm_head
 
+    prepare_draft_lm_head = getattr(eagle_model, "prepare_draft_lm_head", None)
+    effective_draft_lm_head = getattr(eagle_model, "lm_head", None)
+    if prepare_draft_lm_head is not None and effective_draft_lm_head is not None:
+        prepare_draft_lm_head(effective_draft_lm_head)
+
     # MTP shares topk_indices_buffer with the target model. We update
     # every module in the draft that holds a buffer reference so that
     # the per-layer indexer and sparse-attention backends all point to


### PR DESCRIPTION
## Purpose

GLM-5.3 MTP evaluates the vocabulary projection for draft proposals more often
than the target model evaluates it. This change adds an opt-in NVFP4 proposal
head while retaining the BF16 target/verifier head.

## Behavior

- `VLLM_GLM53_MTP_DRAFT_HEAD=nvfp4` creates a dedicated W4A16 NVFP4 proposal
  projection. `bf16` preserves the shared BF16 projection.
- The target projection and standard rejection sampler remain unchanged, so
  the target distribution is preserved. Proposal quantization can change
  acceptance efficiency but cannot bypass target verification.
- Both model-runner implementations retain vocabulary-shard metadata.
- If the runtime already supplied an owned NVFP4 MTP head, the resolver uses it
  directly instead of trying to quantize its packed `uint8` weight again.

The feature commit retains Martin Vit's authorship. The branch is based on the
public `dev/jovian-judgement` head and supersedes #642, whose older base lacks
the runtime-owned MTP-head implementation now present in JJ.

## Validation

- 12 focused GLM MTP head-loading, selection, and duplicate-quantization tests
  passed on this branch.
- Full TP4 MTP depth-3 serving used an 85.08 MiB NVFP4 proposal-head copy per
  rank and retained the BF16 target head.
- On four stock-clock RTX PRO 6000 Blackwell Workstation Edition GPUs, the
  NVFP4 proposal head measured 109.31 verifier steps/s versus approximately
  99.5 steps/s with the BF16 proposal head: +9.9%. Observed C1 output was 258.4
  tokens/s versus a 248.6 tokens/s two-run midpoint: +3.9%.
- The integrated JJ qualification measured 110.1 verifier steps/s at C1 and
  390.1 verifier steps/s at C8, with 14,526-14,537 prompt tokens/s for 32K
  prefill.

