### PR TITLE
[BugFix] Preserve aligned hybrid cache reuse alongside endpoint checkpoints

### DIFF
--- a/tests/distributed/test_kv_cache_events.py
+++ b/tests/distributed/test_kv_cache_events.py
@@ -50,6 +50,9 @@ def _make_block_stored(
     group_idx: int | None = None,
     kv_cache_spec_sliding_window: int | None = None,
     locality: str | None = None,
+    skipped_parent_block_hash: bytes | None = None,
+    skipped_token_ids: list[int] | None = None,
+    skipped_extra_keys: list[tuple[Any, ...] | None] | None = None,
 ) -> BlockStored:
     return BlockStored(
         block_hashes=[_FAKE_HASH],
@@ -59,6 +62,9 @@ def _make_block_stored(
         lora_id=None,
         medium="GPU",
         lora_name=None,
+        skipped_parent_block_hash=skipped_parent_block_hash,
+        skipped_token_ids=skipped_token_ids,
+        skipped_extra_keys=skipped_extra_keys,
         group_idx=group_idx,
         kv_cache_spec_sliding_window=kv_cache_spec_sliding_window,
         locality=locality,
@@ -103,6 +109,12 @@ def test_block_stored_hash_same_for_equal_group_idx():
     event_a = _make_block_stored(group_idx=1)
     event_b = _make_block_stored(group_idx=1)
     assert hash(event_a) == hash(event_b)
+
+
+def test_block_stored_hash_differs_by_skipped_context():
+    event_a = _make_block_stored(skipped_token_ids=[1, 2, 3, 4])
+    event_b = _make_block_stored(skipped_token_ids=[5, 6, 7, 8])
+    assert hash(event_a) != hash(event_b)
 
 
 @pytest.mark.parametrize("group_idx", [1, 2, 3])
@@ -160,19 +172,31 @@ def test_block_stored_locality_is_wire_compatible():
         kv_cache_spec_sliding_window=128,
     )
     legacy_payload = msgspec.msgpack.encode(legacy)
-    assert (
-        msgspec.msgpack.encode(
-            _make_block_stored(
-                group_idx=2,
-                kv_cache_spec_sliding_window=128,
-            )
-        )
-        == legacy_payload
-    )
-    assert msgspec.msgpack.decode(legacy_payload, type=BlockStored).locality is None
+    decoded_legacy = msgspec.msgpack.decode(legacy_payload, type=BlockStored)
+    assert decoded_legacy.locality is None
+    assert decoded_legacy.skipped_parent_block_hash is None
+    assert decoded_legacy.skipped_token_ids is None
+    assert decoded_legacy.skipped_extra_keys is None
+
     new_payload = msgspec.msgpack.encode(_make_block_stored(locality="LOCAL"))
     assert msgspec.msgpack.decode(new_payload)["locality"] == "LOCAL"
-    assert msgspec.msgpack.decode(new_payload, type=_LegacyBlockStored).medium == "GPU"
+    decoded_new = msgspec.msgpack.decode(new_payload, type=_LegacyBlockStored)
+    assert decoded_new.medium == "GPU"
+    assert decoded_new.group_idx is None
+
+
+def test_block_stored_skipped_context_is_wire_compatible():
+    event = _make_block_stored(
+        skipped_parent_block_hash=_FAKE_HASH,
+        skipped_token_ids=[5, 6, 7, 8],
+        skipped_extra_keys=[("salt",)],
+    )
+    payload = msgspec.msgpack.encode(event)
+    decoded = msgspec.msgpack.decode(payload)
+    assert decoded["skipped_parent_block_hash"] == _FAKE_HASH
+    assert decoded["skipped_token_ids"] == [5, 6, 7, 8]
+    assert decoded["skipped_extra_keys"] == [["salt"]]
+    assert msgspec.msgpack.decode(payload, type=_LegacyBlockStored).medium == "GPU"
 
 
 def test_block_removed_locality_is_wire_compatible():

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -4,6 +4,8 @@
 "align") models: scheduler chunk splitting, partial tail registration, CoW
 on partial hits, and same-step deferral."""
 
+import unittest
+from dataclasses import replace
 from math import lcm
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -70,6 +72,19 @@ def test_capable_connector_uses_divergent_partial_hit_lookup():
     manager.get_computed_blocks.assert_not_called()
 
 
+def drain_boundary_state_offloads(manager):
+    """Drain exact boundary-state block ids offered to a connector."""
+    return manager.take_boundary_state_offloads()
+
+
+def _free_block_ids(manager):
+    """Block ids the pool would hand out to the next allocation."""
+    return {
+        block.block_id
+        for block in manager.block_pool.free_block_queue.get_all_free_blocks()
+    }
+
+
 def make_full_mamba_manager(
     *,
     dcp_world_size: int,
@@ -80,6 +95,7 @@ def make_full_mamba_manager(
     use_eagle: bool = False,
     num_prefill_checkpoint_blocks: int = 0,
     enable_boundary_checkpoints: bool = False,
+    enable_kv_cache_events: bool = False,
 ):
     kv_cache_config = KVCacheConfig(
         num_blocks=num_blocks,
@@ -119,6 +135,7 @@ def make_full_mamba_manager(
         hash_block_size=hash_block_size,
         use_eagle=use_eagle,
         enable_boundary_checkpoints=enable_boundary_checkpoints,
+        enable_kv_cache_events=enable_kv_cache_events,
     )
 
 
@@ -220,8 +237,8 @@ def test_mamba_align_split_partial_tail_schedule(dcp_world_size: int):
         max_num_scheduled_tokens=8192,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         use_eagle=False,
-        hash_block_size=hash_block_size,
         drop_last_prefix_cache_block=False,
+        hash_block_size=hash_block_size,
         dcp_world_size=dcp_world_size,
         scheduler_block_size=scheduler_block_size,
         mamba_partial_cache_hit=True,
@@ -269,8 +286,8 @@ def test_mamba_align_split_when_block_exceeds_scheduling_budget():
         max_num_scheduled_tokens=token_budget,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         use_eagle=False,
-        hash_block_size=32,
         drop_last_prefix_cache_block=False,
+        hash_block_size=32,
         mamba_partial_cache_hit=False,
         mamba_has_prefill_checkpoint_blocks=False,
     )
@@ -309,8 +326,8 @@ def test_mamba_align_split_when_block_exceeds_long_prefill_threshold():
             long_prefill_token_threshold=long_prefill_threshold
         ),
         use_eagle=False,
-        hash_block_size=32,
         drop_last_prefix_cache_block=False,
+        hash_block_size=32,
         mamba_partial_cache_hit=False,
         mamba_has_prefill_checkpoint_blocks=False,
     )
@@ -708,10 +725,9 @@ def test_external_mamba_hit_same_block_uses_running_cow_on_continue():
     assert moved[0].block_id == cow_copy.dst_block_id
 
 
-def test_take_partial_tail_offloads_returns_cow_target():
-    """The connector offload hand-off exposes the mamba CoW *target* block Y
-    (the durable boundary state), not the overwritten source X, and only at
-    the CoW step."""
+def test_boundary_state_offloads_returns_cow_target():
+    """Boundary hand-offs expose aligned snapshots and the partial-tail CoW
+    target, never the overwritten CoW source."""
     hash_block_size = 2
     block_size = 2 * hash_block_size
     kv_cache_config = KVCacheConfig(
@@ -750,8 +766,18 @@ def test_take_partial_tail_offloads_returns_cow_target():
     computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
     assert manager.allocate_slots(req0, 6, num_computed, computed_blocks) is not None
 
-    # Step A registered the partial tail but has not CoW'd yet: no offload.
-    assert manager.take_partial_tail_offloads() == {}
+    # Step A offers the materialized aligned checkpoint immediately.
+    ((group_id, block_id, boundary_tokens),) = drain_boundary_state_offloads(manager)[
+        "0"
+    ]
+    assert group_id == 1
+    assert boundary_tokens == 4
+    aligned_hash = req0.block_hashes[4 // hash_block_size - 1]
+    aligned_block = manager.block_pool.get_cached_block(
+        aligned_hash, kv_cache_group_ids=[1]
+    )
+    assert aligned_block is not None
+    assert block_id == aligned_block[0].block_id
 
     partial_mamba_hash = req0.block_hashes[6 // hash_block_size - 1]
     source_block = manager.block_pool.get_cached_block(
@@ -765,34 +791,27 @@ def test_take_partial_tail_offloads_returns_cow_target():
     req0.append_output_token_ids([3])
     assert manager.allocate_slots(req0, 1) is not None
 
-    offloads = manager.take_partial_tail_offloads()
+    offloads = drain_boundary_state_offloads(manager)
     assert list(offloads.keys()) == ["0"]
     assert len(offloads["0"]) == 1
     group_id, block_id, boundary_tokens = offloads["0"][0]
     assert group_id == 1  # the mamba group
     assert boundary_tokens == 6
-    copies, _ = manager.take_kv_cache_block_copies()
+    copies, retained = manager.take_kv_cache_block_copies()
     cow_copy = next(c for c in copies if c.src_block_id == source_block_id)
     # The offload points at the durable CoW target Y, not the overwritten X.
     assert block_id == cow_copy.dst_block_id
     assert block_id != source_block_id
     # Draining clears it.
-    assert manager.take_partial_tail_offloads() == {}
+    assert manager.take_boundary_state_offloads() == {}
 
-    # The hand-off pinned Y (its CoW retention is released after this step,
-    # and Y is off the request block table); freeing the request unpins it.
-    cow_block = manager.block_pool.blocks[block_id]
-    pinned_ref = cow_block.ref_cnt
-    assert pinned_ref >= 1
+    manager.block_pool.free_blocks(retained)
     manager.free(req0)
-    assert cow_block.ref_cnt == pinned_ref - 1
 
 
-def test_partial_tail_pin_survives_released_cow_retention():
-    """If the CoW retention is released before the hand-off is drained
-    (immediate-free mode), the drain must rescue the cow block from the free
-    queue: a raw ref increment would leave a ref>0 block allocatable, and the
-    next allocation would pop it and assert."""
+def test_block_pool_touch_pins_released_cow_target():
+    """The connector can rescue an offered CoW target after its step-scoped
+    retention is released by using the bound BlockPool's touch method."""
     hash_block_size = 2
     block_size = 2 * hash_block_size
     kv_cache_config = KVCacheConfig(
@@ -836,13 +855,18 @@ def test_partial_tail_pin_survives_released_cow_retention():
     _copies, retained = manager.take_kv_cache_block_copies()
     manager.block_pool.free_blocks(retained)
 
-    offloads = manager.take_partial_tail_offloads()
+    offloads = drain_boundary_state_offloads(manager)
     ((_group_id, block_id, boundary_tokens),) = offloads["0"]
     assert boundary_tokens == 6
     cow_block = manager.block_pool.blocks[block_id]
-    assert cow_block.ref_cnt == 1
+    assert cow_block.ref_cnt == 0
+    assert block_id in _free_block_ids(manager)
 
-    # The pinned block is out of the free queue: draining every free block
+    manager.block_pool.touch([cow_block])
+    assert cow_block.ref_cnt == 1
+    assert block_id not in _free_block_ids(manager)
+
+    # The connector-pinned block is out of the free queue: draining every free block
     # neither trips the allocator's ref_cnt assert nor hands it out.
     new_blocks = manager.block_pool.get_new_blocks(
         manager.block_pool.get_num_free_blocks()
@@ -850,7 +874,7 @@ def test_partial_tail_pin_survives_released_cow_retention():
     assert block_id not in {b.block_id for b in new_blocks}
 
 
-def test_partial_tail_offload_dropped_when_request_freed_before_drain():
+def test_boundary_state_offload_dropped_when_request_freed_before_drain():
     """A hand-off recorded in the same scheduling pass as the request's death
     must not be drained: its release hook has already run, so draining would
     leak a pinned block."""
@@ -895,12 +919,12 @@ def test_partial_tail_offload_dropped_when_request_freed_before_drain():
 
     # The request dies (preempt/abort) before the scheduler drains.
     manager.block_pool.free_blocks(manager.pop_blocks_for_free(req0))
-    assert manager.take_partial_tail_offloads() == {}
+    assert manager.take_boundary_state_offloads() == {}
 
 
-def test_take_partial_tail_offloads_empty_without_partial_tail():
-    """A prompt ending on a block boundary registers no partial tail, so there
-    is nothing to offload."""
+def test_boundary_state_offloads_block_aligned_prompt():
+    """A prompt ending on a block boundary registers no CoW partial tail; its
+    boundary state block is handed off as a snapshot instead (once)."""
     hash_block_size = 2
     block_size = 2 * hash_block_size
     kv_cache_config = KVCacheConfig(
@@ -938,12 +962,17 @@ def test_take_partial_tail_offloads_empty_without_partial_tail():
     req0 = make_request("0", [0, 0, 1, 1], hash_block_size, sha256)
     computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
     assert manager.allocate_slots(req0, 4, num_computed, computed_blocks) is not None
-    assert manager.take_partial_tail_offloads() == {}
+    mamba_blocks = manager.coordinator.single_type_managers[1].req_to_blocks["0"]
+    ((group_id, block_id, boundary),) = drain_boundary_state_offloads(manager)["0"]
+    assert group_id == 1
+    assert boundary == block_size
+    assert block_id == mamba_blocks[0].block_id
 
     req0.num_computed_tokens = 4
     req0.append_output_token_ids([2])
     assert manager.allocate_slots(req0, 1) is not None
-    assert manager.take_partial_tail_offloads() == {}
+    # The boundary was already handed off; decoding emits nothing new.
+    assert manager.take_boundary_state_offloads() == {}
 
 
 def test_truncate_computed_blocks_preserves_sparse_prefix_positions():
@@ -1659,7 +1688,85 @@ def test_hybrid_partial_hit_with_eagle_stays_within_group_blocks():
     assert manager.allocate_slots(req1, 4, num_computed, computed_blocks) is not None
 
 
-def test_hybrid_sliding_window_group_disables_partial_hash_hits():
+def _make_hybrid_swa_eagle_config(
+    hash_block_size: int,
+    attn_block_size: int,
+    mamba_block_size: int,
+    sliding_window: int,
+    num_blocks: int = 512,
+) -> KVCacheConfig:
+    """Full attention target + mamba "align" + an EAGLE sliding-window draft
+    group (window == draft block), the GLM-5.3 + DFlash topology."""
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=attn_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=mamba_block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["swa_draft"],
+                SlidingWindowSpec(
+                    block_size=attn_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=sliding_window,
+                ),
+                is_eagle_group=True,
+            ),
+        ],
+    )
+
+
+def _prefill_and_free(manager, request, chunk: int) -> int:
+    """Prefill ``request`` in ``chunk``-token steps (so the mamba group
+    checkpoints every block, as FlashKDA prefill checkpoints do), decode one
+    token, free it. Returns the prefix-cache hit it started from."""
+    num_tokens = len(request.prompt_token_ids)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(request)
+    done = num_computed
+    first = True
+    while done < num_tokens:
+        step = min(chunk, num_tokens - done)
+        if first:
+            result = manager.allocate_slots(
+                request, step, num_computed, computed_blocks
+            )
+            first = False
+        else:
+            result = manager.allocate_slots(request, step)
+        assert result is not None
+        done += step
+        request.num_computed_tokens = done
+        manager.new_step_starts()
+    assert manager.allocate_slots(request, 1) is not None
+    request.num_computed_tokens = done + 1
+    manager.new_step_starts()
+    manager.free(request)
+    manager.new_step_starts()
+    return num_computed
+
+
+def test_hybrid_sliding_window_group_enables_partial_hash_hits():
+    """A sliding-window draft group no longer forces block-aligned hits: with
+    the hash unit finer than the draft block, partial hash hits stay enabled
+    and the draft's EAGLE rewind is one hash unit, not one draft block."""
     hash_block_size = 2
     sliding_window_block_size = 2 * hash_block_size
     mamba_block_size = 2 * sliding_window_block_size
@@ -1705,29 +1812,360 @@ def test_hybrid_sliding_window_group_disables_partial_hash_hits():
         hash_block_size=hash_block_size,
         use_eagle=True,
     )
+    coordinator = manager.coordinator
+    assert coordinator.enable_partial_hash_hits
+    assert all(
+        m.hit_alignment_tokens == hash_block_size
+        for m in coordinator.single_type_managers
+    )
 
     tokens = list(range(3 * sliding_window_block_size))
     request = make_request("0", tokens, hash_block_size, sha256)
-    computed_blocks, num_computed, _ = manager.get_computed_blocks(request)
-    assert not manager.coordinator.enable_partial_hash_hits
-    assert (
-        manager.allocate_slots(request, mamba_block_size, num_computed, computed_blocks)
-        is not None
-    )
-    request.num_computed_tokens = mamba_block_size
-    manager.new_step_starts()
-    assert manager.allocate_slots(request, len(tokens) - mamba_block_size) is not None
-    request.num_computed_tokens = len(tokens)
-    manager.free(request)
-    manager.new_step_starts()
+    # Prefill in mamba-block steps, as the aligned scheduler split does.
+    assert _prefill_and_free(manager, request, mamba_block_size) == 0
 
     cached_request = make_request(
         "1", tokens + [len(tokens), len(tokens) + 1], hash_block_size, sha256
     )
     computed_blocks, num_computed, _ = manager.get_computed_blocks(cached_request)
-
+    # The mamba state at the last block boundary (8) is retained; the draft
+    # matches one hash unit past it (10, inside its cached block 2) and
+    # rewinds by that unit instead of by a whole draft block.
     assert num_computed == mamba_block_size
     assert len(computed_blocks.blocks[0]) * hash_block_size == num_computed
