### PR TITLE
dflash_attn: make the split-KV draft kernel available on the SM120 family

### DIFF
--- a/tests/v1/attention/test_dflash_attn.py
+++ b/tests/v1/attention/test_dflash_attn.py
@@ -12,8 +12,8 @@ H, HKV, D, BLOCK, WINDOW = 8, 2, 128, 256, 2048
 SCALE = D**-0.5
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (12, 0),
-    reason="SM120 split-KV draft attention",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 12,
+    reason="SM120-family split-KV draft attention",
 )
 
 

--- a/vllm/v1/attention/backends/dflash_attn/__init__.py
+++ b/vllm/v1/attention/backends/dflash_attn/__init__.py
@@ -155,7 +155,9 @@ def _load(device: torch.device) -> ctypes.CDLL:
 def is_available(device: torch.device) -> bool:
     if not torch.cuda.is_available() or device.type != "cuda":
         return False
-    if torch.cuda.get_device_capability(device) != (12, 0):
+    # The kernel is built for the device's own arch (``_arch_flag``); it is
+    # qualified on the SM120 family, which includes GB10 (SM121).
+    if torch.cuda.get_device_capability(device)[0] != 12:
         return False
     try:
         _load(device)


### PR DESCRIPTION
## What

`dflash_attn.is_available()` gated on compute capability exactly `(12, 0)`, so on GB10 (`(12, 1)`, DGX Spark) `VLLM_GLM53_DFLASH_ATTN=1` was accepted and silently ignored — the kernel never engaged and nothing logged the reason. The kernel is compiled for the device's own arch (`compute_121a`/`sm_121a`) and loads fine; only the gate excluded it. This gates on the SM120 family instead, and widens the test module's skip gate the same way.

## Validation (four-node DGX Spark, GB10, GLM-5.3-Flash NVFP4 + DFlash2 k=5, TP4)

- `tests/v1/attention/test_dflash_attn.py` inside the serving image on GB10: **40 passed** (previously 40 skipped by the module gate). The library built with the image's nvcc 13.0 at first use.
- Serving with `VLLM_GLM53_DFLASH_ATTN=1 VLLM_GLM53_DFLASH_ATTN_MAX_REQS=16`: engine logs `[dflash_attn] split-KV draft attention enabled: hkv=2 window=2048 max_reqs=16`, no fallbacks.
- Throughput was **not measurably different** on this cluster: decode c1/c8/c16 at 0k context 46.5 / 137.2 / 210.5 tok/s versus a control band of 44.0–46.9 / 139–151 / 201–229 across paired arms. At TP4 the draft's five attention layers are a small share of a ~57 ms step, so that is expected; the SM120 single-GPU numbers in #581 are where the kernel pays.

This is an enablement/consistency fix, not a performance claim for GB10.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded split-KV draft attention support to the broader SM120-family of GPUs.
  * Updated availability checks and tests to recognize compatible SM120-series devices, including newer variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->