### PR TITLE
fix(router): preserve FP32 outputs and stable SM120 graph capture

### DIFF
--- a/tests/kernels/test_gate_linear_rocm_dispatch.py
+++ b/tests/kernels/test_gate_linear_rocm_dispatch.py
@@ -7,7 +7,7 @@ run device-free by mocking the platform predicates. The flag decides whether
 the bf16xbf16->fp32 router GEMM uses ``torch.mm``'s fused out_dtype epilogue
 (one kernel) or falls back to a bf16 matmul plus a standalone bf16->fp32 copy.
 
-ROCm's fused ``torch.mm`` branch and SM120's CuTe branch are both guarded on
+ROCm's fused ``torch.mm`` branch and SM120's router branches are both guarded on
 ``not bias`` so a biased gate cannot silently drop its bias term.
 """
 
@@ -175,3 +175,36 @@ def test_sm120_bf16_output_does_not_enable_fp32_gemm(monkeypatch):
     )
     assert not gate.allow_ll_bf16_gemm
     assert not gate.allow_cublas_router_gemm
+
+
+def test_sm120_capture_preserves_router_graph_pool_layout(monkeypatch):
+    gate = _make_gate(
+        monkeypatch,
+        is_rocm=False,
+        is_cuda=True,
+        device_capability=(12, 0),
+    )
+
+    class FakeInput:
+        dtype = torch.bfloat16
+        shape = (32, 2048)
+
+        def new_empty(self, shape):
+            captured_allocations.append(shape)
+            return self
+
+    x = FakeInput()
+    expected = torch.empty((32, 64), dtype=torch.float32)
+    captured_allocations: list[tuple[int, ...]] = []
+
+    monkeypatch.setattr(
+        "vllm.compilation.breakable_cudagraph.BreakableCUDAGraphCapture.current",
+        lambda: object(),
+    )
+    monkeypatch.setattr(torch, "mm", lambda *args, **kwargs: expected)
+
+    output, output_bias = gate(x)
+
+    assert output is expected
+    assert output_bias is None
+    assert captured_allocations == [(32, 64)]

--- a/tests/kernels/test_gate_linear_rocm_dispatch.py
+++ b/tests/kernels/test_gate_linear_rocm_dispatch.py
@@ -108,7 +108,7 @@ def test_rocm_set_out_dtype_respects_bias_guard(monkeypatch):
     assert not gate.allow_cublas_router_gemm
 
 
-def test_sm120_enables_only_ll_bf16_router(monkeypatch):
+def test_sm120_enables_bf16_fp32_paths_without_datacenter_kernels(monkeypatch):
     gate = _make_gate(
         monkeypatch,
         is_rocm=False,
@@ -119,7 +119,7 @@ def test_sm120_enables_only_ll_bf16_router(monkeypatch):
     assert gate.allow_ll_bf16_gemm
     assert not gate.allow_specialized_router_gemm
     assert not gate.allow_dsv3_router_gemm
-    assert not gate.allow_cublas_router_gemm
+    assert gate.allow_cublas_router_gemm
 
 
 def test_sm120_ll_bf16_respects_bias(monkeypatch):
@@ -132,6 +132,7 @@ def test_sm120_ll_bf16_respects_bias(monkeypatch):
     )
 
     assert not gate.allow_ll_bf16_gemm
+    assert not gate.allow_cublas_router_gemm
 
 
 def test_sm120_force_fp32_compute_preserves_fp32_weight_contract(monkeypatch):
@@ -145,6 +146,7 @@ def test_sm120_force_fp32_compute_preserves_fp32_weight_contract(monkeypatch):
 
     assert gate.weight.dtype == torch.float32
     assert not gate.allow_ll_bf16_gemm
+    assert not gate.allow_cublas_router_gemm
 
 
 def test_sm120_set_out_dtype_enables_ll_bf16(monkeypatch):
@@ -157,5 +159,19 @@ def test_sm120_set_out_dtype_enables_ll_bf16(monkeypatch):
     )
 
     assert not gate.allow_ll_bf16_gemm
+    assert not gate.allow_cublas_router_gemm
     gate.set_out_dtype(torch.float32)
     assert gate.allow_ll_bf16_gemm
+    assert gate.allow_cublas_router_gemm
+
+
+def test_sm120_bf16_output_does_not_enable_fp32_gemm(monkeypatch):
+    gate = _make_gate(
+        monkeypatch,
+        is_rocm=False,
+        is_cuda=True,
+        device_capability=(12, 0),
+        out_dtype=torch.bfloat16,
+    )
+    assert not gate.allow_ll_bf16_gemm
+    assert not gate.allow_cublas_router_gemm

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -127,6 +127,7 @@ class GateLinear(ReplicatedLinear):
         # specialized router kernels above. Preserve FP32 logits when M>16
         # falls through the low-latency BF16 kernel's range.
         self._router_gemm_no_bias = not bias
+        self._sm120_graph_pool_lifetime_guard = is_blackwell_rtx
         self._can_use_cublas_bf16_fp32 = self._can_use_ll_bf16 or (
             current_platform.is_rocm() and self._router_gemm_no_bias
         )
@@ -224,7 +225,26 @@ class GateLinear(ReplicatedLinear):
 
         # Tier 5: cuBLAS bf16→fp32
         if self.allow_cublas_router_gemm and x.dtype == torch.bfloat16:
+            graph_pool_guard = None
+            if self._sm120_graph_pool_lifetime_guard:
+                from vllm.compilation.breakable_cudagraph import (
+                    BreakableCUDAGraphCapture,
+                )
+
+                if (
+                    BreakableCUDAGraphCapture.current() is not None
+                    or torch.cuda.is_current_stream_capturing()
+                ):
+                    # The former linear-plus-cast path reserved a BF16 router
+                    # output before its FP32 result. Preserve that graph-pool
+                    # address layout while using the fused FP32 cuBLAS output;
+                    # auxiliary-stream graph nodes retain addresses across the
+                    # differently sized captures that share this pool.
+                    graph_pool_guard = x.new_empty(
+                        (*x.shape[:-1], self.weight.shape[0])
+                    )
             output = torch.mm(x, self.weight.T, out_dtype=torch.float32)
+            del graph_pool_guard
             return output, None
 
         # Tier 6: F.linear (ReplicatedLinear)

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -123,14 +123,15 @@ class GateLinear(ReplicatedLinear):
         # Fused bf16 x bf16 -> fp32 GEMM eligibility. torch.mm's out_dtype
         # epilogue folds the fp32 cast into the GEMM, removing the standalone
         # bf16->fp32 copy kernel that otherwise runs before grouped_topk.
-        # cuBLAS on CUDA (SM90+, via allow_specialized_router_gemm); hipBLASLt on
-        # ROCm, which supports the same out_dtype epilogue.
+        # SM120 supports this cuBLAS epilogue, but not the datacenter-only
+        # specialized router kernels above. Preserve FP32 logits when M>16
+        # falls through the low-latency BF16 kernel's range.
         self._router_gemm_no_bias = not bias
+        self._can_use_cublas_bf16_fp32 = self._can_use_ll_bf16 or (
+            current_platform.is_rocm() and self._router_gemm_no_bias
+        )
         self.allow_cublas_router_gemm = (
-            (
-                self.allow_specialized_router_gemm
-                or (current_platform.is_rocm() and self._router_gemm_no_bias)
-            )
+            self._can_use_cublas_bf16_fp32
             and self.weight.dtype == torch.bfloat16
             and self.out_dtype == torch.float32
         )
@@ -162,10 +163,7 @@ class GateLinear(ReplicatedLinear):
 
         if (
             not self.allow_cublas_router_gemm
-            and (
-                self.allow_specialized_router_gemm
-                or (current_platform.is_rocm() and self._router_gemm_no_bias)
-            )
+            and self._can_use_cublas_bf16_fp32
             and out_dtype == torch.float32
         ):
             self.allow_cublas_router_gemm = self.weight.dtype == torch.bfloat16


### PR DESCRIPTION
## Purpose

The SM120 MoE router must preserve FP32 gate outputs without making
auxiliary-stream CUDA graph addresses unstable. The prior BF16-output fallback
rounded routing scores before returning them as FP32. Switching directly to
the FP32-output cuBLAS path removes that rounding, but also changes an
allocation that anchors auxiliary-stream graph nodes. Capturing several graph
sizes in a shared private pool can then reuse the address for a differently
sized allocation and fail with an illegal memory access.

## Behavior

Eligible SM120 gates use the existing FP32-output cuBLAS path. During CUDA graph
capture, the router also reserves the former BF16-sized allocation slot. The
reservation has no graph-replay work and does not change eager prefill or
non-SM120 dispatch.

MadeBy561's router correction is retained as the first commit with its original
authorship. The graph-lifetime correction is a separate second commit. This
pull request supersedes #652 because GitHub cannot stack a pull request from
one fork on a branch in another fork.

## Validation

- 13 router dispatch tests passed on an RTX PRO 6000 Blackwell GPU, including
  changed-input graph replay and the shared-pool allocation invariant.
- Seeded comparisons against an FP64 reference reduced expert-choice
  disagreements from 2/32 to 0/32 inputs and from 104/4,096 to 1/4,096 inputs.
- GLM-5.3-Flash-NVFP4 TP4 serving captured 13 piecewise and six full graph
  shapes with shared-expert overlap enabled.
- The packaged stack measured 14,923-14,927 prompt tokens/s for a cold 32K
  prefill, 173.0 output tokens/s at context concurrency 1, and 741.6 output
  tokens/s at concurrency 8.