+
+
+def test_sliding_window_fine_grained_hits():
+    """Manager-level: hits on hash boundaries inside a draft block, the
+    window-coverage requirement, the EAGLE rewind by one hash unit, and a
+    covering entry registered further along the tail block."""
+    from vllm.v1.core.block_pool import BlockPool
+    from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
+
+    hash_block_size = 2
+    block_size = 8
+    spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=block_size,
+    )
+    pool = BlockPool(
+        num_gpu_blocks=16, enable_caching=True, hash_block_size=hash_block_size
+    )
+    req = make_request("0", list(range(100, 116)), hash_block_size, sha256)
+
+    def find(max_length, drop_eagle_block):
+        return SlidingWindowManager.find_longest_cache_hit(
+            block_hashes=req.block_hashes,
+            max_length=max_length,
+            kv_cache_group_ids=[0],
+            block_pool=pool,
+            kv_cache_spec=spec,
+            drop_eagle_block=drop_eagle_block,
+            alignment_tokens=hash_block_size,
+        )
+
+    blocks = pool.get_new_blocks(2)
+    # Block 0 fully cached (8 tokens); block 1 holds a partial entry at 14.
+    pool.cache_full_blocks(
+        request=req,
+        blocks=blocks[:1],
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=block_size,
+        kv_cache_group_id=0,
+    )
+    assert (
+        pool.cache_partial_block(
+            request=req,
+            block=blocks[1],
+            num_tokens=14,
+            kv_cache_group_id=0,
+            block_size=block_size,
+        )
+        is not None
+    )
+
+    # Hit at the registered partial boundary; window [7, 14) needs block 0.
+    hit_blocks, hit_length = find(16, drop_eagle_block=False)
+    assert (hit_length, [b.block_id for b in hit_blocks[0]]) == (
+        14,
+        [blocks[0].block_id, blocks[1].block_id],
+    )
+    # EAGLE rewinds one hash unit; the tail block still covers 12.
+    hit_blocks, hit_length = find(16, drop_eagle_block=True)
+    assert (hit_length, len(hit_blocks[0])) == (12, 2)
+    # A re-query at the rewound length (no entry at 12) is served by the
+    # covering entry at 14 of the same append-only tail block.
+    hit_blocks, hit_length = find(12, drop_eagle_block=False)
+    assert (hit_length, len(hit_blocks[0])) == (12, 2)
+    # Block-aligned boundary: the full block 0 is the tail.
+    hit_blocks, hit_length = find(8, drop_eagle_block=False)
+    assert (hit_length, [b.block_id for b in hit_blocks[0]]) == (
+        8,
+        [blocks[0].block_id],
+    )
+    # Window coverage: with only the partial tail cached (no block 0), the
+    # tail alone cannot serve 14 since its window reaches into block 0.
+    pool = BlockPool(
+        num_gpu_blocks=16, enable_caching=True, hash_block_size=hash_block_size
+    )
+    blocks = pool.get_new_blocks(2)
+    assert (
+        pool.cache_partial_block(
+            request=req,
+            block=blocks[1],
+            num_tokens=14,
+            kv_cache_group_id=0,
+            block_size=block_size,
+        )
+        is not None
+    )
+    hit_blocks, hit_length = find(16, drop_eagle_block=False)
+    assert hit_length == 0
+
+
+def test_sliding_window_fine_grained_reachable_mask():
+    """Sparse retention keeps the full blocks a fine-grained hit at each
+    reachable boundary needs; dense retention keeps everything."""
+    from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
+
+    spec = SlidingWindowSpec(
+        block_size=8,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=8,
+    )
+    mask = SlidingWindowManager.reachable_block_mask(
+        start_block=0,
+        end_block=4,
+        alignment_tokens=2,
+        kv_cache_spec=spec,
+        use_eagle=True,
+        retention_interval=0,
+        reachable_boundaries=[27],  # aligned to 26, inside block 3
+    )
+    # Window (+1 EAGLE unit) before 26 spans [17, 26): blocks 2 and 3 (a
+    # fully cached block 3 covers the boundary inside it), blocks 0-1 not.
+    assert mask == [False, False, True, True]
+    assert (
+        SlidingWindowManager.reachable_block_mask(
+            start_block=0,
+            end_block=4,
+            alignment_tokens=2,
+            kv_cache_spec=spec,
+            use_eagle=True,
+            retention_interval=None,
+            reachable_boundaries=[27],
+        )
+        is None
+    )
+
+
+def test_attention_only_hybrid_keeps_block_aligned_hits():
+    """Without a recurrent group, hashing finer than an attention block does
+    not turn partial hits on: attention-only hybrids keep the block-aligned
+    behaviour they had before sliding-window groups learned fine-grained
+    lookups."""
+    hash_block_size = 2
+    kv_cache_config = KVCacheConfig(
+        num_blocks=64,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=2 * hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["swa"],
+                SlidingWindowSpec(
+                    block_size=4 * hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=4 * hash_block_size,
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    coordinator = manager.coordinator
+    assert not coordinator.enable_partial_hash_hits
+    assert all(
+        m.hit_alignment_tokens == coordinator.scheduler_block_size
+        for m in coordinator.single_type_managers
+    )
+
+
+def test_sliding_window_eagle_margin_is_one_hash_unit_under_partial_hits():
+    """With partial hits on, the coordinator hands the EAGLE sliding-window
+    group a one-hash-unit lookahead margin (not a whole draft block) and the
+    reconciled hit lands back on the candidate length."""
+    hash_block_size = 2
+    manager = make_kv_cache_manager(
+        kv_cache_config=_make_hybrid_swa_eagle_config(
+            hash_block_size=hash_block_size,
+            attn_block_size=16,
+            mamba_block_size=hash_block_size,
+            sliding_window=16,
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        use_eagle=True,
+    )
+    coordinator = manager.coordinator
+    assert coordinator.enable_partial_hash_hits
+    base = list(range(1000, 1045))
+    _prefill_and_free(manager, make_request("0", base, hash_block_size, sha256), 2)
+
+    seen_max_lengths: list[int] = []
+    swa_manager = coordinator.single_type_managers[2]
+    original = type(swa_manager).find_longest_cache_hit
+
+    def spy(cls, *args, **kwargs):
+        seen_max_lengths.append(kwargs["max_length"])
+        return original(*args, **kwargs)
+
+    type(swa_manager).find_longest_cache_hit = classmethod(spy)
+    try:
+        req = make_request("1", base, hash_block_size, sha256)
+        _, hit_length, _ = coordinator.find_longest_cache_hit(
+            req.block_hashes, len(base) - 1
+        )
+    finally:
+        type(swa_manager).find_longest_cache_hit = original
+    # Candidate 44 (the tail): the draft is asked for 44 + one hash unit
+    # (capped by max_length 44), rewinds to 42; the re-query asks for exactly
+    # the rewound length. Nothing is queried a whole draft block ahead.
+    assert hit_length == 42
+    assert seen_max_lengths and max(seen_max_lengths) <= 44
+    assert 42 in seen_max_lengths
+
+
+def _cached_mamba_boundaries(manager, group_id: int = 1) -> list[int]:
+    return sorted(
+        {
+            block.block_hash_num_tokens
+            for block in manager.block_pool.blocks
+            if block.block_hash is not None
+            and block.block_hash_num_tokens
+            and get_group_id(block.block_hash) == group_id
+        }
+    )
+
+
+@pytest.mark.parametrize("prefill_chunk", [2, 16])
+def test_fine_grained_retention_keeps_scheduler_aligned_fallback(prefill_chunk: int):
+    """Sparse retention (interval 0) under fine-grained hits must keep the
+    scheduler-aligned recurrent state and its EAGLE predecessor next to the
+    fine replay boundary. With prefill in scheduler-sized steps the recurrent
+    state is only materialized at step ends, so the fine boundary alone would
+    retain nothing and a repeat request would resume from zero."""
+    hash_block_size = 2
+    attn_block_size = 16  # also the scheduler block (LCM with the mamba block)
+    manager = make_kv_cache_manager(
+        kv_cache_config=_make_hybrid_swa_eagle_config(
+            hash_block_size=hash_block_size,
+            attn_block_size=attn_block_size,
+            mamba_block_size=hash_block_size,
+            sliding_window=attn_block_size,
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        use_eagle=True,
+        retention_interval=0,
+    )
+    assert manager.coordinator.enable_partial_hash_hits
+    base = list(range(1000, 1045))  # replay boundary 44; scheduler-aligned 32
+    _prefill_and_free(
+        manager, make_request("0", base, hash_block_size, sha256), prefill_chunk
+    )
+
+    retained = _cached_mamba_boundaries(manager)
+    # Scheduler-aligned fallback (32) and its predecessor (16) are always kept.
+    assert {16, 32} <= set(retained)
+    if prefill_chunk == hash_block_size:
+        # Fine states exist: the replay boundary (44) and its EAGLE predecessor (42).
+        assert {42, 44} <= set(retained)
+        expected_repeat_hit = 42
+    else:
+        # Only step-end states exist; the fine boundary retains nothing extra.
+        assert retained == [16, 32]
+        expected_repeat_hit = 32
+    repeat = _prefill_and_free(
+        manager, make_request("1", base, hash_block_size, sha256), prefill_chunk
+    )
+    assert repeat == expected_repeat_hit
+
+
+@pytest.mark.parametrize("num_prompt_tokens", [13, 45, 48])
+def test_hybrid_decoupled_blocks_keep_fine_grained_reuse(num_prompt_tokens: int):
+    """Large attention/draft blocks (page parity with the recurrent state)
+    with a fine recurrent block and hash unit reuse prefixes exactly like an
+    all-fine-block layout: a repeat or a shared-prefix request resumes from
+    the last recurrent checkpoint before the prompt tail, minus the draft's
+    EAGLE unit, and once the shared prefix is registered the next request
+    resumes from the tail itself."""
+    hash_block_size = 2
+
+    def hits(attn_block_size: int, mamba_block_size: int) -> tuple[int, int, int]:
+        manager = make_kv_cache_manager(
+            kv_cache_config=_make_hybrid_swa_eagle_config(
+                hash_block_size=hash_block_size,
+                attn_block_size=attn_block_size,
+                mamba_block_size=mamba_block_size,
+                sliding_window=attn_block_size,
+            ),
+            max_model_len=8192,
+            enable_caching=True,
+            hash_block_size=hash_block_size,
+            use_eagle=True,
+        )
+        base = list(range(1000, 1000 + num_prompt_tokens))
+        _prefill_and_free(
+            manager, make_request("0", base, hash_block_size, sha256), mamba_block_size
+        )
+        identical = _prefill_and_free(
+            manager, make_request("1", base, hash_block_size, sha256), mamba_block_size
+        )
+        suffix = _prefill_and_free(
+            manager,
+            make_request("2", base + [7, 7], hash_block_size, sha256),
+            mamba_block_size,
+        )
+        suffix_again = _prefill_and_free(
+            manager,
+            make_request("3", base + [7, 7], hash_block_size, sha256),
+            mamba_block_size,
+        )
+        return identical, suffix, suffix_again
+
+    fine = hits(attn_block_size=2, mamba_block_size=2)
+    decoupled = hits(attn_block_size=16, mamba_block_size=2)
+    # A repeat may hit up to num_prompt - 1; a longer request up to the whole
+    # shared prompt. Either way the draft's EAGLE unit comes off the tail.
+    repeat_tail = (num_prompt_tokens - 1) // hash_block_size * hash_block_size
+    shared_tail = num_prompt_tokens // hash_block_size * hash_block_size
+    assert fine[:2] == (
+        repeat_tail - hash_block_size,
+        shared_tail - hash_block_size,
+    )
+    assert decoupled == fine
 
 
 @pytest.mark.parametrize("dcp_world_size", [1, 2, 4])
@@ -1876,3 +2314,402 @@ def test_dcp_partial_hit_with_eagle_rewinds_one_hash_unit():
     assert num_computed == 4
     assert [len(group) for group in computed_blocks.blocks] == [1, 1]
     assert manager.allocate_slots(req1, 4, num_computed, computed_blocks) is not None
+
+
+@pytest.mark.parametrize("dcp_world_size", [1, 2])
+@pytest.mark.parametrize("events_enabled", [True, False])
+def test_full_replay_reports_fine_hit(dcp_world_size, events_enabled):
+    from vllm.distributed.kv_events import BlockStored
+    from vllm.v1.core.kv_cache_utils import maybe_convert_block_hash
+
+    manager = make_full_mamba_manager(
+        dcp_world_size=dcp_world_size,
+        full_block_size=4,
+        mamba_block_size=16,
+        enable_kv_cache_events=events_enabled,
+    )
+    req = make_request("fine-replay", list(range(49)), 2, sha256)
+    req.kv_cache_report_mode = "full"
+    pool = manager.block_pool
+    hit_tokens = 46
+    for group_idx, single in enumerate(manager.coordinator.single_type_managers):
+        size = single.block_size
+        count = hit_tokens // size
+        blocks = pool.get_new_blocks(count + 1)
+        if group_idx == 0:
+            pool.cache_full_blocks(req, blocks, 0, count, size, group_idx)
+        pool.cache_partial_block(req, blocks[-1], hit_tokens, group_idx, size)
+    pool.take_events()
+    before = [(b.block_hash, b.block_hash_num_tokens, b.ref_cnt) for b in pool.blocks]
+    aliases = {
+        key: set(value) for key, value in pool.cached_block_hashes_by_block.items()
+    }
+    computed, hit, _ = manager.get_computed_blocks(req)
+    assert hit == hit_tokens
+    assert computed.blocks[1][0].is_null
+    events = manager.take_events()
+    assert [
+        (b.block_hash, b.block_hash_num_tokens, b.ref_cnt) for b in pool.blocks
+    ] == before
+    assert pool.cached_block_hashes_by_block == aliases
+    if not events_enabled:
+        assert events == []
+        return
+    assert len(events) == 3
+    assert all(isinstance(event, BlockStored) for event in events)
+    full, full_tail, mamba_tail = events
+    size = 4 * dcp_world_size
+    end = hit_tokens // size * size
+    assert full.block_size == size
+    assert full.token_ids == list(range(end))
+    assert full.block_hashes == [
+        maybe_convert_block_hash(req.block_hashes[i])
+        for i in range(size // 2 - 1, end // 2, size // 2)
+    ]
+    for event, group in [(full_tail, 0), (mamba_tail, 1)]:
+        assert event.group_idx == group
+        assert event.block_hashes == [maybe_convert_block_hash(req.block_hashes[22])]
+        assert event.parent_block_hash == maybe_convert_block_hash(req.block_hashes[21])
+        assert event.token_ids == [44, 45]
+        assert event.block_size == 2
+        assert event.extra_keys == [None]
+
+
+class TestSemanticReplayCheckpoints(unittest.TestCase):
+    def manager(self, block, draft):
+        config = _make_hybrid_swa_eagle_config(
+            block, 2048, block, 2048, num_blocks=4096
+        )
+        config.kv_cache_groups[1].kv_cache_spec = replace(
+            config.kv_cache_groups[1].kv_cache_spec, num_prefill_checkpoint_blocks=1
+        )
+        if draft == "mtp":
+            config.kv_cache_groups[2].kv_cache_spec = FullAttentionSpec(
+                block_size=2048, num_kv_heads=1, head_size=1, dtype=torch.float32
+            )
+        return make_kv_cache_manager(
+            config,
+            max_model_len=524288,
+            enable_caching=True,
+            hash_block_size=block,
+            use_eagle=True,
+            retention_interval=0,
+        )
+
+    def test_large_chunk_materializes_a_reusable_replay_state(self):
+        manager = self.manager(256, "mtp")
+        scheduler = SimpleNamespace(
+            cache_config=SimpleNamespace(
+                block_size=2048,
+                prefix_cache_retention_interval=0,
+                mamba_cache_mode="align",
+            ),
+            kv_cache_manager=manager,
+            block_size=2048,
+            scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+            drop_last_prefix_cache_block=True,
+            mamba_has_prefill_checkpoint_blocks=True,
+            use_eagle=True,
+            max_num_scheduled_tokens=8192,
+            hash_block_size=256,
+            mamba_partial_cache_hit=True,
+        )
+        request = make_request("cold", list(range(65536)), 256, sha256)
+        steps = 0
+        while request.num_computed_tokens < request.num_prompt_tokens:
+            budget = min(8192, request.num_prompt_tokens - request.num_computed_tokens)
+            step = Scheduler._mamba_block_aligned_split(scheduler, request, budget)
+            self.assertGreater(step, 0)
+            self.assertLessEqual(step, budget)
+            self.assertIsNotNone(manager.allocate_slots(request, step))
+            request.num_computed_tokens += step
+            manager.new_step_starts()
+            steps += 1
+            self.assertLessEqual(steps, 16)
+        self.assertIsNotNone(manager.allocate_slots(request, 1))
+        request.num_computed_tokens += 1
+        manager.new_step_starts()
+        manager.free(request)
+        manager.new_step_starts()
+        _, hit, _ = manager.get_computed_blocks(
+            make_request("repeat", list(range(65536)), 256, sha256)
+        )
+        self.assertGreaterEqual(hit, 65024)
+
+    def test_swa_preserves_the_materialized_recurrent_fallback(self):
+        manager = self.manager(256, "dflash")
+        _prefill_and_free(
+            manager, make_request("cold", list(range(65536)), 256, sha256), 4096
+        )
+        retained = {
+            b.block_hash_num_tokens
+            for b in manager.block_pool.blocks
+            if b.block_hash and get_group_id(b.block_hash) == 1
+        }
+        self.assertIn(61440, retained)
+        _, hit, _ = manager.get_computed_blocks(
+            make_request("repeat", list(range(65536)), 256, sha256)
+        )
+        self.assertGreaterEqual(hit, 61440)
+
+    def test_fine_checkpoint_keeps_the_rewind_stop(self):
+        manager = self.manager(256, "mtp")
+        scheduler = SimpleNamespace(
+            cache_config=SimpleNamespace(
+                block_size=2048, prefix_cache_retention_interval=0
+            ),
+            kv_cache_manager=manager,
+            block_size=2048,
+            scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+            drop_last_prefix_cache_block=True,
+            mamba_has_prefill_checkpoint_blocks=True,
+            use_eagle=True,
+            max_num_scheduled_tokens=4096,
+            hash_block_size=256,
+            mamba_partial_cache_hit=True,
+        )
+        request = make_request("tail", list(range(8449)), 256, sha256)
+        request.num_computed_tokens = 6144
+        # The worker captures 8448 internally. Lookup also needs 8192.
+        step = Scheduler._mamba_block_aligned_split(scheduler, request, 2305)
+        self.assertEqual(step, 2048)
+
+
+def test_semantic_checkpoints_support_unitary_recurrent_coordinator():
+    config = _make_hybrid_swa_eagle_config(2048, 2048, 2048, 2048, num_blocks=128)
+    config.kv_cache_groups = [config.kv_cache_groups[1]]
+    manager = make_kv_cache_manager(
+        config,
+        max_model_len=524288,
+        enable_caching=True,
+        hash_block_size=2048,
+        retention_interval=0,
+    )
+    assert not hasattr(manager.coordinator, "_cache_hit_alignment_tokens")
+    scheduler = SimpleNamespace(
+        cache_config=SimpleNamespace(
+            block_size=2048, prefix_cache_retention_interval=0
+        ),
+        kv_cache_manager=manager,
+        block_size=2048,
+        scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+        drop_last_prefix_cache_block=False,
+        mamba_has_prefill_checkpoint_blocks=True,
+        use_eagle=False,
+        max_num_scheduled_tokens=8192,
+        hash_block_size=2048,
+        mamba_partial_cache_hit=False,
+    )
+    request = make_request("unitary-tail", list(range(65536)), 2048, sha256)
+    request.num_computed_tokens = 61440
+    assert Scheduler._mamba_block_aligned_split(scheduler, request, 4096) == 2048
+
+
+def _snapshot_offload_kv_cache_config(
+    hash_block_size: int, block_size: int, num_blocks: int = 24
+):
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+
+
+def test_retention_snapshots_handed_off_with_exact_block_ids():
+    """Under sparse retention, each retained mamba boundary state block is
+    handed to the connector with its exact block id. Connectors must not resolve
+    align-mode state blocks positionally because the block table is not
+    append-only."""
+    hash_block_size = 2
+    block_size = 4
+    manager = make_kv_cache_manager(
+        kv_cache_config=_snapshot_offload_kv_cache_config(hash_block_size, block_size),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    manager.coordinator.retention_interval = 2 * block_size
+
+    req0 = make_request("0", [0] * 16, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(req0, 8, num_computed, computed_blocks) is not None
+
+    mamba_blocks = manager.coordinator.single_type_managers[1].req_to_blocks["0"]
+    offloads = drain_boundary_state_offloads(manager)
+    ((group_id, block_id, boundary),) = offloads["0"]
+    assert group_id == 1
+    assert boundary == 2 * block_size
+    assert block_id == mamba_blocks[1].block_id
+
+    req0.num_computed_tokens = 8
+    manager.new_step_starts()
+    assert manager.allocate_slots(req0, 8) is not None
+
+    offloads = drain_boundary_state_offloads(manager)
+    ((group_id, block_id2, boundary2),) = offloads["0"]
+    assert group_id == 1
+    assert boundary2 == 4 * block_size
+    assert block_id2 == mamba_blocks[3].block_id
+    # Interior align-mode positions stay null and are never handed off.
+    assert mamba_blocks[0].is_null and mamba_blocks[2].is_null
+
+    manager.free(req0)
+
+
+def test_snapshot_handoff_dense_default_retention():
+    """With dense (default) retention, every materialized mamba boundary
+    state block is handed off — regular mamba-align + prefix-match-unit
+    deployments get store-able boundary snapshots without setting
+    VLLM_PREFIX_CACHE_RETENTION_INTERVAL."""
+    hash_block_size = 2
+    block_size = 4
+    manager = make_kv_cache_manager(
+        kv_cache_config=_snapshot_offload_kv_cache_config(hash_block_size, block_size),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    assert manager.coordinator.retention_interval is None
+
+    req0 = make_request("0", [0] * 16, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(req0, 8, num_computed, computed_blocks) is not None
+
+    mamba_blocks = manager.coordinator.single_type_managers[1].req_to_blocks["0"]
+    ((group_id, block_id, boundary),) = drain_boundary_state_offloads(manager)["0"]
+    assert group_id == 1
+    assert boundary == 2 * block_size
+    assert block_id == mamba_blocks[1].block_id
+
+    req0.num_computed_tokens = 8
+    manager.new_step_starts()
+    assert manager.allocate_slots(req0, 8) is not None
+    ((group_id, block_id2, boundary2),) = drain_boundary_state_offloads(manager)["0"]
+    assert group_id == 1
+    assert boundary2 == 4 * block_size
+    assert block_id2 == mamba_blocks[3].block_id
+
+
+def _run_chunked_prefill(manager, req, chunk_size, num_chunks):
+    """Prefill ``req`` one ``chunk_size`` chunk per scheduler step, yielding the
+    boundary-state hand-offs offered (and claimed) at each step."""
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req)
+    for step in range(num_chunks):
+        manager.new_step_starts()
+        req.num_computed_tokens = step * chunk_size
+        if step == 0:
+            allocated = manager.allocate_slots(
+                req, chunk_size, num_computed, computed_blocks
+            )
+        else:
+            allocated = manager.allocate_slots(req, chunk_size)
+        assert allocated is not None
+        yield drain_boundary_state_offloads(manager).get(req.request_id, [])
+
+
+def test_boundary_state_offer_includes_more_mamba_groups_than_two():
+    """One offer batch carries one exact block entry per mamba group."""
+    block_size = 8
+    num_mamba_groups = 3
+    manager = make_kv_cache_manager(
+        kv_cache_config=KVCacheConfig(
+            num_blocks=200,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["full"],
+                    FullAttentionSpec(
+                        block_size=block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                    ),
+                ),
+                *(
+                    KVCacheGroupSpec(
+                        [f"mamba{i}"],
+                        MambaSpec(
+                            block_size=block_size,
+                            shapes=(1, 1),
+                            dtypes=(torch.float32,),
+                            mamba_cache_mode="align",
+                        ),
+                    )
+                    for i in range(num_mamba_groups)
+                ),
+            ],
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    req0 = make_request("0", [0] * (2 * block_size), block_size, sha256)
+    entries = next(_run_chunked_prefill(manager, req0, block_size, 1))
+
+    assert [group_id for group_id, _, _ in entries] == [1, 2, 3]
+    assert {boundary for _, _, boundary in entries} == {block_size}
+
+
+def test_boundary_states_offered_past_prompt_for_resumed_prefill():
+    """The core offers every committed boundary, including past
+    ``num_prompt_tokens``. A resumed request re-prefills its generated tokens
+    and every group re-saves them, so filtering on the original prompt length
+    would silently strip the mamba key for boundaries full attention still
+    stores; only the connector knows where its save window ends."""
+    block_size = 8
+    prompt_len = block_size
+    manager = make_kv_cache_manager(
+        kv_cache_config=_snapshot_offload_kv_cache_config(
+            hash_block_size=block_size, block_size=block_size, num_blocks=200
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    req0 = make_request("0", [0] * prompt_len, block_size, sha256)
+    assert [
+        boundary
+        for entries in _run_chunked_prefill(manager, req0, block_size, 1)
+        for _, _, boundary in entries
+    ] == [prompt_len]
+
+    # Generate past the next mamba boundary, then replay it as a resumed
+    # prefill: its committed boundary is offered even though it is past the
+    # prompt, matching what full attention saves for the same range.
+    for i in range(block_size):
+        manager.new_step_starts()
+        req0.num_computed_tokens = prompt_len + i
+        req0.append_output_token_ids([1])
+        assert manager.allocate_slots(req0, 1) is not None
+        drain_boundary_state_offloads(manager)
+    assert req0.num_tokens == 2 * block_size
+
+    manager.free(req0)
+    manager.new_step_starts()
+    req0.num_computed_tokens = 0
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(req0, req0.num_tokens - num_computed, num_computed)
+    offered = [b for _, _, b in drain_boundary_state_offloads(manager).get("0", [])]
+    assert 2 * block_size in offered
+    assert req0.num_prompt_tokens < 2 * block_size

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
@@ -565,3 +565,64 @@ def test_partial_block_promotes_to_direct_full_block_hash(dcp_world_size: int):
     )
     assert pool.get_cached_block(promoted_full_hash, [kv_cache_group_id]) == [blocks[1]]
     assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None
+
+
+@pytest.mark.parametrize("tail", ["alias", "unregistered", "null"])
+def test_replay_preserves_partial_alias_residency(tail):
+    req = make_request("alias-replay", list(range(16)), 2, sha256)
+    pool = BlockPool(3, True, 2, True)
+    blocks = pool.get_new_blocks(2)
+    pool.cache_full_blocks(req, blocks, 0, 2, 8, 0)
+    if tail == "alias":
+        pool.cache_partial_block(req, blocks[1], 10, 0, 8)
+    pool.take_events()
+    primary_hash = blocks[1].block_hash
+    aliases = {
+        key: set(value) for key, value in pool.cached_block_hashes_by_block.items()
+    }
+    returned = [blocks[0], pool.null_block if tail == "null" else blocks[1]]
+    pool.emit_cached_block_events(req, returned, 10, 8, 0)
+    events = pool.take_events()
+    assert len(events) == (2 if tail == "alias" else 1)
+    assert events[0].token_ids == list(range(8))
+    if tail == "alias":
+        assert events[1].block_hashes == [
+            kv_cache_utils.maybe_convert_block_hash(req.block_hashes[4])
+        ]
+        assert events[1].parent_block_hash == kv_cache_utils.maybe_convert_block_hash(
+            req.block_hashes[3]
+        )
+        assert events[1].token_ids == [8, 9]
+        assert events[1].block_size == 2
+    assert blocks[1].block_hash == primary_hash
+    assert pool.cached_block_hashes_by_block == aliases
+
+
+def test_sparse_promotion_removes_aliases_before_stored_runs():
+    req = make_request("promotion-runs", list(range(24)), 2, sha256)
+    pool = BlockPool(4, True, 2, True)
+    blocks = pool.get_new_blocks(3)
+    pool.cache_partial_block(req, blocks[0], 6, 0, 8)
+    pool.cache_partial_block(req, blocks[2], 22, 0, 8)
+    pool.take_events()
+    pool.cache_full_blocks(req, blocks, 0, 3, 8, 0, [True, False, True])
+    events = pool.take_events()
+    assert [type(event) for event in events] == [
+        BlockRemoved,
+        BlockRemoved,
+        BlockStored,
+        BlockStored,
+    ]
+    assert [event.block_hashes for event in events] == [
+        [kv_cache_utils.maybe_convert_block_hash(req.block_hashes[i])]
+        for i in (2, 10, 3, 11)
+    ]
+    pool.free_blocks(blocks)
+    assert pool.take_events() == []
+    pool.get_new_blocks(3)
+    removed = pool.take_events()
+    assert len(removed) == 2
+    assert all(isinstance(event, BlockRemoved) for event in removed)
+    assert {h for event in removed for h in event.block_hashes} == {
+        kv_cache_utils.maybe_convert_block_hash(req.block_hashes[i]) for i in (3, 11)
+    }

--- a/tests/v1/core/prefix_cache/test_sparse_event_context.py
+++ b/tests/v1/core/prefix_cache/test_sparse_event_context.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from tests.v1.core.test_prefix_caching import make_request
+from vllm.distributed.kv_events import BlockStored
+from vllm.multimodal.inputs import PlaceholderRange
+from vllm.utils.hashing import sha256
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import init_none_hash, maybe_convert_block_hash
+
+
+@pytest.fixture(autouse=True)
+def init_hash():
+    init_none_hash(sha256)
+
+
+@pytest.mark.parametrize("retain_first", [False, True])
+def test_context_survives_chunk_gap(retain_first):
+    req = make_request("chunks", list(range(16)), 4, sha256)
+    pool = BlockPool(5, True, 4, True)
+    blocks = pool.get_new_blocks(4)
+    pool.cache_full_blocks(req, blocks, 0, 2, 4, 0, [retain_first, False])
+    first = pool.take_events()
+    assert len(first) == int(retain_first)
+    pool.cache_full_blocks(req, blocks, 2, 4, 4, 0, [False, True])
+    (event,) = pool.take_events()
+    start = 4 if retain_first else 0
+    assert event.token_ids == list(range(12, 16))
+    assert event.skipped_token_ids == list(range(start, 12))
+    assert event.skipped_extra_keys == [None] * ((12 - start) // 4)
+    expected_parent = maybe_convert_block_hash(req.block_hashes[0]) if start else None
+    assert event.skipped_parent_block_hash == expected_parent
+    assert event.block_hashes == [maybe_convert_block_hash(req.block_hashes[3])]
+
+
+@pytest.mark.parametrize("retain_full", [False, True])
+def test_partial_replay_supplies_context(retain_full):
+    req = make_request(
+        "partial",
+        list(range(16)),
+        2,
+        sha256,
+        mm_positions=[PlaceholderRange(offset=8, length=2)],
+        mm_hashes=["image"],
+        cache_salt="tenant",
+    )
+    pool = BlockPool(3, True, 2, True)
+    blocks = pool.get_new_blocks(2)
+    if retain_full:
+        pool.cache_full_blocks(req, blocks, 0, 1, 8, 0)
+    pool.cache_partial_block(req, blocks[1], 14, 0, 8)
+    pool.take_events()
+    returned = [blocks[0] if retain_full else pool.null_block, blocks[1]]
+    before = [(b.block_hash, b.block_hash_num_tokens, b.ref_cnt) for b in blocks]
+    pool.emit_cached_block_events(req, returned, 14, 8, 0)
+    events = pool.take_events()
+    assert len(events) == 1 + int(retain_full)
+    event = events[-1]
+    start = 8 if retain_full else 0
+    assert isinstance(event, BlockStored)
+    assert event.token_ids == [12, 13]
+    assert event.block_size == 2
+    assert event.skipped_token_ids == list(range(start, 12))
+    keys = [("tenant",), None, None, None, (("image", 0),), None]
+    assert event.skipped_extra_keys == keys[start // 2 :]
+    expected_parent = maybe_convert_block_hash(req.block_hashes[3]) if start else None
+    assert event.skipped_parent_block_hash == expected_parent
+    assert event.parent_block_hash == maybe_convert_block_hash(req.block_hashes[5])
+    assert event.block_hashes == [maybe_convert_block_hash(req.block_hashes[6])]
+    assert [
+        (b.block_hash, b.block_hash_num_tokens, b.ref_cnt) for b in blocks
+    ] == before
+
+
+@pytest.mark.parametrize("boundary", ["group", "request", "reset"])
+def test_context_stays_with_its_request_group_and_cache(boundary):
+    req = make_request("reused-id", list(range(8)), 4, sha256)
+    pool = BlockPool(5, True, 4, True)
+    first = pool.get_new_blocks(1)
+    pool.cache_full_blocks(req, first, 0, 1, 4, 0)
+    pool.take_events()
+    group = int(boundary == "group")
+    if boundary == "request":
+        req = make_request("reused-id", list(range(8)), 4, sha256)
+    if boundary == "reset":
+        pool.free_blocks(first)
+        assert pool.reset_prefix_cache()
+        pool.take_events()
+    tail = pool.get_new_blocks(1)[0]
+    pool.cache_full_blocks(req, [pool.null_block, tail], 1, 2, 4, group)
+    (event,) = pool.take_events()
+    assert event.skipped_parent_block_hash is None
+    assert event.skipped_token_ids == list(range(4))
+
+
+def test_partial_store_supplies_context():
+    req = make_request("partial-store", list(range(16)), 2, sha256)
+    pool = BlockPool(2, True, 2, True)
+    block = pool.get_new_blocks(1)[0]
+    pool.cache_partial_block(req, block, 14, 0, 8)
+    (event,) = pool.take_events()
+    assert event.token_ids == [12, 13]
+    assert event.skipped_parent_block_hash is None
+    assert event.skipped_token_ids == list(range(12))
+    assert event.skipped_extra_keys == [None] * 6
+
+
+def test_stale_anchor_restarts_context_from_root():
+    req = make_request("stale-anchor", list(range(16)), 4, sha256)
+    pool = BlockPool(5, True, 4, True)
+    blocks = pool.get_new_blocks(4)
+    pool.cache_full_blocks(req, blocks, 0, 2, 4, 0)
+    pool.take_events()
+    # Streaming updates truncate a session in place and rebuild its hash
+    # chain (scheduler._update_request_as_session), which can change the
+    # request's block hashes under a saved anchor. A stale anchor must not
+    # suppress skipped context, so validation restarts from the root.
+    req._all_token_ids[1] = 999
+    req.block_hashes = []
+    req.update_block_hashes()
+    pool.cache_full_blocks(req, blocks, 2, 4, 4, 0, [False, True])
+    (event,) = pool.take_events()
+    assert event.skipped_parent_block_hash is None
+    assert event.skipped_token_ids == req.all_token_ids[:12]
+    assert event.skipped_extra_keys == [None] * 3
+    assert event.block_hashes == [maybe_convert_block_hash(req.block_hashes[3])]
+
+
+def test_partial_only_replay_ignores_saved_anchor():
+    req = make_request("partial-only-replay", list(range(16)), 2, sha256)
+    pool = BlockPool(3, True, 2, True)
+    full_block, partial_block = pool.get_new_blocks(2)
+    pool.cache_full_blocks(req, [full_block], 0, 1, 8, 0)
+    pool.cache_partial_block(req, partial_block, 14, 0, 8)
+    pool.take_events()
+
+    pool.emit_cached_block_events(req, [pool.null_block, partial_block], 14, 8, 0)
+    (event,) = pool.take_events()
+    assert event.token_ids == [12, 13]
+    assert event.skipped_token_ids == list(range(12))
+    assert event.skipped_parent_block_hash is None
+    assert event.skipped_extra_keys == [None] * 6
+
+
+@pytest.mark.parametrize("continuation", ["full", "partial"])
+def test_full_replay_advances_incremental_context(continuation):
+    producer = make_request("producer", list(range(32)), 2, sha256)
+    req = make_request("replay-continuation", list(range(32)), 2, sha256)
+    pool = BlockPool(4, True, 2, True)
+    full_block, partial_block, tail = pool.get_new_blocks(3)
+    pool.cache_full_blocks(producer, [full_block], 0, 1, 8, 0)
+    pool.take_events()
+
+    pool.emit_cached_block_events(req, [full_block], 8, 8, 0)
+    (replay,) = pool.take_events()
+    assert replay.token_ids == list(range(8))
+    assert replay.skipped_token_ids is None
+    if continuation == "partial":
+        pool.cache_partial_block(req, partial_block, 14, 0, 8)
+        (partial,) = pool.take_events()
+        assert partial.token_ids == [12, 13]
+        assert partial.skipped_token_ids == list(range(8, 12))
+        assert partial.skipped_extra_keys == [None] * 2
+        assert partial.skipped_parent_block_hash == maybe_convert_block_hash(
+            req.block_hashes[3]
+        )
+
+    pool.cache_full_blocks(
+        req, [full_block, pool.null_block, pool.null_block, tail], 1, 4, 8, 0
+    )
+    (event,) = pool.take_events()
+    assert event.token_ids == list(range(24, 32))
+    assert event.skipped_token_ids == list(range(8, 24))
+    assert event.skipped_extra_keys == [None] * 2
+    assert event.skipped_parent_block_hash == maybe_convert_block_hash(
+        req.block_hashes[3]
+    )

--- a/tests/v1/core/test_kv_connector_block_state.py
+++ b/tests/v1/core/test_kv_connector_block_state.py
@@ -41,7 +41,7 @@ def _hybrid_config() -> KVCacheConfig:
     )
 
 
-def test_connector_block_state_has_snapshot_and_retained_boundaries() -> None:
+def test_connector_block_state_has_snapshot_and_only_explicit_boundaries() -> None:
     grouped_ids = (
         [201, 202, 203, 204],
         [0, 0, 0, 0, 0, 0, 0, 107, 0, 0, 110, 0, 0, 0, 0, 115],
@@ -57,9 +57,7 @@ def test_connector_block_state_has_snapshot_and_retained_boundaries() -> None:
     )
 
     assert state.block_ids == {"req": grouped_ids}
-    assert state.boundary_state_offloads == {
-        "req": [(1, 999, 7680), (1, 107, 4096), (1, 115, 8192)]
-    }
+    assert state.boundary_state_offloads == {"req": [(1, 999, 7680)]}
     manager.get_block_ids.assert_called_once_with("req")
 
 
@@ -89,3 +87,13 @@ def test_connector_block_state_rejects_misaligned_retention() -> None:
             None,
             retention_interval=4100,
         )
+
+
+def test_connector_block_state_never_infers_uncomputed_boundary():
+    manager = SimpleNamespace(
+        get_block_ids=MagicMock(return_value=([1], [0] * 7 + [9]))
+    )
+    state = _build_kv_connector_block_state(
+        _hybrid_config(), manager, ["req"], None, retention_interval=4096
+    )
+    assert state.boundary_state_offloads == {}

--- a/tests/v1/core/test_kv_connector_block_state.py
+++ b/tests/v1/core/test_kv_connector_block_state.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 

--- a/tests/v1/core/test_lp27_review_invariants.py
+++ b/tests/v1/core/test_lp27_review_invariants.py
@@ -1,86 +1,200 @@
-from dataclasses import replace
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 from types import SimpleNamespace as NS
+
 import pytest
 import torch
-from tests.v1.core.test_prefix_caching import make_request, make_kv_cache_manager
+
+from tests.v1.core.test_prefix_caching import make_kv_cache_manager, make_request
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import (
+    ExternalCachedBlockPool,
+    MooncakeStoreCoordinator,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
+    ChunkedTokenDatabase,
+    KeyMetadata,
+    RequestTracker,
+)
 from vllm.utils.hashing import sha256
 from vllm.v1.core.kv_cache_utils import init_none_hash
 from vllm.v1.core.sched.scheduler import Scheduler
-from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec, SlidingWindowSpec, KVCacheConfig, KVCacheGroupSpec
-from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import MooncakeStoreCoordinator
-from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import RequestTracker, ChunkedTokenDatabase, KeyMetadata
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+    SlidingWindowSpec,
+)
+
 
 @pytest.fixture(autouse=True)
 def init_hash():
     init_none_hash(sha256)
 
+
 def config(block=256, attention=2048, spec_blocks=0):
-    return KVCacheConfig(num_blocks=512, kv_cache_tensors=[], kv_cache_groups=[
-        KVCacheGroupSpec(['full'], FullAttentionSpec(block_size=attention, num_kv_heads=1, head_size=1, dtype=torch.float32)),
-        KVCacheGroupSpec(['mamba'], MambaSpec(block_size=block, shapes=((1, 1),), dtypes=(torch.float32,), mamba_cache_mode='align', num_speculative_blocks=spec_blocks)),
-        KVCacheGroupSpec(['draft'], SlidingWindowSpec(block_size=attention, num_kv_heads=1, head_size=1, dtype=torch.float32, sliding_window=attention), is_eagle_group=True)])
+    return KVCacheConfig(
+        num_blocks=512,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=attention,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                    num_speculative_blocks=spec_blocks,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["draft"],
+                SlidingWindowSpec(
+                    block_size=attention,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=attention,
+                ),
+                is_eagle_group=True,
+            ),
+        ],
+    )
+
 
 def test_external_fine_hit_gate_matches_engine():
-    cfg=config()
-    engine=make_kv_cache_manager(cfg, max_model_len=65536, hash_block_size=256, enable_caching=True, use_eagle=True, retention_interval=0)
-    external=MooncakeStoreCoordinator(cfg.kv_cache_groups, 2048, 256, use_eagle=True, retention_interval=0)
+    cfg = config()
+    engine = make_kv_cache_manager(
+        cfg,
+        max_model_len=65536,
+        hash_block_size=256,
+        enable_caching=True,
+        use_eagle=True,
+        retention_interval=0,
+    )
+    external = MooncakeStoreCoordinator(
+        cfg.kv_cache_groups, 2048, 256, use_eagle=True, retention_interval=0
+    )
     assert engine.coordinator.enable_partial_hash_hits
-    assert external.enable_partial_hash_hits, 'Engine enables fine hits but Mooncake disables them'
+    assert external.enable_partial_hash_hits, (
+        "Engine enables fine hits but Mooncake disables them"
+    )
+
 
 def test_positive_retention_boundary_is_materialized():
-    req=make_request('retention',list(range(16384)),512,sha256)
-    req.num_computed_tokens=3584
-    scheduler=NS(cache_config=NS(block_size=512,prefix_cache_retention_interval=4096),
+    req = make_request("retention", list(range(16384)), 512, sha256)
+    req.num_computed_tokens = 3584
+    scheduler = NS(
+        cache_config=NS(block_size=512, prefix_cache_retention_interval=4096),
         scheduler_config=NS(long_prefill_token_threshold=0),
-        max_num_scheduled_tokens=4096, use_eagle=True, drop_last_prefix_cache_block=False,
-        mamba_has_prefill_checkpoint_blocks=True,hash_block_size=512,mamba_partial_cache_hit=False)
-    step=Scheduler._mamba_block_aligned_split(scheduler,req,4089)
-    assert step == 512, f'Crosses required token 4096 and ends at {3584+step}'
+        max_num_scheduled_tokens=4096,
+        use_eagle=True,
+        drop_last_prefix_cache_block=False,
+        mamba_has_prefill_checkpoint_blocks=True,
+        hash_block_size=512,
+        mamba_partial_cache_hit=False,
+    )
+    step = Scheduler._mamba_block_aligned_split(scheduler, req, 4089)
+    assert step == 512, f"Crosses required token 4096 and ends at {3584 + step}"
+
 
 def test_semantic_replay_expands_each_boundary_once():
-    cfg=config()
-    core=make_kv_cache_manager(cfg,max_model_len=65536,hash_block_size=256,enable_caching=True,use_eagle=True,retention_interval=0)
-    mamba=core.coordinator.single_type_managers[1]
-    assert set(mamba._expand_reachable_boundaries([65535])) == {61440,63488,65024,65280}
+    cfg = config()
+    core = make_kv_cache_manager(
+        cfg,
+        max_model_len=65536,
+        hash_block_size=256,
+        enable_caching=True,
+        use_eagle=True,
+        retention_interval=0,
+    )
+    mamba = core.coordinator.single_type_managers[1]
+    assert set(mamba._expand_reachable_boundaries([65535])) == {
+        61440,
+        63488,
+        65024,
+        65280,
+    }
     for mgr in core.coordinator.single_type_managers:
         if isinstance(mgr.kv_cache_spec, SlidingWindowSpec):
             import inspect
-            inspect.signature(mgr.cache_blocks).bind(object(),0,alignment_tokens=256)
+
+            inspect.signature(mgr.cache_blocks).bind(object(), 0, alignment_tokens=256)
+
 
 def test_positional_store_does_not_read_relocated_speculative_block():
-    cfg=config(16,16,2)
-    cfg.kv_cache_groups=cfg.kv_cache_groups[:2]
-    core=make_kv_cache_manager(cfg,max_model_len=1024,hash_block_size=16,enable_caching=True,use_eagle=True,retention_interval=48)
-    req=make_request('producer',list(range(128)),16,sha256)
-    first=core.allocate_slots(req,32,num_lookahead_tokens=2)
+    cfg = config(16, 16, 2)
+    cfg.kv_cache_groups = cfg.kv_cache_groups[:2]
+    core = make_kv_cache_manager(
+        cfg,
+        max_model_len=1024,
+        hash_block_size=16,
+        enable_caching=True,
+        use_eagle=True,
+        retention_interval=48,
+    )
+    req = make_request("producer", list(range(128)), 16, sha256)
+    first = core.allocate_slots(req, 32, num_lookahead_tokens=2)
     assert first is not None
-    tracker=RequestTracker(req_id=req.request_id,token_len=32,allocated_block_ids=core.get_blocks(req.request_id).get_block_ids(),num_saved_tokens=0)
-    req.num_computed_tokens=32
+    tracker = RequestTracker(
+        req_id=req.request_id,
+        token_len=32,
+        allocated_block_ids=core.get_blocks(req.request_id).get_block_ids(),
+        num_saved_tokens=0,
+    )
+    req.num_computed_tokens = 32
     core.new_step_starts()
-    second=core.allocate_slots(req,64,num_lookahead_tokens=2)
+    second = core.allocate_slots(req, 64, num_lookahead_tokens=2)
     assert second is not None
     tracker.update(second.get_block_ids())
-    req.num_computed_tokens=96
-    current=core.get_blocks(req.request_id).get_block_ids()[1]
-    old=tracker.allocated_block_ids[1]
-    print('Mamba current block IDs:',current,'connector snapshot:',old)
-    assert old[2] == current[5], 'Reproducer requires the 48-token slot to alias the 96-token state'
-    coord=MooncakeStoreCoordinator(cfg.kv_cache_groups,16,16,use_eagle=True,retention_interval=48)
-    masks=coord.store_mask(96,0,num_prompt_tokens=128)
-    db=ChunkedTokenDatabase(KeyMetadata('review',0,0,0,0,group_id=1),block_size=16)
-    stored=list(db.process_tokens(96,req.block_hashes,chunk_mask=masks[1]))
-    print('Mamba store spans:',[(s,e) for s,e,_ in stored])
-    assert not any(e == 48 for s,e,_ in stored), 'Stores the 96-token state under the valid 48-token prefix hash'
+    req.num_computed_tokens = 96
+    current = core.get_blocks(req.request_id).get_block_ids()[1]
+    old = tracker.allocated_block_ids[1]
+    print("Mamba current block IDs:", current, "connector snapshot:", old)
+    assert old[2] == current[5], (
+        "Reproducer requires the 48-token slot to alias the 96-token state"
+    )
+    coord = MooncakeStoreCoordinator(
+        cfg.kv_cache_groups, 16, 16, use_eagle=True, retention_interval=48
+    )
+    masks = coord.store_mask(96, 0, num_prompt_tokens=128)
+    db = ChunkedTokenDatabase(
+        KeyMetadata("review", 0, 0, 0, 0, group_id=1), block_size=16
+    )
+    stored = list(db.process_tokens(96, req.block_hashes, chunk_mask=masks[1]))
+    print("Mamba store spans:", [(s, e) for s, e, _ in stored])
+    assert not any(e == 48 for s, e, _ in stored), (
+        "Stores the 96-token state under the valid 48-token prefix hash"
+    )
 
 
 def test_fine_swa_lookup_accepts_mooncake_hash_sequence():
-    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import BlobBlockHashes
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
+        BlobBlockHashes,
+    )
     from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
     from vllm.v1.kv_cache_interface import SlidingWindowSpec
+
     hashes = BlobBlockHashes(memoryview(bytes(range(32)) * 8), 32)
-    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import ExternalCachedBlockPool
     pool = ExternalCachedBlockPool(32, set())
-    spec = SlidingWindowSpec(block_size=64, num_kv_heads=1, head_size=1, dtype=torch.float32, sliding_window=128)
+    spec = SlidingWindowSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=128,
+    )
     blocks, hit = SlidingWindowManager.find_longest_cache_hit(
-        hashes, 256, [0], pool, spec, False, alignment_tokens=32)
+        hashes, 256, [0], pool, spec, False, alignment_tokens=32
+    )
     assert hit == 0

--- a/tests/v1/core/test_lp27_review_invariants.py
+++ b/tests/v1/core/test_lp27_review_invariants.py
@@ -1,0 +1,86 @@
+from dataclasses import replace
+from types import SimpleNamespace as NS
+import pytest
+import torch
+from tests.v1.core.test_prefix_caching import make_request, make_kv_cache_manager
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import init_none_hash
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec, SlidingWindowSpec, KVCacheConfig, KVCacheGroupSpec
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import MooncakeStoreCoordinator
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import RequestTracker, ChunkedTokenDatabase, KeyMetadata
+
+@pytest.fixture(autouse=True)
+def init_hash():
+    init_none_hash(sha256)
+
+def config(block=256, attention=2048, spec_blocks=0):
+    return KVCacheConfig(num_blocks=512, kv_cache_tensors=[], kv_cache_groups=[
+        KVCacheGroupSpec(['full'], FullAttentionSpec(block_size=attention, num_kv_heads=1, head_size=1, dtype=torch.float32)),
+        KVCacheGroupSpec(['mamba'], MambaSpec(block_size=block, shapes=((1, 1),), dtypes=(torch.float32,), mamba_cache_mode='align', num_speculative_blocks=spec_blocks)),
+        KVCacheGroupSpec(['draft'], SlidingWindowSpec(block_size=attention, num_kv_heads=1, head_size=1, dtype=torch.float32, sliding_window=attention), is_eagle_group=True)])
+
+def test_external_fine_hit_gate_matches_engine():
+    cfg=config()
+    engine=make_kv_cache_manager(cfg, max_model_len=65536, hash_block_size=256, enable_caching=True, use_eagle=True, retention_interval=0)
+    external=MooncakeStoreCoordinator(cfg.kv_cache_groups, 2048, 256, use_eagle=True, retention_interval=0)
+    assert engine.coordinator.enable_partial_hash_hits
+    assert external.enable_partial_hash_hits, 'Engine enables fine hits but Mooncake disables them'
+
+def test_positive_retention_boundary_is_materialized():
+    req=make_request('retention',list(range(16384)),512,sha256)
+    req.num_computed_tokens=3584
+    scheduler=NS(cache_config=NS(block_size=512,prefix_cache_retention_interval=4096),
+        scheduler_config=NS(long_prefill_token_threshold=0),
+        max_num_scheduled_tokens=4096, use_eagle=True, drop_last_prefix_cache_block=False,
+        mamba_has_prefill_checkpoint_blocks=True,hash_block_size=512,mamba_partial_cache_hit=False)
+    step=Scheduler._mamba_block_aligned_split(scheduler,req,4089)
+    assert step == 512, f'Crosses required token 4096 and ends at {3584+step}'
+
+def test_semantic_replay_expands_each_boundary_once():
+    cfg=config()
+    core=make_kv_cache_manager(cfg,max_model_len=65536,hash_block_size=256,enable_caching=True,use_eagle=True,retention_interval=0)
+    mamba=core.coordinator.single_type_managers[1]
+    assert set(mamba._expand_reachable_boundaries([65535])) == {61440,63488,65024,65280}
+    for mgr in core.coordinator.single_type_managers:
+        if isinstance(mgr.kv_cache_spec, SlidingWindowSpec):
+            import inspect
+            inspect.signature(mgr.cache_blocks).bind(object(),0,alignment_tokens=256)
+
+def test_positional_store_does_not_read_relocated_speculative_block():
+    cfg=config(16,16,2)
+    cfg.kv_cache_groups=cfg.kv_cache_groups[:2]
+    core=make_kv_cache_manager(cfg,max_model_len=1024,hash_block_size=16,enable_caching=True,use_eagle=True,retention_interval=48)
+    req=make_request('producer',list(range(128)),16,sha256)
+    first=core.allocate_slots(req,32,num_lookahead_tokens=2)
+    assert first is not None
+    tracker=RequestTracker(req_id=req.request_id,token_len=32,allocated_block_ids=core.get_blocks(req.request_id).get_block_ids(),num_saved_tokens=0)
+    req.num_computed_tokens=32
+    core.new_step_starts()
+    second=core.allocate_slots(req,64,num_lookahead_tokens=2)
+    assert second is not None
+    tracker.update(second.get_block_ids())
+    req.num_computed_tokens=96
+    current=core.get_blocks(req.request_id).get_block_ids()[1]
+    old=tracker.allocated_block_ids[1]
+    print('Mamba current block IDs:',current,'connector snapshot:',old)
+    assert old[2] == current[5], 'Reproducer requires the 48-token slot to alias the 96-token state'
+    coord=MooncakeStoreCoordinator(cfg.kv_cache_groups,16,16,use_eagle=True,retention_interval=48)
+    masks=coord.store_mask(96,0,num_prompt_tokens=128)
+    db=ChunkedTokenDatabase(KeyMetadata('review',0,0,0,0,group_id=1),block_size=16)
+    stored=list(db.process_tokens(96,req.block_hashes,chunk_mask=masks[1]))
+    print('Mamba store spans:',[(s,e) for s,e,_ in stored])
+    assert not any(e == 48 for s,e,_ in stored), 'Stores the 96-token state under the valid 48-token prefix hash'
+
+
+def test_fine_swa_lookup_accepts_mooncake_hash_sequence():
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import BlobBlockHashes
+    from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
+    from vllm.v1.kv_cache_interface import SlidingWindowSpec
+    hashes = BlobBlockHashes(memoryview(bytes(range(32)) * 8), 32)
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import ExternalCachedBlockPool
+    pool = ExternalCachedBlockPool(32, set())
+    spec = SlidingWindowSpec(block_size=64, num_kv_heads=1, head_size=1, dtype=torch.float32, sliding_window=128)
+    blocks, hit = SlidingWindowManager.find_longest_cache_hit(
+        hashes, 256, [0], pool, spec, False, alignment_tokens=32)
+    assert hit == 0

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -89,12 +89,16 @@ def _split(
     partial_hit: bool = False,
     num_prefill_checkpoint_blocks: int = 0,
     allow_speculative_checkpoints: bool = False,
+    retention_interval: int | None = None,
 ) -> int:
     """Call the real `Scheduler._mamba_block_aligned_split` on a stub self."""
     if use_eagle is None:
         use_eagle = drop_last_prefix_cache_block
     stub = SimpleNamespace(
-        cache_config=SimpleNamespace(block_size=MAMBA_BLOCK_SIZE),
+        cache_config=SimpleNamespace(
+            block_size=MAMBA_BLOCK_SIZE,
+            prefix_cache_retention_interval=retention_interval,
+        ),
         drop_last_prefix_cache_block=drop_last_prefix_cache_block,
         use_eagle=use_eagle,
         max_num_scheduled_tokens=16384,
@@ -183,6 +187,45 @@ def test_dflash_checkpoint_keeps_intermediate_chunks_aligned_and_joins_prompt_ta
             allow_speculative_checkpoints=True,
         )
         == 17
+    )
+
+
+def test_dflash_fragmented_budget_stops_at_external_retention_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A DFlash target chunk cannot jump over an externally retained state.
+
+    Seven parallel draft queries leave 4089 target slots in a 4096-token input
+    budget. The first target step therefore ends at 3584. The next step must
+    stop after 512 tokens so the recurrent state at token 4096 is materialized
+    for an external cache connector.
+    """
+    block_size = 512
+    (request,) = create_requests(1, num_tokens=16384, block_size=ATTN_BLOCK_SIZE)
+    monkeypatch.setattr(sys.modules[__name__], "MAMBA_BLOCK_SIZE", block_size)
+
+    assert (
+        _split(
+            request,
+            4089,
+            use_eagle=True,
+            num_prefill_checkpoint_blocks=1,
+            allow_speculative_checkpoints=True,
+            retention_interval=4096,
+        )
+        == 3584
+    )
+    request.num_computed_tokens = 3584
+    assert (
+        _split(
+            request,
+            4089,
+            use_eagle=True,
+            num_prefill_checkpoint_blocks=1,
+            allow_speculative_checkpoints=True,
+            retention_interval=4096,
+        )
+        == 512
     )
 
 

--- a/tests/v1/core/test_micro_slicing.py
+++ b/tests/v1/core/test_micro_slicing.py
@@ -361,3 +361,120 @@ def test_async_external_restore_does_not_consume_local_partial_slot(opt_model_pa
     assert output.total_num_scheduled_tokens == 0
     assert scheduler.num_active_local_partial_prefills == 0
     assert request in scheduler._inflight_prefills
+
+
+@pytest.mark.parametrize("prefill_budget", [2048, 4096])
+def test_split_cache_geometry_allocates_usable_prefill_slices(
+    opt_model_path, monkeypatch, prefill_budget
+):
+    """Three prefills must not divide a usable budget into sub-block slices."""
+    from functools import partial
+
+    import torch
+
+    from vllm.config import CacheConfig
+    from vllm.v1.core.sched.scheduler import Scheduler
+    from vllm.v1.kv_cache_interface import MambaSpec
+
+    from . import utils
+
+    monkeypatch.setattr(
+        utils, "CacheConfig", partial(CacheConfig, mamba_cache_mode="align")
+    )
+    scheduler = _create_micro_scheduler(
+        opt_model_path,
+        block_size=2048,
+        kv_cache_spec=MambaSpec(
+            block_size=256,
+            shapes=((1, 1),),
+            dtypes=(torch.float32,),
+            mamba_cache_mode="align",
+        ),
+        max_num_prefill_tokens_per_step=prefill_budget,
+    )
+    requests = create_requests(3, num_tokens=16384, block_size=256)
+    controller = scheduler.micro_slicing_controller
+    assert controller is not None
+    limits = controller.select_running_limits(
+        [request.request_id for request in requests], prefill_budget
+    )
+    actual = [
+        Scheduler._mamba_block_aligned_split(
+            scheduler, request, limits[request.request_id]
+        )
+        for request in requests
+        if request.request_id in limits
+    ]
+    assert actual and all(tokens > 0 for tokens in actual)
+    assert sum(actual) == prefill_budget
+
+
+def test_split_cache_geometry_rejects_unusable_micro_budget(
+    opt_model_path, monkeypatch
+):
+    from functools import partial
+
+    import torch
+
+    from vllm.config import CacheConfig
+    from vllm.v1.kv_cache_interface import MambaSpec
+
+    from . import utils
+
+    monkeypatch.setattr(
+        utils, "CacheConfig", partial(CacheConfig, mamba_cache_mode="align")
+    )
+    with pytest.raises(ValueError, match="scheduler prefill quantum"):
+        _create_micro_scheduler(
+            opt_model_path,
+            block_size=2048,
+            kv_cache_spec=MambaSpec(
+                block_size=256,
+                shapes=((1, 1),),
+                dtypes=(torch.float32,),
+                mamba_cache_mode="align",
+            ),
+            max_num_prefill_tokens_per_step=2304,
+        )
+
+
+@pytest.mark.parametrize("global_budget,long_threshold", [(1024, 0), (8192, 1024)])
+def test_split_cache_geometry_preserves_global_sub_block_progress(
+    opt_model_path, monkeypatch, global_budget, long_threshold
+):
+    from functools import partial
+
+    import torch
+
+    from vllm.config import CacheConfig
+    from vllm.v1.core.sched.scheduler import Scheduler
+    from vllm.v1.kv_cache_interface import MambaSpec
+
+    from . import utils
+
+    monkeypatch.setattr(
+        utils, "CacheConfig", partial(CacheConfig, mamba_cache_mode="align")
+    )
+    scheduler = _create_micro_scheduler(
+        opt_model_path,
+        block_size=2048,
+        kv_cache_spec=MambaSpec(
+            block_size=256,
+            shapes=((1, 1),),
+            dtypes=(torch.float32,),
+            mamba_cache_mode="align",
+        ),
+        max_num_batched_tokens=global_budget,
+        long_prefill_token_threshold=long_threshold,
+        max_num_prefill_tokens_per_step=1024,
+    )
+    (request,) = create_requests(1, num_tokens=16384, block_size=256)
+    controller = scheduler.micro_slicing_controller
+    assert controller is not None
+    limits = controller.select_running_limits([request.request_id], 1024)
+    assert (
+        Scheduler._mamba_block_aligned_split(
+            scheduler, request, limits[request.request_id]
+        )
+        == 1024
+    )

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -731,7 +731,10 @@ def _test_partial_request_hit(
 
 
 def _make_hybrid_kv_cache_config(
-    block_size: int, num_blocks: int, spec_types: list[str]
+    block_size: int,
+    num_blocks: int,
+    spec_types: list[str],
+    eagle_group_ids: set[int] | None = None,
 ) -> KVCacheConfig:
     """
     Create a KVCacheConfig with the specified spec types.
@@ -744,6 +747,7 @@ def _make_hybrid_kv_cache_config(
             - "sliding_window": SlidingWindowSpec with window=2*block_size
             - "sliding_window_large": SlidingWindowSpec with window=4*block_size
             - "mamba": MambaSpec
+        eagle_group_ids: Group indices explicitly marked for EAGLE/MTP.
     """
     spec_map = {
         "full": lambda: FullAttentionSpec(
@@ -779,8 +783,13 @@ def _make_hybrid_kv_cache_config(
         ),
     }
 
+    eagle_group_ids = eagle_group_ids or set()
     kv_cache_groups = [
-        KVCacheGroupSpec([f"layer{i}"], spec_map[spec_type]())
+        KVCacheGroupSpec(
+            [f"layer{i}"],
+            spec_map[spec_type](),
+            is_eagle_group=i in eagle_group_ids,
+        )
         for i, spec_type in enumerate(spec_types)
     ]
 
@@ -1087,6 +1096,7 @@ def test_hybrid_cache_mamba_align_shared_prefix_detection():
         max_num_scheduled_tokens=3 * block_size,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         use_eagle=False,
+        drop_last_prefix_cache_block=False,
         hash_block_size=block_size,
         mamba_partial_cache_hit=False,
         mamba_has_prefill_checkpoint_blocks=False,
@@ -2500,21 +2510,28 @@ def test_emit_cached_block_events():
     )
     assert len(req.block_hashes) >= num_cached_blocks
 
+    blocks = pool.get_new_blocks(num_cached_blocks)
+    pool.cache_full_blocks(
+        req, blocks, 0, num_cached_blocks, block_size, kv_cache_group_id
+    )
+    pool.take_events()
+    before = [(block.block_hash, block.ref_cnt) for block in blocks]
     # Snapshot block state to prove emit_cached_block_events does not mutate it.
     free_before = pool.get_num_free_blocks()
-    assert len(pool.cached_block_hash_to_block) == 0
+    assert len(pool.cached_block_hash_to_block) == num_cached_blocks
 
     pool.emit_cached_block_events(
         request=req,
-        num_cached_blocks=num_cached_blocks,
+        blocks=blocks,
+        num_cached_tokens=num_cached_blocks * block_size,
         block_size=block_size,
         kv_cache_group_id=kv_cache_group_id,
     )
 
-    # No block-state mutation: nothing allocated, nothing inserted into the
-    # prefix-cache map.
+    assert [(block.block_hash, block.ref_cnt) for block in blocks] == before
+    # Replay does not allocate blocks or change cache membership.
     assert pool.get_num_free_blocks() == free_before
-    assert len(pool.cached_block_hash_to_block) == 0
+    assert len(pool.cached_block_hash_to_block) == num_cached_blocks
 
     events = pool.take_events()
     assert len(events) == 1
@@ -2554,7 +2571,8 @@ def test_emit_cached_block_events_disabled():
 
     pool.emit_cached_block_events(
         request=req,
-        num_cached_blocks=3,
+        blocks=pool.get_new_blocks(3),
+        num_cached_tokens=3 * block_size,
         block_size=block_size,
         kv_cache_group_id=0,
     )
@@ -2563,7 +2581,7 @@ def test_emit_cached_block_events_disabled():
 
 
 def test_emit_cached_block_events_zero_cached():
-    """No events are emitted when num_cached_blocks == 0."""
+    """No events are emitted when no blocks were reused."""
     block_size = 4
     pool = BlockPool(
         num_gpu_blocks=8,
@@ -2580,7 +2598,8 @@ def test_emit_cached_block_events_zero_cached():
 
     pool.emit_cached_block_events(
         request=req,
-        num_cached_blocks=0,
+        blocks=[],
+        num_cached_tokens=0,
         block_size=block_size,
         kv_cache_group_id=0,
     )
@@ -3461,8 +3480,8 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     )
 
     # 127 tokens: latest replay boundary is floor((127 - 1) / 32) * 32 = 96.
-    # The EAGLE/MTP SWA lookup group must cache the local tail ending at
-    # 104 tokens, and that tail is two 8-token blocks wide: hashes 11 and 12.
+    # The EAGLE/MTP SWA lookup group must cache two-block proof tails ending
+    # at 104 tokens and at the reachable predecessor after 64 tokens.
     token_ids = [i for i in range(15) for _ in range(block_size)] + [15] * 7
     req0 = make_request("0", token_ids, block_size, sha256)
     computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
@@ -3476,7 +3495,7 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     assert blocks is not None
 
     pool = manager.block_pool
-    expected_swa_cached = {11, 12}
+    expected_swa_cached = {7, 8, 11, 12}
     for i in range(15):
         cached = pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
         if i in expected_swa_cached:
@@ -3490,6 +3509,440 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
     assert num_computed_tokens == 12 * block_size
     assert [len(blocks) for blocks in computed_blocks.blocks] == [3, 12]
+
+
+def test_hybrid_local_kv_retention_mtp_reuses_exact_boundary():
+    """An unavailable SWA proof block must fall back one aligned boundary."""
+    block_size = 8
+    kv_cache_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=4 * block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["swa_mtp"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=block_size,
+                ),
+                is_eagle_group=True,
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    token_ids = [i // block_size for i in range(129)]
+    request = make_request("0", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(request)
+    blocks = manager.allocate_slots(
+        request,
+        len(token_ids),
+        num_computed_tokens,
+        computed_blocks,
+    )
+    assert blocks is not None
+    manager.free(request)
+
+    replay = make_request("1", token_ids, block_size, sha256)
+    _, num_computed_tokens, _ = manager.get_computed_blocks(replay)
+    assert num_computed_tokens == 12 * block_size
+
+
+@pytest.mark.parametrize("annotate_eagle_groups", [None, "full_only", "both"])
+def test_hybrid_mamba_retention_mtp_boundary_reachable_after_eagle_drop(
+    annotate_eagle_groups,
+):
+    """Verify Mamba latest-only retention serves an MTP/EAGLE lookup.
+
+    The full-attention EAGLE lookup drops one block below what it matched, so
+    until a request decodes past the block boundary after its prompt, the only
+    candidate the coordinator can offer the Mamba group is one block below the
+    replay boundary. Mamba retention must keep that state too; keeping only the
+    boundary state leaves every retained state one block above every reachable
+    candidate, and the reconciled hit is always zero (found live on
+    GLM-5.3-Flash MTP: 0 hits across 16,897 queries).
+
+    Parametrized over how the groups are annotated, because the three cases
+    reach the manager's ``use_eagle`` bit by different routes and only one of
+    them is what production hits today: ``None`` is the coordinator's flag-all
+    fallback (no model annotator exists for glm5_next, so this is the live
+    path), ``full_only`` is a single annotated group (what a future annotator
+    would produce), and ``both`` is the hand-flagged case.
+    """
+    block_size = 32
+    num_spec = 3
+    full_is_eagle = annotate_eagle_groups in ("full_only", "both")
+    mamba_is_eagle = annotate_eagle_groups == "both"
+    kv_cache_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                ),
+                is_eagle_group=full_is_eagle,
+            ),
+            KVCacheGroupSpec(
+                ["mamba_mtp"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                    num_speculative_blocks=num_spec,
+                ),
+                is_eagle_group=mamba_is_eagle,
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    # 127 tokens: replay boundary floor(126 / 32) * 32 = 96, i.e. block 2's end.
+    # Prefill in block-aligned chunks the way the align-mode scheduler does:
+    # the state one block below the boundary only materializes as a chunk's
+    # running-state block, so a single-shot prefill could not retain it.
+    token_ids = [i for i in range(3) for _ in range(block_size)] + [3] * 31
+    req0 = make_request("0", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    for chunk_end in (32, 64, 96, 127):
+        blocks = manager.allocate_slots(
+            req0,
+            chunk_end - req0.num_computed_tokens,
+            num_computed_tokens,
+            computed_blocks,
+            num_lookahead_tokens=num_spec,
+        )
+        assert blocks is not None
+        req0.num_computed_tokens = chunk_end
+
+    # Mamba keeps the boundary state (block 2) plus the state one block below
+    # (block 1) -- the only position an EAGLE-dropped lookup can reach while
+    # the request has not decoded past the next block boundary.
+    pool = manager.block_pool
+    expected_mamba_cached = {1, 2}
+    for i in range(3):
+        cached = pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
+        if i in expected_mamba_cached:
+            assert cached is not None, f"mamba hash {i} should be cached"
+        else:
+            assert cached is None, f"mamba hash {i} should not be cached"
+    manager.free(req0)
+
+    # Identical resend: full attention matches blocks 0-2 (96 tokens) and the
+    # EAGLE drop caps the candidate at 64; the retained state at 64 serves it.
+    req1 = make_request("1", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    assert num_computed_tokens == 2 * block_size
+    assert [len(blocks) for blocks in computed_blocks.blocks] == [2, 2]
+
+
+@pytest.mark.parametrize("fine_hits", [False, True])
+def test_hybrid_mamba_retention_eagle_backoff_is_one_alignment_unit(fine_hits):
+    """The EAGLE back-off is one ALIGNMENT unit, which is not one Mamba block.
+
+    When the groups' block sizes differ, the scheduler alignment is their LCM,
+    and the full-attention finder subtracts ``min(alignment, its block_size)``
+    and re-floors -- landing one alignment unit below the boundary regardless.
+    Backing off one Mamba block instead retains a state at the wrong offset:
+    Mamba's own finder then rejects it (its hit must be alignment-aligned) and
+    the reconciled hit stays 0, so the extra block is dead weight.
+
+    Here alignment is 64 and the Mamba block is 32, so the reachable position
+    is two Mamba blocks below the boundary, not one.
+    """
+    mamba_block = 32
+    full_block = 64  # scheduler alignment = lcm(64, 32) = 64 = 2 mamba blocks
+    kv_cache_config = KVCacheConfig(
+        num_blocks=200,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=full_block,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                ),
+                is_eagle_group=True,
+            ),
+            KVCacheGroupSpec(
+                ["mamba_mtp"],
+                MambaSpec(
+                    block_size=mamba_block,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+                is_eagle_group=True,
+            ),
+        ],
+    )
+    # hash_block_size must divide every group's block size, so it is the
+    # smaller (Mamba) block; the scheduler alignment is still the LCM, 64.
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=mamba_block,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    # Preserve both the coarse fallback contract and the newly enabled fine path.
+    manager.coordinator.enable_partial_hash_hits = fine_hits
+    for group in manager.coordinator.single_type_managers:
+        group.hit_alignment_tokens = manager.coordinator._cache_hit_alignment_tokens
+
+    # 255 tokens: replay boundary floor(254 / 64) * 64 = 192. In Mamba blocks
+    # that is index 5; the EAGLE-reachable position 192 - 64 = 128 is index 3.
+    token_ids = [i for i in range(7) for _ in range(mamba_block)] + [7] * 31
+    req0 = make_request("0", token_ids, mamba_block, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    for chunk_end in (64, 128, 192, 255):
+        blocks = manager.allocate_slots(
+            req0,
+            chunk_end - req0.num_computed_tokens,
+            num_computed_tokens,
+            computed_blocks,
+        )
+        assert blocks is not None
+        req0.num_computed_tokens = chunk_end
+
+    pool = manager.block_pool
+    cached_mamba = {
+        i
+        for i in range(len(req0.block_hashes))
+        if pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
+        is not None
+    }
+    # Index 3 is the one a post-drop lookup can ask for; index 4 (one block
+    # below the boundary) is what a block-sized back-off would have kept.
+    assert 3 in cached_mamba, f"reachable state missing; cached={sorted(cached_mamba)}"
+    assert 4 not in cached_mamba, "one-block back-off retained an unreachable state"
+
+    manager.free(req0)
+    req1 = make_request("1", token_ids, mamba_block, sha256)
+    _, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    assert num_computed_tokens == (192 if fine_hits else 128)
+
+
+def _cache_in_chunks(manager, request, chunk_ends, num_lookahead_tokens=0):
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(request)
+    for chunk_end in chunk_ends:
+        blocks = manager.allocate_slots(
+            request,
+            chunk_end - request.num_computed_tokens,
+            num_computed_tokens,
+            computed_blocks,
+            num_lookahead_tokens=num_lookahead_tokens,
+        )
+        assert blocks is not None
+        request.num_computed_tokens = chunk_end
+
+
+@pytest.mark.parametrize(
+    "eagle_group_ids",
+    [
+        pytest.param(None, id="fallback"),
+        pytest.param({0}, id="full_only"),
+        pytest.param({0, 1, 2}, id="all_groups"),
+    ],
+)
+def test_hybrid_swa_retention_keeps_eagle_reachable_predecessor(eagle_group_ids):
+    """SWA and Mamba must retain the same post-drop replay boundary."""
+    block_size = 32
+    manager = make_kv_cache_manager(
+        kv_cache_config=_make_hybrid_kv_cache_config(
+            block_size,
+            300,
+            ["full", "mamba_align", "sliding_window"],
+            eagle_group_ids=eagle_group_ids,
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    token_ids = [i for i in range(3) for _ in range(block_size)] + [3] * 31
+    req0 = make_request("0", token_ids, block_size, sha256)
+    _cache_in_chunks(manager, req0, (32, 64, 96, 127), num_lookahead_tokens=3)
+    manager.free(req0)
+
+    req1 = make_request("1", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    assert num_computed_tokens == 2 * block_size
+    assert [len(blocks) for blocks in computed_blocks.blocks] == [2, 2, 2]
+
+
+def test_hybrid_mamba_retention_follows_swa_eagle_drop():
+    """Mamba must retain a boundary lowered by another sparse group."""
+    block_size = 32
+    manager = make_kv_cache_manager(
+        kv_cache_config=_make_hybrid_kv_cache_config(
+            block_size,
+            300,
+            ["sliding_window", "mamba_align"],
+            eagle_group_ids={0},
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    token_ids = [i for i in range(8) for _ in range(block_size)] + [8] * 31
+    req0 = make_request("0", token_ids, block_size, sha256)
+    _cache_in_chunks(
+        manager,
+        req0,
+        (32, 64, 96, 128, 160, 192, 224, 256, 287),
+        num_lookahead_tokens=3,
+    )
+    manager.free(req0)
+
+    req1 = make_request("1", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    assert num_computed_tokens == 7 * block_size
+    assert [len(blocks) for blocks in computed_blocks.blocks] == [7, 7]
+
+
+def test_hybrid_sparse_retention_uses_fine_hit_alignment(monkeypatch):
+    """Sparse retention must use the same fine alignment as cache lookup."""
+    hash_block_size = 32
+    cache_block_size = 64
+    manager = make_kv_cache_manager(
+        kv_cache_config=_make_hybrid_kv_cache_config(
+            cache_block_size, 300, ["full", "mamba_align"]
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+    assert manager.coordinator._cache_hit_alignment_tokens == hash_block_size
+
+    mamba_manager = manager.coordinator.single_type_managers[1]
+    original_mask = type(mamba_manager).reachable_block_mask
+    observed_alignments = []
+
+    def record_alignment(cls, **kwargs):
+        observed_alignments.append(kwargs["alignment_tokens"])
+        return original_mask(**kwargs)
+
+    monkeypatch.setattr(
+        type(mamba_manager),
+        "reachable_block_mask",
+        classmethod(record_alignment),
+    )
+
+    token_ids = [i for i in range(3) for _ in range(hash_block_size)] + [3] * 31
+    req0 = make_request("0", token_ids, hash_block_size, sha256)
+    _cache_in_chunks(manager, req0, (64, 127), num_lookahead_tokens=3)
+    assert observed_alignments
+    assert set(observed_alignments) == {hash_block_size}
+
+
+def test_hybrid_fine_hit_retention_preserves_materialized_fallback():
+    """A fine boundary without a state must not displace a usable snapshot."""
+    full = lambda size: FullAttentionSpec(
+        block_size=size, num_kv_heads=1, head_size=1, dtype=torch.float32
+    )
+    config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["full128"], full(128)),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=64,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+            KVCacheGroupSpec(["full32"], full(32)),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=32,
+        retention_interval=0,
+    )
+    assert manager.coordinator._cache_hit_alignment_tokens == 32
+    request = make_request("producer", list(range(480)), 32, sha256)
+    scheduler = SimpleNamespace(
+        # EngineCore uses the smallest group block size here, not the LCM.
+        cache_config=SimpleNamespace(
+            block_size=min(g.kv_cache_spec.block_size for g in config.kv_cache_groups)
+        ),
+        use_eagle=False,
+        drop_last_prefix_cache_block=False,
+        max_num_scheduled_tokens=384,
+        scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+        mamba_partial_cache_hit=True,
+        hash_block_size=32,
+        mamba_has_prefill_checkpoint_blocks=False,
+    )
+    chunk_ends = []
+    while request.num_computed_tokens < request.num_tokens:
+        num_new_tokens = Scheduler._mamba_block_aligned_split(
+            scheduler,
+            request,
+            min(384, request.num_tokens - request.num_computed_tokens),
+        )
+        assert num_new_tokens > 0
+        assert manager.allocate_slots(request, num_new_tokens) is not None
+        request.num_computed_tokens += num_new_tokens
+        chunk_ends.append(request.num_computed_tokens)
+    assert chunk_ends == [384, 480]
+    # No chunk materialized state@448. State@480 exceeds replay's 479-token cap.
+    mamba = manager.coordinator.single_type_managers[1]
+    assert mamba.req_to_blocks[request.request_id][6].is_null
+    manager.free(request)
+
+    replay = make_request("replay", list(range(480)), 32, sha256)
+    _, hit_tokens, _ = manager.get_computed_blocks(replay)
+    assert hit_tokens == 384
 
 
 def test_block_lookup_cache_single_block_per_key():
@@ -4038,6 +4491,30 @@ def test_pure_swa_retention_latest_only():
     assert num_computed == 240
 
 
+def test_pure_swa_eagle_retention_keeps_reachable_predecessor():
+    block_size = 32
+    manager = _make_pure_swa_manager(
+        block_size,
+        sliding_window=2 * block_size,
+        retention_interval=0,
+        use_eagle=True,
+    )
+
+    token_ids = [i for i in range(8) for _ in range(block_size)] + [8] * 31
+    request = make_request("0", token_ids, block_size, sha256)
+    _cache_in_chunks(
+        manager,
+        request,
+        (32, 64, 96, 128, 160, 192, 224, 256, 287),
+        num_lookahead_tokens=3,
+    )
+    manager.free(request)
+
+    replay = make_request("1", token_ids, block_size, sha256)
+    _, num_computed, _ = manager.get_computed_blocks(replay)
+    assert num_computed == 7 * block_size
+
+
 def test_pure_swa_dense_retention_caches_all():
     """With retention set to ``None``, a pure-SWA model keeps dense behavior:
     every block boundary is a potential hit, so all blocks are cached."""
@@ -4334,3 +4811,232 @@ def test_swa_shared_prefix_reuse_under_zero_retention():
     assert last_req_hit(retention=0, pin=False) == 0
     # retention=0 with the pin keeps the junction window -> reuse restored.
     assert last_req_hit(retention=0, pin=True) == 4 * block_size
+
+
+@pytest.mark.parametrize(
+    "start,mask,null_indices,runs",
+    [
+        pytest.param(
+            0,
+            [False, True, True, False, True, True],
+            (),
+            [(1, 3), (4, 6)],
+            id="leading-and-interior-mask",
+        ),
+        pytest.param(0, None, (2,), [(0, 2), (3, 6)], id="interior-null"),
+        pytest.param(0, None, (0,), [(1, 6)], id="leading-null"),
+        pytest.param(0, [False] * 6, (), [], id="all-masked"),
+        pytest.param(0, None, tuple(range(6)), [], id="all-null"),
+        pytest.param(
+            2, [False, True, False, True], (), [(3, 4), (5, 6)], id="cached-offset"
+        ),
+        pytest.param(5, [False], (), [], id="masked-decode"),
+        pytest.param(0, None, (), [(0, 6)], id="dense"),
+    ],
+)
+@pytest.mark.parametrize("events_enabled", [True, False])
+def test_sparse_block_stored_runs(start, mask, null_indices, runs, events_enabled):
+    import msgspec
+
+    from vllm.distributed.kv_events import KVEventBatch
+
+    block_size = 4
+    pool = BlockPool(16, True, block_size, events_enabled)
+    req = make_request(
+        "sparse-events",
+        list(range(24)),
+        block_size,
+        sha256,
+        mm_positions=[
+            PlaceholderRange(offset=4, length=4),
+            PlaceholderRange(offset=16, length=4),
+        ],
+        mm_hashes=["first-image", "second-image"],
+        cache_salt="tenant",
+    )
+    blocks = pool.get_new_blocks(6)
+    for i in null_indices:
+        blocks[i] = pool.null_block
+    pool.cache_full_blocks(req, blocks, start, 6, block_size, 2, mask)
+    retained = {i for lo, hi in runs for i in range(lo, hi)}
+    for i, block_hash in enumerate(req.block_hashes):
+        cached = pool.get_cached_block(block_hash, [2])
+        assert cached == ([blocks[i]] if i in retained else None)
+    events = pool.take_events()
+    assert len(events) == (len(runs) if events_enabled else 0)
+    expected_keys = [
+        ("tenant",),
+        (("first-image", 0),),
+        None,
+        None,
+        (("second-image", 0),),
+        None,
+    ]
+    # Nothing was published before this call, so the first run's skipped
+    # context starts at the root even when the caller's offset is nonzero.
+    previous_end = 0
+    for event, (lo, hi) in zip(events, runs):
+        assert isinstance(event, BlockStored)
+        assert event.block_hashes == [
+            kv_cache_utils.maybe_convert_block_hash(h) for h in req.block_hashes[lo:hi]
+        ]
+        assert event.token_ids == list(range(lo * block_size, hi * block_size))
+        assert event.parent_block_hash == (
+            kv_cache_utils.maybe_convert_block_hash(req.block_hashes[lo - 1])
+            if lo
+            else None
+        )
+        assert event.extra_keys == expected_keys[lo:hi]
+        if lo > previous_end:
+            assert event.skipped_parent_block_hash == (
+                kv_cache_utils.maybe_convert_block_hash(
+                    req.block_hashes[previous_end - 1]
+                )
+                if previous_end
+                else None
+            )
+            assert event.skipped_token_ids == list(
+                range(previous_end * block_size, lo * block_size)
+            )
+            assert event.skipped_extra_keys == expected_keys[previous_end:lo]
+        else:
+            assert event.skipped_parent_block_hash is None
+            assert event.skipped_token_ids is None
+            assert event.skipped_extra_keys is None
+        assert event.block_size == block_size
+        assert event.group_idx == 2
+        assert event.medium == MEDIUM_GPU
+        assert len(event.token_ids) == block_size * len(event.block_hashes)
+        previous_end = hi
+    batch = KVEventBatch(ts=0.0, events=events)
+    encoded = msgspec.msgpack.encode(batch)
+    assert (
+        msgspec.msgpack.encode(msgspec.msgpack.decode(encoded, type=KVEventBatch))
+        == encoded
+    )
+
+
+@pytest.mark.parametrize("kind", ["swa", "mamba"])
+def test_sparse_block_stored_manager_masks(kind):
+    from vllm.v1.core.single_type_kv_cache_manager import (
+        MambaManager,
+        SlidingWindowManager,
+    )
+
+    if kind == "swa":
+        spec = SlidingWindowSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=32,
+        )
+        mask = SlidingWindowManager.reachable_block_mask(0, 64, 512, spec, False)
+        runs = [(30, 32), (62, 64)]
+        count = 64
+    else:
+        spec = MambaSpec(
+            block_size=16,
+            shapes=((1, 1),),
+            dtypes=(torch.float32,),
+            mamba_cache_mode="align",
+        )
+        mask = MambaManager.reachable_block_mask(0, 8, 32, spec, True, 0, (127,))
+        runs = [(3, 4), (5, 6)]
+        count = 8
+    assert mask is not None
+    assert [i for i, keep in enumerate(mask) if keep] == [
+        i for lo, hi in runs for i in range(lo, hi)
+    ]
+    pool = BlockPool(count + 1, True, 16, True)
+    req = make_request("mask-events", list(range(count * 16)), 16, sha256)
+    pool.cache_full_blocks(req, pool.get_new_blocks(count), 0, count, 16, 0, mask)
+    events = pool.take_events()
+    assert len(events) == len(runs)
+    for event, (lo, hi) in zip(events, runs):
+        assert event.token_ids == list(range(lo * 16, hi * 16))
+        assert event.block_hashes == [
+            kv_cache_utils.maybe_convert_block_hash(h) for h in req.block_hashes[lo:hi]
+        ]
+        assert event.parent_block_hash == kv_cache_utils.maybe_convert_block_hash(
+            req.block_hashes[lo - 1]
+        )
+
+
+@pytest.mark.parametrize("kind", ["swa", "mamba", "full"])
+@pytest.mark.parametrize("events_enabled", [True, False])
+def test_full_replay_reports_retained_blocks(kind, events_enabled):
+    block_size = 16
+    full_spec = FullAttentionSpec(
+        block_size=block_size, num_kv_heads=1, head_size=1, dtype=torch.float32
+    )
+    if kind == "mamba":
+        spec = MambaSpec(
+            block_size=block_size,
+            shapes=((1, 1),),
+            dtypes=(torch.float32,),
+            mamba_cache_mode="align",
+        )
+        retained = [5]
+    elif kind == "swa":
+        spec = SlidingWindowSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=32,
+        )
+        retained = [4, 5]
+    else:
+        spec = full_spec
+        retained = list(range(6))
+    manager = make_kv_cache_manager(
+        KVCacheConfig(
+            num_blocks=32,
+            kv_cache_tensors=[],
+            kv_cache_groups=[KVCacheGroupSpec(["layer"], spec)],
+        ),
+        max_model_len=256,
+        enable_caching=True,
+        enable_kv_cache_events=events_enabled,
+        hash_block_size=block_size,
+    )
+    req = make_request(
+        "replay", list(range(97)), block_size, sha256, cache_salt="tenant"
+    )
+    req.kv_cache_report_mode = "full"
+    pool = manager.block_pool
+    blocks = pool.get_new_blocks(6)
+    pool.cache_full_blocks(
+        req, blocks, 0, 6, block_size, 0, [i in retained for i in range(6)]
+    )
+    pool.take_events()
+    before = [(b.block_hash, b.ref_cnt) for b in blocks]
+    cache_size = len(pool.cached_block_hash_to_block)
+    computed, hit, _ = manager.get_computed_blocks(req)
+    assert hit == 96
+    assert [i for i, b in enumerate(computed.blocks[0]) if not b.is_null] == retained
+    events = manager.take_events()
+    assert [(b.block_hash, b.ref_cnt) for b in blocks] == before
+    assert len(pool.cached_block_hash_to_block) == cache_size
+    if not events_enabled:
+        assert events == []
+        return
+    assert len(events) == 1
+    event = events[0]
+    assert isinstance(event, BlockStored)
+    assert event.block_hashes == [
+        kv_cache_utils.maybe_convert_block_hash(req.block_hashes[i]) for i in retained
+    ]
+    assert event.token_ids == list(range(retained[0] * block_size, 96))
+    assert event.parent_block_hash == (
+        kv_cache_utils.maybe_convert_block_hash(req.block_hashes[retained[0] - 1])
+        if retained[0]
+        else None
+    )
+    assert event.extra_keys == (
+        [None] * len(retained) if retained[0] else [("tenant",)] + [None] * 5
+    )
+    assert event.kv_cache_spec_kind == kind.replace("full", "full_attention").replace(
+        "swa", "sliding_window"
+    )

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -14,16 +14,91 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager,
+    FullAttentionManager,
+    MambaManager,
     RSWAManager,
     SlidingWindowManager,
 )
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
+    FullAttentionSpec,
+    MambaSpec,
     RSWASpec,
     SlidingWindowSpec,
 )
 
 pytestmark = pytest.mark.cpu_test
+
+
+def test_external_computed_blocks_do_not_corrupt_free_pool():
+    block_size = 4
+    spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=10,
+        enable_caching=False,
+        hash_block_size=block_size,
+    )
+    manager = FullAttentionManager(
+        spec,
+        block_pool=block_pool,
+        enable_caching=False,
+        kv_cache_group_id=0,
+        scheduler_block_size=block_size,
+    )
+    request_id = "request"
+    manager.allocate_new_blocks(
+        request_id,
+        num_tokens=3 * block_size,
+        num_tokens_main_model=3 * block_size,
+    )
+    num_free_blocks = block_pool.get_num_free_blocks()
+
+    # Speculative allocations can exceed the blocks implied by the eventual
+    # external computed-token count. This must not request a negative number
+    # of blocks, which inflates the free-queue counter.
+    manager.allocate_external_computed_blocks(
+        request_id,
+        num_local_computed_tokens=0,
+        num_external_computed_tokens=block_size,
+    )
+
+    assert block_pool.get_num_free_blocks() == num_free_blocks
+    assert len(manager.req_to_blocks[request_id]) == 3
+
+
+def test_mamba_speculative_block_relocation_requires_exclusive_ownership():
+    spec = MambaSpec(
+        block_size=4,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+        num_speculative_blocks=1,
+    )
+    block_pool = BlockPool(num_gpu_blocks=4, enable_caching=True, hash_block_size=4)
+    manager = MambaManager(
+        spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        scheduler_block_size=4,
+    )
+    block = block_pool.get_new_blocks(1)[0]
+    blocks = [block]
+
+    manager._relocate_speculative_block(blocks, 0)
+
+    assert blocks == [block_pool.null_block, block]
+    assert block.ref_cnt == 1
+
+    pinned_block = block_pool.get_new_blocks(1)[0]
+    block_pool.touch((pinned_block,))
+    with pytest.raises(AssertionError, match="exclusively owned and unhashed"):
+        manager._relocate_speculative_block([pinned_block], 0)
 
 
 def get_sliding_window_manager(

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -39,7 +39,12 @@ from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
+    KVCacheBlockCopy,
     make_block_hash_with_group_id,
+)
+from vllm.v1.core.sched.output import (
+    KVConnectorBlockState,
+    SchedulerOutput,
 )
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
@@ -117,7 +122,12 @@ def test_partial_tail_store_uses_attention_and_recurrent_cow_sources():
         generate_store_output(keys)
     )
 
-    output = SimpleNamespace(partial_tail_offloads={"req": [(1, 99, 28)]})
+    output = SimpleNamespace(
+        kv_connector_block_state=KVConnectorBlockState(
+            block_ids={},
+            boundary_state_offloads={"req": [(1, 99, 28)]},
+        )
+    )
     jobs = scheduler._build_partial_tail_store_jobs(output)
 
     assert len(jobs) == 1
@@ -159,6 +169,83 @@ def test_partial_tail_store_uses_attention_and_recurrent_cow_sources():
     assert recurrent_event.token_ids == []
     assert len(recurrent_event.block_hashes) == 1
     assert recurrent_event.parent_block_hash is None
+
+
+def test_aligned_boundary_store_uses_exact_source_with_partial_tail():
+    scheduler = _make_partial_tail_scheduler()
+    _make_partial_tail_request(scheduler)
+    req_status = scheduler._req_status["req"]
+    req_status.group_states[0].block_ids[:] = [11, 12]
+    req_status.group_states[1].block_ids[:] = [0, 21]
+    scheduler.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+
+    output = SimpleNamespace(
+        kv_connector_block_state=KVConnectorBlockState(
+            block_ids={},
+            boundary_state_offloads={"req": [(1, 98, 16), (1, 99, 28)]},
+        )
+    )
+    jobs = scheduler._build_partial_tail_store_jobs(output)
+
+    assert len(jobs) == 2
+    src_spec = next(
+        job.src_spec for job in jobs.values() if len(job.src_spec.block_ids) == 1
+    )
+    assert isinstance(src_spec, GPULoadStoreSpec)
+    assert src_spec.block_ids.tolist() == [98]
+    assert src_spec.group_sizes == [0, 1]
+    assert src_spec.block_indices == [0, 0]
+
+
+def test_aligned_boundary_store_flushes_before_cow_destination_reuse():
+    scheduler = _make_partial_tail_scheduler()
+    _make_partial_tail_request(scheduler)
+    scheduler.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+
+    output = SchedulerOutput.make_empty()
+    output.kv_connector_block_state = KVConnectorBlockState(
+        block_ids={},
+        boundary_state_offloads={"req": [(1, 99, 16)]},
+    )
+    meta = scheduler.build_connector_meta(output)
+    [job_id] = meta.store_jobs
+
+    output = SchedulerOutput.make_empty()
+    output.kv_cache_block_copies = [KVCacheBlockCopy(98, 99)]
+    meta = scheduler.build_connector_meta(output)
+
+    assert meta.jobs_to_flush == {job_id}
+
+
+def test_normal_store_excludes_align_mode_mamba_sources():
+    scheduler = _make_partial_tail_scheduler()
+    request = _make_partial_tail_request(scheduler)
+    request.num_computed_tokens = 0
+    request.status = RequestStatus.RUNNING
+    req_status = scheduler._req_status["req"]
+    req_status.group_states[0].block_ids[:] = [11]
+    req_status.group_states[1].block_ids[:] = [99]
+    req_status.update_offload_keys()
+    scheduler.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+
+    output = SimpleNamespace(
+        num_scheduled_tokens={"req": 16},
+        finished_req_ids=set(),
+    )
+    jobs = scheduler._build_store_jobs(output)
+
+    assert len(jobs) == 1
+    [job] = jobs.values()
+    src_spec = job.src_spec
+    assert isinstance(src_spec, GPULoadStoreSpec)
+    assert src_spec.block_ids.tolist() == [11]
+    assert src_spec.group_sizes == [1, 0]
 
 
 def test_partial_lookup_returns_exact_boundary_and_group_load_keys():
@@ -3629,7 +3716,21 @@ class TestMambaHybridOffloadServing:
             num_scheduled_tokens={"A": self.PROMPT_TOKENS},
             finished_req_ids=set(),
         )
+        out.kv_connector_block_state = KVConnectorBlockState(
+            block_ids={},
+            boundary_state_offloads={
+                "A": [
+                    (
+                        1,
+                        req_status.group_states[1].block_ids[i],
+                        (i + 1) * self.MAMBA_BLOCK,
+                    )
+                    for i in range(n_mamba)
+                ]
+            },
+        )
         scheduler._build_store_jobs(out)
+        scheduler._build_partial_tail_store_jobs(out)
         complete_all_jobs()
 
         req.num_computed_tokens = self.PROMPT_TOKENS

--- a/tests/v1/kv_connector/unit/test_lp27_snapshot_coverage.py
+++ b/tests/v1/kv_connector/unit/test_lp27_snapshot_coverage.py
@@ -1,0 +1,60 @@
+import pytest
+from unittest.mock import MagicMock
+
+from tests.v1.core.utils import create_requests, create_scheduler, mock_kv
+from tests.v1.core.test_micro_slicing import _update
+from tests.v1.kv_connector.unit.test_mooncake_store_scheduler import (
+    _make_bare_scheduler,
+)
+
+
+@pytest.mark.parametrize(
+    "batch_tokens,save_decode_cache,steps", [(8, False, 3), (8192, True, 18)]
+)
+def test_store_has_current_snapshot_without_new_allocation(
+    tmp_path, batch_tokens, save_decode_cache, steps
+):
+    (tmp_path / "config.json").write_text(
+        '{"architectures":["OPTForCausalLM"],"model_type":"opt","max_position_embeddings":32768}'
+    )
+    core = create_scheduler(
+        model=str(tmp_path),
+        skip_tokenizer_init=True,
+        device="cpu",
+        enable_prefix_caching=True,
+        block_size=16,
+        max_num_seqs=2,
+        max_model_len=32768,
+        max_num_batched_tokens=batch_tokens,
+        use_kv_connector=mock_kv(0, False),
+        kv_role="kv_both",
+    )
+    mooncake = _make_bare_scheduler(
+        kv_role="kv_both", save_decode_cache=save_decode_cache
+    )
+    mooncake._gpu_block_pool = core.kv_cache_manager.block_pool
+    mooncake._boundary_state_group_ids = frozenset()
+    mooncake.client = MagicMock()
+    core.connector.update_state_after_alloc = mooncake.update_state_after_alloc
+    captured = []
+
+    def build(output):
+        captured.append(
+            (
+                dict(output.num_scheduled_tokens),
+                dict(output.kv_connector_block_state.block_ids),
+                list(output.scheduled_cached_reqs.new_block_ids),
+            )
+        )
+        print("snapshot", captured[-1])
+        return mooncake.build_connector_meta(output)
+
+    core.connector.build_connector_meta = build
+    (request,) = create_requests(
+        1, num_tokens=32, block_size=16, max_tokens=32, req_ids=["req-0"]
+    )
+    core.add_request(request)
+    for step in range(steps):
+        output = core.schedule()
+        _update(core, output)
+    assert captured

--- a/tests/v1/kv_connector/unit/test_lp27_snapshot_coverage.py
+++ b/tests/v1/kv_connector/unit/test_lp27_snapshot_coverage.py
@@ -1,8 +1,12 @@
-import pytest
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 from unittest.mock import MagicMock
 
-from tests.v1.core.utils import create_requests, create_scheduler, mock_kv
+import pytest
+
 from tests.v1.core.test_micro_slicing import _update
+from tests.v1.core.utils import create_requests, create_scheduler, mock_kv
 from tests.v1.kv_connector.unit.test_mooncake_store_scheduler import (
     _make_bare_scheduler,
 )

--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -5,6 +5,9 @@ import threading
 import time
 from unittest.mock import MagicMock, patch
 
+import pytest
+import torch
+
 from vllm.config import set_current_vllm_config
 from vllm.distributed.kv_events import BlockStored
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
@@ -29,6 +32,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheTensor,
+    MambaSpec,
 )
 from vllm.v1.outputs import KVConnectorOutput
 
@@ -58,6 +62,30 @@ def _make_kv_cache_config() -> KVCacheConfig:
         ],
         kv_cache_groups=[KVCacheGroupSpec(["layer0"], spec)],
     )
+
+
+def test_scheduler_requires_align_mode_for_mamba():
+    vllm_config = _make_vllm_config()
+    mamba_spec = MambaSpec(
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="none",
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=4,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["mamba"], mamba_spec)],
+    )
+
+    with (
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store."
+            "scheduler.LookupKeyClient"
+        ),
+        pytest.raises(AssertionError, match="requires mamba_cache_mode='align'"),
+    ):
+        scheduler.MooncakeStoreScheduler(vllm_config, kv_cache_config)
 
 
 def _make_block_stored() -> BlockStored:
@@ -95,6 +123,10 @@ def test_scheduler_role_initializes_store_scheduler_only():
     mock_worker.assert_not_called()
     assert connector.connector_scheduler is mock_scheduler.return_value
     assert connector.connector_worker is None
+    block_pool = MagicMock()
+
+    connector.bind_gpu_block_pool(block_pool)
+    mock_scheduler.return_value.bind_gpu_block_pool.assert_called_once_with(block_pool)
 
 
 def test_worker_methods_delegate_to_store_worker():
@@ -235,9 +267,13 @@ def test_update_connector_output_and_take_events():
 
     kv_events = mooncake_store_connector.MooncakeStoreKVEvents(num_workers=1)
     kv_events.add_events([event])
-    connector.update_connector_output(KVConnectorOutput(kv_cache_events=kv_events))
+    output = KVConnectorOutput(kv_cache_events=kv_events)
+    connector.update_connector_output(output)
 
     assert connector._kv_cache_events is kv_events
+    connector.connector_scheduler.update_connector_output.assert_called_once_with(
+        output
+    )
     assert list(connector.take_events()) == [event]
     assert connector._kv_cache_events is None
 

--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -3,6 +3,7 @@
 
 from math import lcm
 
+import pytest
 import torch
 
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import (  # noqa: E501
@@ -14,6 +15,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
 )
 from vllm.v1.core.kv_cache_utils import BlockHash
 from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     KVCacheGroupSpec,
     MambaSpec,
@@ -449,6 +451,117 @@ def test_store_mask_retention_prefix_stable_as_aligned_length_grows():
     assert shorter is not None
     assert longer is not None
     assert longer[: len(shorter)] == shorter
+
+
+def test_store_mask_retains_shared_eagle_predecessor():
+    groups = [
+        KVCacheGroupSpec(["full"], _full(32), is_eagle_group=True),
+        KVCacheGroupSpec(["mamba"], _mamba_align(32)),
+        KVCacheGroupSpec(["swa"], _swa(32, 64)),
+    ]
+    coord = _make_coord(
+        groups,
+        hash_block_size=32,
+        use_eagle=True,
+        retention_interval=0,
+    )
+
+    masks = coord.store_mask(288, num_prompt_tokens=287)
+    assert masks[0] is None
+    assert masks[1] == [False] * 9
+    assert masks[2] == [i in (5, 6, 7) for i in range(9)]
+
+
+def test_store_mask_uses_fine_hit_alignment():
+    groups = [
+        KVCacheGroupSpec(["full"], _full(128)),
+        KVCacheGroupSpec(["mamba"], _mamba_align(64)),
+    ]
+    coord = _make_coord(groups, hash_block_size=32, retention_interval=0)
+    assert coord.enable_partial_hash_hits
+
+    masks = coord.store_mask(512, num_prompt_tokens=501)
+    assert masks[0] is None
+    assert masks[1] == [False] * 8
+
+
+@pytest.mark.parametrize("use_eagle, retained", [(False, {5, 6}), (True, {3, 5, 6})])
+def test_store_mask_preserves_fine_and_materialized_boundaries(use_eagle, retained):
+    groups = [
+        KVCacheGroupSpec(["full128"], _full(128)),
+        KVCacheGroupSpec(["mamba"], _mamba_align(64)),
+        KVCacheGroupSpec(["full32"], _full(32)),
+    ]
+    coord = _make_coord(
+        groups, hash_block_size=32, use_eagle=use_eagle, retention_interval=0
+    )
+    assert coord.enable_partial_hash_hits
+    # Fine replay positions: 448 (and 416 under EAGLE).
+    # Materialized fallback positions: 384 (and 256 under EAGLE).
+    assert coord.store_mask(480, num_prompt_tokens=480)[1] == [False for i in range(7)]
+    assert coord.store_mask(384, num_prompt_tokens=480)[1] == [False for i in range(6)]
+    assert coord.store_mask(480, start_token=384, num_prompt_tokens=480)[1] == [False]
+
+
+def test_store_mask_enables_fine_hits_for_swa():
+    groups = [
+        KVCacheGroupSpec(["full"], _full(32), is_eagle_group=True),
+        KVCacheGroupSpec(["mamba"], _mamba_align(64)),
+        KVCacheGroupSpec(["swa"], _swa(64, 128)),
+    ]
+    coord = _make_coord(
+        groups,
+        hash_block_size=32,
+        use_eagle=True,
+        retention_interval=0,
+    )
+
+    assert coord.enable_partial_hash_hits
+    masks = coord.store_mask(384, num_prompt_tokens=383)
+    assert masks[0] is None
+    assert masks[1] is not None
+    assert masks[2] is not None
+
+
+def test_coarse_chunked_group_disables_fine_hits():
+    groups = [
+        KVCacheGroupSpec(["full"], _full(32)),
+        KVCacheGroupSpec(["mamba"], _mamba_align(64)),
+        KVCacheGroupSpec(
+            ["chunked"],
+            ChunkedLocalAttentionSpec(
+                block_size=64,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+                attention_chunk_size=128,
+            ),
+        ),
+    ]
+    coord = _make_coord(groups, hash_block_size=32)
+    assert not coord.enable_partial_hash_hits
+    assert coord.align_lookup_length(383) == 320
+
+
+def test_store_mask_excludes_mamba_groups_lookup_unaffected():
+    """Align-mode mamba block tables are not append-only (interior states are
+    nulled/freed; speculative blocks relocate), so the positional normal save
+    must never cover mamba chunks — regardless of retention. Lookups still
+    probe mamba boundaries: their keys come from the pinned snapshot/CoW
+    hand-off path instead."""
+    groups = [
+        KVCacheGroupSpec(["L0"], _full(16)),
+        KVCacheGroupSpec(["L1"], _mamba_align(16)),
+    ]
+    coord = _make_coord(groups, hash_block_size=16)
+    masks = coord.store_mask(64)
+    assert masks[0] is None  # full attn stays dense
+    assert masks[1] == [False] * 4
+
+    coord = _make_coord(groups, hash_block_size=16, retention_interval=32)
+    assert coord.store_mask(64)[1] == [False] * 4
+
+    assert coord.lookup_mask(64)[1] is None
 
 
 # ----- Eagle / MTP interaction with load_mask -----

--- a/tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py
@@ -236,6 +236,7 @@ def test_e2e_swa_plus_full_save_then_lookup_hits():
     )
 
     hs = [BlockHash(bytes([i + 1]) * 4) for i in range(4)]
+    # 1-based: block 0 is the reserved null block and the save skips it.
     save_req = ReqMeta(
         req_id="r0",
         token_len_chunk=64,
@@ -441,10 +442,10 @@ def test_sub_block_partial_tail_offload_reads_cow_block():
         block_hashes=hs,
         can_save=True,
         num_prompt_tokens=20,
-        partial_tail_offloads=[(1, mamba_cow_block, 12)],
+        boundary_state_offloads=[(1, mamba_cow_block, 12)],
     )
 
-    send._maybe_offload_partial_tail(req)
+    send._maybe_offload_boundary_states(req)
 
     # boundary = 12 // 4 * 4 = 12 -> keyed by hs[12 // 4 - 1] = hs[2].
     partial_hash = hs[2]
@@ -512,8 +513,8 @@ def test_offload_syncs_event_before_put():
         block_hashes=hs,
         can_save=True,
         num_prompt_tokens=12,
-        partial_tail_offloads=[(1, 7, 12)],
         store_job_id=1,
+        boundary_state_offloads=[(1, 7, 12)],
     )
     req.current_event = event
 
@@ -589,10 +590,10 @@ def test_sub_block_partial_tail_offload_covers_smaller_group_blocks():
         block_hashes=hs,
         can_save=True,
         num_prompt_tokens=12,
-        partial_tail_offloads=[(1, mamba_cow_block, 12)],
+        boundary_state_offloads=[(1, mamba_cow_block, 12)],
     )
 
-    send._maybe_offload_partial_tail(req)
+    send._maybe_offload_boundary_states(req)
 
     # FA (block 4): full blocks ending at 4, 8 and 12, keyed by their normal
     # block-end hashes; mamba (block 16): the partial boundary block under

--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -15,6 +15,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.scheduler impor
     MooncakeStoreScheduler,
 )
 from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.sched.output import KVConnectorBlockState
 
 
 def _make_bare_scheduler(
@@ -43,7 +44,18 @@ def _make_bare_scheduler(
     scheduler._num_workers = 1
     scheduler._next_store_job_id = 0
     scheduler._pinned_saves = {}
+    scheduler._boundary_state_group_ids = frozenset({1})
     return scheduler
+
+
+def _make_connector_block_state(
+    block_ids: tuple[list[int], ...] | None = None,
+    offloads: list[tuple[int, int, int]] | None = None,
+) -> KVConnectorBlockState:
+    return KVConnectorBlockState(
+        block_ids={} if block_ids is None else {"req-0": block_ids},
+        boundary_state_offloads=({} if offloads is None else {"req-0": offloads}),
+    )
 
 
 def _make_scheduler_output(*, scheduled_spec_tokens: list[int] | None):
@@ -61,6 +73,7 @@ def _make_scheduler_output(*, scheduled_spec_tokens: list[int] | None):
         scheduled_spec_decode_tokens=(
             {"req-0": scheduled_spec_tokens} if scheduled_spec_tokens else {}
         ),
+        kv_connector_block_state=_make_connector_block_state(block_ids=([0, 1, 2],)),
     )
 
 
@@ -80,6 +93,7 @@ def _make_decode_scheduler_output(
         ),
         num_scheduled_tokens={"req-0": num_scheduled_tokens},
         scheduled_spec_decode_tokens={},
+        kv_connector_block_state=_make_connector_block_state(block_ids=([0, 1, 2],)),
     )
 
 
@@ -105,6 +119,7 @@ def _make_new_scheduler_output() -> SimpleNamespace:
         ),
         num_scheduled_tokens={"req-0": 32},
         scheduled_spec_decode_tokens={},
+        kv_connector_block_state=_make_connector_block_state(block_ids=([0, 1],)),
     )
 
 
@@ -473,6 +488,7 @@ def _make_resumed_scheduler_output(*, num_scheduled_tokens: int) -> SimpleNamesp
         ),
         num_scheduled_tokens={"req-0": num_scheduled_tokens},
         scheduled_spec_decode_tokens={},
+        kv_connector_block_state=_make_connector_block_state(block_ids=([0, 1, 2],)),
     )
 
 
@@ -897,7 +913,10 @@ def _add_pending_partial_tail_request(
         ),
         num_scheduled_tokens={},
         scheduled_spec_decode_tokens={},
-        partial_tail_offloads={"req-0": [(1, 7, 12)]},
+        kv_connector_block_state=_make_connector_block_state(
+            block_ids=block_ids,
+            offloads=[(1, 7, 12)],
+        ),
     )
 
 
@@ -922,15 +941,262 @@ def test_pending_partial_tail_emits_offload_only_reqmeta():
     assert req_meta.req_id == "req-0"
     assert req_meta.can_save is True
     assert req_meta.token_len_chunk == 0
-    assert req_meta.partial_tail_offloads == [(1, 7, 12)]
+    assert req_meta.boundary_state_offloads == [(1, 7, 12)]
     assert req_meta.num_prompt_tokens == 12
     assert req_meta.block_ids == ([0],)
+    store_job_id = req_meta.store_job_id
+    assert scheduler._pinned_saves[store_job_id][0] == [7]
+    assert scheduler._gpu_block_pool.blocks[0].ref_cnt == 0
+    assert scheduler._gpu_block_pool.blocks[7].ref_cnt == 1
     tracker = scheduler._request_trackers["req-0"]
     assert tracker.num_saved_tokens == 0
     assert tracker.has_pending_offload is True
 
 
-def test_resumed_partial_tail_uses_handoff_boundary():
+def test_decode_boundary_state_offload_dropped_unclaimed():
+    # A hand-off past the prefill end can never complete a joint hybrid hit
+    # (every other group stops saving there), so it is neither transferred nor
+    # claimed — leaving the core free to release the block immediately.
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    request = SimpleNamespace(
+        all_token_ids=list(range(24)),
+        block_hashes=[b"h0", b"h1", b"h2", b"h3", b"h4", b"h5"],
+        num_output_placeholders=0,
+        num_prompt_tokens=12,
+    )
+    scheduler._unfinished_requests["req-0"] = (request, ([0],))
+    scheduler._request_trackers["req-0"] = RequestTracker(
+        req_id="req-0",
+        token_len=12,
+        allocated_block_ids=([0],),
+        num_saved_tokens=12,
+        token_ids=list(range(12)),
+        prefill_end_tokens=12,
+    )
+
+    out = SimpleNamespace(
+        finished_req_ids=set(),
+        preempted_req_ids=set(),
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=[],
+            new_block_ids=[],
+            num_computed_tokens=[],
+            resumed_req_ids=set(),
+        ),
+        num_scheduled_tokens={},
+        scheduled_spec_decode_tokens={},
+        # Boundary 16 is a decode boundary for a 12-token prefill.
+        kv_connector_block_state=_make_connector_block_state(offloads=[(1, 7, 16)]),
+    )
+
+    meta = scheduler.build_connector_meta(out)
+
+    assert meta.requests == []
+    assert scheduler._pinned_saves == {}
+    assert scheduler._gpu_block_pool.blocks[7].ref_cnt == 0
+    assert scheduler._request_trackers["req-0"].has_pending_offload is False
+
+
+def _register_offload_request(scheduler, *, prefill_end_tokens, num_prompt_tokens):
+    request = SimpleNamespace(
+        all_token_ids=list(range(64)),
+        block_hashes=[bytes([i]) for i in range(16)],
+        num_output_placeholders=0,
+        num_prompt_tokens=num_prompt_tokens,
+    )
+    scheduler._unfinished_requests["req-0"] = (request, ([0],))
+    scheduler._request_trackers["req-0"] = RequestTracker(
+        req_id="req-0",
+        token_len=prefill_end_tokens,
+        allocated_block_ids=([0],),
+        num_saved_tokens=prefill_end_tokens,
+        token_ids=list(range(prefill_end_tokens)),
+        prefill_end_tokens=prefill_end_tokens,
+    )
+
+
+def _make_offload_only_output(entries, block_ids=([0],)):
+    return SimpleNamespace(
+        finished_req_ids=set(),
+        preempted_req_ids=set(),
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=[],
+            new_block_ids=[],
+            num_computed_tokens=[],
+            resumed_req_ids=set(),
+        ),
+        num_scheduled_tokens={},
+        scheduled_spec_decode_tokens={},
+        kv_connector_block_state=_make_connector_block_state(
+            block_ids=block_ids,
+            offloads=entries,
+        ),
+    )
+
+
+def test_resumed_prefill_claims_boundaries_past_prompt_length():
+    # A resumed request re-prefills its previously generated tokens, so its
+    # save window (`prefill_end_tokens`) extends past `num_prompt_tokens`.
+    # Boundaries in that range must still be claimed, or the mamba key would be
+    # missing for boundaries full attention does store and no joint hit could
+    # complete there.
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    _register_offload_request(scheduler, prefill_end_tokens=20, num_prompt_tokens=12)
+    out = _make_offload_only_output([(1, 7, 16), (1, 9, 20), (1, 11, 24)])
+
+    meta = scheduler.build_connector_meta(out)
+
+    # 16 and 20 are inside the resumed prefill; 24 is past it.
+    assert meta.requests[0].boundary_state_offloads == [(1, 7, 16), (1, 9, 20)]
+    store_job_id = meta.requests[0].store_job_id
+    assert scheduler._pinned_saves[store_job_id][0] == [7, 9]
+
+
+def test_boundary_state_job_pins_exact_blocks_once():
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    _register_offload_request(scheduler, prefill_end_tokens=64, num_prompt_tokens=64)
+    scheduler._request_trackers["req-0"].allocated_block_ids = ([7],)
+    out = _make_offload_only_output(
+        [(1, 7, 16), (1, 8, 32), (1, 9, 48)], block_ids=([7],)
+    )
+
+    meta = scheduler.build_connector_meta(out)
+
+    req_meta = meta.requests[0]
+    assert req_meta.boundary_state_offloads == [
+        (1, 7, 16),
+        (1, 8, 32),
+        (1, 9, 48),
+    ]
+    store_job_id = req_meta.store_job_id
+    assert scheduler._pinned_saves[store_job_id][0] == [7, 8, 9]
+    assert [scheduler._gpu_block_pool.blocks[i].ref_cnt for i in (7, 8, 9)] == [
+        1,
+        1,
+        1,
+    ]
+
+    scheduler.update_connector_output(_make_worker_output({store_job_id: 1}))
+    assert [scheduler._gpu_block_pool.blocks[i].ref_cnt for i in (7, 8, 9)] == [
+        0,
+        0,
+        0,
+    ]
+
+
+def test_store_job_pins_current_non_null_non_mamba_blocks():
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    request = SimpleNamespace(
+        all_token_ids=list(range(48)),
+        block_hashes=[bytes([i]) for i in range(12)],
+        num_output_placeholders=0,
+    )
+    scheduler._unfinished_requests["req-0"] = (request, ([7, 2, 0], [21, 0, 22]))
+    scheduler._request_trackers["req-0"] = RequestTracker(
+        req_id="req-0",
+        token_len=44,
+        allocated_block_ids=([7, 2, 0], [21, 0, 22]),
+        num_saved_tokens=32,
+        token_ids=list(range(44)),
+        prefill_end_tokens=48,
+    )
+    stale_block_ids = ([7, 2, 0, 5], [21, 0, 22, 23])
+    current_block_ids = ([7, 2, 0, 6], [24, 0, 25, 26])
+    out = SimpleNamespace(
+        finished_req_ids=set(),
+        preempted_req_ids=set(),
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=["req-0"],
+            new_block_ids=[([5], [23])],
+            num_computed_tokens=[44],
+            resumed_req_ids=set(),
+        ),
+        num_scheduled_tokens={"req-0": 4},
+        scheduled_spec_decode_tokens={},
+        kv_connector_block_state=_make_connector_block_state(
+            block_ids=current_block_ids,
+            offloads=[(1, 8, 16)],
+        ),
+    )
+    pool = scheduler._gpu_block_pool
+
+    meta = scheduler.build_connector_meta(out)
+
+    assert scheduler._request_trackers["req-0"].allocated_block_ids == stale_block_ids
+    req_meta = meta.requests[0]
+    assert req_meta.block_ids == current_block_ids
+    store_job_id = req_meta.store_job_id
+    assert scheduler._pinned_saves[store_job_id][0] == [8, 7, 2, 6]
+    assert pool.blocks[0].ref_cnt == 0
+    assert pool.blocks[5].ref_cnt == 0
+    assert [pool.blocks[i].ref_cnt for i in (21, 22, 23, 24, 25, 26)] == [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ]
+    assert [pool.blocks[i].ref_cnt for i in (8, 7, 2, 6)] == [1, 1, 1, 1]
+
+    scheduler.update_connector_output(_make_worker_output({store_job_id: 1}))
+
+    assert [pool.blocks[i].ref_cnt for i in (8, 7, 2, 6)] == [0, 0, 0, 0]
+
+
+def test_boundary_state_release_is_per_store_job():
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    _register_offload_request(scheduler, prefill_end_tokens=64, num_prompt_tokens=64)
+    first = scheduler.build_connector_meta(_make_offload_only_output([(1, 7, 16)]))
+    second = scheduler.build_connector_meta(_make_offload_only_output([(1, 8, 32)]))
+    first_job_id = first.requests[0].store_job_id
+    second_job_id = second.requests[0].store_job_id
+
+    scheduler.update_connector_output(_make_worker_output({first_job_id: 1}))
+
+    assert scheduler._gpu_block_pool.blocks[7].ref_cnt == 0
+    assert scheduler._gpu_block_pool.blocks[8].ref_cnt == 1
+    assert first_job_id not in scheduler._pinned_saves
+    assert second_job_id in scheduler._pinned_saves
+
+
+def test_preemption_and_request_id_reuse_do_not_release_inflight_job():
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    _register_offload_request(scheduler, prefill_end_tokens=64, num_prompt_tokens=64)
+    first = scheduler.build_connector_meta(_make_offload_only_output([(1, 7, 16)]))
+    first_job_id = first.requests[0].store_job_id
+
+    scheduler.build_connector_meta(_make_preemption_scheduler_output())
+    assert scheduler._gpu_block_pool.blocks[7].ref_cnt == 1
+    assert first_job_id in scheduler._pinned_saves
+
+    _register_offload_request(scheduler, prefill_end_tokens=64, num_prompt_tokens=64)
+    second = scheduler.build_connector_meta(_make_offload_only_output([(1, 8, 32)]))
+    second_job_id = second.requests[0].store_job_id
+    assert second.requests[0].boundary_state_offloads == [(1, 8, 32)]
+
+    scheduler.update_connector_output(_make_worker_output({first_job_id: 1}))
+    assert scheduler._gpu_block_pool.blocks[7].ref_cnt == 0
+    assert scheduler._gpu_block_pool.blocks[8].ref_cnt == 1
+    assert second_job_id in scheduler._pinned_saves
+
+
+def test_boundary_state_never_claimed_without_a_send_thread():
+    # A kv_consumer has no store job that can acknowledge the block reference.
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    scheduler.kv_role = "kv_consumer"
+    _register_offload_request(scheduler, prefill_end_tokens=64, num_prompt_tokens=64)
+    out = _make_offload_only_output([(1, 7, 16)])
+
+    assert scheduler.build_connector_meta(out).requests == []
+    assert scheduler._pinned_saves == {}
+    assert scheduler._gpu_block_pool.blocks[7].ref_cnt == 0
+
+
+def test_resumed_partial_tail_uses_exact_boundary():
     scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
     # Resumption replays prompt + previously generated tokens.
     out = _add_pending_partial_tail_request(
@@ -943,7 +1209,7 @@ def test_resumed_partial_tail_uses_handoff_boundary():
     meta = scheduler.build_connector_meta(out)
 
     assert len(meta.requests) == 1
-    assert meta.requests[0].partial_tail_offloads == [(1, 7, 12)]
+    assert meta.requests[0].boundary_state_offloads == [(1, 7, 12)]
     # Ordinary metadata retains the full resumed prefill range.
     assert meta.requests[0].num_prompt_tokens == 20
     tracker = scheduler._request_trackers["req-0"]
@@ -951,8 +1217,9 @@ def test_resumed_partial_tail_uses_handoff_boundary():
     assert tracker.has_pending_offload is True
 
 
-def test_resumed_partial_tail_attached_to_save_keeps_handoff_boundary():
+def test_resumed_partial_tail_attached_to_save_keeps_exact_boundary():
     scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    scheduler._boundary_state_group_ids = frozenset({0})
     request = SimpleNamespace(
         all_token_ids=list(range(48)),
         block_hashes=[b"h0", b"h1", b"h2"],
@@ -969,13 +1236,13 @@ def test_resumed_partial_tail_attached_to_save_keeps_handoff_boundary():
         prefill_end_tokens=48,
     )
     out = _make_scheduler_output(scheduled_spec_tokens=None)
-    out.partial_tail_offloads = {"req-0": [(0, 7, 36)]}
+    out.kv_connector_block_state.boundary_state_offloads = {"req-0": [(0, 7, 36)]}
 
     meta = scheduler.build_connector_meta(out)
 
     assert len(meta.requests) == 1
     assert meta.requests[0].can_save is True
-    assert meta.requests[0].partial_tail_offloads == [(0, 7, 36)]
+    assert meta.requests[0].boundary_state_offloads == [(0, 7, 36)]
     assert meta.requests[0].num_prompt_tokens == 48
     # Ordinary saving still covers the full resumed prefill range.
     tracker = scheduler._request_trackers["req-0"]
@@ -1001,7 +1268,8 @@ def test_partial_tail_cow_block_is_referenced_for_the_job():
     store_job_id = meta.requests[0].store_job_id
     # It leads the list, as in `pop_blocks_for_free`, so that the reversed free
     # puts it last in eviction priority.
-    assert scheduler._pinned_saves[store_job_id][0] == [7, 0]
+    assert scheduler._pinned_saves[store_job_id][0] == [7]
+    assert pool.blocks[0].ref_cnt == 0
     assert pool.blocks[7].ref_cnt == 1
 
     scheduler.update_connector_output(_make_worker_output({store_job_id: 1}))

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -177,6 +177,7 @@ def _run_store_req(thread, req_meta: ReqMeta) -> None:
 
 
 def _make_store_req(req_id: str, block_hashes: list[bytes]) -> ReqMeta:
+    # 1-based: block 0 is the reserved null block and the save skips it.
     return ReqMeta(
         req_id=req_id,
         token_len_chunk=32,
@@ -646,6 +647,7 @@ def _make_partial_tail_send_thread(
         enable_partial_hash_hits=True,
         hash_block_size=4,
         lcm_block_size=16,
+        mamba_group_ids={1},
     )
     db = ChunkedTokenDatabase(
         KeyMetadata("test-model", 0, 0, 0, 0),
@@ -654,10 +656,18 @@ def _make_partial_tail_send_thread(
     )
     db.set_kv_caches_base_addr([0x1000])
     db.set_block_len([256])
+    # Group 1 models the mamba "align" group the hand-offs reference.
+    db_mamba = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0, group_id=1),
+        block_size=16,
+        hash_block_size=4,
+    )
+    db_mamba.set_kv_caches_base_addr([0x2000])
+    db_mamba.set_block_len([256])
     return _make_store_sending_thread(
         store,
         coord=coord,
-        token_databases=[db],
+        token_databases=[db, db_mamba],
         replicate_config=replicate_config,
         enable_group_semantics=enable_group_semantics,
         supports_group_ids=supports_group_ids,
@@ -668,20 +678,20 @@ def _make_partial_tail_req(block_ids: list[int]) -> ReqMeta:
     return ReqMeta(
         req_id="req-a",
         token_len_chunk=0,
-        block_ids=(block_ids,),
+        block_ids=(block_ids, [1]),
         block_hashes=[b"a0", b"a1", b"a2"],
         can_save=True,
-        partial_tail_offloads=[(1, 7, 12)],
+        boundary_state_offloads=[(1, 7, 12)],
     )
 
 
 def test_partial_tail_offload_skips_null_source_blocks():
     store = MagicMock()
     store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
-    store.batch_put_from_multi_buffers.return_value = [256, 256]
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
     thread = _make_partial_tail_send_thread(store)
 
-    assert thread._maybe_offload_partial_tail(_make_partial_tail_req([0, 2, 3]))
+    assert thread._maybe_offload_boundary_states(_make_partial_tail_req([0, 2, 3]))
 
     keys, addrs, _sizes, _replicate_config = (
         store.batch_put_from_multi_buffers.call_args.args
@@ -689,15 +699,21 @@ def test_partial_tail_offload_skips_null_source_blocks():
     assert keys == [
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6131",
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6132",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:1@6132",
     ]
-    assert addrs == [[0x1000 + 2 * 256], [0x1000 + 3 * 256]]
+    # FA reads blocks 2 and 3 (block 0 is null and skipped); the mamba
+    # boundary block reads the core-provided CoW block 7, not block_ids.
+    assert addrs == [
+        [0x1000 + 2 * 256],
+        [0x1000 + 3 * 256],
+        [0x2000 + 7 * 256],
+    ]
 
 
 def test_store_sending_thread_skips_null_sparse_group_blocks():
     from vllm.v1.kv_cache_interface import (
         FullAttentionSpec,
         KVCacheGroupSpec,
-        MambaSpec,
     )
 
     store = MagicMock()
@@ -706,16 +722,11 @@ def test_store_sending_thread_skips_null_sparse_group_blocks():
         lambda keys, addrs, sizes, replicate_config: [256] * len(keys)
     )
     full = FullAttentionSpec(block_size=16, num_kv_heads=8, head_size=64, dtype=None)
-    mamba = MambaSpec(
-        block_size=16,
-        shapes=((1, 1),),
-        dtypes=(torch.float32,),
-        mamba_cache_mode="align",
-    )
+    sparse = FullAttentionSpec(block_size=16, num_kv_heads=8, head_size=64, dtype=None)
     coord = mooncake_store_worker.MooncakeStoreCoordinator(
         [
             KVCacheGroupSpec(["full"], full),
-            KVCacheGroupSpec(["mamba"], mamba),
+            KVCacheGroupSpec(["sparse"], sparse),
         ],
         scheduler_block_size=16,
         hash_block_size=16,
@@ -727,17 +738,17 @@ def test_store_sending_thread_skips_null_sparse_group_blocks():
     )
     db_full.set_kv_caches_base_addr([0x1000])
     db_full.set_block_len([256])
-    db_mamba = ChunkedTokenDatabase(
+    db_sparse = ChunkedTokenDatabase(
         KeyMetadata("test-model", 0, 0, 0, 0, group_id=1),
         block_size=16,
     )
-    db_mamba.set_kv_caches_base_addr([0x2000])
-    db_mamba.set_block_len([512])
+    db_sparse.set_kv_caches_base_addr([0x2000])
+    db_sparse.set_block_len([512])
 
     thread = _make_store_sending_thread(
         store,
         coord=coord,
-        token_databases=[db_full, db_mamba],
+        token_databases=[db_full, db_sparse],
     )
     _run_store_req(
         thread,
@@ -751,15 +762,86 @@ def test_store_sending_thread_skips_null_sparse_group_blocks():
     )
 
     keys, addrs, _, _ = store.batch_put_from_multi_buffers.call_args.args
-    mamba_keys = [key for key in keys if "@group:1" in key]
-    assert [key.rsplit("@", 1)[-1] for key in mamba_keys] == [b"a1".hex()]
+    sparse_keys = [key for key in keys if "@group:1" in key]
+    assert [key.rsplit("@", 1)[-1] for key in sparse_keys] == [b"a1".hex()]
     assert all(addr[0] >= 0x2000 for key, addr in zip(keys, addrs) if "@group:1" in key)
+
+
+def test_partial_tail_offload_skips_cap_omitted_mamba_group():
+    """A Mamba group omitted by the handoff cap must not fall back to the
+    connector's positional block table."""
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        KVCacheGroupSpec,
+        MambaSpec,
+    )
+
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+
+    full_spec = FullAttentionSpec(
+        block_size=4, num_kv_heads=8, head_size=64, dtype=torch.float32
+    )
+    mamba_spec = MambaSpec(
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    coord = mooncake_store_worker.MooncakeStoreCoordinator(
+        [
+            KVCacheGroupSpec(["full"], full_spec),
+            KVCacheGroupSpec(["mamba-1"], mamba_spec),
+            KVCacheGroupSpec(["mamba-2"], mamba_spec),
+        ],
+        scheduler_block_size=16,
+        hash_block_size=4,
+    )
+
+    def make_db(group_id: int, block_size: int, base_addr: int):
+        db = ChunkedTokenDatabase(
+            KeyMetadata("test-model", 0, 0, 0, 0, group_id=group_id),
+            block_size=block_size,
+            hash_block_size=4,
+        )
+        db.set_kv_caches_base_addr([base_addr])
+        db.set_block_len([256])
+        return db
+
+    db_full = make_db(0, 4, 0x1000)
+    db_mamba_1 = make_db(1, 16, 0x2000)
+    db_mamba_2 = make_db(2, 16, 0x3000)
+    thread = _make_store_sending_thread(
+        store,
+        coord=coord,
+        token_databases=[db_full, db_mamba_1, db_mamba_2],
+    )
+
+    req = ReqMeta(
+        req_id="req-a",
+        token_len_chunk=0,
+        block_ids=([1, 2, 3], [5], [9]),
+        block_hashes=[b"a0", b"a1", b"a2"],
+        can_save=True,
+        # The scheduler accepted group 1 and omitted group 2 at boundary 12.
+        boundary_state_offloads=[(1, 7, 12)],
+    )
+    assert thread._maybe_offload_boundary_states(req)
+
+    keys, addrs, _sizes, _replicate_config = (
+        store.batch_put_from_multi_buffers.call_args.args
+    )
+    puts = list(zip(keys, addrs, strict=True))
+    boundary_hash = BlockHash(b"a2")
+    assert (db_mamba_1.key_for(boundary_hash), [0x2000 + 7 * 256]) in puts
+    assert (db_mamba_2.key_for(boundary_hash), [0x3000 + 9 * 256]) not in puts
 
 
 def test_partial_tail_offload_replaces_stale_group_ids_after_filtering():
     store = MagicMock()
-    store.batch_is_exist.return_value = [1, 0, 0]
-    store.batch_put_from_multi_buffers.return_value = [256, 256]
+    store.batch_is_exist.return_value = [1, 0, 0, 0]
+    store.batch_put_from_multi_buffers.return_value = [256, 256, 256]
     replicate_config = SimpleNamespace(group_ids=["stale"])
     thread = _make_partial_tail_send_thread(
         store,
@@ -768,16 +850,18 @@ def test_partial_tail_offload_replaces_stale_group_ids_after_filtering():
         supports_group_ids=True,
     )
 
-    assert thread._maybe_offload_partial_tail(_make_partial_tail_req([1, 2, 3]))
+    assert thread._maybe_offload_boundary_states(_make_partial_tail_req([1, 2, 3]))
 
     keys, _addrs, _sizes, config = store.batch_put_from_multi_buffers.call_args.args
     assert keys == [
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6131",
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6132",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:1@6132",
     ]
     assert config is replicate_config
     assert config.group_ids == [
         "vllm-mooncake-store:test-model@6131",
+        "vllm-mooncake-store:test-model@6132",
         "vllm-mooncake-store:test-model@6132",
     ]
 
@@ -808,6 +892,165 @@ def test_partial_tail_put_failure_activates_pressure_gate():
 
     _run_store_req(thread, _make_partial_tail_req([1, 2, 3]))
     assert store.batch_put_from_multi_buffers.call_count == 1
+
+
+def test_normal_save_excludes_mamba_group_and_null_blocks():
+    """The positional normal save must never cover mamba chunks (align-mode
+    block tables are not append-only) and must skip chunks whose block is the
+    reserved null block, for any group."""
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        KVCacheGroupSpec,
+        MambaSpec,
+    )
+
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+
+    full_spec = FullAttentionSpec(
+        block_size=16, num_kv_heads=8, head_size=64, dtype=None
+    )
+    mamba_spec = MambaSpec(
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    coord = mooncake_store_worker.MooncakeStoreCoordinator(
+        [KVCacheGroupSpec(["L0"], full_spec), KVCacheGroupSpec(["L1"], mamba_spec)],
+        scheduler_block_size=16,
+        hash_block_size=16,
+    )
+    db_full = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0, group_id=0), block_size=16
+    )
+    db_full.set_kv_caches_base_addr([0x1000])
+    db_full.set_block_len([256])
+    db_mamba = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0, group_id=1), block_size=16
+    )
+    db_mamba.set_kv_caches_base_addr([0x2000])
+    db_mamba.set_block_len([256])
+    thread = _make_store_sending_thread(
+        store, coord=coord, token_databases=[db_full, db_mamba]
+    )
+
+    _run_store_req(
+        thread,
+        ReqMeta(
+            req_id="r0",
+            token_len_chunk=64,
+            # FA has a null at chunk 1; the mamba table is align-mode shaped
+            # (interior nulls + one state block) and must not be read at all.
+            block_ids=([1, 0, 3, 4], [0, 0, 0, 9]),
+            block_hashes=[b"a0", b"a1", b"a2", b"a3"],
+            can_save=True,
+        ),
+    )
+
+    keys, addrs, _sizes, _ = store.batch_put_from_multi_buffers.call_args.args
+    assert all("@group:0@" in k for k in keys)
+    assert [k.rsplit("@", 1)[-1] for k in keys] == ["6130", "6132", "6133"]
+    assert addrs == [[0x1000 + 256], [0x1000 + 3 * 256], [0x1000 + 4 * 256]]
+
+
+def test_block_aligned_snapshot_offload_uses_provided_block():
+    """A block-aligned hand-off (sparse-retention mamba checkpoint) uploads
+    exactly the core-pinned block under the boundary-end hash key; the
+    positional block table entry for that chunk must be ignored."""
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+    thread = _make_partial_tail_send_thread(store)
+
+    hs = [bytes([i + 1]) * 4 for i in range(8)]  # 8 hash units = 32 tokens
+    req = ReqMeta(
+        req_id="req-a",
+        token_len_chunk=0,
+        block_ids=([1, 2, 3], [5]),
+        block_hashes=hs,
+        can_save=True,
+        boundary_state_offloads=[(1, 7, 32)],
+    )
+    assert thread._maybe_offload_boundary_states(req)
+
+    keys, addrs, _sizes, _ = store.batch_put_from_multi_buffers.call_args.args
+    # boundary 32 is block-aligned for the mamba group (block 16): one key,
+    # keyed by hs[32 // 4 - 1], read from the handed-off block 7 — not from
+    # block_ids[1] and with no FA gap coverage.
+    assert keys == [thread.token_databases[1].key_for(BlockHash(hs[7]))]
+    assert addrs == [[0x2000 + 7 * 256]]
+
+
+def test_mixed_snapshot_and_sub_block_offloads():
+    """A retention snapshot and the prompt-end sub-block CoW tail can arrive
+    in one hand-off; the sub-block path covers FA gap blocks but reads the
+    mamba boundary only from the CoW block, never positionally."""
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+    thread = _make_partial_tail_send_thread(store)
+
+    hs = [bytes([i + 1]) * 4 for i in range(11)]  # 11 hash units = 44 tokens
+    req = ReqMeta(
+        req_id="req-a",
+        token_len_chunk=0,
+        block_ids=([1, 2, 3], [0, 0, 0]),
+        block_hashes=hs,
+        can_save=True,
+        boundary_state_offloads=[(1, 9, 32), (1, 7, 44)],
+    )
+    assert thread._maybe_offload_boundary_states(req)
+
+    keys, addrs, _sizes, _ = store.batch_put_from_multi_buffers.call_args.args
+    db_full, db_mamba = thread.token_databases
+    assert keys == [
+        # Aligned snapshot: boundary 32 from the handed-off block 9.
+        db_mamba.key_for(BlockHash(hs[7])),
+        # Sub-block boundary 44: FA gap blocks ending at 4, 8, 12.
+        db_full.key_for(BlockHash(hs[0])),
+        db_full.key_for(BlockHash(hs[1])),
+        db_full.key_for(BlockHash(hs[2])),
+        # Mamba boundary block from the CoW hand-off (block 7).
+        db_mamba.key_for(BlockHash(hs[10])),
+    ]
+    assert addrs == [
+        [0x2000 + 9 * 256],
+        [0x1000 + 1 * 256],
+        [0x1000 + 2 * 256],
+        [0x1000 + 3 * 256],
+        [0x2000 + 7 * 256],
+    ]
+
+
+def test_snapshot_offload_skips_null_handoff_block():
+    """A hand-off the core could not materialize (null block) carries no
+    committed state; persisting it would poison the boundary key."""
+    store = MagicMock()
+    thread = _make_partial_tail_send_thread(store)
+
+    hs = [bytes([i + 1]) * 4 for i in range(8)]
+    assert thread._maybe_offload_boundary_states(
+        ReqMeta(
+            req_id="req-a",
+            token_len_chunk=0,
+            block_ids=([1, 2, 3], [5]),
+            block_hashes=hs,
+            can_save=True,
+            boundary_state_offloads=[(1, NULL_BLOCK_ID, 32)],
+        )
+    )
+    store.batch_is_exist.assert_not_called()
+    store.batch_put_from_multi_buffers.assert_not_called()
+
+
+def test_worker_meta_is_absent_before_any_completed_job():
+    send_thread = _make_partial_tail_send_thread(MagicMock())
+    store_worker = object.__new__(mooncake_store_worker.MooncakeStoreWorker)
+    store_worker.kv_send_thread = send_thread
+
+    assert store_worker.build_connector_worker_meta() is None
 
 
 def test_store_sending_thread_delta_start_rank_saves_second_local_chunk():

