### PR TITLE
[BugFix] Handle specialized scalar indices in checkpoint restore

### DIFF
--- a/tests/v1/worker/test_boundary_checkpoint_restore_scalars.py
+++ b/tests/v1/worker/test_boundary_checkpoint_restore_scalars.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Restore endpoint state for ordinary and specialized scalar arguments."""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.worker.gpu.boundary_checkpoint import _restore_auxiliary_state_kernel
+
+pytestmark = pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+
+
+@pytest.mark.parametrize("slot", [0, 1, 2])
+@pytest.mark.parametrize("block", [0, 1, 2])
+@pytest.mark.parametrize("size", [17, 1057])
+def test_restore_accepts_specialized_scalar_indices(slot, block, size):
+    width = size + 11
+    pool_cpu = torch.arange(3 * width).to(torch.uint8).reshape(3, width)
+    pool = pool_cpu.to("cuda")
+    destination = torch.full((3, size), 165, dtype=torch.uint8, device="cuda")
+    metadata = torch.tensor(
+        [[destination.data_ptr(), destination.stride(0), size, 5]],
+        dtype=torch.int64,
+        device="cuda",
+    )
+
+    _restore_auxiliary_state_kernel[(1,)](
+        metadata, pool, pool.stride(0), block, slot, BLOCK=1024
+    )
+
+    expected = torch.full((3, size), 165, dtype=torch.uint8)
+    expected[slot].copy_(pool_cpu[block, 5 : 5 + size])
+    torch.testing.assert_close(destination.cpu(), expected)

--- a/vllm/v1/worker/gpu/boundary_checkpoint.py
+++ b/vllm/v1/worker/gpu/boundary_checkpoint.py
@@ -156,8 +156,11 @@ def _restore_auxiliary_state_kernel(
     stride = tl.load(metadata_ptr + state * 4 + 1)
     size = tl.load(metadata_ptr + state * 4 + 2)
     offset = tl.load(metadata_ptr + state * 4 + 3)
-    source = pool_ptr + block.to(tl.int64) * pool_stride + offset
-    destination = (base + slot.to(tl.int64) * stride).to(tl.pointer_type(tl.uint8))
+    # Scalar one can be specialized to a Python constant by Triton.
+    source = pool_ptr + tl.cast(block, tl.int64) * pool_stride + offset
+    destination = (base + tl.cast(slot, tl.int64) * stride).to(
+        tl.pointer_type(tl.uint8)
+    )
     x = tl.arange(0, BLOCK)
     for start in range(0, size, BLOCK):
         data = tl.load(source + start + x, start + x < size, other=0)


### PR DESCRIPTION
Endpoint restoration fails to compile when a request slot or checkpoint block is1. Triton can specialize that scalar into a Python integer, so calling .to(tl.int64) raises AttributeError. MTP3 reached this path during a concurrent multi-turn serving test after its prefix and long-context cache checks passed.

Use tl.cast for the two host-supplied scalar indices. Metadata loaded from GPU memory retains its existing tensor casts. The copied byte ranges and address arithmetic are unchanged.

A real-GPU regression covers block and slot0/1/2 with short and multi-chunk auxiliary buffers. It checks the exact restored bytes and that other slots remain unchanged. Before the fix:10 failures and8 passing controls. After:all18 cases pass. Ruff and whitespace checks pass.

This changes no model arithmetic or cache policy. It is separate from #672's recurrent-state column fix. Full MTP3 serving will be rerun with both fixes, followed by DFlash2. Prepared with AI assistance; independent review is pending.

### Final MTP3 serving qualification

The combined immutable candidate containing #653, #667, #669, #670, #672 and #674 passed full MTP3 serving qualification. All cold/warm/appended cache canaries, 16 shared-prefix requests, 64 agent turns, tools/parser/vision checks and 491,520-token cold/warm retrieval passed, with zero preemptions or runtime errors. The long prompt was fully reused and returned the correct answer in 1.36 seconds warm versus 56.73 seconds cold. Ten decode repeats averaged 133.98 tokens/s.

The installed image passed 1,000 CPU regressions plus three cache contracts, and all 18 scalar restore GPU cases. DFlash2 also passed full serving qualification and two repeated concurrency matrices. Every throughput and latency metric met the 5% LP26 parity gate, with zero preemptions or runtime errors. The qualified image is promoted on port 8100. This is a combined-source qualification, not a standalone performance claim for this PR.

Independent source review found no blockers. The GPU matrix reproduces ten failures and eight passing controls before this fix; all 18 pass in the built candidate.
