### PR TITLE
[Test] Cover per-builder GDN replay buffers after #667

### DIFF
--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -1311,8 +1311,9 @@ def test_glm5next_b12x_kda_plan_reserves_null_state_zero(monkeypatch) -> None:
 @pytest.mark.parametrize(
     "speculative,uniform", [(False, False), (True, False), (True, True)]
 )
+@pytest.mark.parametrize("separate_acceptance", [False, True])
 def test_b12x_kda_shares_counts_but_preserves_each_layers_state_indices(
-    monkeypatch, speculative: bool, uniform: bool
+    monkeypatch, speculative: bool, uniform: bool, separate_acceptance: bool
 ) -> None:
     calls: dict[str, list] = {"bind": [], "run": []}
 
@@ -1381,7 +1382,11 @@ def test_b12x_kda_shares_counts_but_preserves_each_layers_state_indices(
             output=output,
             state_indices=indices,
             query_start_loc=query_start_loc.clone() if uniform else query_start_loc[:],
-            num_accepted_tokens=accepted[:] if accepted is not None else None,
+            num_accepted_tokens=(
+                accepted.clone() if separate_acceptance else accepted[:]
+            )
+            if accepted is not None
+            else None,
             num_requests=2,
         )
 
@@ -1402,7 +1407,13 @@ def test_b12x_kda_shares_counts_but_preserves_each_layers_state_indices(
         "num_seqs",
         "num_tokens",
     ):
-        assert getattr(calls["bind"][0], name) is getattr(calls["bind"][1], name)
+        first = getattr(calls["bind"][0], name)
+        second = getattr(calls["bind"][1], name)
+        if speculative and separate_acceptance:
+            assert first is not second
+            torch.testing.assert_close(first, second)
+        else:
+            assert first is second
     assert torch.equal(
         layers[0]._b12x_kda_num_accepted_tokens,
         torch.zeros(2, dtype=torch.int32)
@@ -1411,8 +1422,9 @@ def test_b12x_kda_shares_counts_but_preserves_each_layers_state_indices(
     )
     assert layers[0]._b12x_kda_num_seqs.item() == 2
     assert layers[0]._b12x_kda_num_tokens.item() == 2
-    assert layers[1]._b12x_kda_num_seqs.item() == 0
-    assert layers[1]._b12x_kda_num_tokens.item() == 0
+    expected_second_count = 2 if speculative and separate_acceptance else 0
+    assert layers[1]._b12x_kda_num_seqs.item() == expected_second_count
+    assert layers[1]._b12x_kda_num_tokens.item() == expected_second_count
 
 
 @pytest.mark.parametrize("is_mtp_layer", [False, True])

--- a/tests/models/test_glm5next_model_state.py
+++ b/tests/models/test_glm5next_model_state.py
@@ -124,7 +124,6 @@ def test_glm5next_kda_reuses_captured_metadata_after_reordering(monkeypatch) -> 
     state._align_mode = True
     state._aligned_metadata_groups = state._aligned_metadata_ctx = None
     state._aligned_metadata_builders = []
-    state._gdn_spec_accepted_tokens = torch.ones(8, dtype=torch.int32)
     state.recoverssm = None
     state._get_mamba_group_info = lambda _: ([0, 1], None)
     indices = torch.arange(64, dtype=torch.int32).reshape(2, 8, 4)
@@ -172,6 +171,10 @@ def test_glm5next_kda_reuses_captured_metadata_after_reordering(monkeypatch) -> 
         )
 
     captured = prepare(for_capture=True)
+    accepted_pointers = [
+        captured[str(i)].num_accepted_tokens.data_ptr() for i in range(2)
+    ]
+    assert accepted_pointers[0] != accepted_pointers[1]
     for slot, accepted in ((5, 4), (1, 2), (5, 1)):
         batch.idx_mapping.fill_(slot)
         state.num_accepted_tokens_gpu[slot] = accepted