--- a/tests/v1/kv_connector/unit/test_offloading_connector.py
+++ b/tests/v1/kv_connector/unit/test_offloading_connector.py
@@ -212,12 +212,21 @@ def _accuracy_test(llm: LLM, subscriber: MockSubscriber | None):
     if subscriber is not None:
         subscriber.get_new_cpu_stored_events()
 
-    # Pad prompt so its token count is a multiple of cpu_block_size.
-    # Use the tokenizer directly to avoid expensive llm.generate() calls.
+    # Align the reusable prefix; the final token must be recomputed for logits.
     tokenizer = llm.get_tokenizer()
-    prompt = "Let's count to 10. One, two, three, four,"
-    while len(tokenizer.encode(prompt)) % cpu_block_size != 0:
-        prompt = ". " + prompt
+    prompt_token_ids = tokenizer.encode("Let's count to 10. One, two, three, four,")
+    reusable_prefix = prompt_token_ids[:-1]
+    final_token = prompt_token_ids[-1:]
+
+    [padding_token_id] = tokenizer.encode(".", add_special_tokens=False)
+    padding = [padding_token_id] * (-len(reusable_prefix) % cpu_block_size)
+    insert_at = int(reusable_prefix[0] == tokenizer.bos_token_id)
+    reusable_prefix[insert_at:insert_at] = padding
+    assert len(reusable_prefix) % cpu_block_size == 0
+
+    prompt = TokensPrompt(
+        prompt_token_ids=reusable_prefix + final_token,
+    )
 
     # Seed the CPU cache with the prompt.
     llm.generate(prompt, sampling_params, use_tqdm=False)

