### PR TITLE
gdn: keep the uniform spec-decode fast path on the graph buffers

### DIFF
--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -184,7 +184,6 @@ def test_uniform_spec_decode_reuses_metadata_with_new_accepted_states(
     builder.vllm_config.cache_config.mamba_cache_mode = "align"
     source = torch.arange(num_reqs * 4, dtype=torch.int32).reshape(num_reqs, 4)
     builder.mamba_aligned_state_indices = source
-    builder.mamba_spec_accepted_tokens = torch.ones(num_reqs, dtype=torch.int32)
     common = create_common_attn_metadata(
         BatchSpec(seq_lens=[64] * num_reqs, query_lens=[4] * num_reqs),
         BLOCK_SIZE,
@@ -210,7 +209,6 @@ def test_uniform_spec_decode_reuses_metadata_with_new_accepted_states(
     other = _create_gdn_builder(3, full_cuda_graph=True)
     other.vllm_config.cache_config.mamba_cache_mode = "align"
     other.mamba_aligned_state_indices = source.clone() + 32
-    other.mamba_spec_accepted_tokens = builder.mamba_spec_accepted_tokens
     captured_other = other.build_for_cudagraph_capture(common)
     pointer = reference.spec_state_indices_tensor.data_ptr()
     for count in (4, 2, 1):
@@ -227,7 +225,7 @@ def test_uniform_spec_decode_reuses_metadata_with_new_accepted_states(
         torch.testing.assert_close(captured_other.num_accepted_tokens, accepted)
         assert (
             updated.num_accepted_tokens.data_ptr()
-            == metadata.num_accepted_tokens.data_ptr()
+            == other.num_accepted_tokens.data_ptr()
         )
 
 
@@ -243,7 +241,6 @@ def test_uniform_spec_decode_falls_back_for_nonuniform_requests(
     builder.mamba_aligned_state_indices = torch.arange(8, dtype=torch.int32).reshape(
         2, 4
     )
-    builder.mamba_spec_accepted_tokens = torch.ones(2, dtype=torch.int32)
     metadata = _build(
         builder, BatchSpec(seq_lens=[64, 32], query_lens=query_lens), drafts
     )
@@ -595,6 +592,88 @@ def test_gdn_spec_update_uses_current_builders_graph_buffers() -> None:
     torch.testing.assert_close(
         metadata_b.num_accepted_tokens,
         metadata_a.num_accepted_tokens,
+    )
+
+
+def test_uniform_spec_fastpath_shares_graph_buffers_with_generic_path(
+    monkeypatch,
+) -> None:
+    """A graph captured from a uniform batch must stay valid for a padded one.
+
+    Full-cudagraph capture for a token count that is a whole number of spec
+    windows builds a uniform batch, so the fast path builds it. At run time a
+    batch with fewer live requests pads up to the same graph with a padded
+    request row, which is not uniform, so the generic path builds it. Both
+    builds must hand the layers the builder-owned graph buffers, or the replay
+    reads whichever buffers were captured while the other path fills different
+    ones.
+    """
+    monkeypatch.setenv("VLLM_GDN_SPEC_DECODE_METADATA_FASTPATH", "1")
+    builder = _create_gdn_builder(num_speculative_tokens=2, full_cuda_graph=True)
+    builder.vllm_config.cache_config.mamba_cache_mode = "align"
+    builder.mamba_aligned_state_indices = torch.tensor(
+        [[101, 102, 103, 104], [201, 202, 203, 204]], dtype=torch.int32
+    )
+
+    # Capture: two uniform spec requests, 3 tokens each.
+    uniform = create_common_attn_metadata(
+        BatchSpec(seq_lens=[40, 30], query_lens=[3, 3]), BLOCK_SIZE, DEVICE
+    ).replace(is_prefilling=torch.zeros(2, dtype=torch.bool))
+    captured = builder.build_for_cudagraph_capture(uniform)
+    assert captured.is_uniform_spec_decode
+
+    # Replay: one live spec request plus one padded request row (draft -1),
+    # padded to the same two-row graph.
+    padded = create_common_attn_metadata(
+        BatchSpec(seq_lens=[40, 0], query_lens=[3, 0]), BLOCK_SIZE, DEVICE
+    ).replace(is_prefilling=torch.zeros(2, dtype=torch.bool))
+    replayed = builder.build(
+        0,
+        padded,
+        torch.tensor([2, 1], dtype=torch.int32),
+        torch.tensor([2, -1], dtype=torch.int32),
+    )
+    assert not replayed.is_uniform_spec_decode
+    assert replayed.num_spec_decodes == 1
+
+    for field in (
+        "spec_state_indices_tensor",
+        "spec_sequence_masks",
+        "spec_query_start_loc",
+        "spec_token_indx",
+        "num_accepted_tokens",
+    ):
+        captured_tensor = getattr(captured, field)
+        replayed_tensor = getattr(replayed, field)
+        assert captured_tensor is not None and replayed_tensor is not None
+        assert captured_tensor.data_ptr() == replayed_tensor.data_ptr(), field
+        graph_buffer = {
+            "spec_state_indices_tensor": builder.spec_state_indices_tensor,
+            "spec_sequence_masks": builder.spec_sequence_masks,
+            "spec_query_start_loc": builder.spec_query_start_loc,
+            "spec_token_indx": builder.spec_token_indx,
+            "num_accepted_tokens": builder.num_accepted_tokens,
+        }[field]
+        assert captured_tensor.data_ptr() == graph_buffer.data_ptr(), field
+
+    # A second group's builder reusing the uniform build must likewise land in
+    # its own graph buffers, with its own group's state indices.
+    other = _create_gdn_builder(num_speculative_tokens=2, full_cuda_graph=True)
+    other.vllm_config.cache_config.mamba_cache_mode = "align"
+    other.mamba_aligned_state_indices = builder.mamba_aligned_state_indices + 10
+    reused = other.update_block_table(
+        captured, uniform.block_table_tensor, torch.zeros(6, dtype=torch.int64)
+    )
+    assert (
+        reused.spec_state_indices_tensor.data_ptr()
+        == other.spec_state_indices_tensor.data_ptr()
+    )
+    assert reused.num_accepted_tokens.data_ptr() == other.num_accepted_tokens.data_ptr()
+    assert (
+        reused.spec_query_start_loc.data_ptr() == other.spec_query_start_loc.data_ptr()
+    )
+    torch.testing.assert_close(
+        reused.spec_state_indices_tensor, other.mamba_aligned_state_indices[:, :3]
     )
 
 

--- a/tests/v1/worker/test_mamba_hybrid_model_state.py
+++ b/tests/v1/worker/test_mamba_hybrid_model_state.py
@@ -91,14 +91,8 @@ def test_aligned_metadata_reuses_views_and_rebinds_with_the_cache() -> None:
     state._aligned_metadata_groups = None
     state._aligned_metadata_ctx = None
     state._aligned_metadata_builders = []
-    state._gdn_spec_accepted_tokens = torch.ones(3, dtype=torch.int32)
     state._get_mamba_group_info = lambda _: ([1, 2], None)
-    builders = [
-        SimpleNamespace(
-            mamba_aligned_state_indices=None, mamba_spec_accepted_tokens=None
-        )
-        for _ in range(2)
-    ]
+    builders = [SimpleNamespace(mamba_aligned_state_indices=None) for _ in range(2)]
     groups = [
         [SimpleNamespace(get_metadata_builder=Mock(return_value=builder))]
         for builder in builders
@@ -117,7 +111,6 @@ def test_aligned_metadata_reuses_views_and_rebinds_with_the_cache() -> None:
             views = [builder.mamba_aligned_state_indices for builder in builders]
         indices.add_(10)
         for index, builder in enumerate(builders):
-            assert builder.mamba_spec_accepted_tokens is state._gdn_spec_accepted_tokens
             assert builder.mamba_aligned_state_indices is views[index]
             torch.testing.assert_close(
                 builder.mamba_aligned_state_indices, indices[index]

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -113,7 +113,6 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
 
     # Runner-owned stable storage, with NULL_BLOCK_ID in padded request rows.
     mamba_aligned_state_indices: torch.Tensor | None = None
-    mamba_spec_accepted_tokens: torch.Tensor | None = None
 
     reorder_batch_threshold: int = 1
 
@@ -198,9 +197,11 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         self._decode_state_indices_source: torch.Tensor | None = None
         self._decode_state_indices_view: torch.Tensor | None = None
         self._reuse_spec_decode_inputs = envs.VLLM_GDN_SPEC_DECODE_METADATA_FASTPATH
-        self._uniform_spec_masks = torch.ones(
-            self.decode_cudagraph_max_bs, dtype=torch.bool, device=device
-        )
+        # Constant sources for the uniform spec-decode fast path. They are
+        # copied into the builder-owned graph buffers above, never handed to
+        # the layers directly: a full cudagraph captured from a uniform batch
+        # replays for a padded batch of the same size, which the generic path
+        # builds into those same buffers, so both paths must share addresses.
         self._uniform_spec_masks_cpu = torch.ones(
             self.decode_cudagraph_max_bs, dtype=torch.bool
         )
@@ -210,8 +211,6 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         self._uniform_spec_query_start = torch.arange(
             self.decode_cudagraph_max_bs + 1, dtype=torch.int32, device=device
         ) * (self.num_spec + 1)
-        self._spec_state_indices_source: torch.Tensor | None = None
-        self._spec_state_indices_view: torch.Tensor | None = None
 
     def _can_reuse_spec_inputs(
         self,
@@ -225,7 +224,6 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             and self.use_full_cuda_graph
             and self.vllm_config.cache_config.mamba_cache_mode == "align"
             and self.mamba_aligned_state_indices is not None
-            and self.mamba_spec_accepted_tokens is not None
             and num_accepted_tokens is not None
             and num_decode_draft_tokens_cpu is not None
             and 0 < m.num_actual_tokens <= self.decode_cudagraph_max_bs
@@ -235,24 +233,32 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             and (m.is_prefilling is None or not bool(torch.any(m.is_prefilling)))
         )
 
-    def _get_spec_state_indices_view(self, num_reqs: int) -> torch.Tensor:
-        source = self.mamba_aligned_state_indices
-        assert source is not None
-        if (
-            self._spec_state_indices_source is not source
-            or self._spec_state_indices_view is None
-            or self._spec_state_indices_view.shape[0] != num_reqs
-        ):
-            self._spec_state_indices_source = source
-            self._spec_state_indices_view = source[:num_reqs, : self.num_spec + 1]
-        return self._spec_state_indices_view
-
     def _build_uniform_spec_decode(
         self, m: CommonAttentionMetadata, num_accepted_tokens: torch.Tensor
     ) -> GDNAttentionMetadata:
+        """Build an all-spec, uniform-window batch without any host-side work.
+
+        Everything the layers read is written into the builder-owned graph
+        buffers, exactly where the generic path writes it, so a full cudagraph
+        captured through either path replays correctly through the other.
+        """
         num_reqs = m.num_reqs
-        assert self.mamba_spec_accepted_tokens is not None
-        accepted = self.mamba_spec_accepted_tokens[:num_reqs]
+        num_tokens = m.num_actual_tokens
+        source = self.mamba_aligned_state_indices
+        assert source is not None
+        spec_state_indices = self.spec_state_indices_tensor[:num_reqs]
+        spec_state_indices.copy_(
+            source[:num_reqs, : self.num_spec + 1], non_blocking=True
+        )
+        spec_sequence_masks = self.spec_sequence_masks[:num_reqs]
+        spec_sequence_masks.fill_(True)
+        spec_token_indx = self.spec_token_indx[:num_tokens]
+        spec_token_indx.copy_(self._uniform_spec_tokens[:num_tokens], non_blocking=True)
+        spec_query_start_loc = self.spec_query_start_loc[: num_reqs + 1]
+        spec_query_start_loc.copy_(
+            self._uniform_spec_query_start[: num_reqs + 1], non_blocking=True
+        )
+        accepted = self.num_accepted_tokens[:num_reqs]
         accepted.copy_(num_accepted_tokens[:num_reqs], non_blocking=True)
         return GDNAttentionMetadata(
             num_prefills=0,
@@ -260,14 +266,14 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             num_decodes=0,
             num_decode_tokens=0,
             num_spec_decodes=num_reqs,
-            num_spec_decode_tokens=m.num_actual_tokens,
-            num_actual_tokens=m.num_actual_tokens,
-            spec_query_start_loc=self._uniform_spec_query_start[: num_reqs + 1],
-            spec_state_indices_tensor=self._get_spec_state_indices_view(num_reqs),
-            spec_sequence_masks=self._uniform_spec_masks[:num_reqs],
+            num_spec_decode_tokens=num_tokens,
+            num_actual_tokens=num_tokens,
+            spec_query_start_loc=spec_query_start_loc,
+            spec_state_indices_tensor=spec_state_indices,
+            spec_sequence_masks=spec_sequence_masks,
             spec_sequence_masks_cpu=self._uniform_spec_masks_cpu[:num_reqs],
-            spec_token_indx=self._uniform_spec_tokens[: m.num_actual_tokens],
-            non_spec_token_indx=self._uniform_spec_tokens[:0],
+            spec_token_indx=spec_token_indx,
+            non_spec_token_indx=self.non_spec_token_indx[:0],
             num_accepted_tokens=accepted,
             num_reqs=num_reqs,
             seq_lens=m.seq_lens,
@@ -752,23 +758,6 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         del slot_mapping
         assert metadata.num_reqs > 0
         assert metadata.seq_lens is not None
-
-        if (
-            metadata.is_uniform_spec_decode
-            and self._reuse_spec_decode_inputs
-            and self.mamba_aligned_state_indices is not None
-            and self.mamba_spec_accepted_tokens is not None
-        ):
-            updated = copy(metadata)
-            updated.spec_state_indices_tensor = self._get_spec_state_indices_view(
-                metadata.num_reqs
-            )
-            accepted = self.mamba_spec_accepted_tokens[: metadata.num_reqs]
-            assert metadata.num_accepted_tokens is not None
-            if accepted.data_ptr() != metadata.num_accepted_tokens.data_ptr():
-                accepted.copy_(metadata.num_accepted_tokens, non_blocking=True)
-            updated.num_accepted_tokens = accepted
-            return updated
 
         if (
             metadata.num_prefills == 0

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -7,7 +7,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from vllm import envs
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.triton_utils import tl, triton
@@ -84,11 +83,6 @@ class MambaHybridModelState(DefaultModelState):
         self.cache_config = vllm_config.cache_config
         self.num_accepted_tokens_gpu = torch.ones(
             self.max_num_reqs, dtype=torch.int32, device=self.device
-        )
-        self._gdn_spec_accepted_tokens = (
-            torch.ones_like(self.num_accepted_tokens_gpu)
-            if envs.VLLM_GDN_SPEC_DECODE_METADATA_FASTPATH
-            else None
         )
         # Pre-copy "align" prefix-cache state (V2). The migration of each
         # request's mamba state across block boundaries runs as a fused GPU
@@ -199,10 +193,6 @@ class MambaHybridModelState(DefaultModelState):
                     builder = group.get_metadata_builder(0)
                     if hasattr(builder, "mamba_aligned_state_indices"):
                         self._aligned_metadata_builders.append((group_idx, builder))
-                    if hasattr(builder, "mamba_spec_accepted_tokens"):
-                        builder.mamba_spec_accepted_tokens = (
-                            self._gdn_spec_accepted_tokens
-                        )
             self._aligned_metadata_groups = attn_groups
             self._aligned_metadata_ctx = None
         if not self._aligned_metadata_builders:


### PR DESCRIPTION
## TL;DR

With `VLLM_GDN_SPEC_DECODE_METADATA_FASTPATH` on (the default since 3512b066e), GLM-5.3-Flash + DFlash2 on a four-node DGX Spark TP4 cluster loses speculative decoding partway through a run: acceptance length drops to exactly 1.00 and stays there for the life of the server, halving decode throughput at concurrency >= 2. The target's own output is unaffected (GSM8K 94-97/100 throughout), so it presents as a pure speed regression.

Cause: the fast path handed the layers views of runner-owned tensors instead of the builder-owned buffers the generic path fills, and full cudagraphs captured through one path replay through the other. This PR keeps the fast path (still no host-side work) but makes it write the same graph buffers.

| build (heavy probe: 3 x c8/c16 passes per server start) | fast path | starts | collapsed |
|---|---|---|---|
| current heads (V6) | on (default) | 2 | **2** |
| current heads, async scheduling off | on | 2 | **2** |
| current heads | `=0` | 3 | 0 |
| **current heads + this commit** | **on (default)** | **3** | **0** |

Every one of the nine passes on the fixed build held 2.49-2.70 at both c8 and c16. Unfixed, acceptance was already sagging at c8 (2.1-2.2) and hit 1.00 in the c16 cell.

## Mechanism

Full cudagraphs replay whatever addresses were captured; that is why `GDNAttentionMetadataBuilder` owns persistent buffers (`spec_state_indices_tensor`, `spec_sequence_masks`, `spec_query_start_loc`, `spec_token_indx`, `num_accepted_tokens`) and the generic build copies into them. The fast path (`_build_uniform_spec_decode`, 03a8a588d) instead returned a view of the runner's aligned-state-index context and a shared runner-owned accepted-token buffer.

- Capture for a token count that is a whole number of spec windows (24/48/72/96 tokens = 4/8/12/16 requests x 6 here) produces a uniform batch, so those graphs were captured reading the fast-path tensors.
- At run time a batch with fewer live requests pads up to the same graph (`num_reqs_padded = batch_desc.num_reqs`) with a padded request row whose draft count is -1. That is not uniform, so the generic path builds into the builder buffers, while the replayed graph keeps reading the fast-path addresses: stale state indices and accepted counts, and an all-ones sequence mask over the padded row.

That predicts the observed shape exactly: c1/c2 immune (their 8/16-token graphs are captured through the generic path), c8 degrading (48-token graph, 5-7 live requests), c16 collapsing (96 tokens, 13-15 live), intermittent per start, and latched once a bad replay writes recurrent state into the wrong slots. Async scheduling was ruled out directly (table above).

## Fix

- `_build_uniform_spec_decode` copies into the builder-owned graph buffers, keeping the constant uniform tensors (`_uniform_spec_tokens`, `_uniform_spec_query_start`, the CPU masks) only as copy sources. No host-side masking, argsort, `.item()` or H2D is added; the fast path's build stays GPU-only.
- The shared runner-owned accepted buffer (`_gdn_spec_accepted_tokens` / `mamba_spec_accepted_tokens`) and the cached state-index view are removed.
- `update_block_table` takes its generic path for uniform metadata, which already lands in the current builder's buffers (the invariant `test_gdn_spec_update_uses_current_builders_graph_buffers` encodes).

The `is_uniform_spec_decode` flag is kept: the b12x KDA metadata cache still uses it to share bound metadata across builders with identical boundaries.

## Tests

- New `test_uniform_spec_fastpath_shares_graph_buffers_with_generic_path`: captures a uniform batch, then builds a padded batch of the same size, and requires both to hand out the builder's buffers (and a second group's builder to land in its own). Fails on the previous code at `spec_state_indices_tensor`; passes here.
- `test_uniform_spec_decode_reuses_metadata_with_new_accepted_states` updated: a second builder's reused metadata now points at that builder's accepted buffer, matching the generic-path invariant.
- `tests/v1/attention/test_gdn_metadata_builder.py`, `tests/v1/worker/test_mamba_hybrid_model_state.py`, `test_attn_utils.py`, `test_mamba_utils.py`: 58 passed, 40 skipped (CPU).
- Serving: four-node DGX Spark TP4 (GB10), GLM-5.3-Flash NVFP4 + DFlash2 (k=5), fp8 KV, `--block-size 2048 --mamba-block-size 256 --prefix-match-unit 256`, full cudagraphs, b12x master `b58f34e`. Numbers above; the fixed build is `dev/jovian-judgement@a8c796f3a` + #646 + this commit, and the only delta from the collapsing build is this commit.

## Mitigation without this change

`VLLM_GDN_SPEC_DECODE_METADATA_FASTPATH=0` avoids it (3/3 clean starts above) at the cost of the fast path's host-side savings.

## Not covered

Only the GLM-5.3-Flash + DFlash2 deployment was measured. The mechanism is not model-specific: any GDN/KDA hybrid with speculative decoding, full cudagraphs and `mamba_cache_mode=align` reaches the same capture/replay split whenever live requests pad to a graph captured from a uniform batch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved speculative decoding metadata handling by reducing host-side processing and reusing shared GPU buffers.
  - Improved consistency when replaying captured graphs across uniform and padded batches.
  - Ensured metadata remains correctly associated with each builder during reuse and block-table updates.

- **Reliability**
  - Expanded coverage for graph-buffer sharing and metadata reuse scenarios.
  - Simplified state handling to reduce reliance on separately managed intermediate buffers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->