@@ -183,10 +186,10 @@ def test_glm5next_kda_reuses_captured_metadata_after_reordering(monkeypatch) -> 
                 captured[str(i)].spec_state_indices_tensor, indices[i, :1]
             )
             assert captured[str(i)].num_accepted_tokens.item() == accepted
-        assert (
-            current["0"].num_accepted_tokens.data_ptr()
-            == current["1"].num_accepted_tokens.data_ptr()
-        )
+            assert (
+                current[str(i)].num_accepted_tokens.data_ptr() == accepted_pointers[i]
+            )
+            assert accepted_pointers[i] == builders[i].num_accepted_tokens.data_ptr()
 
 
 def test_glm5next_draft_metadata_preserves_first_step_acceptance() -> None:
@@ -327,7 +330,9 @@ def test_glm5next_rejects_unaligned_fresh_prefix(
     ):
         state.add_request(
             3,
-            SimpleNamespace(num_computed_tokens=prefix_length),
+            SimpleNamespace(
+                num_computed_tokens=prefix_length, boundary_checkpoint=None
+            ),
         )
 
     assert calls == []

--- a/tests/v1/attention/test_gdn_capture_transition.py
+++ b/tests/v1/attention/test_gdn_capture_transition.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Keep graph-captured speculative metadata valid when requests are padded."""
+
+from types import SimpleNamespace as NS
+
+import pytest
+import torch
+
+from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+from vllm.v1.kv_cache_interface import MambaSpec
+
+
+def _common(query_lens, padded_tokens=32):
+    starts = torch.tensor([0] + query_lens, dtype=torch.int32).cumsum(0).to(torch.int32)
+    seq_lens = torch.tensor([64 if n else 0 for n in query_lens], dtype=torch.int32)
+    return CommonAttentionMetadata(
+        query_start_loc=starts,
+        query_start_loc_cpu=starts.clone(),
+        seq_lens=seq_lens,
+        seq_lens_cpu_upper_bound=seq_lens.clone(),
+        num_reqs=len(query_lens),
+        num_actual_tokens=padded_tokens,
+        max_query_len=max(query_lens),
+        max_seq_len=64,
+        block_table_tensor=torch.arange(len(query_lens) * 4, dtype=torch.int32).reshape(
+            len(query_lens), 4
+        ),
+        slot_mapping=torch.arange(padded_tokens, dtype=torch.int64),
+        is_prefilling=torch.zeros(len(query_lens), dtype=torch.bool),
+        causal=True,
+    )
+
+
+@pytest.mark.parametrize("fastpath", [False, True])
+@pytest.mark.parametrize("active_reqs", [1, 5, 8])
+@pytest.mark.parametrize("alias_accepted", [False, True])
+@pytest.mark.parametrize("consumer", ["build", "update_block_table"])
+def test_padded_replay_updates_captured_spec_buffers(
+    monkeypatch, fastpath, active_reqs, consumer, alias_accepted
+):
+    monkeypatch.setenv("VLLM_GDN_SPEC_DECODE_METADATA_FASTPATH", str(int(fastpath)))
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn._resolve_gdn_prefill_backend",
+        lambda config: ("triton", "triton"),
+    )
+    monkeypatch.setattr(
+        "vllm.v1.attention.backends.gdn_attn.async_tensor_h2d",
+        lambda data, dtype=None, device="cpu", **kwargs: torch.as_tensor(
+            data, dtype=dtype, device=device
+        ),
+    )
+    config = NS(
+        compilation_config=NS(
+            cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+            max_cudagraph_capture_size=32,
+        ),
+        speculative_config=NS(num_speculative_tokens=3, parallel_drafting=False),
+        scheduler_config=NS(max_num_seqs=8),
+        parallel_config=NS(decode_context_parallel_size=1),
+        cache_config=NS(mamba_cache_mode="align"),
+    )
+    builder = GDNAttentionMetadataBuilder(
+        MambaSpec(
+            block_size=16,
+            shapes=((16, 64),),
+            dtypes=(torch.float16,),
+            mamba_cache_mode="align",
+        ),
+        ["layer.0"],
+        config,
+        torch.device("cpu"),
+    )
+    builder.mamba_aligned_state_indices = torch.arange(32, dtype=torch.int32).reshape(
+        8, 4
+    )
+    captured = builder.build_for_cudagraph_capture(_common([4] * 8))
+    other = GDNAttentionMetadataBuilder(
+        builder.kv_cache_spec, ["layer.1"], config, torch.device("cpu")
+    )
+    other.mamba_aligned_state_indices = builder.mamba_aligned_state_indices.clone() + 64
+    captured_other = other.build_for_cudagraph_capture(_common([4] * 8))
+    fields = [
+        "spec_state_indices_tensor",
+        "spec_query_start_loc",
+        "spec_sequence_masks",
+        "num_accepted_tokens",
+    ]
+    captured = captured_other if consumer == "update_block_table" else captured
+    owner = other if consumer == "update_block_table" else builder
+    pointers = {name: getattr(captured, name).data_ptr() for name in fields}
+    for count in (active_reqs, 8, active_reqs):
+        for group, current in enumerate((builder, other)):
+            current.mamba_aligned_state_indices.copy_(
+                torch.arange(32, dtype=torch.int32).reshape(8, 4) + 100 + group * 64
+            )
+            current.mamba_aligned_state_indices[count:].fill_(NULL_BLOCK_ID)
+        expected_accepted = torch.tensor([1, 2, 1, 3, 2, 1, 1, 1], dtype=torch.int32)
+        expected_accepted[count:] = 1
+        accepted = expected_accepted.clone()
+        if alias_accepted:
+            builder.num_accepted_tokens[:8].copy_(accepted)
+            accepted = builder.num_accepted_tokens[:8]
+        runtime_common = _common([4] * count + [0] * (8 - count))
+        replay = builder.build(
+            0,
+            runtime_common,
+            accepted,
+            torch.tensor([3] * count + [-1] * (8 - count), dtype=torch.int32),
+        )
+        if consumer == "update_block_table":
+            replay = other.update_block_table(
+                replay, runtime_common.block_table_tensor, None
+            )
+        for name in fields:
+            assert getattr(replay, name).data_ptr() == pointers[name], name
+            torch.testing.assert_close(getattr(captured, name), getattr(replay, name))
+        torch.testing.assert_close(captured.num_accepted_tokens, expected_accepted)
+        torch.testing.assert_close(
+            captured.spec_query_start_loc, runtime_common.query_start_loc
+        )
+        torch.testing.assert_close(
+            captured.spec_sequence_masks, torch.arange(8) < count
+        )
+        torch.testing.assert_close(
+            captured.spec_state_indices_tensor, owner.mamba_aligned_state_indices
+        )


### PR DESCRIPTION
Follow up #667 with test coverage for its per-builder graph buffers. This PR is stacked on #667 and changes no runtime code.

The existing GLM model-state test still expected both builders to share an acceptance pointer. It fails against #667. The corrected assertion requires distinct builder-owned pointers that remain stable across request reorderings. The related unaligned-prefix fixture now supplies the endpoint-checkpoint field read by the current API.

The added 24 transition cases cover full/padded/full replay, one/five/eight active requests, build and update_block_table, actual destination aliases, and distinct state values for each builder. The Kimi binding test now covers both shared acceptance storage and separate per-builder cache entries.

Validation: the obsolete pointer assertion fails before this correction; the focused model-state, Kimi, and transition set passes 40 cases with one CUDA-only skip. Ruff and whitespace checks pass. The combined #667/#669/#653 image passed 956 existing regressions, three cache contracts, and the earlier external transition fixture. Fresh installed-image validation will include these corrected tests before final promotion.

This preserves useful coverage from duplicate #668 without carrying its alternative runtime implementation. Prepared with AI assistance; independent Astra review approved this test-only follow-up and confirmed the qualification-test blocker is resolved.