--- a/tests/v1/kv_connector/unit/test_scheduler_kv_connector_override.py
+++ b/tests/v1/kv_connector/unit/test_scheduler_kv_connector_override.py
@@ -22,8 +22,13 @@ from vllm.v1.request import Request
 
 
 class DummyConnectorMetadata(KVConnectorMetadata):
-    def __init__(self, block_hashes_by_req: dict[str, list[BlockHash]]):
+    def __init__(
+        self,
+        block_hashes_by_req: dict[str, list[BlockHash]],
+        block_ids_by_req: dict[str, tuple[list[int], ...]],
+    ):
         self.block_hashes_by_req = block_hashes_by_req
+        self.block_ids_by_req = block_ids_by_req
 
 
 class DummyKVConnector(KVConnectorBase_V1):
@@ -47,8 +52,12 @@ class DummyKVConnector(KVConnectorBase_V1):
         assert block_hashes_by_req is not None, (
             "DummyKVConnector expected 'block_hashes_by_req' on scheduler_output"
         )
+        block_state = scheduler_output.kv_connector_block_state
+        assert block_state is not None
+        block_ids_by_req = block_state.block_ids
         return DummyConnectorMetadata(
             block_hashes_by_req=block_hashes_by_req,
+            block_ids_by_req=block_ids_by_req,
         )
 
     def start_load_kv(self, kv_caches, finished_req_ids):
@@ -129,3 +138,9 @@ def test_connector_receives_block_hashes(_load_plugin):
             num_tokens // block_size
         )
         assert meta.block_hashes_by_req[req.request_id] == req.block_hashes
+
+    expected_block_ids = {
+        req.req_id: req.block_ids for req in output.scheduled_new_reqs
+    }
+    assert meta.block_ids_by_req == expected_block_ids
+    assert output.kv_connector_block_state is None

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -76,6 +76,15 @@ class BlockStored(KVCacheEvent):
     locality: str | None = None
     """LOCAL or REMOTE relative to the publisher; None means unspecified."""
 
+    skipped_parent_block_hash: ExternalBlockHash | None = None
+    """Parent hash for skipped token context preceding this store event."""
+
+    skipped_token_ids: list[int] | None = None
+    """Logical token span for skipped blocks preceding this store event."""
+
+    skipped_extra_keys: list[tuple[Any, ...] | None] | None = None
+    """Extra keys for skipped_token_ids, one entry per skipped block."""
+
     def __hash__(self) -> int:
         return hash(
             (
@@ -90,6 +99,9 @@ class BlockStored(KVCacheEvent):
                 self.kv_cache_spec_kind,
                 self.kv_cache_spec_sliding_window,
                 self.locality,
+                self.skipped_parent_block_hash,
+                tuple(self.skipped_token_ids) if self.skipped_token_ids else None,
+                tuple(self.skipped_extra_keys) if self.skipped_extra_keys else None,
             )
         )
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -15,11 +15,15 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
 )
+from vllm.v1.core.single_type_kv_cache_manager import (
+    resolve_sparse_retention_inputs,
+)
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheGroupSpec,
     KVCacheSpec,
     MambaSpec,
+    SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
@@ -80,6 +84,11 @@ class MooncakeStoreCoordinator:
             for g in kv_cache_groups
         ), "scheduler_block_size must be a multiple of each group's block_size"
         self.kv_cache_groups = kv_cache_groups
+        self.mamba_group_ids = {
+            group_id
+            for group_id, group in enumerate(kv_cache_groups)
+            if isinstance(_unwrap_spec(group.kv_cache_spec), MambaSpec)
+        }
         self.hash_block_size = hash_block_size
         self.lcm_block_size = scheduler_block_size
         self.enable_partial_hash_hits = partial_hash_hits_enabled(
@@ -133,6 +142,10 @@ class MooncakeStoreCoordinator:
         self.eagle_group_ids = {
             gid for g in attention_groups if g.use_eagle for gid in g.group_ids
         }
+        self.lookup_drops_eagle_block = any(
+            group.use_eagle and group.manager_cls.drops_eagle_block
+            for group in attention_groups
+        )
 
     def find_longest_cache_hit(
         self,
@@ -198,12 +211,23 @@ class MooncakeStoreCoordinator:
 
         Reuses the engine's ``SingleTypeKVCacheManager.reachable_block_mask``
         so the store retains exactly the blocks the local prefix cache would.
+
+        Mamba groups are always all-False: the normal save resolves blocks
+        positionally from the connector's append-only block-ID snapshot, but
+        an align-mode mamba block table is not append-only (interior state
+        blocks are nulled/freed, and speculative decoding relocates the spec
+        blocks in place), so a positional read may hit a null, freed, or live
+        speculative-state block and persist wrong bytes under a valid prefix
+        hash. Mamba state is persisted only through the connector-pinned exact
+        block hand-off path
+        (``SchedulerOutput.kv_connector_block_state.boundary_state_offloads``).
         """
         return self._reachable_masks(
             aligned_token_len,
             start_token,
             retention_interval=self.retention_interval,
             num_prompt_tokens=num_prompt_tokens,
+            exclude_mamba=True,
         )
 
     def lookup_mask(
@@ -230,6 +254,7 @@ class MooncakeStoreCoordinator:
         *,
         retention_interval: int | None,
         num_prompt_tokens: int | None,
+        exclude_mamba: bool = False,
     ) -> tuple[list[bool] | None, ...]:
         mask_alignment = (
             self.hash_block_size
@@ -245,16 +270,27 @@ class MooncakeStoreCoordinator:
             spec = _unwrap_spec(g.kv_cache_spec)
             end_chunk = aligned_token_len // spec.block_size
             start_chunk = min(end_chunk, max(0, cdiv(start_token, spec.block_size)))
+            if exclude_mamba and isinstance(spec, MambaSpec):
+                masks.append([False] * (end_chunk - start_chunk))
+                continue
             manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
             assert manager_cls is not None
             use_eagle = g_idx in self.eagle_group_ids
-            reachable_boundaries = (
+            reachable_boundaries: Sequence[int] = (
                 () if num_prompt_tokens is None else (num_prompt_tokens - 1,)
+            )
+            use_eagle, reachable_boundaries = resolve_sparse_retention_inputs(
+                spec,
+                use_eagle,
+                self.lookup_drops_eagle_block,
+                reachable_boundaries,
+                lookup_alignment_tokens=mask_alignment,
+                state_materialization_alignment_tokens=self.lcm_block_size,
             )
             mask = manager_cls.reachable_block_mask(
                 start_block=start_chunk,
                 end_block=end_chunk,
-                alignment_tokens=self.lcm_block_size,
+                alignment_tokens=mask_alignment,
                 kv_cache_spec=spec,
                 use_eagle=use_eagle,
                 retention_interval=retention_interval,
@@ -337,10 +373,10 @@ class MooncakeStoreCoordinator:
                     apply_eagle and group_eagle and idx not in eagle_verified
                 )
                 _max_length = curr_hit_length
-                # No eagle peek margin for a recurrent (Mamba) group: its finder
-                # never drops a block, so a widened bound would match past the
-                # attention-verified hit and resume from speculative state (#43559).
-                if drop_eagle_block and not isinstance(spec, MambaSpec):
+                # Only managers whose finder drops a block receive a peek
+                # margin. Otherwise a widened bound can resume past the
+                # attention-verified hit (#43559).
+                if drop_eagle_block and manager_cls.drops_eagle_block:
                     eagle_margin = (
                         self.hash_block_size
                         if self.enable_partial_hash_hits
@@ -404,9 +440,38 @@ def partial_hash_hits_enabled(
     (its dcp == 1 clause holds: the connector rejects hybrid + DCP/PCP > 1).
     Single copy on purpose — scheduler and coordinator must not disagree.
     """
-    return any(
+    has_partial_mamba_group = any(
         isinstance(spec := _unwrap_spec(g.kv_cache_spec), MambaSpec)
         and spec.mamba_cache_mode == "align"
         and spec.block_size > hash_block_size
         for g in kv_cache_groups
     )
+    has_mamba_align_group = any(
+        isinstance(spec := _unwrap_spec(g.kv_cache_spec), MambaSpec)
+        and spec.mamba_cache_mode == "align"
+        for g in kv_cache_groups
+    )
+    has_partial_attention_group = has_mamba_align_group and any(
+        isinstance(
+            spec := _unwrap_spec(g.kv_cache_spec),
+            FullAttentionSpec | SlidingWindowSpec,
+        )
+        and spec.block_size > hash_block_size
+        and (manager := KVCacheSpecRegistry.get_manager_class(spec)) is not None
+        and manager.supports_fine_grained_hash_lookup
+        for g in kv_cache_groups
+    )
+    if not (has_partial_mamba_group or has_partial_attention_group):
+        return False
+
+    for group in kv_cache_groups:
+        spec = _unwrap_spec(group.kv_cache_spec)
+        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        if manager_cls is None:
+            return False
+        if (
+            not manager_cls.supports_fine_grained_hash_lookup
+            and spec.block_size != hash_block_size
+        ):
+            return False
+    return True

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -372,11 +372,11 @@ class ReqMeta:
     # serve that purpose: it is reused once a preempted request resumes, so it
     # would release the wrong job's blocks.
     store_job_id: int | None = None
-    # Core-provided per-mamba-group
-    # (group_id, cow_block_id, boundary_tokens) for this request's partial tail.
-    # Present only on the producer's CoW step; drives the connector's offload
-    # (the FA group's block is derived from block_ids and boundary_tokens).
-    partial_tail_offloads: list[tuple[int, int, int]] | None = None
+    # Core-provided (group_id, block_id, boundary_tokens) mamba "align"
+    # boundary states. A block-aligned entry is a committed boundary snapshot;
+    # a non-aligned entry is the sub-block CoW tail. The store-job reference
+    # keeps each exact block alive until every worker rank finishes the job.
+    boundary_state_offloads: list[tuple[int, int, int]] | None = None
 
     @staticmethod
     def from_request_tracker(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -23,11 +23,12 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.worker import (
     LookupKeyClient,
 )
 from vllm.logger import init_logger
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 
@@ -77,18 +78,27 @@ class MooncakeStoreScheduler:
         self.enable_partial_hash_hits = partial_hash_hits_enabled(
             kv_cache_config.kv_cache_groups, self._hash_block_size
         )
-
-        # Per-request state
-        self.load_specs: dict[str, LoadSpec] = {}  # to be loaded
-        self._request_trackers: dict[str, RequestTracker] = {}  # scheduled new requests
-        self._unfinished_requests: dict[str, tuple[Request, tuple[list[int], ...]]] = {}
-        self._unfinished_request_ids: set[str] = set()
+        mamba_groups = {
+            group_id: group.kv_cache_spec
+            for group_id, group in enumerate(kv_cache_config.kv_cache_groups)
+            if isinstance(group.kv_cache_spec, MambaSpec)
+        }
+        assert all(
+            spec.mamba_cache_mode == "align" for spec in mamba_groups.values()
+        ), "MooncakeStoreScheduler requires mamba_cache_mode='align'"
+        self._boundary_state_group_ids = frozenset(mamba_groups)
 
         self._gpu_block_pool: BlockPool | None = None
         self._num_workers = vllm_config.parallel_config.world_size
         self._next_store_job_id = 0
         # store_job_id -> (referenced block ids, ranks yet to report completion)
         self._pinned_saves: dict[int, tuple[list[int], int]] = {}
+
+        # Per-request state
+        self.load_specs: dict[str, LoadSpec] = {}  # to be loaded
+        self._request_trackers: dict[str, RequestTracker] = {}  # scheduled new requests
+        self._unfinished_requests: dict[str, tuple[Request, tuple[list[int], ...]]] = {}
+        self._unfinished_request_ids: set[str] = set()
 
     def bind_gpu_block_pool(self, gpu_block_pool: BlockPool) -> None:
         self._gpu_block_pool = gpu_block_pool
@@ -373,46 +383,40 @@ class MooncakeStoreScheduler:
                 if req_meta is not None:
                     meta.add_request(req_meta)
 
-        # Flush partial-tail offloads in the step they arrive: the CoW copy is
-        # enqueued before the connector event records, so this step's event
-        # fences the cow block. Ride the request's save meta when present, else
-        # emit an offload-only ReqMeta (token_len_chunk=0 skips the normal
-        # save; can_save=True takes the normal enqueue path).
-        step_partial_tails = getattr(scheduler_output, "partial_tail_offloads", None)
-        if step_partial_tails and not is_consumer:
-            pending = dict(step_partial_tails)
-            for req_meta in meta.requests:
-                if req_meta.can_save:
-                    groups = pending.pop(req_meta.req_id, None)
-                    if groups:
-                        req_meta.partial_tail_offloads = groups
-                        tracker = self._request_trackers.get(req_meta.req_id)
-                        if tracker is not None:
-                            tracker.has_pending_offload = True
-            for req_id, groups in pending.items():
-                tracker = self._request_trackers.get(req_id)
-                req_tuple = self._unfinished_requests.get(req_id)
-                if tracker is None or req_tuple is None:
-                    # Request finished/preempted within this step; its blocks
-                    # are going away, so the offload is conservatively dropped.
-                    logger.debug("Dropping partial-tail offload for request %s", req_id)
-                    continue
-                assert len({boundary for _, _, boundary in groups}) == 1
-                tracker.has_pending_offload = True
-                meta.add_request(
-                    ReqMeta(
-                        req_id=req_id,
-                        token_len_chunk=0,
-                        block_ids=tracker.allocated_block_ids,
-                        block_hashes=req_tuple[0].block_hashes,
-                        can_save=True,
-                        num_prompt_tokens=tracker.prefill_end_tokens,
-                        partial_tail_offloads=groups,
-                    )
-                )
+        block_state = getattr(scheduler_output, "kv_connector_block_state", None)
+        if (
+            block_state is not None
+            and block_state.boundary_state_offloads
+            and not is_consumer
+        ):
+            self._handle_boundary_state_offloads(
+                block_state.boundary_state_offloads, meta
+            )
 
+        self._apply_current_save_block_ids(meta, scheduler_output)
         self._reference_save_blocks(meta)
         return meta
+
+    def _apply_current_save_block_ids(
+        self,
+        meta: MooncakeStoreConnectorMetadata,
+        scheduler_output: SchedulerOutput,
+    ) -> None:
+        """Replace append-only mirrors with the core's current block tables."""
+        save_metas = [req_meta for req_meta in meta.requests if req_meta.can_save]
+        if not save_metas:
+            return
+
+        block_state = scheduler_output.kv_connector_block_state
+        assert block_state is not None, (
+            "Current block tables are required for Mooncake store jobs"
+        )
+        for req_meta in save_metas:
+            block_ids = block_state.block_ids.get(req_meta.req_id)
+            assert block_ids is not None, (
+                f"Missing current block table for store request {req_meta.req_id}"
+            )
+            req_meta.block_ids = block_ids
 
     def _reference_save_blocks(self, meta: MooncakeStoreConnectorMetadata) -> None:
         """Take a GPU block reference for every store job this step emits.
@@ -431,21 +435,86 @@ class MooncakeStoreScheduler:
             req_meta.store_job_id = store_job_id = self._next_store_job_id
             self._next_store_job_id += 1
             block_ids: list[int] = []
-            if req_meta.partial_tail_offloads:
-                # A partial-tail CoW block is deliberately kept out of the
-                # request's block table, so it is absent from `block_ids` even
-                # though the worker DMAs out of it just as asynchronously.
-                # It leads the list, as in `pop_blocks_for_free`.
-                block_ids += [bid for _, bid, _ in req_meta.partial_tail_offloads]
+            if req_meta.boundary_state_offloads:
+                block_ids.extend(
+                    block_id for _, block_id, _ in req_meta.boundary_state_offloads
+                )
+            assert NULL_BLOCK_ID not in block_ids, (
+                "A null block cannot back a boundary-state offload"
+            )
             # Every allocated block is referenced, not just the ones covering
             # this job's token range: a rank resumes from its own last
             # successful offset, which lags the scheduler's whenever a save was
             # skipped or failed, so it may read anywhere below the range.
-            block_ids += [bid for group in req_meta.block_ids for bid in group]
+            block_ids.extend(
+                block_id
+                for group_id, group in enumerate(req_meta.block_ids)
+                if group_id not in self._boundary_state_group_ids
+                for block_id in group
+                if block_id != NULL_BLOCK_ID
+            )
+            # An aligned boundary block may also be present in the request's
+            # block table. Take and release exactly one reference per block.
+            block_ids = list(dict.fromkeys(block_ids))
+            assert NULL_BLOCK_ID not in block_ids
             if not block_ids:
                 continue
             self._pinned_saves[store_job_id] = (block_ids, self._num_workers)
-            pool.touch([pool.blocks[bid] for bid in block_ids])
+            pool.touch([pool.blocks[block_id] for block_id in block_ids])
+
+    def _handle_boundary_state_offloads(
+        self,
+        offloads: dict[str, list[tuple[int, int, int]]],
+        meta: MooncakeStoreConnectorMetadata,
+    ) -> None:
+        """Attach exact boundary-state blocks to store jobs for this step.
+
+        Flushed in the step they arrive: the CoW copy is enqueued before the
+        connector event records, so this step's event fences the exact block.
+        Entries ride the request's save meta when present, else an
+        offload-only ReqMeta (``token_len_chunk=0`` skips the normal save,
+        ``can_save=True`` takes the normal enqueue and store-job pinning path).
+        """
+        save_metas = {m.req_id: m for m in meta.requests if m.can_save}
+        for req_id, entries in offloads.items():
+            tracker = self._request_trackers.get(req_id)
+            req_tuple = self._unfinished_requests.get(req_id)
+            if tracker is None or req_tuple is None:
+                # Request finished/preempted within this step; its blocks are
+                # going away, so the offload is conservatively dropped.
+                logger.debug("Dropping boundary-state offload for request %s", req_id)
+                continue
+            accepted: list[tuple[int, int, int]] = []
+            for group_id, block_id, boundary_tokens in entries:
+                # Every other group stops saving at the end of this prefill, so
+                # a mamba-only key past it can never complete a joint hybrid
+                # hit. `prefill_end_tokens` — not the original prompt length —
+                # is the boundary: a resumed request re-prefills and re-saves
+                # its previously generated tokens for every group.
+                if boundary_tokens > tracker.prefill_end_tokens:
+                    continue
+                if block_id == NULL_BLOCK_ID:
+                    continue
+                if group_id not in self._boundary_state_group_ids:
+                    continue
+                accepted.append((group_id, block_id, boundary_tokens))
+            if not accepted:
+                continue
+            tracker.has_pending_offload = True
+            if (req_meta := save_metas.get(req_id)) is not None:
+                req_meta.boundary_state_offloads = accepted
+                continue
+            meta.add_request(
+                ReqMeta(
+                    req_id=req_id,
+                    token_len_chunk=0,
+                    block_ids=tracker.allocated_block_ids,
+                    block_hashes=req_tuple[0].block_hashes,
+                    can_save=True,
+                    num_prompt_tokens=tracker.prefill_end_tokens,
+                    boundary_state_offloads=accepted,
+                )
+            )
 
     def update_connector_output(self, connector_output: KVConnectorOutput) -> None:
         """Drop the block references of store jobs every rank has finished."""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -644,48 +644,76 @@ class KVCacheStoreSendingThread(KVTransferThread):
             self._skip_store_requests.clear()
         return True
 
-    def _maybe_offload_partial_tail(self, req_meta: ReqMeta) -> bool:
-        """Offload the request's sub-block partial tail (its last prompt hash
-        boundary) so a later request can hit the sub-block prefix.
+    def _boundary_snapshot_puts(
+        self, req_meta: ReqMeta, entries: list[tuple[int, int, int]]
+    ) -> list[tuple[str, list[int], list[int], KeyMetadata]]:
+        """Puts for committed mamba "align" boundary-state snapshots.
 
-        Covers every block from the normal save's lcm floor to the boundary:
-        the normal save floors to ``lcm_block_size``, so a smaller-block
-        group's full blocks in that gap are never persisted elsewhere, and
-        the consumer's lookup needs every group at every probed boundary.
-        Full blocks are keyed by their block-end hash, the partial boundary
-        block by the boundary sub-hash; the mamba "align" boundary block is
-        the core-provided CoW block. All keys are deduped against the store.
+        These are block-aligned boundaries, i.e. exactly what the normal save
+        would key — but ``store_mask`` masks mamba groups out of it entirely, so
+        this is their *only* writer. The exclusion is not an optimization: the
+        normal save resolves a chunk's address as
+        ``req_meta.block_ids[g][start // block_size]``, and ``block_ids`` is the
+        connector's append-only mirror of the core's per-group table. An
+        align-mode table is mutated in place (a superseded state block is freed
+        and nulled; speculative blocks relocate), and the connector is never
+        told, so a stale mirror entry is indistinguishable from a live one — a
+        retry of a failed or pressure-skipped chunk would read a block that now
+        belongs to another request.
 
-        Returns:
-            True when no put is needed or every put succeeds, False otherwise.
+        Each entry's handed-off block *is* the boundary state and is pinned by
+        the core, so it is uploaded under its boundary-end hash key and never
+        resolved positionally.
         """
-        if not self.coord.enable_partial_hash_hits or not req_meta.block_hashes:
-            return True
-        partial_tail_offloads = req_meta.partial_tail_offloads
-        if not partial_tail_offloads:
-            return True
         hash_block_size = self.coord.hash_block_size
-        boundaries = {boundary for _, _, boundary in partial_tail_offloads}
+        puts: list[tuple[str, list[int], list[int], KeyMetadata]] = []
+        for group_id, block_id, boundary in entries:
+            if boundary == 0 or block_id == NULL_BLOCK_ID:
+                continue
+            hash_idx = boundary // hash_block_size - 1
+            if hash_idx >= len(req_meta.block_hashes):
+                continue
+            db = self.token_databases[group_id]
+            # Distribute across ranks by the same rule as normal chunks.
+            put_step = self.group_put_steps[group_id]
+            put_step_rank = (self.tp_rank + group_id) % put_step
+            if (boundary // db.block_size - 1) % put_step != put_step_rank:
+                continue
+            addr, size = db.prepare_value_for_block(block_id)
+            puts.append(
+                (db.key_for(req_meta.block_hashes[hash_idx]), addr, size, db.metadata)
+            )
+        return puts
+
+    def _sub_block_tail_puts(
+        self, req_meta: ReqMeta, entries: list[tuple[int, int, int]]
+    ) -> list[tuple[str, list[int], list[int], KeyMetadata]]:
+        """Puts for the request's sub-block partial tail (its last prompt hash
+        boundary), so a later request can hit the sub-block prefix.
+
+        Covers every group's blocks from the normal save's lcm floor to the
+        boundary: the normal save floors to ``lcm_block_size``, so a
+        smaller-block group's full blocks in that gap are never persisted
+        elsewhere, and the consumer's lookup needs every group at every probed
+        boundary. Full blocks are keyed by their block-end hash and the partial
+        boundary block by the boundary sub-hash; a mamba "align" group
+        contributes only its boundary block, from the core-provided CoW block.
+        """
+        boundaries = {boundary for _, _, boundary in entries}
         if len(boundaries) != 1:
             raise ValueError(
-                "Partial-tail offloads for one request must share a boundary"
+                "Sub-block partial-tail offloads for one request must share a boundary"
             )
         boundary = boundaries.pop()
-        if boundary == 0:
-            return True
-        if boundary // hash_block_size - 1 >= len(req_meta.block_hashes):
-            return True
-        mamba_offloads = {
-            group_id: block_id for group_id, block_id, _ in partial_tail_offloads
-        }
+        hash_block_size = self.coord.hash_block_size
+        if boundary == 0 or boundary // hash_block_size - 1 >= len(
+            req_meta.block_hashes
+        ):
+            return []
 
-        keys: list[str] = []
-        addrs: list[list[int]] = []
-        sizes: list[list[int]] = []
-        group_ids: list[str] | None = (
-            [] if self.enable_group_semantics and self.supports_group_ids else None
-        )
+        mamba_offloads = {group_id: block_id for group_id, block_id, _ in entries}
         saved = self._saved_offset.get(req_meta.req_id, 0)
+        puts: list[tuple[str, list[int], list[int], KeyMetadata]] = []
         for g_idx, db in enumerate(self.token_databases):
             group_blocks = req_meta.block_ids[g_idx]
             # Distribute across ranks by the same rule as normal chunks.
@@ -701,16 +729,20 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     continue
                 valid_end = min((block_idx + 1) * db.block_size, boundary)
                 key_hash = req_meta.block_hashes[valid_end // hash_block_size - 1]
-                if (
-                    g_idx in mamba_offloads
-                    and valid_end == boundary
-                    and boundary % db.block_size != 0
-                ):
-                    block_id = mamba_offloads[g_idx]
-                else:
-                    if block_idx >= len(group_blocks):
+                if g_idx in mamba_offloads:
+                    if valid_end != boundary:
+                        # Interior align-mode state positions are null or
+                        # stale (the block table is not append-only) and never
+                        # valid gap content; only the boundary block is
+                        # persisted, from the core-provided hand-off.
                         continue
+                    block_id = mamba_offloads[g_idx]
+                elif g_idx in self.coord.mamba_group_ids:
+                    continue
+                elif block_idx < len(group_blocks):
                     block_id = group_blocks[block_idx]
+                else:
+                    continue
                 if block_id == NULL_BLOCK_ID:
                     logger.debug(
                         "Skipping unavailable partial-tail source block "
@@ -721,20 +753,58 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     )
                     continue
                 addr, size = db.prepare_value_for_block(block_id)
-                key = db.key_for(key_hash)
-                keys.append(key)
-                addrs.append(addr)
-                sizes.append(size)
-                if group_ids is not None:
-                    group_ids.append(
-                        _make_mooncake_group_id(
-                            db.metadata,
-                            key.rsplit("@", 1)[-1],
-                        )
-                    )
+                puts.append((db.key_for(key_hash), addr, size, db.metadata))
+        return puts
 
-        if not keys:
+    def _maybe_offload_boundary_states(self, req_meta: ReqMeta) -> bool:
+        """Persist connector-pinned mamba "align" boundary states handed off
+        for this request, deduped against the store.
+
+        This is every mamba key the connector writes — ``store_mask`` excludes
+        mamba groups from the positional normal save, aligned boundaries
+        included (see :meth:`_boundary_snapshot_puts`).
+
+        The two entry kinds are keyed and sourced differently, so they are
+        prepared separately and put in one batch:
+
+        - block-aligned for its group: a committed boundary-state snapshot,
+          the handed-off block itself;
+        - not block-aligned: the sub-block CoW partial tail, which also has to
+          cover the other groups' blocks in the normal save's lcm gap.
+
+        Returns:
+            True when no put is needed or every put succeeds, False otherwise.
+        """
+        offloads = req_meta.boundary_state_offloads
+        if not offloads or not req_meta.block_hashes:
             return True
+
+        snapshots: list[tuple[int, int, int]] = []
+        sub_block: list[tuple[int, int, int]] = []
+        for group_id, block_id, boundary in offloads:
+            entry = (group_id, block_id, boundary)
+            if boundary % self.token_databases[group_id].block_size == 0:
+                snapshots.append(entry)
+            else:
+                sub_block.append(entry)
+
+        puts = self._boundary_snapshot_puts(req_meta, snapshots)
+        if sub_block and self.coord.enable_partial_hash_hits:
+            puts.extend(self._sub_block_tail_puts(req_meta, sub_block))
+
+        if not puts:
+            return True
+        keys = [key for key, _, _, _ in puts]
+        addrs = [addr for _, addr, _, _ in puts]
+        sizes = [size for _, _, size, _ in puts]
+        group_ids: list[str] | None = (
+            [
+                _make_mooncake_group_id(metadata, key.rsplit("@", 1)[-1])
+                for key, _, _, metadata in puts
+            ]
+            if self.enable_group_semantics and self.supports_group_ids
+            else None
+        )
         exists_start = time.perf_counter()
         try:
             exists = self.store.batch_is_exist(keys)
@@ -747,7 +817,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 num_failed_keys=len(keys),
             )
             logger.error(
-                "Failed to check partial-tail keys for request %s: %s",
+                "Failed to check boundary-state keys for request %s: %s",
                 req_meta.req_id,
                 e,
             )
@@ -783,7 +853,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 num_failed_keys=len(keys),
             )
             logger.error(
-                "Failed to put partial-tail keys for request %s: %s",
+                "Failed to put boundary-state keys for request %s: %s",
                 req_meta.req_id,
                 e,
             )
@@ -801,7 +871,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
         if failed:
             failed_codes = {res[i] for i in failed}
             logger.warning(
-                "Partial-tail put failed for request %s: %d/%d keys failed (codes=%s)",
+                "Boundary-state put failed for request %s: %d/%d keys failed "
+                "(codes=%s)",
                 req_meta.req_id,
                 len(failed),
                 len(keys),
@@ -814,7 +885,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         if self._clear_store_pressure():
             logger.info(
                 "Mooncake CPU/disk offloading pressure cleared after a "
-                "successful partial-tail batch"
+                "successful boundary-state batch"
             )
         return True
 
@@ -853,10 +924,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 )
                 return
 
-            # Offload the sub-block partial tail (independent of the normal
-            # block-aligned save, which may be skipped this step).
-            if req_meta.partial_tail_offloads is not None and not (
-                self._maybe_offload_partial_tail(req_meta)
+            # Offload the handed-off mamba boundary states (independent of the
+            # normal positional save, which may be skipped this step).
+            if req_meta.boundary_state_offloads is not None and not (
+                self._maybe_offload_boundary_states(req_meta)
             ):
                 return
 
@@ -883,6 +954,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 # Rotate the stride phase per group to balance load across ranks.
                 put_step = self.group_put_steps[g_idx]
                 put_step_rank = (self.tp_rank + g_idx) % put_step
+                group_blocks = block_ids_per_group[g_idx]
                 for start, end, block_hash in db.process_tokens(
                     token_len,
                     req_meta.block_hashes,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -1161,6 +1161,9 @@ class OffloadingConnectorScheduler:
                         if bid != 0:
                             self._current_batch_allocated_block_ids.add(bid)
 
+        for copy in scheduler_output.kv_cache_block_copies or ():
+            self._current_batch_allocated_block_ids.add(copy.dst_block_id)
+
         # Zero out stale block_ids in sliding window groups' pending-store
         # positions. Only sliding window groups can have stale entries (blocks
         # freed by remove_skipped_blocks then reallocated). Only positions in
@@ -1182,18 +1185,89 @@ class OffloadingConnectorScheduler:
                         ):
                             group_state.block_ids[j] = 0
 
+    def _build_aligned_boundary_store_jobs(
+        self, handoffs: dict[str, list[tuple[int, int, int]]]
+    ) -> dict[int, TransferJob]:
+        store_jobs: dict[int, TransferJob] = {}
+        num_groups = len(self.config.kv_group_configs)
+        for req_id, entries in handoffs.items():
+            req_status = self._req_status.get(req_id)
+            if req_status is None:
+                continue
+            req = req_status.req
+            max_boundary = self._calc_num_offloadable_tokens(req_status, req.num_tokens)
+            for group_idx, block_id, boundary in entries:
+                group_config = self.config.kv_group_configs[group_idx]
+                if (
+                    block_id == 0
+                    or boundary > max_boundary
+                    or boundary % group_config.tokens_per_chunk != 0
+                ):
+                    continue
+
+                key = self._make_boundary_key(req, group_idx, boundary)
+                store_output = self.manager.prepare_store([key], req_status.req_context)
+                if store_output is None:
+                    self._connector_stats.increase_counter(
+                        _ConnectorMetricName.ALLOCATION_FAILURE
+                    )
+                    continue
+                if not store_output.keys_to_store:
+                    continue
+
+                job_id = self._generate_job_id()
+                req_status.transfer_jobs.add(job_id)
+                self._block_id_to_pending_jobs.setdefault(block_id, set()).add(job_id)
+                self._jobs[job_id] = TransferJobStatus(
+                    req_id=req_id,
+                    pending_count=self.config.num_workers,
+                    keys={key},
+                    is_store=True,
+                    fenced_block_ids=[block_id],
+                )
+                group_sizes = [0] * num_groups
+                group_sizes[group_idx] = 1
+                block_indices = [0] * num_groups
+                block_indices[group_idx] = boundary // group_config.tokens_per_block - 1
+                store_jobs[job_id] = TransferJob(
+                    req_id=req_id,
+                    src_spec=GPULoadStoreSpec(
+                        [block_id],
+                        group_sizes=group_sizes,
+                        block_indices=block_indices,
+                    ),
+                    dst_spec=store_output.store_spec,
+                )
+                self._events_tracker.record_store(
+                    req,
+                    group_config,
+                    boundary // group_config.tokens_per_chunk - 1,
+                    key,
+                )
+        return store_jobs
+
     def _build_partial_tail_store_jobs(
         self, scheduler_output: SchedulerOutput
     ) -> dict[int, TransferJob]:
-        handoffs = scheduler_output.partial_tail_offloads
-        if not self.config.supports_partial_tail or not handoffs:
+        block_state = scheduler_output.kv_connector_block_state
+        handoffs = block_state.boundary_state_offloads if block_state else None
+        if not handoffs:
             return {}
 
-        store_jobs: dict[int, TransferJob] = {}
+        store_jobs = self._build_aligned_boundary_store_jobs(handoffs)
+        if not self.config.supports_partial_tail:
+            return store_jobs
+
         for req_id, entries in handoffs.items():
+            entries = [
+                entry
+                for entry in entries
+                if entry[2] % self._partial_tail_block_size != 0
+            ]
+            if not entries:
+                continue
             req_status = self._req_status.get(req_id)
             assert req_status is not None
-            assert entries
             boundaries = {boundary for _, _, boundary in entries}
             assert len(boundaries) == 1
             boundary = boundaries.pop()
@@ -1312,6 +1386,9 @@ class OffloadingConnectorScheduler:
                 num_chunks = req_status.storable_chunks(
                     group_config, group_state, num_offloadable_tokens
                 )
+
+                if group_config.requires_cow_source:
+                    continue
 
                 start_chunk_idx = group_state.next_stored_chunk_idx
                 if num_chunks <= start_chunk_idx:

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -860,10 +860,14 @@ class Platform:
                     "VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE must be a positive "
                     "multiple of 64 after automatic resolution."
                 )
-            if mamba_block_size <= 0 or mamba_block_size % target_block_size != 0:
+            if mamba_block_size <= 0 or (
+                mamba_block_size % target_block_size != 0
+                and target_block_size % mamba_block_size != 0
+            ):
                 raise ValueError(
-                    "VLLM_GLM53_SPLIT_MAMBA_BLOCK_SIZE must be a positive "
-                    "multiple of VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE."
+                    "VLLM_GLM53_SPLIT_MAMBA_BLOCK_SIZE must be positive and "
+                    "either a multiple or a divisor of "
+                    "VLLM_GLM53_SPLIT_TARGET_BLOCK_SIZE."
                 )
             if cache_config.mamba_cache_mode != "align":
                 raise ValueError(
@@ -872,8 +876,12 @@ class Platform:
                 )
 
             # The target MLA cache and recurrent-state cache use independent
-            # physical pages. Their token block sizes remain scheduler-visible,
-            # so the recurrent block must be a multiple of the target block.
+            # physical pages. Their token block sizes remain scheduler-visible
+            # (the scheduler block is their LCM), so one must be a multiple of
+            # the other. A recurrent block finer than the target block keeps
+            # recurrent checkpoints (and so prefix-cache reuse, with
+            # ``prefix_match_unit`` set to the recurrent block) fine-grained
+            # while the target page grows to match the recurrent page.
             cache_config.block_size = target_block_size
             cache_config.mamba_block_size = mamba_block_size
             cache_config.mamba_page_size_padded = None

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import weakref
 from collections.abc import Iterable, Sequence
+from itertools import groupby
 from typing import TYPE_CHECKING, Any
 
 from vllm.distributed.kv_events import (
@@ -197,6 +199,16 @@ class BlockPool:
         self.enable_kv_cache_events = enable_kv_cache_events
         self.kv_event_queue: list[KVCacheEvent] = []
 
+        # Last published full-block endpoint per request and cache group, so a
+        # later publication reports only the unannounced span as skipped
+        # context instead of re-announcing blocks consumers already hold.
+        # Entries map the cache group id to (endpoint, last published block
+        # hash), where the endpoint counts full blocks in the group's block
+        # size. Weak keys let completed requests release their bookkeeping.
+        self.published_full_block_anchors: weakref.WeakKeyDictionary[
+            Request, dict[int, tuple[int, BlockHash]]
+        ] = weakref.WeakKeyDictionary()
+
         self.metrics_collector = metrics_collector
 
     def get_cached_block(
@@ -269,9 +281,7 @@ class BlockPool:
         )
 
         new_block_hashes = block_hashes[num_cached_blocks:]
-        new_hashes: list[ExternalBlockHash] | None = (
-            [] if self.enable_kv_cache_events else None
-        )
+        stored_indices: list[int] | None = [] if self.enable_kv_cache_events else None
         for i, blk in enumerate(new_full_blocks):
             # Some blocks may be null or masked out when enabling sparse attention
             # like sliding window attention, or Mamba models with prefix-caching
@@ -299,62 +309,213 @@ class BlockPool:
                 blk,
                 num_tokens=num_hash_tokens,
             )
-            if new_hashes is not None:
-                new_hashes.append(maybe_convert_block_hash(block_hash))
+            if stored_indices is not None:
+                stored_indices.append(num_cached_blocks + i)
 
-        if self.enable_kv_cache_events:
-            if num_cached_blocks == 0:
-                parent_block_hash: ExternalBlockHash | None = None
-            else:
-                parent_block_hash = maybe_convert_block_hash(
-                    block_hashes[num_cached_blocks - 1]
-                )
+        # Publish after all insertions and promotion removals, as for dense
+        # stores. Skipped context chains from the last published full-block
+        # endpoint, not from ``num_cached_blocks``: the caller's counter
+        # advances over masked and null blocks that were never announced.
+        if stored_indices:
+            self._emit_stored_block_runs(
+                request,
+                stored_indices,
+                block_size,
+                kv_cache_group_id,
+                context_start_block_idx=self._published_full_block_context_start(
+                    request, block_size, kv_cache_group_id
+                ),
+            )
 
-            # Calculate token range for the blocks being cached
-            start_token_idx = num_cached_blocks * block_size
-            end_token_idx = num_full_blocks * block_size
-
-            # Generate extra keys for each block individually.
-            # Each block may have different extra_keys (e.g., different MM
-            # features, or cache_salt only for the first block).
-            # Skip null/masked-out blocks to match the length of new_hashes.
-            extra_keys_list: list[tuple[Any, ...] | None] = []
-            curr_mm_idx = 0
-            for i in range(num_cached_blocks, num_full_blocks):
-                if blocks[i].is_null:
-                    continue
-                if block_mask is not None and not block_mask[i - num_cached_blocks]:
-                    continue
-                block_start = i * block_size
-                block_end = block_start + block_size
-                extra_keys, curr_mm_idx = generate_block_hash_extra_keys(
-                    request, block_start, block_end, curr_mm_idx
-                )
-                extra_keys_list.append(extra_keys)
-
+    def _emit_stored_block_runs(
+        self,
+        request: Request,
+        block_indices: list[int],
+        block_size: int,
+        kv_cache_group_id: int,
+        context_start_block_idx: int = 0,
+    ) -> None:
+        """Publish maximal contiguous runs of sorted retained block indices."""
+        block_hashes = resolve_block_hashes(
+            request.block_hashes, self.hash_block_size, block_size
+        )
+        previous_end = context_start_block_idx
+        for _, run in groupby(
+            enumerate(block_indices), key=lambda pair: pair[1] - pair[0]
+        ):
+            indices = [index for _, index in run]
+            start, end = indices[0], indices[-1] + 1
+            extra_keys_list = self._generate_block_extra_keys(
+                request, start, end, block_size
+            )
+            (
+                skipped_parent_block_hash,
+                skipped_start_token_idx,
+                skipped_end_token_idx,
+                skipped_extra_keys,
+            ) = self._get_skipped_context(
+                request,
+                previous_end * block_size,
+                start * block_size,
+                block_size,
+            )
             self.kv_event_queue.append(
                 self._build_block_stored_event(
                     request,
-                    block_hashes=new_hashes,
-                    parent_block_hash=parent_block_hash,
-                    start_token_idx=start_token_idx,
-                    end_token_idx=end_token_idx,
+                    block_hashes=[
+                        maybe_convert_block_hash(block_hashes[i]) for i in indices
+                    ],
+                    parent_block_hash=(
+                        maybe_convert_block_hash(block_hashes[start - 1])
+                        if start
+                        else None
+                    ),
+                    start_token_idx=start * block_size,
+                    end_token_idx=end * block_size,
                     block_size=block_size,
                     kv_cache_group_id=kv_cache_group_id,
                     extra_keys_list=extra_keys_list,
+                    skipped_parent_block_hash=skipped_parent_block_hash,
+                    skipped_start_token_idx=skipped_start_token_idx,
+                    skipped_end_token_idx=skipped_end_token_idx,
+                    skipped_extra_keys=skipped_extra_keys,
                 )
             )
+            # Stores and full replays both advance publication context.
+            self._advance_full_block_anchor(
+                request, end, block_hashes[end - 1], kv_cache_group_id
+            )
+            previous_end = end
+
+    @staticmethod
+    def _generate_block_extra_keys(
+        request: Request,
+        start_block_idx: int,
+        end_block_idx: int,
+        block_size: int,
+    ) -> list[tuple[Any, ...] | None]:
+        extra_keys_list: list[tuple[Any, ...] | None] = []
+        curr_mm_idx = 0
+        for i in range(start_block_idx, end_block_idx):
+            extra_keys, curr_mm_idx = generate_block_hash_extra_keys(
+                request, i * block_size, (i + 1) * block_size, curr_mm_idx
+            )
+            extra_keys_list.append(extra_keys)
+        return extra_keys_list
+
+    def _get_skipped_context(
+        self,
+        request: Request,
+        context_start_token_idx: int,
+        end_token_idx: int,
+        extra_keys_block_size: int,
+    ) -> tuple[
+        ExternalBlockHash | None,
+        int | None,
+        int | None,
+        list[tuple[Any, ...] | None] | None,
+    ]:
+        """Build the skipped-context fields for an unannounced token span.
+
+        The span ``[context_start_token_idx, end_token_idx)`` covers tokens
+        that no published event announced for this request yet.
+        ``context_start_token_idx`` is the boundary up to which consumers
+        already hold context (0 at the root). Returns
+        ``(skipped_parent_block_hash, skipped_start_token_idx,
+        skipped_end_token_idx, skipped_extra_keys)``, all ``None`` when the
+        span is empty. The parent hash is the prefix-chain hash at the span's
+        start boundary; extra keys are generated per ``extra_keys_block_size``,
+        which is the group's block size for full-block events and
+        ``self.hash_block_size`` for partial events.
+        """
+        if context_start_token_idx >= end_token_idx:
+            return None, None, None, None
+        assert context_start_token_idx % self.hash_block_size == 0
+        num_hash_blocks = context_start_token_idx // self.hash_block_size
+        skipped_parent_block_hash = (
+            maybe_convert_block_hash(request.block_hashes[num_hash_blocks - 1])
+            if num_hash_blocks
+            else None
+        )
+        skipped_extra_keys = self._generate_block_extra_keys(
+            request,
+            context_start_token_idx // extra_keys_block_size,
+            end_token_idx // extra_keys_block_size,
+            extra_keys_block_size,
+        )
+        return (
+            skipped_parent_block_hash,
+            context_start_token_idx,
+            end_token_idx,
+            skipped_extra_keys,
+        )
+
+    def _published_full_block_context_start(
+        self,
+        request: Request,
+        block_size: int,
+        kv_cache_group_id: int,
+    ) -> int:
+        """Return the validated published endpoint for this request and group.
+
+        The endpoint counts the full blocks whose publication already reached
+        the event queue for this request in this cache group, so the next
+        publication can report only tokens beyond it as skipped context.
+        Streaming updates truncate and re-extend a request in place and
+        recompute its block hashes, so the saved hash is validated before the
+        anchor is reused; an invalid or missing anchor starts at the root.
+        """
+        anchors = self.published_full_block_anchors.get(request)
+        if anchors is None:
+            return 0
+        anchor = anchors.get(kv_cache_group_id)
+        if anchor is None:
+            return 0
+        endpoint, published_hash = anchor
+        block_hashes = resolve_block_hashes(
+            request.block_hashes, self.hash_block_size, block_size
+        )
+        if (
+            endpoint <= 0
+            or endpoint > len(block_hashes)
+            or block_hashes[endpoint - 1] != published_hash
+        ):
+            # The request's prefix changed under the anchor: restart from the
+            # root and drop the stale entry.
+            del anchors[kv_cache_group_id]
+            if not anchors:
+                del self.published_full_block_anchors[request]
+            return 0
+        return endpoint
+
+    def _advance_full_block_anchor(
+        self,
+        request: Request,
+        endpoint: int,
+        last_block_hash: BlockHash,
+        kv_cache_group_id: int,
+    ) -> None:
+        """Record the last published full-block endpoint for request and group."""
+        anchors = self.published_full_block_anchors.get(request)
+        if anchors is None:
+            anchors = {}
+            self.published_full_block_anchors[request] = anchors
+        anchors[kv_cache_group_id] = (endpoint, last_block_hash)
 
     def _build_block_stored_event(
         self,
         request: Request,
-        block_hashes: list[ExternalBlockHash] | None,
+        block_hashes: list[ExternalBlockHash],
         parent_block_hash: ExternalBlockHash | None,
         start_token_idx: int,
         end_token_idx: int,
         block_size: int,
         kv_cache_group_id: int,
         extra_keys_list: list[tuple[Any, ...] | None],
+        skipped_parent_block_hash: ExternalBlockHash | None = None,
+        skipped_start_token_idx: int | None = None,
+        skipped_end_token_idx: int | None = None,
+        skipped_extra_keys: list[tuple[Any, ...] | None] | None = None,
     ) -> BlockStored:
         """Build a ``BlockStored`` KV event for ``request``.
 
@@ -371,78 +532,103 @@ class BlockPool:
             medium=MEDIUM_GPU,
             lora_name=request.lora_request.name if request.lora_request else None,
             extra_keys=extra_keys_list if extra_keys_list else None,
+            skipped_parent_block_hash=skipped_parent_block_hash,
+            skipped_token_ids=(
+                request.all_token_ids[skipped_start_token_idx:skipped_end_token_idx]
+                if skipped_start_token_idx is not None
+                and skipped_end_token_idx is not None
+                else None
+            ),
+            skipped_extra_keys=skipped_extra_keys,
             group_idx=kv_cache_group_id,
         )
 
     def emit_cached_block_events(
         self,
         request: Request,
-        num_cached_blocks: int,
+        blocks: Sequence[KVCacheBlock],
+        num_cached_tokens: int,
         block_size: int,
         kv_cache_group_id: int,
     ) -> None:
-        """Generate BlockStored events for blocks reused from prefix cache.
+        """Publish retained entries returned by lookup without changing block state.
 
-        Unlike cache_full_blocks(), this does NOT modify block state —
-        the blocks are already cached. It only generates events so that
-        external consumers (e.g. gateway) can learn about reused blocks.
-
-        Args:
-            request: The request whose prefix cache blocks were reused.
-            num_cached_blocks: Number of blocks that were cache hits.
-            block_size: Number of tokens per block.
-            kv_cache_group_id: The KV cache group ID.
+        ``blocks`` includes sparse null placeholders. ``num_cached_tokens`` is
+        the reconciled hit length, which may end inside the last physical block.
+        Only registered hashes owned by the returned blocks are advertised.
         """
-        if not self.enable_kv_cache_events or num_cached_blocks == 0:
+        if not self.enable_kv_cache_events or not blocks or num_cached_tokens == 0:
             return
 
         block_hashes = resolve_block_hashes(
             request.block_hashes, self.hash_block_size, block_size
         )
-
-        # Collect external hashes and extra_keys for cached blocks.
-        cached_hashes: list[ExternalBlockHash] = []
-        extra_keys_list: list[tuple[Any, ...] | None] = []
-        curr_mm_idx = 0
-        for i in range(num_cached_blocks):
-            block_start = i * block_size
-            block_end = block_start + block_size
-            cached_hashes.append(maybe_convert_block_hash(block_hashes[i]))
-            extra_keys, curr_mm_idx = generate_block_hash_extra_keys(
-                request, block_start, block_end, curr_mm_idx
+        num_full_blocks = num_cached_tokens // block_size
+        stored_indices = [
+            i
+            for i, block in enumerate(blocks[:num_full_blocks])
+            if not block.is_null
+            and self.cached_block_hash_to_block.contain(
+                make_block_hash_with_group_id(block_hashes[i], kv_cache_group_id),
+                block.block_id,
             )
-            extra_keys_list.append(extra_keys)
+        ]
+        if stored_indices:
+            self._emit_stored_block_runs(
+                request, stored_indices, block_size, kv_cache_group_id
+            )
+            # A full replay re-announces from the root, so a partial event in
+            # the same replay chains from the run just published.
+            partial_context_start = (stored_indices[-1] + 1) * block_size
+        else:
+            # A full replay without a full run still starts at the root.
+            partial_context_start = 0
 
-        if not cached_hashes:
+        if num_cached_tokens % block_size == 0 or num_full_blocks >= len(blocks):
             return
-
-        # Prefix-cache hits always form a contiguous prefix starting at block 0,
-        # so the first (and thus the whole group's) parent block hash is None.
-        parent_block_hash: ExternalBlockHash | None = None
-        start_token_idx = 0
-        end_token_idx = num_cached_blocks * block_size
-
-        logger.debug(
-            "EmitCachedBlock event: block_size=%d, "
-            "num_cached_blocks=%d, parent_block_hash=%s, "
-            "token_ids_len=%d, group_idx=%s",
-            block_size,
-            num_cached_blocks,
-            parent_block_hash,
-            len(request.all_token_ids[start_token_idx:end_token_idx]),
-            kv_cache_group_id,
+        block = blocks[num_full_blocks]
+        if block.is_null:
+            return
+        partial_hash = self._get_partial_block_hash(request, num_cached_tokens)
+        if not self.cached_block_hash_to_block.contain(
+            make_block_hash_with_group_id(partial_hash, kv_cache_group_id),
+            block.block_id,
+        ):
+            # A longer group's hit can be truncated inside a full block during
+            # reconciliation. Do not invent a partial entry for that boundary.
+            return
+        parent_hash, start = self._get_partial_block_parent_hash_and_start(
+            request, num_cached_tokens
         )
-
+        extra_keys, _ = generate_block_hash_extra_keys(
+            request, start, num_cached_tokens, 0
+        )
+        (
+            skipped_parent_block_hash,
+            skipped_start_token_idx,
+            skipped_end_token_idx,
+            skipped_extra_keys,
+        ) = self._get_skipped_context(
+            request, partial_context_start, start, self.hash_block_size
+        )
         self.kv_event_queue.append(
             self._build_block_stored_event(
                 request,
-                block_hashes=cached_hashes,
-                parent_block_hash=parent_block_hash,
-                start_token_idx=start_token_idx,
-                end_token_idx=end_token_idx,
-                block_size=block_size,
+                block_hashes=[maybe_convert_block_hash(partial_hash)],
+                parent_block_hash=(
+                    maybe_convert_block_hash(parent_hash)
+                    if parent_hash is not None
+                    else None
+                ),
+                start_token_idx=start,
+                end_token_idx=num_cached_tokens,
+                block_size=num_cached_tokens - start,
                 kv_cache_group_id=kv_cache_group_id,
-                extra_keys_list=extra_keys_list,
+                extra_keys_list=[extra_keys],
+                skipped_parent_block_hash=skipped_parent_block_hash,
+                skipped_start_token_idx=skipped_start_token_idx,
+                skipped_end_token_idx=skipped_end_token_idx,
+                skipped_extra_keys=skipped_extra_keys,
             )
         )
 
@@ -528,21 +714,34 @@ class BlockPool:
             extra_keys, _ = generate_block_hash_extra_keys(
                 request, block_start, block_end, curr_mm_idx
             )
+            (
+                skipped_parent_block_hash,
+                skipped_start_token_idx,
+                skipped_end_token_idx,
+                skipped_extra_keys,
+            ) = self._get_skipped_context(
+                request,
+                self._published_full_block_context_start(
+                    request, block_size, kv_cache_group_id
+                )
+                * block_size,
+                block_start,
+                self.hash_block_size,
+            )
             self.kv_event_queue.append(
-                BlockStored(
+                self._build_block_stored_event(
+                    request,
                     block_hashes=[maybe_convert_block_hash(block_hash)],
                     parent_block_hash=parent_block_hash,
-                    token_ids=request.all_token_ids[block_start:block_end],
+                    start_token_idx=block_start,
+                    end_token_idx=block_end,
                     block_size=block_end - block_start,
-                    lora_id=request.lora_request.adapter_id
-                    if request.lora_request
-                    else None,
-                    medium=MEDIUM_GPU,
-                    lora_name=request.lora_request.name
-                    if request.lora_request
-                    else None,
-                    extra_keys=[extra_keys],
-                    group_idx=kv_cache_group_id,
+                    kv_cache_group_id=kv_cache_group_id,
+                    extra_keys_list=[extra_keys],
+                    skipped_parent_block_hash=skipped_parent_block_hash,
+                    skipped_start_token_idx=skipped_start_token_idx,
+                    skipped_end_token_idx=skipped_end_token_idx,
+                    skipped_extra_keys=skipped_extra_keys,
                 )
             )
         return block_hash_with_group_id
@@ -723,6 +922,10 @@ class BlockPool:
             if self.metrics_collector:
                 self.metrics_collector.on_block_accessed(block)
 
+    def is_block_writable(self, block: KVCacheBlock) -> bool:
+        """Return whether a block can be mutated by its sole owner."""
+        return not block.is_null and block.ref_cnt == 1 and block.block_hash is None
+
     def free_blocks(self, ordered_blocks: Iterable[KVCacheBlock]) -> None:
         """Free a list of blocks. The blocks should be ordered by their
         eviction priority, where the first block will be evicted first.
@@ -807,6 +1010,9 @@ class BlockPool:
         logger.info("Successfully reset prefix cache")
 
         if self.enable_kv_cache_events:
+            # Cached blocks are no longer reachable, so a kept anchor would
+            # wrongly suppress skipped context after the reset.
+            self.published_full_block_anchors.clear()
             self.kv_event_queue.append(AllBlocksCleared())
 
         return True

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -14,7 +14,9 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     CrossAttentionManager,
+    FullAttentionManager,
     SingleTypeKVCacheManager,
+    SlidingWindowManager,
     get_manager_for_kv_cache_spec,
 )
 from vllm.v1.kv_cache_interface import (
@@ -148,6 +150,13 @@ class KVCacheCoordinator(ABC):
             )
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
+
+        lookup_drops_eagle_block = any(
+            i in self.eagle_group_ids and manager.drops_eagle_block
+            for i, manager in enumerate(self.single_type_managers)
+        )
+        for manager in self.single_type_managers:
+            manager.lookup_drops_eagle_block = lookup_drops_eagle_block
 
         # A positive retention interval must be a multiple of the base hit granularity
         # (``scheduler_block_size``) to land on real cache-hit boundaries.
@@ -641,7 +650,25 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             )
             for g in kv_cache_config.kv_cache_groups
         )
-        self.enable_partial_hash_hits = has_partial_mamba_group
+        # Recurrent hybrids may instead hash finer than their attention
+        # blocks (``prefix_match_unit`` at the recurrent block, attention
+        # pages grown to match the recurrent page): partial hits then keep
+        # prefix reuse at the recurrent checkpoint granularity. Attention-only
+        # hybrids keep block-aligned hits, as before.
+        has_mamba_align_group = any(
+            isinstance(g.kv_cache_spec, MambaSpec)
+            and g.kv_cache_spec.mamba_cache_mode == "align"
+            for g in kv_cache_config.kv_cache_groups
+        )
+        has_partial_attention_group = has_mamba_align_group and any(
+            isinstance(manager, (FullAttentionManager, SlidingWindowManager))
+            and manager.block_size > hash_block_size
+            and manager.supports_fine_grained_hash_lookup
+            for manager in self.single_type_managers
+        )
+        self.enable_partial_hash_hits = (
+            has_partial_mamba_group or has_partial_attention_group
+        )
         if self.enable_partial_hash_hits:
             unsupported_partial_hit_managers = {
                 type(manager).__name__
@@ -656,6 +683,8 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     "cache managers require block-aligned lookups: %s.",
                     ", ".join(sorted(unsupported_partial_hit_managers)),
                 )
+        for manager in self.single_type_managers:
+            manager.hit_alignment_tokens = self._cache_hit_alignment_tokens
         self.verify_and_split_kv_cache_groups()
 
     @property
@@ -771,6 +800,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 request,
                 num_tokens_to_cache,
                 retention_interval=self.retention_interval,
+                alignment_tokens=self._cache_hit_alignment_tokens,
             )
 
     def find_longest_cache_hit(
@@ -838,12 +868,11 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 drop_eagle_block = use_eagle and idx not in eagle_verified
 
                 _max_length = curr_hit_length
-                # Eagle matches one extra drop unit (one hash unit for
+                # EAGLE matches one extra drop unit (one hash unit for
                 # fine-grained managers, else one cache block) and then drops
-                # it, landing back at the candidate length. No margin for
-                # mamba: its finder never drops (draft models have no mamba
-                # layers), so the hit would grow past the candidate.
-                if drop_eagle_block and not isinstance(spec, MambaSpec):
+                # it, landing back at the candidate length. Managers whose
+                # finder does not drop receive no margin.
+                if drop_eagle_block and manager_cls.drops_eagle_block:
                     eagle_margin = (
                         self.hash_block_size
                         if self.enable_partial_hash_hits

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -195,9 +195,6 @@ class KVCacheManager:
             tuple(() for _ in range(self.num_kv_cache_groups))
         )
 
-        # Off-table cow blocks handed to a KV connector for partial-tail
-        # offload; pinned until the request's blocks are freed.
-        self._partial_tail_pins: dict[str, list[KVCacheBlock]] = {}
         self.boundary_checkpoints = (
             BoundaryCheckpointCache(self.block_pool)
             if enable_boundary_checkpoints and enable_caching
@@ -315,16 +312,14 @@ class KVCacheManager:
             and getattr(request, "kv_cache_report_mode", "incremental") == "full"
         ):
             for group_idx, group_blocks in enumerate(computed_blocks):
-                num_blocks = len(group_blocks)
-                if num_blocks > 0:
-                    group = self.kv_cache_config.kv_cache_groups[group_idx]
-                    block_size = group.kv_cache_spec.block_size
-                    self.block_pool.emit_cached_block_events(
-                        request,
-                        num_blocks,
-                        block_size,
-                        group_idx,
-                    )
+                manager = self.coordinator.single_type_managers[group_idx]
+                self.block_pool.emit_cached_block_events(
+                    request,
+                    group_blocks,
+                    num_new_computed_tokens,
+                    manager.block_size,
+                    group_idx,
+                )
 
         # The junction to pin is where the lagging sparse-retention group stops
         # (``num_new_computed_tokens``) plus the uncached shared prefix -- i.e.
@@ -671,9 +666,6 @@ class KVCacheManager:
         """
         boundary_blocks = self._pop_boundary_blocks(request)
         self.block_pool.free_blocks(boundary_blocks)
-        pins = self._partial_tail_pins.pop(request.request_id, None)
-        if pins:
-            self.block_pool.free_blocks(pins)
         self.coordinator.free(request.request_id)
 
     def _pop_boundary_blocks(self, request: Request) -> list[KVCacheBlock]:
@@ -767,12 +759,6 @@ class KVCacheManager:
         """
         blocks = self.coordinator.pop_blocks_for_free(request.request_id)
         blocks.extend(self._pop_boundary_blocks(request))
-        # Pins ride the same (possibly deferred) free as the request blocks.
-        # Preemption may release a pin under a still-queued offload — the same
-        # exposure normal saves of table blocks already have.
-        pins = self._partial_tail_pins.pop(request.request_id, None)
-        if pins:
-            blocks = pins + blocks
         return blocks
 
     def evict_blocks(self, block_ids: set[int]) -> None:
@@ -1010,18 +996,18 @@ class KVCacheManager:
         retained_blocks = [block for pair in pending_copies for block in pair]
         return copies, retained_blocks
 
-    def take_partial_tail_offloads(self) -> dict[str, list[tuple[int, int, int]]]:
-        """Drain producer partial-tail offload hand-offs per request.
+    def take_boundary_state_offloads(
+        self,
+    ) -> dict[str, list[tuple[int, int, int]]]:
+        """Drain this step's boundary-state hand-offs for a KV connector.
 
         Returns ``{request_id: [(group_id, block_id, boundary_tokens), ...]}``
-        for the durable boundary blocks of producers' last-prompt-boundary
-        partial tails. Only mamba "align" groups contribute; empty otherwise.
-        A KV connector reads the referenced blocks and offloads them so a later
-        request can hit the sub-block prefix.
-
-        Each handed-off block lives off the request block table, so it is
-        pinned here and unpinned when the request's blocks are freed — for a
-        producer with saved tokens, after the connector reports sends done.
+        for mamba "align" boundary states: the
+        request's committed boundary-state snapshots and, on a sub-block partial
+        hit, the CoW copy of its last-prompt-boundary state. Only mamba "align"
+        groups contribute; empty otherwise. A connector reads the referenced
+        blocks — never resolving them positionally — and offloads them so a
+        later request can hit that prefix.
         """
         offloads: dict[str, list[tuple[int, int, int]]] = {}
         for mgr in self.coordinator.single_type_managers:
@@ -1030,9 +1016,7 @@ class KVCacheManager:
                 group_id,
                 block,
                 boundary_tokens,
-            ) in mgr.take_pending_partial_tail_offloads():
-                self.block_pool.touch((block,))
-                self._partial_tail_pins.setdefault(req_id, []).append(block)
+            ) in mgr.take_pending_boundary_state_offloads():
                 offloads.setdefault(req_id, []).append(
                     (group_id, block.block_id, boundary_tokens)
                 )

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -214,14 +214,7 @@ class ScheduledEncoderInputStats:
 
 @dataclass
 class KVConnectorBlockState:
-    """Authoritative scheduler-side KV source state for external stores.
-
-    ``block_ids`` is a full per-group snapshot for every request scheduled in
-    this step. ``boundary_state_offloads`` identifies the exact recurrent
-    state block at each durable token boundary; connectors must not reconstruct
-    these sources from allocation deltas because align-mode Mamba tables are
-    sparse and mutable.
-    """
+    """Scheduler-local current tables and exact retained-state offers."""
 
     block_ids: dict[str, tuple[list[int], ...]]
     boundary_state_offloads: dict[str, list[tuple[int, int, int]]]
@@ -298,15 +291,7 @@ class SchedulerOutput:
     # CoW copies to apply after zeroing new blocks and before forward.
     kv_cache_block_copies: list[KVCacheBlockCopy] | None = None
 
-    # Producer partial-tail offload hand-off for external KV connectors:
-    # {request_id: [(group_id, block_id, boundary_tokens), ...]} pointing at
-    # the durable boundary block of a producer's last-prompt-boundary partial
-    # tail (mamba "align" CoW target). None unless partial hash hits are active.
-    partial_tail_offloads: dict[str, list[tuple[int, int, int]]] | None = None
-
-    # Authoritative source tables and recurrent boundary blocks for external
-    # KV stores. This is scheduler-only metadata consumed while connector
-    # metadata is built; workers use the resulting opaque connector metadata.
+    # Scheduler-local; always None by the time this reaches a worker.
     kv_connector_block_state: KVConnectorBlockState | None = None
 
     # Dynamic speculative decoding: optimal K chosen by scheduler.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -90,45 +90,24 @@ def _build_kv_connector_block_state(
     partial_tail_offloads: dict[str, list[tuple[int, int, int]]] | None,
     retention_interval: int | None,
 ) -> KVConnectorBlockState:
-    """Snapshot exact source blocks for connector stores in this step."""
-    current_block_ids = {
-        req_id: kv_cache_manager.get_block_ids(req_id) for req_id in request_ids
-    }
-    boundary_state_offloads = {
-        req_id: list(entries)
-        for req_id, entries in (partial_tail_offloads or {}).items()
-    }
+    """Copy explicitly offered states without inferring validity from allocation."""
     if retention_interval is not None and retention_interval > 0:
-        for group_id, group in enumerate(kv_cache_config.kv_cache_groups):
-            spec = group.kv_cache_spec
-            if not isinstance(spec, MambaSpec):
-                continue
-            if retention_interval % spec.block_size != 0:
+        for group in kv_cache_config.kv_cache_groups:
+            if (
+                isinstance(group.kv_cache_spec, MambaSpec)
+                and retention_interval % group.kv_cache_spec.block_size
+            ):
                 raise ValueError(
-                    "prefix_cache_retention_interval must be divisible by "
-                    f"Mamba block size: {retention_interval=} {spec.block_size=}"
+                    "prefix_cache_retention_interval must be divisible by the Mamba block size"
                 )
-            blocks_per_boundary = retention_interval // spec.block_size
-            for req_id, grouped_ids in current_block_ids.items():
-                if group_id >= len(grouped_ids):
-                    continue
-                entries = boundary_state_offloads.setdefault(req_id, [])
-                existing = {
-                    (entry_group, boundary_tokens)
-                    for entry_group, _, boundary_tokens in entries
-                }
-                for block_index in range(
-                    blocks_per_boundary - 1,
-                    len(grouped_ids[group_id]),
-                    blocks_per_boundary,
-                ):
-                    block_id = grouped_ids[group_id][block_index]
-                    boundary_tokens = (block_index + 1) * spec.block_size
-                    if block_id > 0 and (group_id, boundary_tokens) not in existing:
-                        entries.append((group_id, block_id, boundary_tokens))
     return KVConnectorBlockState(
-        block_ids=current_block_ids,
-        boundary_state_offloads=boundary_state_offloads,
+        block_ids={
+            req_id: kv_cache_manager.get_block_ids(req_id) for req_id in request_ids
+        },
+        boundary_state_offloads={
+            req_id: list(entries)
+            for req_id, entries in (partial_tail_offloads or {}).items()
+        },
     )
 
 
@@ -423,6 +402,18 @@ class Scheduler(SchedulerInterface):
             for group in kv_cache_config.kv_cache_groups
             if isinstance(group.kv_cache_spec, MambaSpec)
         ]
+        max_prefill_tokens = self.max_num_scheduled_tokens
+        if self.scheduler_config.long_prefill_token_threshold > 0:
+            max_prefill_tokens = min(
+                max_prefill_tokens, self.scheduler_config.long_prefill_token_threshold
+            )
+        if (
+            self.need_mamba_block_aligned_split
+            and self.cache_config.block_size <= max_prefill_tokens
+        ):
+            # Match the grid enforced by _mamba_block_aligned_split. Otherwise
+            # several recurrent-sized slices can all round down to zero.
+            mamba_block_sizes.append(self.cache_config.block_size)
         prefill_quantum = (
             math.lcm(*mamba_block_sizes)
             if self.need_mamba_block_aligned_split and mamba_block_sizes
@@ -593,6 +584,14 @@ class Scheduler(SchedulerInterface):
                 end = aligned_end
 
         next_block_boundary = (start // block_size + 1) * block_size
+        retention_interval = getattr(
+            self.cache_config, "prefix_cache_retention_interval", None
+        )
+        next_retention_boundary = (
+            (start // retention_interval + 1) * retention_interval
+            if retention_interval is not None and retention_interval > 0
+            else 0
+        )
         tail_boundary = (
             request.num_prompt_tokens // self.hash_block_size * self.hash_block_size
             if self.mamba_partial_cache_hit
@@ -602,6 +601,10 @@ class Scheduler(SchedulerInterface):
             # Same invariant: a chunk starting mid-block stops at the boundary
             # rather than running past it.
             next_block_boundary if start % block_size != 0 else 0,
+            # Sparse recurrent-state retention makes these boundaries part of
+            # the external cache contract. A fragmented scheduler budget must
+            # not jump over one without materializing its exact state.
+            next_retention_boundary,
             # Never run past the last cacheable block boundary mid-chunk.
             last_cache_position,
             # Fine-grained hits: the prompt's partial-tail entry can only be
@@ -616,6 +619,36 @@ class Scheduler(SchedulerInterface):
             if start < request.shared_prefix_boundary < end
             else 0,
         )
+        if getattr(self.cache_config, "prefix_cache_retention_interval", None) == 0:
+            # Retention cannot preserve a recurrent state that prefill skipped.
+            # Use the same fine and coarse replay positions as the cache masks.
+            managers = [
+                manager
+                for manager in self.kv_cache_manager.coordinator.single_type_managers
+                if isinstance(manager.kv_cache_spec, MambaSpec)
+            ]
+            boundaries = [request.num_prompt_tokens - 1]
+            if request.shared_prefix_boundary:
+                boundaries.append(request.shared_prefix_boundary)
+            reuse_stops = {
+                position
+                for manager in managers
+                for position in manager._expand_reachable_boundaries(boundaries)
+                if start < position < end
+            }
+            if use_internal_checkpoint:
+                # The worker's checkpoint grid belongs to each recurrent group.
+                internal_positions = {
+                    end // manager.block_size * manager.block_size
+                    if end % manager.block_size
+                    else None
+                    for manager in managers
+                }
+                if len(internal_positions) == 1:
+                    internal = internal_positions.pop()
+                    if internal is not None and internal > start:
+                        reuse_stops.discard(internal)
+            stops = (*stops, *reuse_stops)
         # Stop at the earliest mandatory position strictly inside the chunk.
         end = min((s for s in stops if start < s < end), default=end)
         return max(end - start, 0)
@@ -1779,27 +1812,23 @@ class Scheduler(SchedulerInterface):
             self.prev_step_scheduled_req_ids.clear()
             self.prev_step_scheduled_req_ids.update(num_scheduled_tokens.keys())
 
-        # Producer partial-tail hand-off for external KV connectors. Drained
-        # before the CoW retentions are released below, so the pin lands while
-        # the cow block still holds a retention ref. Without a producer-side
-        # connector nothing consumes the hand-off, so skip the drain (and its
-        # pin); the manager drops stale entries when the request's blocks are
-        # popped for free.
-        pending_partial_tail_offloads = None
+        # Mamba "align" boundary states must be handed off with exact block ids;
+        # they cannot be reconstructed from a connector's append-only block
+        # table. Drained every step so stale offers cannot accumulate.
+        boundary_state_offloads = self.kv_cache_manager.take_boundary_state_offloads()
+
         kv_connector_block_state = None
-        if (
-            self.connector is not None
-            and self.vllm_config.kv_transfer_config is not None
-            and self.vllm_config.kv_transfer_config.is_kv_producer
-        ):
-            pending_partial_tail_offloads = (
-                self.kv_cache_manager.take_partial_tail_offloads() or None
+        if self.connector is not None:
+            # Filling an existing block can create a store without new allocation.
+            snapshot_req_ids = set(num_scheduled_tokens)
+            snapshot_req_ids.update(
+                req_id for req_id in boundary_state_offloads if req_id in self.requests
             )
             kv_connector_block_state = _build_kv_connector_block_state(
                 self.kv_cache_config,
                 self.kv_cache_manager,
-                num_scheduled_tokens,
-                pending_partial_tail_offloads,
+                snapshot_req_ids,
+                boundary_state_offloads,
                 self.cache_config.prefix_cache_retention_interval,
             )
 
@@ -1860,7 +1889,6 @@ class Scheduler(SchedulerInterface):
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=self._get_new_block_ids_to_zero(),
             kv_cache_block_copies=pending_kv_cache_block_copies,
-            partial_tail_offloads=pending_partial_tail_offloads,
             kv_connector_block_state=kv_connector_block_state,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
             ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
@@ -1895,6 +1923,9 @@ class Scheduler(SchedulerInterface):
                 scheduler_output
             )
             scheduler_output.ec_connector_metadata = ec_meta
+
+        # Connector-only block state must not be dispatched to workers.
+        scheduler_output.kv_connector_block_state = None
 
         # Advance the fence only for non-empty steps (those that actually
         # write KV and have their output processed later in update_from_output).

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -98,7 +98,8 @@ def _build_kv_connector_block_state(
                 and retention_interval % group.kv_cache_spec.block_size
             ):
                 raise ValueError(
-                    "prefix_cache_retention_interval must be divisible by the Mamba block size"
+                    "prefix_cache_retention_interval must be divisible by "
+                    "the Mamba block size"
                 )
     return KVConnectorBlockState(
         block_ids={

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -9,6 +9,7 @@ from typing import ClassVar
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
     BlockHashList,
     BlockHashListWithBlockSize,
     BlockHashWithGroupId,
@@ -33,6 +34,80 @@ from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
 
 
+def reachable_hit_positions(
+    boundary_tokens: int,
+    alignment_tokens: int,
+    use_eagle: bool,
+) -> tuple[int, ...]:
+    """Token positions a cache hit can land on for one reachable boundary.
+
+    A lookup floors the boundary to ``alignment_tokens``. Under EAGLE an
+    attention finder removes its lookahead block and re-floors to the
+    alignment. The result is either the aligned boundary or one alignment unit
+    below it, depending on the finder's block size. Sparse-retention masks must
+    treat both as reachable.
+
+    Expressing the back-off in tokens rather than blocks is what makes this
+    correct when a group's block size differs from the alignment: one block is
+    the right step only when they are equal.
+    """
+    aligned = boundary_tokens // alignment_tokens * alignment_tokens
+    if not use_eagle:
+        return (aligned,)
+    return (aligned, max(aligned - alignment_tokens, 0))
+
+
+def resolve_sparse_retention_inputs(
+    kv_cache_spec: KVCacheSpec,
+    use_eagle: bool,
+    lookup_drops_eagle_block: bool,
+    reachable_boundaries: Sequence[int],
+    *,
+    lookup_alignment_tokens: int,
+    state_materialization_alignment_tokens: int,
+) -> tuple[bool, tuple[int, ...]]:
+    """Resolve the mask's EAGLE flag and retained token boundaries.
+
+    Lookup alignment can be finer than the scheduler alignment used to
+    materialize recurrent states. Keep both sets of Mamba positions so a
+    missing fine state does not displace a usable scheduler-aligned fallback.
+    """
+    boundaries = tuple(reachable_boundaries)
+    if isinstance(kv_cache_spec, MambaSpec):
+        alignments = dict.fromkeys(
+            (lookup_alignment_tokens, state_materialization_alignment_tokens)
+        )
+        positions = tuple(
+            dict.fromkeys(
+                position
+                for boundary in boundaries
+                for alignment in alignments
+                for position in reachable_hit_positions(
+                    boundary, alignment, use_eagle or lookup_drops_eagle_block
+                )
+            )
+        )
+        # Each alignment's EAGLE predecessor is already included. The mask
+        # must not apply another lookup-sized drop to materialized positions.
+        return False, positions
+    if not lookup_drops_eagle_block:
+        return use_eagle, boundaries
+    if isinstance(kv_cache_spec, SlidingWindowSpec):
+        alignments = dict.fromkeys(
+            (lookup_alignment_tokens, state_materialization_alignment_tokens)
+        )
+        boundaries = tuple(
+            dict.fromkeys(
+                position
+                for boundary in boundaries
+                for alignment in alignments
+                for position in reachable_hit_positions(boundary, alignment, True)
+                if position > 0
+            )
+        )
+    return use_eagle, boundaries
+
+
 class SingleTypeKVCacheManager(ABC):
     """
     An abstract base class for a manager that handle the kv cache management
@@ -40,6 +115,7 @@ class SingleTypeKVCacheManager(ABC):
     """
 
     supports_fine_grained_hash_lookup: ClassVar[bool] = False
+    drops_eagle_block: ClassVar[bool] = False
 
     def __init__(
         self,
@@ -71,6 +147,15 @@ class SingleTypeKVCacheManager(ABC):
                 block until the request finishes.
         """
         self.scheduler_block_size = scheduler_block_size
+        # Token alignment of prefix-cache hits for this manager. Defaults to
+        # the scheduler block; the coordinator lowers it to the hash block when
+        # fine-grained partial hash hits are enabled, so retention masks keep
+        # the tails those finer hits need.
+        self.hit_alignment_tokens = scheduler_block_size
+        # Whether any EAGLE/MTP group rewinds the reconciled hit by one hit
+        # alignment unit, so sparse retention must also keep the state one
+        # unit below each reachable boundary. Set by the coordinator.
+        self.retention_eagle_rewind = False
         # The block size for this manager; used for actual block allocation.
         self.block_size = kv_cache_spec.block_size
         self.dcp_world_size = dcp_world_size
@@ -102,23 +187,28 @@ class SingleTypeKVCacheManager(ABC):
         self.kv_cache_group_id = kv_cache_group_id
         self._null_block = block_pool.null_block
 
-        # Whether this group's prefix-cache hits drop the EAGLE/MTP lookahead
-        # block. Only consulted by managers whose hit logic is sparse within an
-        # aligned segment (SWA). Initialized lazily by the coordinator after
+        # Whether THIS group's own prefix-cache lookup drops the EAGLE/MTP
+        # lookahead block. Initialized lazily by the coordinator after
         # determining the attention groups.
         self.use_eagle = False
+
+        # Whether an attention-group lookup applies that drop. Sparse retention
+        # must account for it because the coordinator reconciles every group to
+        # one hit length. Set by the coordinator.
+        self.lookup_drops_eagle_block = False
 
         # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
         # managers (full attention, mamba "align"); harmlessly empty elsewhere.
         self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
         self._pending_cow_copies: list[tuple[KVCacheBlock, KVCacheBlock]] = []
-        # Partial-tail offload hand-off for external KV connectors: when a
-        # producer registers its last-prompt-boundary partial tail and the
-        # durable boundary block is not on the append-only request block table
-        # (mamba "align" CoW target), record the request, group, block, and
-        # exact token boundary so a connector can offload it under the right
-        # hash. Populated only by mamba "align".
-        self._pending_partial_tail_offloads: list[
+        # Boundary-state offload hand-off for external KV connectors. A mamba
+        # "align" block table is not append-only (interior states are
+        # nulled/freed and speculative blocks relocate in place), so a
+        # connector cannot resolve its state blocks positionally. Record
+        # (request, group, block, exact token boundary) for each committed
+        # boundary state so a connector can offload the right block under the
+        # right hash. Populated only by mamba "align".
+        self._pending_boundary_state_offloads: list[
             tuple[str, int, KVCacheBlock, int]
         ] = []
 
@@ -327,9 +417,10 @@ class SingleTypeKVCacheManager(ABC):
             return
 
         req_blocks = self.req_to_blocks[request_id]
-        allocated_blocks = self.block_pool.get_new_blocks(
-            cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
+        num_new_blocks = max(
+            0, cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
         )
+        allocated_blocks = self.block_pool.get_new_blocks(num_new_blocks)
         req_blocks.extend(allocated_blocks)
         if self._record_new_block_ids:
             self.new_block_ids.extend(b.block_id for b in allocated_blocks)
@@ -394,20 +485,50 @@ class SingleTypeKVCacheManager(ABC):
         self._pending_cow_copies = []
         return pending_copies
 
-    def take_pending_partial_tail_offloads(
+    def take_pending_boundary_state_offloads(
         self,
     ) -> list[tuple[str, int, KVCacheBlock, int]]:
-        """Drain producer partial-tail hand-offs.
+        """Drain producer boundary-state hand-offs.
 
         Entries are ``(req_id, group_id, block, boundary_tokens)``.
 
-        Only mamba "align" populates this. The block lives off the request
-        block table, so the caller must pin it until the connector has read
-        it — nothing else keeps it alive once the CoW retention is released.
+        Only mamba "align" populates this. The blocks are not kept alive by
+        the request block table for the whole request, so a caller that reads
+        them asynchronously must pin them first.
         """
-        pending = self._pending_partial_tail_offloads
-        self._pending_partial_tail_offloads = []
+        pending = self._pending_boundary_state_offloads
+        self._pending_boundary_state_offloads = []
         return pending
+
+    def _cache_partial_tail_block(
+        self,
+        request: Request,
+        num_tokens: int,
+    ) -> BlockHashWithGroupId | None:
+        """Cache the prompt tail when it ends inside a cache block.
+
+        Only the final prompt hash boundary is registered as a partial
+        prefix-cache entry; intermediate hash boundaries inside the same cache
+        block are intentionally skipped.
+        """
+        hash_block_size = self.block_pool.hash_block_size
+        boundary_tokens = request.num_prompt_tokens // hash_block_size * hash_block_size
+        if boundary_tokens == 0 or boundary_tokens > num_tokens:
+            return None
+        if boundary_tokens % self.block_size == 0:
+            return None
+
+        blocks = self.req_to_blocks[request.request_id]
+        block_idx = boundary_tokens // self.block_size
+        if block_idx >= len(blocks):
+            return None
+        return self.block_pool.cache_partial_block(
+            request=request,
+            block=blocks[block_idx],
+            num_tokens=boundary_tokens,
+            kv_cache_group_id=self.kv_cache_group_id,
+            block_size=self.block_size,
+        )
 
     def _apply_cow(
         self,
@@ -436,6 +557,7 @@ class SingleTypeKVCacheManager(ABC):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        alignment_tokens: int | None = None,
     ) -> None:
         """
         Cache the blocks for the request.
@@ -448,6 +570,8 @@ class SingleTypeKVCacheManager(ABC):
                 keeps dense checkpointing; ``0`` keeps only the latest replay
                 boundary; a positive multiple of ``scheduler_block_size`` keeps
                 a tail once per that-sized segment. Only SWA acts on it.
+            alignment_tokens: Cache-hit alignment. Defaults to the scheduler
+                block size for non-hybrid coordinators.
         """
         num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
         num_full_blocks = num_tokens // self.block_size
@@ -455,19 +579,35 @@ class SingleTypeKVCacheManager(ABC):
         if num_cached_blocks >= num_full_blocks:
             return
 
+        mask_alignment_tokens = (
+            self.hit_alignment_tokens if alignment_tokens is None else alignment_tokens
+        )
+
         # Token boundaries whose reachable tail must be retained under sparse
         # retention: the replay boundary (``num_prompt - 1``, capped by
         # ``get_computed_blocks``) and any detected shared-prefix junction.
-        reachable_boundaries = [request.num_prompt_tokens - 1]
+        reachable_boundaries: Sequence[int] = (request.num_prompt_tokens - 1,)
         if request.shared_prefix_boundary:
-            reachable_boundaries.append(request.shared_prefix_boundary)
+            reachable_boundaries = (
+                *reachable_boundaries,
+                request.shared_prefix_boundary,
+            )
+
+        retention_use_eagle, reachable_boundaries = resolve_sparse_retention_inputs(
+            self.kv_cache_spec,
+            self.use_eagle,
+            self.lookup_drops_eagle_block,
+            reachable_boundaries,
+            lookup_alignment_tokens=mask_alignment_tokens,
+            state_materialization_alignment_tokens=self.scheduler_block_size,
+        )
 
         block_mask = self.reachable_block_mask(
             start_block=num_cached_blocks,
             end_block=num_full_blocks,
-            alignment_tokens=self.scheduler_block_size,
+            alignment_tokens=mask_alignment_tokens,
             kv_cache_spec=self.kv_cache_spec,
-            use_eagle=self.use_eagle,
+            use_eagle=retention_use_eagle,
             retention_interval=retention_interval,
             reachable_boundaries=reachable_boundaries,
         )
@@ -482,6 +622,18 @@ class SingleTypeKVCacheManager(ABC):
         )
 
         self.num_cached_block[request.request_id] = num_full_blocks
+
+    def _expand_reachable_boundaries(self, boundaries: Sequence[int]) -> list[int]:
+        """Use the retention mask's replay positions for scheduler checkpoints."""
+        _, positions = resolve_sparse_retention_inputs(
+            self.kv_cache_spec,
+            self.use_eagle,
+            self.lookup_drops_eagle_block,
+            boundaries,
+            lookup_alignment_tokens=self.hit_alignment_tokens,
+            state_materialization_alignment_tokens=self.scheduler_block_size,
+        )
+        return list(positions)
 
     @classmethod
     def reachable_block_mask(
@@ -689,6 +841,7 @@ class SingleTypeKVCacheManager(ABC):
 
 class FullAttentionManager(SingleTypeKVCacheManager):
     supports_fine_grained_hash_lookup: ClassVar[bool] = True
+    drops_eagle_block: ClassVar[bool] = True
 
     @classmethod
     def find_longest_cache_hit(
@@ -762,16 +915,34 @@ class FullAttentionManager(SingleTypeKVCacheManager):
                 max_length // alignment_tokens,
                 len(block_hashes),
             )
-            for fine_idx in range(max_partial_idx - 1, first_partial_idx - 1, -1):
-                cached_tail = block_pool.get_cached_block(
-                    block_hashes[fine_idx], kv_cache_group_ids
+            # A block's KV is append-only, so a fully cached block also covers
+            # every interior boundary below ``max_length`` (e.g. a re-query at
+            # a rewound length inside the block); the tail is then a partial
+            # hit that the consumer CoW-redirects.
+            partial_block_idx = len(computed_blocks[0])
+            if (
+                max_partial_idx > first_partial_idx
+                and (partial_block_idx + 1) * scale_factor <= len(block_hashes)
+                and (
+                    cached_full := block_pool.get_cached_block(
+                        full_block_hashes[partial_block_idx], kv_cache_group_ids
+                    )
                 )
-                if not cached_tail:
-                    continue
-                for computed, cached in zip(computed_blocks, cached_tail):
+            ):
+                for computed, cached in zip(computed_blocks, cached_full):
                     computed.append(cached)
-                hit_length = (fine_idx + 1) * alignment_tokens
-                break
+                hit_length = max_partial_idx * alignment_tokens
+            else:
+                for fine_idx in range(max_partial_idx - 1, first_partial_idx - 1, -1):
+                    cached_tail = block_pool.get_cached_block(
+                        block_hashes[fine_idx], kv_cache_group_ids
+                    )
+                    if not cached_tail:
+                        continue
+                    for computed, cached in zip(computed_blocks, cached_tail):
+                        computed.append(cached)
+                    hit_length = (fine_idx + 1) * alignment_tokens
+                    break
 
         # Eagle needs the tokens right before the generation point recomputed:
         # drop one hash unit when fine-grained (the tail block's KV is
@@ -793,42 +964,18 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        alignment_tokens: int | None = None,
     ) -> None:
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            alignment_tokens=alignment_tokens,
+        )
         hash_block_size = self.block_pool.hash_block_size
         if self.block_size == hash_block_size:
             return
         self._cache_partial_tail_block(request, num_tokens)
-
-    def _cache_partial_tail_block(
-        self,
-        request: Request,
-        num_tokens: int,
-    ) -> None:
-        """Cache the prompt tail when it ends inside a cache block.
-
-        Only the final prompt hash boundary is registered as a partial
-        prefix-cache entry; intermediate hash boundaries inside the same cache
-        block are intentionally skipped.
-        """
-        hash_block_size = self.block_pool.hash_block_size
-        boundary_tokens = request.num_prompt_tokens // hash_block_size * hash_block_size
-        if boundary_tokens == 0 or boundary_tokens > num_tokens:
-            return
-        if boundary_tokens % self.block_size == 0:
-            return
-
-        blocks = self.req_to_blocks[request.request_id]
-        block_idx = boundary_tokens // self.block_size
-        if block_idx >= len(blocks):
-            return
-        self.block_pool.cache_partial_block(
-            request=request,
-            block=blocks[block_idx],
-            num_tokens=boundary_tokens,
-            kv_cache_group_id=self.kv_cache_group_id,
-            block_size=self.block_size,
-        )
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         blocks = self.req_to_blocks[running_request_id]
@@ -888,6 +1035,9 @@ class RSWAManager(FullAttentionManager):
 
 
 class SlidingWindowManager(SingleTypeKVCacheManager):
+    drops_eagle_block: ClassVar[bool] = True
+    supports_fine_grained_hash_lookup: ClassVar[bool] = True
+
     def __init__(self, kv_cache_spec: SlidingWindowSpec, **kwargs) -> None:
         super().__init__(kv_cache_spec, **kwargs)
         self.sliding_window = kv_cache_spec.sliding_window
@@ -931,12 +1081,6 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         assert pcp_world_size == 1 or kv_cache_spec.dcp_replicated, (
             "PCP only supports sliding-window KV when it is replicated."
         )
-        # Fine-grained partial hits are not supported for sliding window now.
-        # Fall back to block-aligned hits instead of crashing the engine when
-        # the coordinator alignment is finer than this group's block size
-        # (e.g. a hybrid mamba target with a finer `prefix_match_unit`).
-        if alignment_tokens % kv_cache_spec.block_size != 0:
-            alignment_tokens = kv_cache_spec.block_size
         block_hashes = resolve_block_hashes(
             block_hashes,
             block_pool.hash_block_size,
@@ -944,6 +1088,24 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
             alignment_tokens=alignment_tokens,
         )
+        if (
+            alignment_tokens < kv_cache_spec.block_size
+            and kv_cache_spec.block_size % alignment_tokens == 0
+        ):
+            # Fine-grained mode (alignment_tokens == hash_block_size <
+            # block_size): resolve_block_hashes kept the raw hash-granularity
+            # list so hits can land on boundaries inside a cache block.
+            assert isinstance(block_hashes, Sequence)
+            return cls._find_longest_fine_grained_cache_hit(
+                block_hashes=block_hashes,
+                max_length=max_length,
+                kv_cache_group_ids=kv_cache_group_ids,
+                block_pool=block_pool,
+                kv_cache_spec=kv_cache_spec,
+                drop_eagle_block=drop_eagle_block,
+                alignment_tokens=alignment_tokens,
+            )
+        assert alignment_tokens % kv_cache_spec.block_size == 0
 
         # The number of contiguous blocks needed for a prefix cache hit.
         sliding_window_contiguous_blocks = cls._contiguous_blocks_for_hit(
@@ -1015,6 +1177,169 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         return computed_blocks, hit_length
 
     @classmethod
+    def _fine_grained_need_tokens(
+        cls, window_size: int, alignment_tokens: int, use_eagle: bool
+    ) -> int:
+        """Cached tokens a fine-grained hit ending at a hash boundary needs
+        before that boundary: the sliding window of the next token, plus one
+        hash unit when EAGLE rewinds the hit by that unit (the rewound window
+        starts one unit earlier, so the cached run must reach one unit further
+        back)."""
+        return window_size - 1 + (alignment_tokens if use_eagle else 0)
+
+    @classmethod
+    def _find_longest_fine_grained_cache_hit(
+        cls,
+        block_hashes: Sequence[BlockHash],
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: SlidingWindowSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        """Fine-grained (partial) hit search for sliding window layers.
+
+        Candidates are hash boundaries, probed high-to-low. Boundary ``L``
+        hits when the cache block ending at ``L`` is cached (a full block when
+        ``L`` is block-aligned, else a partial entry keyed by the hash at
+        ``L``) and every full block covering the window before ``L`` is cached
+        too. As in ``FullAttentionManager``, EAGLE rewinds the hit by one hash
+        unit: the required run is one unit longer so the rewound window stays
+        covered, and blocks past the rewound length are trimmed. Blocks before
+        the window are null, as in the block-aligned path.
+        """
+        block_size = kv_cache_spec.block_size
+        num_groups = len(kv_cache_group_ids)
+        scale_factor = block_size // alignment_tokens
+        full_block_hashes = BlockHashListWithBlockSize(
+            block_hashes, alignment_tokens, block_size
+        )
+        need_tokens = cls._fine_grained_need_tokens(
+            kv_cache_spec.sliding_window, alignment_tokens, drop_eagle_block
+        )
+        max_units = min(max_length // alignment_tokens, len(block_hashes))
+        # Per tail block: the highest registered boundary found so far and how
+        # far down the block has been scanned. A block's KV is append-only, so
+        # an entry registered at a higher boundary of the same block covers
+        # every lower boundary (the tail is then a partial hit, CoW-redirected
+        # by the consumer); this is what lets a re-query at a rewound length
+        # land inside a block whose only entry sits further along.
+        tail_found: dict[int, list[KVCacheBlock] | None] = {}
+        tail_scanned_to: dict[int, int] = {}
+        for unit_idx in range(max_units - 1, -1, -1):
+            hit_tokens = (unit_idx + 1) * alignment_tokens
+            tail_block_idx = (hit_tokens - 1) // block_size
+            tail_blocks = tail_found.get(tail_block_idx)
+            if tail_blocks is None:
+                top_unit = min((tail_block_idx + 1) * scale_factor, len(block_hashes))
+                scan_from = tail_scanned_to.get(tail_block_idx, top_unit) - 1
+                for probe_unit in range(scan_from, unit_idx - 1, -1):
+                    probe_tokens = (probe_unit + 1) * alignment_tokens
+                    probe_hash = (
+                        full_block_hashes[tail_block_idx]
+                        if probe_tokens % block_size == 0
+                        else block_hashes[probe_unit]
+                    )
+                    tail_blocks = block_pool.get_cached_block(
+                        probe_hash, kv_cache_group_ids
+                    )
+                    if tail_blocks:
+                        tail_found[tail_block_idx] = tail_blocks
+                        break
+                tail_scanned_to[tail_block_idx] = unit_idx
+            if not tail_blocks:
+                continue
+            first_block_idx = max(0, (hit_tokens - need_tokens) // block_size)
+            run: list[list[KVCacheBlock]] = [[] for _ in range(num_groups)]
+            for block_idx in range(first_block_idx, tail_block_idx):
+                cached = block_pool.get_cached_block(
+                    full_block_hashes[block_idx], kv_cache_group_ids
+                )
+                if not cached:
+                    break
+                for per_group, block in zip(run, cached):
+                    per_group.append(block)
+            else:
+                hit_length = hit_tokens
+                if drop_eagle_block:
+                    hit_length -= alignment_tokens
+                num_blocks = cdiv(hit_length, block_size)
+                computed_blocks = tuple(
+                    [block_pool.null_block] * first_block_idx + per_group + [tail]
+                    for per_group, tail in zip(run, tail_blocks)
+                )
+                for computed in computed_blocks:
+                    del computed[num_blocks:]
+                return computed_blocks, hit_length
+        return tuple([] for _ in range(num_groups)), 0
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+        alignment_tokens: int | None = None,
+    ) -> None:
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            alignment_tokens=alignment_tokens,
+        )
+        hit_alignment = (
+            self.hit_alignment_tokens if alignment_tokens is None else alignment_tokens
+        )
+        if hit_alignment < self.block_size:
+            self._cache_partial_tail_block(request, num_tokens)
+
+    @classmethod
+    def _fine_grained_reachable_block_mask(
+        cls,
+        start_block: int,
+        end_block: int,
+        alignment_tokens: int,
+        kv_cache_spec: SlidingWindowSpec,
+        use_eagle: bool,
+        retention_interval: int | None,
+        reachable_boundaries: Sequence[int],
+    ) -> list[bool] | None:
+        """Retention mask when hits align to hash units inside a block.
+
+        A hit at hash boundary ``B`` needs the full blocks covering
+        ``[B - need_tokens, B)``; the tail block itself is registered as a
+        partial entry separately. Segment boundaries (``retention_interval``
+        > 0) and reachable boundaries keep exactly those blocks; ``None``
+        retention caches every block.
+        """
+        if retention_interval is None:
+            return None
+        block_size = kv_cache_spec.block_size
+        need_tokens = cls._fine_grained_need_tokens(
+            kv_cache_spec.sliding_window, alignment_tokens, use_eagle
+        )
+        mask = [False] * (end_block - start_block)
+
+        def keep_tail(boundary_tokens: int) -> None:
+            first = max(0, (boundary_tokens - need_tokens) // block_size)
+            last = cdiv(boundary_tokens, block_size)  # exclusive
+            for i in range(max(first, start_block), min(last, end_block)):
+                mask[i - start_block] = True
+
+        if retention_interval > 0:
+            segment = retention_interval
+            if need_tokens + block_size >= segment:
+                # Every block lies in some segment tail; keep them all.
+                return None
+            first_segment = (start_block * block_size) // segment * segment
+            last_token = end_block * block_size + need_tokens
+            for boundary in range(first_segment + segment, last_token + 1, segment):
+                keep_tail(boundary)
+        for boundary_tokens in reachable_boundaries:
+            keep_tail(boundary_tokens // alignment_tokens * alignment_tokens)
+        return mask
+
+    @classmethod
     def reachable_block_mask(
         cls,
         start_block: int,
@@ -1029,6 +1354,19 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         if alignment_tokens is None:
             # Fast path: when the coordinator imposes no alignment constraint.
             return None
+        if (
+            alignment_tokens < kv_cache_spec.block_size
+            and kv_cache_spec.block_size % alignment_tokens == 0
+        ):
+            return cls._fine_grained_reachable_block_mask(
+                start_block,
+                end_block,
+                alignment_tokens,
+                kv_cache_spec,
+                use_eagle,
+                retention_interval,
+                reachable_boundaries,
+            )
         assert alignment_tokens % kv_cache_spec.block_size == 0
 
         block_size = kv_cache_spec.block_size
@@ -1307,7 +1645,7 @@ class MambaManager(SingleTypeKVCacheManager):
             # Requests that registered their own last-prompt-boundary partial
             # tail (producers). On the next step's CoW the boundary state moves
             # into a private cow_block; we record that block for connector
-            # offload (see _pending_partial_tail_offloads).
+            # offload (see _pending_boundary_state_offloads).
             self._producer_partial_tail_reqs: dict[str, int] = {}
 
     @classmethod
@@ -1420,9 +1758,11 @@ class MambaManager(SingleTypeKVCacheManager):
         mask = [False] * (end_block - start_block)
 
         # (1) Segment-boundary states. A Mamba hit needs exactly the single
-        # state block ending on the boundary (no window, and draft models have
-        # no mamba layers, so no eagle shift). Block ``i`` ends at token
-        # ``(i + 1) * block_size``.
+        # state block ending on the boundary (no window). Segment tails get no
+        # EAGLE shift: under the EAGLE drop the fixed point settles on the next
+        # lower tail, costing at most one segment of hit length, unlike the
+        # reachable boundaries below where the unshifted state is the only one.
+        # Block ``i`` ends at token ``(i + 1) * block_size``.
         segment_tokens = None if retention_interval == 0 else retention_interval
         if segment_tokens is not None:
             per_segment = segment_tokens // block_size
@@ -1438,12 +1778,15 @@ class MambaManager(SingleTypeKVCacheManager):
         # (2) Reachable-boundary states: the replay boundary (``num_prompt - 1``,
         # capped by ``get_computed_blocks``) and any shared-prefix junction, both
         # of which segments would otherwise skip under sparse retention. A Mamba
-        # hit needs exactly the single state block ending on the boundary.
+        # hit needs exactly the single state block ending on the reachable
+        # position, so retain one block per position rather than a run.
         for boundary_tokens in reachable_boundaries:
-            aligned = boundary_tokens // alignment_tokens * alignment_tokens
-            boundary_block = aligned // block_size - 1
-            if start_block <= boundary_block < end_block:
-                mask[boundary_block - start_block] = True
+            for position in reachable_hit_positions(
+                boundary_tokens, alignment_tokens, use_eagle
+            ):
+                boundary_block = position // block_size - 1
+                if start_block <= boundary_block < end_block:
+                    mask[boundary_block - start_block] = True
 
         return mask
 
@@ -1640,13 +1983,12 @@ class MambaManager(SingleTypeKVCacheManager):
                     )
 
                 if blocks_allocated:
-                    # reuse previous speculative blocks in this step
+                    # Relocate exclusively owned speculative scratch blocks.
                     for block_idx in range(
                         prev_block_len - self.num_speculative_blocks, prev_block_len
                     ):
                         if block_idx < num_skipped_blocks:
-                            req_blocks.append(req_blocks[block_idx])
-                            req_blocks[block_idx] = self._null_block
+                            self._relocate_speculative_block(req_blocks, block_idx)
                         else:
                             break
                 num_new_blocks = num_required_blocks - len(req_blocks)
@@ -1679,7 +2021,7 @@ class MambaManager(SingleTypeKVCacheManager):
                             # This CoW preserved a producer's own boundary
                             # state in cow_block; hand it to the connector for
                             # partial-tail offload once the copy has run.
-                            self._pending_partial_tail_offloads.append(
+                            self._pending_boundary_state_offloads.append(
                                 (
                                     request_id,
                                     self.kv_cache_group_id,
@@ -1700,17 +2042,31 @@ class MambaManager(SingleTypeKVCacheManager):
                 returned_blocks.extend(new_blocks)
                 return returned_blocks
 
+    def _relocate_speculative_block(
+        self, req_blocks: list[KVCacheBlock], block_idx: int
+    ) -> None:
+        block = req_blocks[block_idx]
+        assert self.block_pool.is_block_writable(block), (
+            "Speculative Mamba blocks must be exclusively owned and unhashed "
+            "before relocation"
+        )
+        req_blocks.append(block)
+        req_blocks[block_idx] = self._null_block
+
     def pop_blocks_for_free(self, request_id: str) -> list[KVCacheBlock]:
         if self.mamba_cache_mode == "align":
             self._allocated_block_reqs.discard(request_id)
             self.last_state_block_idx.pop(request_id, None)
             self._num_checkpoint_blocks.pop(request_id, None)
             self._producer_partial_tail_reqs.pop(request_id, None)
-            # A hand-off whose request died in this same scheduling pass must
-            # not reach the connector: its unpin hook (free) has already run.
-            self._pending_partial_tail_offloads = [
+            # An offer is only guaranteed to hold committed bytes until the end
+            # of the pass that made it. This request's blocks are going back to
+            # the pool now, so drop its not-yet-offered hand-offs rather than
+            # let a connector claim a block another request may already have
+            # been handed.
+            self._pending_boundary_state_offloads = [
                 entry
-                for entry in self._pending_partial_tail_offloads
+                for entry in self._pending_boundary_state_offloads
                 if entry[0] != request_id
             ]
         return super().pop_blocks_for_free(request_id)
@@ -1728,6 +2084,7 @@ class MambaManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        alignment_tokens: int | None = None,
     ) -> None:
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
         if request.use_boundary_checkpoints:
@@ -1735,16 +2092,21 @@ class MambaManager(SingleTypeKVCacheManager):
             # publish their own immutable state copies after GPU completion.
             self.num_cached_block[request.request_id] = num_tokens // self.block_size
             return
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            alignment_tokens=alignment_tokens,
+        )
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
         if self.mamba_cache_mode == "align":
             partial_hash = self._cache_partial_tail_block(request, num_tokens)
             if partial_hash is not None:
                 self.cached_blocks_this_step.add(partial_hash)
         if num_cached_blocks_after > num_cached_blocks_before:
-            for block in self.req_to_blocks[request.request_id][
-                num_cached_blocks_before:num_cached_blocks_after
-            ]:
+            blocks = self.req_to_blocks[request.request_id]
+            for idx in range(num_cached_blocks_before, num_cached_blocks_after):
+                block = blocks[idx]
                 # Skip null blocks (align-mode skipped states) and blocks that
                 # were not cached this step — with sparse retention
                 # (reachable_block_mask) the intermediate state snapshots carry
@@ -1752,6 +2114,18 @@ class MambaManager(SingleTypeKVCacheManager):
                 if block.is_null or block.block_hash is None:
                     continue
                 self.cached_blocks_this_step.add(block.block_hash)
+                if self.mamba_cache_mode == "align":
+                    # Offer every retained boundary with its exact block.
+                    # The connector filters against its save window, which may
+                    # extend past the original prompt during resumed prefill.
+                    self._pending_boundary_state_offloads.append(
+                        (
+                            request.request_id,
+                            self.kv_cache_group_id,
+                            block,
+                            (idx + 1) * self.block_size,
+                        )
+                    )
 
     def new_step_starts(self) -> None:
         self.cached_blocks_this_step.clear()
@@ -1828,6 +2202,7 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        alignment_tokens: int | None = None,
     ) -> None:
         # We do not cache blocks for cross-attention to be shared between
         # requests, so this method is not relevant.


### PR DESCRIPTION
The new endpoint-checkpoint mechanism excludes DFlash2 and external connectors, which still use aligned recurrent checkpoints. That path fails three LP26 cache regressions on the current branch: missing reuse, missing fallback state, and skipped rewind boundaries. This ports the qualified fixes while preserving private endpoint bundles and their ownership guards.

The shared handoff API changes are kept together so core and connector consumers remain compatible. Review the port in these groups:

- Aligned reuse and scheduling: retained checkpoints, fine sliding-window lookup, committed state publication, and aligned prefill budgets. Endpoint requests retain their bypass and private-state guard.
- External stores: explicit boundary-state offers, per-job ownership, exact Mooncake and generic-offload consumers, and snapshots for scheduled requests that allocate no new blocks.
- Cache events: truthful sparse stores, parent continuity, full-report replay, and partial-tail visibility, with protocol tests.

This carries behavior from #643, #645, #646, #655, #656, #557, #657, and #663. Authorship is preserved in commit trailers. It supersedes logprobz follow-ups #643, #645, #655, #656, #657, and #663; other authors' PRs remain independently owned.

Validation:
- This cache port passed 910 CPU regressions and three aligned-cache contracts before the independent sampling and GDN corrections.
- The combined image passed 952 regressions plus those contracts, 25 installed sampling cases, and 14 upstream sampling regressions.
- Matched four-GPU DFlash2 K3, Marlin, TP4/DCP1, FP8 KV, 524288-context serving passed cache replay, shared prefixes, tools, vision, 491520-token retrieval, all 64 agent turns, and the finite speed matrix. Warm long-context retrieval reused 491264 tokens in 1.75 seconds. Initial throughput and latency ratios are within the existing 5% LP26 parity limits.
- The exact LP26 service was restored. Promotion and the final repeated parity gate remain pending.

The initial serving evidence includes the local GDN variant from now-closed #668 and #653's sampling RNG fix as production prerequisites. BF16 LM-head precision is retained. External connectors have CPU coverage; no live external store was qualified. Concurrent MTP endpoint admission is outside this DFlash2 profile.

Base tested: b7e3d033676d5db46fb7d6cdd40d760365a1e239. Prepared with AI assistance. Independent Astra release review verified source hashes, image provenance, sampling identity, and serving receipts, with bounded candidate approval. A separate local promotion-script preemption check is being corrected before production cutover.

PR #667 already fixes the same GDN defect, so #668 is closed as a duplicate. Our transition cases and #667 metadata/worker tests pass (53 passed, 3 skipped). Final qualification is switching to #667 + this PR + #653; fresh combined-image GPU validation is required before promotion.


MTP qualification update: native2048 recurrent blocks passed full serving qualification. Fine256 MTP exposed a resumed recurrent-state column using target-page units; #672 is the narrow required correction. Fine MTP replay is being requalified with that dependency. Do not interpret cache-hit counts alone as MTP correctness.

### Final MTP3 serving qualification

The combined immutable candidate containing #653, #667, #669, #670, #672 and #674 passed full MTP3 serving qualification. All cold/warm/appended cache canaries, 16 shared-prefix requests, 64 agent turns, tools/parser/vision checks and 491,520-token cold/warm retrieval passed, with zero preemptions or runtime errors. The long prompt was fully reused and returned the correct answer in 1.36 seconds warm versus 56.73 seconds cold. Ten decode repeats averaged 133.98 tokens/s.

The installed image passed 1,000 CPU regressions plus three cache contracts, and all 18 scalar restore GPU cases. DFlash2 also passed full serving qualification and two repeated concurrency matrices. Every throughput and latency metric met the 5% LP26 parity gate, with zero preemptions or runtime errors. The qualified image is promoted on port 8100. This is a combined-source qualification, not a standalone performance claim for this PR.
