### PR TITLE
Cache leading chat instructions at recurrent request boundaries

### DIFF
--- a/docs/features/automatic_prefix_caching.md
+++ b/docs/features/automatic_prefix_caching.md
@@ -37,7 +37,7 @@ The settings control different parts of caching:
 | Setting | Purpose |
 | --- | --- |
 | `--mamba-cache-mode align` | Maintains the running recurrent state and temporary speculative rollback states. |
-| `--recurrent-checkpoint-policy request_boundaries` | Publishes reusable state after the full prompt and at the processed response endpoint. Intermediate recurrent prefix checkpoints are disabled. |
+| `--recurrent-checkpoint-policy request_boundaries` | Publishes reusable state after a verified leading system/developer segment, the full prompt, and the processed response endpoint. Arbitrary intermediate recurrent checkpoints are disabled. |
 | `--recurrent-checkpoint-policy aligned` | Uses the previous block-aligned checkpoint policy. |
 | `--recurrent-checkpoint-policy auto` | Selects request boundaries for supported configurations and the aligned policy otherwise. |
 | `--prefix-cache-retention-interval` | Controls intermediate retention under the aligned policy; it does not add recurrent checkpoints under the request-boundary policy. |
@@ -47,6 +47,14 @@ processed. The final emitted token usually has not been processed, so the next
 chat turn replays it before processing new user input. EOS, token-stop, and
 length-limited responses can publish this endpoint. Cancellation and stops
 detected by the frontend do not publish a response checkpoint.
+
+For OpenAI chat requests, the renderer separately tokenizes consecutive leading
+`system` and `developer` messages without an assistant generation marker. The
+instruction checkpoint is enabled only when that token sequence exactly matches
+the beginning of the complete rendered prompt. This validation accommodates
+conversation-dependent chat templates without deriving message boundaries from
+model-specific token IDs. Templates that cannot represent the instruction-only
+segment continue to use full-prompt and response checkpoints.
 
 Each checkpoint includes the recurrent state, attention tails, private selector
 state, and final hidden state. MTP additionally saves its selector state and

--- a/tests/entrypoints/openai/test_render_parity.py
+++ b/tests/entrypoints/openai/test_render_parity.py
@@ -258,6 +258,77 @@ def serving_responses(
 
 @pytest.mark.asyncio
 class TestConversationRenderParity:
+    async def test_verified_instruction_token_boundary_is_forwarded(
+        self, online_renderer
+    ):
+        """Only an exact rendering of leading instructions becomes a marker."""
+        online_renderer.enable_recurrent_instruction_checkpoints = True
+        calls: list[tuple[list[Any], ChatParams]] = []
+
+        async def render_chat_async(
+            conversations,
+            chat_params,
+            tok_params=None,
+            *,
+            prompt_extras=None,
+            skip_mm_cache=False,
+        ):
+            messages = list(conversations[0])
+            calls.append((messages, chat_params))
+            token_ids = [11, 12] if len(messages) == 1 else [11, 12, 21, 22]
+            return [messages], [tokens_input(token_ids)]
+
+        online_renderer.renderer.render_chat_async = render_chat_async
+        request = ChatCompletionRequest(
+            model=_MODEL,
+            messages=[
+                {"role": "system", "content": "Shared instructions"},
+                {"role": "user", "content": "Request-specific question"},
+            ],
+        )
+
+        result = await online_renderer.render_chat(request)
+
+        assert not isinstance(result, ErrorResponse)
+        _, engine_inputs = result
+        assert engine_inputs[0]["recurrent_instruction_boundary"] == 2
+        assert len(calls) == 2
+        assert calls[1][1].chat_template_kwargs["add_generation_prompt"] is False
+        assert calls[1][1].chat_template_kwargs["continue_final_message"] is False
+
+    async def test_mismatched_instruction_rendering_does_not_set_boundary(
+        self, online_renderer
+    ):
+        """Conversation-dependent templates fail closed on token mismatch."""
+        online_renderer.enable_recurrent_instruction_checkpoints = True
+
+        async def render_chat_async(
+            conversations,
+            chat_params,
+            tok_params=None,
+            *,
+            prompt_extras=None,
+            skip_mm_cache=False,
+        ):
+            messages = list(conversations[0])
+            token_ids = [11, 99] if len(messages) == 1 else [11, 12, 21, 22]
+            return [messages], [tokens_input(token_ids)]
+
+        online_renderer.renderer.render_chat_async = render_chat_async
+        request = ChatCompletionRequest(
+            model=_MODEL,
+            messages=[
+                {"role": "developer", "content": "Shared instructions"},
+                {"role": "user", "content": "Request-specific question"},
+            ],
+        )
+
+        result = await online_renderer.render_chat(request)
+
+        assert not isinstance(result, ErrorResponse)
+        _, engine_inputs = result
+        assert "recurrent_instruction_boundary" not in engine_inputs[0]
+
     async def test_multiturn_tool_calling(self, online_renderer, serving_responses):
         """System/instructions, tool-call turn, and a follow-up user message."""
         await _assert_parity(

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -156,7 +156,7 @@ def test_request_boundaries_reuse_exact_prompt_and_response_with_private_state(
     _, hit, _ = manager.get_computed_blocks(request)
     assert hit == 0
     assert manager.allocate_slots(request, prompt_len) is not None
-    prompt = manager.publish_boundary_checkpoint(request, prompt_len, is_response=False)
+    prompt = manager.publish_boundary_checkpoint(request, prompt_len, kind="prompt")
     assert prompt is not None
     request.num_computed_tokens = prompt_len
     request.append_output_token_ids([20])
@@ -165,7 +165,7 @@ def test_request_boundaries_reuse_exact_prompt_and_response_with_private_state(
     request.append_output_token_ids([21])
     request.status = RequestStatus.FINISHED_STOPPED
     response = manager.publish_boundary_checkpoint(
-        request, prompt_len + 1, is_response=True
+        request, prompt_len + 1, kind="response"
     )
     assert response is not None
     manager.free(request)
@@ -207,7 +207,7 @@ def test_request_boundaries_keep_prompt_but_no_intermediate_recurrent_states():
     request = make_request("producer", [1, 2, 3], 4, sha256)
     manager.get_computed_blocks(request)
     assert manager.allocate_slots(request, 3) is not None
-    checkpoint = manager.publish_boundary_checkpoint(request, 3, is_response=False)
+    checkpoint = manager.publish_boundary_checkpoint(request, 3, kind="prompt")
     request.num_computed_tokens = 3
     for token in range(12):
         request.append_output_token_ids([token + 10])
@@ -221,6 +221,56 @@ def test_request_boundaries_keep_prompt_but_no_intermediate_recurrent_states():
     assert manager.boundary_checkpoints.find(repeat, 3) == checkpoint
     manager.free(request)
     assert manager.reset_prefix_cache()
+
+
+def test_request_boundaries_reuse_leading_instructions_across_user_prompts():
+    """A verified chat instruction endpoint can seed divergent user turns."""
+    manager = make_full_mamba_manager(
+        dcp_world_size=1,
+        hash_block_size=4,
+        num_blocks=64,
+        enable_boundary_checkpoints=True,
+        use_eagle=True,
+    )
+    instruction_len = 5
+    producer = make_request("producer", [1, 2, 3, 4, 5, 10, 11], 4, sha256)
+    producer.recurrent_instruction_boundary = instruction_len
+    manager.get_computed_blocks(producer)
+    assert manager.allocate_slots(producer, instruction_len) is not None
+    checkpoint = manager.publish_boundary_checkpoint(
+        producer, instruction_len, kind="instruction"
+    )
+    assert checkpoint is not None
+    assert checkpoint.kind == "instruction"
+    manager.free(producer)
+
+    sibling = make_request("sibling", [1, 2, 3, 4, 5, 20, 21], 4, sha256)
+    sibling.recurrent_instruction_boundary = instruction_len
+    blocks, hit, _ = manager.get_computed_blocks(sibling)
+    assert hit == instruction_len
+    assert manager.allocate_slots(sibling, 2, hit, blocks) is not None
+    manager.free(sibling)
+    _, retained = manager.take_kv_cache_block_copies()
+    manager.block_pool.free_blocks(retained)
+
+    divergent = make_request("divergent", [1, 2, 3, 9, 5, 20, 21], 4, sha256)
+    divergent.recurrent_instruction_boundary = instruction_len
+    _, hit, _ = manager.get_computed_blocks(divergent)
+    assert hit == 0
+    manager.free(divergent)
+    assert manager.reset_prefix_cache()
+
+
+def test_request_boundaries_split_prefill_at_instruction_endpoint():
+    request = make_request("chat", [0] * 9000, 32, sha256)
+    request.use_boundary_checkpoints = True
+    request.recurrent_instruction_boundary = 3000
+    scheduler = SimpleNamespace()
+
+    request.num_computed_tokens = 0
+    assert Scheduler._mamba_block_aligned_split(scheduler, request, 4096) == 3000
+    request.num_computed_tokens = 3000
+    assert Scheduler._mamba_block_aligned_split(scheduler, request, 4096) == 4096
 
 
 @pytest.mark.parametrize("dcp_world_size", [1, 4])

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -73,7 +73,7 @@ def test_full_boundary_hit_preserves_async_speculative_decode_token_count():
     )
     manager.get_computed_blocks(producer)
     assert manager.allocate_slots(producer, 32) is not None
-    manager.publish_boundary_checkpoint(producer, 32, is_response=False)
+    manager.publish_boundary_checkpoint(producer, 32, kind="prompt")
     manager.free(producer)
     scheduler.add_request(repeat)
 

--- a/tests/v1/worker/test_gpu_input_batch_v2.py
+++ b/tests/v1/worker/test_gpu_input_batch_v2.py
@@ -70,11 +70,21 @@ def test_boundary_auxiliary_restore_survives_slot_reuse_and_virtual_attention_pa
         model_state, config, {"attn": SimpleNamespace(kv_cache=cache)}, draft
     )
     state.blocks.copy_(
-        torch.tensor([[[4, 8], [5, 9]], [[6, 10], [7, 11]]], device=device)
+        torch.tensor(
+            [
+                [[4, 8], [5, 9], [12, 13]],
+                [[6, 10], [7, 11], [14, 15]],
+            ],
+            device=device,
+        )
     )
     idx = torch.tensor([1, 0], dtype=torch.int32, device=device)
     capture = torch.tensor(
-        [[[7, 0], [0, 11]], [[0, 0], [0, 0]], [[0, -1], [-1, 1]]],
+        [
+            [[7, 0, 0], [0, 11, 0]],
+            [[0, 0, 0], [0, 0, 0]],
+            [[0, -1, 0], [-1, 1, 0]],
+        ],
         dtype=torch.int32,
         device=device,
     )
@@ -133,46 +143,68 @@ def test_boundary_capture_uses_stop_trimmed_endpoint_and_leaves_middle_steps_pri
     state = SimpleNamespace(
         metadata=t(
             [
-                [1, 7, 7, 8, 1],
-                [1, 7, 7, 30, 1],
-                [0, 7, 7, 30, 1],
-                [1, 7, 12, 30, 1],
+                [1, 7, 0, 7, 8, 1],
+                [1, 7, 0, 7, 30, 1],
+                [0, 7, 0, 7, 30, 1],
+                [1, 7, 0, 12, 30, 1],
+                [1, 9, 4, 9, 30, 1],
             ]
         ),
-        stop_tokens=torch.full((4, 128), 99, dtype=torch.int32, device="cuda"),
-        seen=t([[0, 0], [1, 0], [1, 0], [1, 0]]),
+        stop_tokens=torch.full((5, 128), 99, dtype=torch.int32, device="cuda"),
+        seen=t([[0, 0, 0], [1, 0, 0], [1, 0, 0], [1, 0, 0], [0, 0, 0]]),
     )
-    sampled = t([[10, 0, 0, 0], [10, 99, 12, 13], [10, 99, 12, 13], [99, 10, 99, 11]])
-    computed = t([0, 8, 8, 8])
-    total = t([7, 9, 9, 9])
-    num_sampled = t([1, 4, 4, 4])
-    rejected = t([0, 0, 0, 0])
-    last_sampled = t([0, 0, 0, 0])
-    all_tokens = torch.zeros((4, 32), dtype=torch.int32, device="cuda")
-    capture = torch.empty((3, 4, 2), dtype=torch.int32, device="cuda")
+    sampled = t(
+        [
+            [10, 0, 0, 0],
+            [10, 99, 12, 13],
+            [10, 99, 12, 13],
+            [99, 10, 99, 11],
+            [0, 0, 0, 0],
+        ]
+    )
+    computed = t([0, 8, 8, 8, 0])
+    total = t([7, 9, 9, 9, 9])
+    num_sampled = t([1, 4, 4, 4, 0])
+    rejected = t([0, 0, 0, 0, 0])
+    last_sampled = t([0, 0, 0, 0, 0])
+    all_tokens = torch.zeros((5, 32), dtype=torch.int32, device="cuda")
+    capture = torch.empty((3, 5, 3), dtype=torch.int32, device="cuda")
     post_update(
-        t([0, 1, 2, 3]),
+        t([0, 1, 2, 3, 4]),
         computed,
         last_sampled,
         None,
         sampled,
         num_sampled,
         rejected,
-        t([0, 7, 11, 15, 19]),
+        t([0, 7, 11, 15, 19, 23]),
         all_tokens,
         total,
         state,
         capture,
     )
-    assert capture[0].tolist() == [[7, 7], [0, 10], [0, 0], [0, 11]]
-    assert capture[1].tolist() == [[0, 0], [0, 1], [0, 3], [0, 2]]
-    assert num_sampled.tolist() == [1, 2, 4, 3]
-    assert computed.tolist() == [7, 10, 12, 11]
-    assert total.tolist() == [8, 11, 13, 12]
-    assert last_sampled.tolist() == [10, 99, 13, 99]
-    assert capture[2][0].tolist() == [6, 6]
+    assert capture[0].tolist() == [
+        [7, 7, 0],
+        [0, 10, 0],
+        [0, 0, 0],
+        [0, 11, 0],
+        [0, 0, 4],
+    ]
+    assert capture[1].tolist() == [
+        [0, 0, 0],
+        [0, 1, 0],
+        [0, 3, 0],
+        [0, 2, 0],
+        [0, 0, 0],
+    ]
+    assert num_sampled.tolist() == [1, 2, 4, 3, 0]
+    assert computed.tolist() == [7, 10, 12, 11, 4]
+    assert total.tolist() == [8, 11, 13, 12, 9]
+    assert last_sampled.tolist() == [10, 99, 13, 99, 0]
+    assert capture[2][0].tolist() == [6, 6, -1]
     assert capture[2][1, 1].item() == 8
     assert capture[2][3, 1].item() == 17
+    assert capture[2][4, 2].item() == 22
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -921,13 +921,13 @@ def test_boundary_checkpoint_copies_only_selected_committed_states(monkeypatch):
 
     tables = t([[1, 2, 3, 4, 5, 6], [14, 15, 16, 17, 18, 19]])
     ctx.initialize_from_forward_context(config, context, _COPY_FUNCS, [tables])
-    destinations = torch.zeros((8, 2, 1), device=device, dtype=torch.int32)
-    destinations[3, :, 0] = t([20, 21])
-    destinations[1, :, 0] = t([22, 23])
+    destinations = torch.zeros((8, 3, 1), device=device, dtype=torch.int32)
+    destinations[3, :, 0] = t([20, 21, 0])
+    destinations[1, :, 0] = t([22, 23, 0])
     idx = t([3, 1])
     states = t([0, 1, 0, 0, 0, 0, 0, 0])
-    capture = t([[7, 9], [0, 23]])
-    bias = t([[0, 2], [0, 1]])
+    capture = t([[7, 9, 0], [0, 23, 0]])
+    bias = t([[0, 2, 0], [0, 1, 0]])
 
     def copy():
         ctx.checkpoint_request_boundaries(idx, states, capture, bias, destinations)

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -167,11 +167,12 @@ class CacheConfig:
     Applies only to sliding-window and Mamba cache groups."""
     recurrent_checkpoint_policy: RecurrentCheckpointPolicy = "auto"
     """Retention policy for reusable recurrent state. ``request_boundaries``
-    retains the completed prompt and committed response endpoint, disabling
-    intermediate reusable checkpoints. ``aligned`` preserves block-aligned
-    retention. ``auto`` selects request boundaries for supported configurations
-    and aligned retention otherwise. Temporary speculative rollback state is
-    independent of this policy."""
+    retains a verified leading chat-instruction prefix, the completed prompt,
+    and the committed response endpoint, disabling arbitrary intermediate
+    checkpoints. ``aligned`` preserves block-aligned retention. ``auto`` selects
+    request boundaries for supported configurations and aligned retention
+    otherwise. Temporary speculative rollback state is independent of this
+    policy."""
     kv_cache_dtype_skip_layers: list[str] = field(default_factory=list)
     """Layer patterns to skip KV cache quantization. Accepts layer indices
     (e.g., '0', '2', '4') or attention type names (e.g., 'sliding_window')."""

--- a/vllm/entrypoints/launchers/api_server/app_state.py
+++ b/vllm/entrypoints/launchers/api_server/app_state.py
@@ -92,6 +92,9 @@ async def init_app_state(
         reasoning_parser=args.structured_outputs_config.reasoning_parser,
         default_chat_template_kwargs=args.default_chat_template_kwargs,
         log_error_stack=args.log_error_stack,
+        enable_recurrent_instruction_checkpoints=(
+            vllm_config.use_request_boundary_checkpoints
+        ),
     )
     state.online_renderer.warmup()
 

--- a/vllm/entrypoints/launchers/render/app_state.py
+++ b/vllm/entrypoints/launchers/render/app_state.py
@@ -60,6 +60,9 @@ async def init_render_app_state(
         reasoning_parser=args.reasoning_parser,
         default_chat_template_kwargs=args.default_chat_template_kwargs,
         log_error_stack=args.log_error_stack,
+        enable_recurrent_instruction_checkpoints=(
+            vllm_config.use_request_boundary_checkpoints
+        ),
     )
     state.online_renderer.warmup()
 

--- a/vllm/inputs/engine.py
+++ b/vllm/inputs/engine.py
@@ -49,6 +49,15 @@ class TokensInput(_InputOptions):
     Populated when ``return_assistant_tokens_mask=True`` is set on the
     render request and the chat template supports ``{% generation %}``."""
 
+    recurrent_instruction_boundary: NotRequired[int]
+    """Exclusive token offset after leading system or developer messages.
+
+    The OpenAI chat renderer sets this internal marker only when rendering the
+    instruction-only conversation produces an exact prefix of the complete
+    prompt. Recurrent cache implementations can retain state at this semantic
+    boundary without inferring message structure from token IDs.
+    """
+
 
 def tokens_input(
     prompt_token_ids: list[int],

--- a/vllm/renderers/online_renderer.py
+++ b/vllm/renderers/online_renderer.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Sequence
+from dataclasses import replace
 from http import HTTPStatus
 from typing import Any
 
@@ -36,7 +37,7 @@ from vllm.inputs import (
 )
 from vllm.logger import init_logger
 from vllm.parser import Parser, ParserManager
-from vllm.renderers import BaseRenderer, ChatParams, merge_kwargs
+from vllm.renderers import BaseRenderer, ChatParams, TokenizeParams, merge_kwargs
 from vllm.renderers.inputs.preprocess import (
     parse_model_prompt,
     prompt_to_seq,
@@ -45,6 +46,8 @@ from vllm.utils.mistral import is_mistral_tokenizer, is_mistral_tool_parser
 from vllm.utils.mistral import mt as _mt
 
 logger = init_logger(__name__)
+
+_INSTRUCTION_ROLES = frozenset(("system", "developer"))
 
 
 def _reused_prompt_token_ids(request: Any) -> list[int] | None:
@@ -76,6 +79,7 @@ class OnlineRenderer:
         reasoning_parser: str | None = None,
         default_chat_template_kwargs: dict[str, Any] | None = None,
         log_error_stack: bool = False,
+        enable_recurrent_instruction_checkpoints: bool = False,
     ) -> None:
         self.model_config = model_config
         self.renderer = renderer
@@ -102,6 +106,9 @@ class OnlineRenderer:
         self.trust_request_chat_template = trust_request_chat_template
 
         self.log_error_stack = log_error_stack
+        self.enable_recurrent_instruction_checkpoints = (
+            enable_recurrent_instruction_checkpoints
+        )
         self.supports_browsing = False
         self.supports_code_interpreter = False
 
@@ -434,6 +441,13 @@ class OnlineRenderer:
                 },
                 skip_mm_cache=skip_mm_cache,
             )
+            await self._set_recurrent_instruction_boundary(
+                messages,
+                chat_params,
+                tok_params,
+                engine_input,
+                skip_mm_cache=skip_mm_cache,
+            )
 
         # tool parsing is done only if a tool_parser has been set and if
         # tool_choice is not "none" (if tool_choice is "none" but a tool_parser
@@ -475,3 +489,73 @@ class OnlineRenderer:
                 )
 
         return conversation, [engine_input]
+
+    async def _set_recurrent_instruction_boundary(
+        self,
+        messages: list[Any],
+        chat_params: ChatParams,
+        tok_params: TokenizeParams,
+        engine_input: EngineInput,
+        *,
+        skip_mm_cache: bool,
+    ) -> None:
+        """Attach a verified token boundary after leading chat instructions.
+
+        Chat templates can depend on the complete conversation, so message
+        counts cannot be translated into token offsets directly. Rendering the
+        leading system/developer segment without a generation prompt produces a
+        candidate offset. The marker is emitted only when those token IDs are
+        an exact prefix of the complete rendered prompt.
+        """
+        if (
+            not self.enable_recurrent_instruction_checkpoints
+            or engine_input["type"] != "token"
+        ):
+            return
+
+        instruction_count = 0
+        for message in messages:
+            role = (
+                message.get("role")
+                if isinstance(message, dict)
+                else getattr(message, "role", None)
+            )
+            if role not in _INSTRUCTION_ROLES:
+                break
+            instruction_count += 1
+        if instruction_count == 0:
+            return
+
+        instruction_params = replace(
+            chat_params,
+            chat_template_kwargs=merge_kwargs(
+                chat_params.chat_template_kwargs,
+                {
+                    "add_generation_prompt": False,
+                    "continue_final_message": False,
+                },
+                unset_values=(),
+            ),
+        )
+        try:
+            (_,), (instruction_input,) = await self.renderer.render_chat_async(
+                [messages[:instruction_count]],
+                instruction_params,
+                tok_params,
+                skip_mm_cache=skip_mm_cache,
+            )
+        except Exception:
+            logger.debug(
+                "Chat template cannot render the leading instruction segment; "
+                "recurrent instruction checkpoint disabled for this request",
+                exc_info=True,
+            )
+            return
+
+        if instruction_input["type"] != "token":
+            return
+        instruction_ids = instruction_input["prompt_token_ids"]
+        prompt_ids = engine_input["prompt_token_ids"]
+        boundary = len(instruction_ids)
+        if 0 < boundary < len(prompt_ids) and prompt_ids[:boundary] == instruction_ids:
+            engine_input["recurrent_instruction_boundary"] = boundary

--- a/vllm/v1/core/boundary_checkpoint.py
+++ b/vllm/v1/core/boundary_checkpoint.py
@@ -14,6 +14,15 @@ if TYPE_CHECKING:
 
 MAX_BOUNDARY_STOP_TOKENS = 128
 
+# Prompt and response retain their original slots so cached request state and
+# worker metadata remain compatible when an instruction checkpoint is absent.
+PROMPT_CHECKPOINT_SLOT = 0
+RESPONSE_CHECKPOINT_SLOT = 1
+INSTRUCTION_CHECKPOINT_SLOT = 2
+NUM_BOUNDARY_CHECKPOINT_SLOTS = 3
+
+BoundaryCheckpointKind = Literal["instruction", "prompt", "response"]
+
 
 @dataclass(frozen=True)
 class BoundaryCheckpoint:
@@ -22,7 +31,7 @@ class BoundaryCheckpoint:
     block_ids: tuple[tuple[int, ...], ...]
     auxiliary_block_ids: tuple[int, ...] = ()
     draft_prefix_len: int = 0
-    kind: Literal["prompt", "response"] = "prompt"
+    kind: BoundaryCheckpointKind = "prompt"
 
     @property
     def dependencies(self) -> frozenset[int]:

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -10,8 +10,12 @@ from vllm.distributed.kv_events import BlockStored, KVCacheEvent
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.boundary_checkpoint import (
+    INSTRUCTION_CHECKPOINT_SLOT,
+    PROMPT_CHECKPOINT_SLOT,
+    RESPONSE_CHECKPOINT_SLOT,
     BoundaryCheckpoint,
     BoundaryCheckpointCache,
+    BoundaryCheckpointKind,
 )
 from vllm.v1.core.kv_cache_coordinator import (
     HybridKVCacheCoordinator,
@@ -205,7 +209,8 @@ class KVCacheManager:
         if self.boundary_checkpoints is not None:
             logger.info(
                 "Request-boundary recurrent checkpoint caching is enabled. "
-                "Supported requests retain prompt and response endpoints."
+                "Supported chat requests retain leading instructions, the "
+                "complete prompt, and the response endpoint."
             )
 
     @property
@@ -503,7 +508,10 @@ class KVCacheManager:
         boundary_replay_managers = []
         if request.use_boundary_checkpoints:
             if request.request_id not in self._boundary_allocations:
-                boundary_blocks = 2 * (self.num_kv_cache_groups + 1)
+                checkpoint_slots = 2 + int(
+                    request.recurrent_instruction_boundary is not None
+                )
+                boundary_blocks = checkpoint_slots * (self.num_kv_cache_groups + 1)
             if request.boundary_checkpoint is not None:
                 boundary_blocks += sum(
                     self.block_pool.blocks[i].ref_cnt == 0
@@ -631,11 +639,14 @@ class KVCacheManager:
             request.request_id not in self._boundary_allocations
         ):
             width = self.num_kv_cache_groups + 1
-            allocation = self.block_pool.get_new_blocks(2 * width)
+            checkpoint_slots = 2 + int(
+                request.recurrent_instruction_boundary is not None
+            )
+            allocation = self.block_pool.get_new_blocks(checkpoint_slots * width)
             self._boundary_allocations[request.request_id] = allocation
             request.boundary_checkpoint_blocks = tuple(
                 tuple(block.block_id for block in allocation[start : start + width])
-                for start in (0, width)
+                for start in range(0, checkpoint_slots * width, width)
             )
 
         # P/D: delay caching blocks if we have to recv from
@@ -678,14 +689,14 @@ class KVCacheManager:
         return blocks
 
     def publish_boundary_checkpoint(
-        self, request: Request, num_tokens: int, *, is_response: bool
+        self, request: Request, num_tokens: int, *, kind: BoundaryCheckpointKind
     ) -> BoundaryCheckpoint | None:
         """Publish a validated endpoint after all workers completed their copies."""
         cache = self.boundary_checkpoints
         allocation = request.boundary_checkpoint_blocks
         if cache is None or allocation is None or num_tokens <= 0:
             return None
-        if is_response:
+        if kind == "response":
             if (
                 request.status
                 not in (
@@ -695,9 +706,17 @@ class KVCacheManager:
                 or num_tokens != request.num_tokens - 1
             ):
                 return None
-        elif num_tokens != request.num_prompt_tokens:
+            slot = RESPONSE_CHECKPOINT_SLOT
+        elif kind == "prompt":
+            if num_tokens != request.num_prompt_tokens:
+                return None
+            slot = PROMPT_CHECKPOINT_SLOT
+        else:
+            if num_tokens != request.recurrent_instruction_boundary:
+                return None
+            slot = INSTRUCTION_CHECKPOINT_SLOT
+        if slot >= len(allocation):
             return None
-        kind = int(is_response)
         grouped_blocks = []
         for group_id, manager in enumerate(self.coordinator.single_type_managers):
             count = cdiv(num_tokens, manager.block_size)
@@ -713,15 +732,15 @@ class KVCacheManager:
                 ]
                 if len(blocks) != count - 1 or 0 in blocks:
                     return None
-            blocks.append(allocation[kind][group_id])
+            blocks.append(allocation[slot][group_id])
             grouped_blocks.append(tuple(blocks))
         checkpoint = BoundaryCheckpoint(
             cache.next_id(),
             num_tokens,
             tuple(grouped_blocks),
-            (allocation[kind][-1],),
+            (allocation[slot][-1],),
             draft_prefix_len=max(num_tokens - 1, 0) if self.use_eagle else num_tokens,
-            kind="response" if is_response else "prompt",
+            kind=kind,
         )
         cache.stage(request, checkpoint, num_ranks=1)
         cache.acknowledge(checkpoint.checkpoint_id, 0)

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -52,6 +52,7 @@ class NewRequestData:
     prefill_token_ids: list[int] | None = None
     boundary_checkpoint: BoundaryCheckpoint | None = None
     boundary_checkpoint_blocks: tuple[tuple[int, ...], ...] | None = None
+    recurrent_instruction_boundary: int | None = None
 
     @classmethod
     def from_request(
@@ -81,6 +82,7 @@ class NewRequestData:
             prefill_token_ids=prefill_token_ids,
             boundary_checkpoint=request.boundary_checkpoint,
             boundary_checkpoint_blocks=request.boundary_checkpoint_blocks,
+            recurrent_instruction_boundary=request.recurrent_instruction_boundary,
         )
 
     @property

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -533,7 +533,12 @@ class Scheduler(SchedulerInterface):
         )
         if request.use_boundary_checkpoints:
             # Running-state migration still happens in the worker, but these
-            # requests do not publish intermediate block-aligned checkpoints.
+            # requests publish only semantic endpoints. Stop exactly at the
+            # leading instruction boundary so the worker can snapshot the
+            # recurrent state associated with that token prefix.
+            instruction_boundary = request.recurrent_instruction_boundary
+            if instruction_boundary is not None and start < instruction_boundary:
+                return min(num_new_tokens, instruction_boundary - start)
             return num_new_tokens
         # Split only during prefill: `request.num_tokens - 1` extends this to
         # resumed requests replaying their output tokens.
@@ -2750,14 +2755,20 @@ class Scheduler(SchedulerInterface):
             finish_reason = None
             captures = model_runner_output.boundary_checkpoint_tokens
             if captures is not None and not output_is_stale:
-                prompt_boundary, response_boundary = captures[req_index]
+                prompt_boundary, response_boundary, instruction_boundary = captures[
+                    req_index
+                ]
+                if instruction_boundary:
+                    self.kv_cache_manager.publish_boundary_checkpoint(
+                        request, instruction_boundary, kind="instruction"
+                    )
                 if prompt_boundary:
                     self.kv_cache_manager.publish_boundary_checkpoint(
-                        request, prompt_boundary, is_response=False
+                        request, prompt_boundary, kind="prompt"
                     )
                 if stopped and response_boundary:
                     self.kv_cache_manager.publish_boundary_checkpoint(
-                        request, response_boundary, is_response=True
+                        request, response_boundary, kind="response"
                     )
             if stopped:
                 # Capture finish_reason BEFORE _handle_stopped_request, which may

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -157,6 +157,12 @@ class EngineCoreRequest(
 
     session_id: str | None = None
 
+    # Exclusive token offset after the leading system/developer instruction
+    # segment. Appended to preserve positional serialization compatibility.
+    # The renderer supplies it only after exact token-prefix validation;
+    # direct token requests leave it unset.
+    recurrent_instruction_boundary: int | None = None
+
     @property
     def params(self) -> SamplingParams | PoolingParams:
         """Return the processed params (sampling or pooling)."""

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -431,6 +431,9 @@ class InputProcessor:
             trace_headers=trace_headers,
             resumable=resumable,
             session_id=session_id,
+            recurrent_instruction_boundary=decoder_input.get(
+                "recurrent_instruction_boundary"
+            ),
         )
 
     def _validate_prompt_len(

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -375,7 +375,8 @@ class ModelRunnerOutput:
 
     # ``None`` when ``return_sampling_mask`` is off.
     sampling_masks: SamplingMaskLists | None = None
-    # Per request: completed prompt and response checkpoint token counts, or 0.
+    # Per request: completed prompt, response, and leading-instruction
+    # checkpoint token counts, or 0.
     boundary_checkpoint_tokens: list[list[int]] | None = None
 
     @staticmethod

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -79,6 +79,7 @@ class Request:
         reasoning_ended: bool | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
         abort_immediately: bool = False,
+        recurrent_instruction_boundary: int | None = None,
     ) -> None:
         self.request_id = request_id
         self.client_index = client_index
@@ -142,6 +143,13 @@ class Request:
         self.num_prompt_tokens = length_from_prompt_token_ids_or_embeds(
             prompt_token_ids, prompt_embeds
         )
+        if recurrent_instruction_boundary is not None and not (
+            0 < recurrent_instruction_boundary < self.num_prompt_tokens
+        ):
+            raise ValueError(
+                "The recurrent instruction boundary must be inside the prompt"
+            )
+        self.recurrent_instruction_boundary = recurrent_instruction_boundary
         self._output_token_ids: list[int] = []
         if self.prompt_token_ids is None:
             self._all_token_ids: list[int] = [0] * self.num_prompt_tokens
@@ -264,6 +272,7 @@ class Request:
             reasoning_ended=request.reasoning_ended,
             reasoning_parser_kwargs=request.reasoning_parser_kwargs,
             abort_immediately=request.abort_immediately,
+            recurrent_instruction_boundary=request.recurrent_instruction_boundary,
         )
 
     def append_output_token_ids(

--- a/vllm/v1/worker/gpu/async_utils.py
+++ b/vllm/v1/worker/gpu/async_utils.py
@@ -185,7 +185,7 @@ class AsyncOutput(AsyncModelRunnerOutput):
         self.model_runner_output.sampled_token_ids = sampled_token_ids
         if self.boundary_checkpoint_tokens_np is not None:
             tokens = self.boundary_checkpoint_tokens_np.tolist()
-            if any(prompt or response for prompt, response in tokens):
+            if any(any(boundary for boundary in row) for row in tokens):
                 self.model_runner_output.boundary_checkpoint_tokens = tokens
 
         if self.sampling_mask_tensors is not None:

--- a/vllm/v1/worker/gpu/boundary_checkpoint.py
+++ b/vllm/v1/worker/gpu/boundary_checkpoint.py
@@ -9,7 +9,13 @@ from typing import TYPE_CHECKING, cast
 import torch
 
 from vllm.triton_utils import tl, triton
-from vllm.v1.core.boundary_checkpoint import MAX_BOUNDARY_STOP_TOKENS
+from vllm.v1.core.boundary_checkpoint import (
+    INSTRUCTION_CHECKPOINT_SLOT,
+    MAX_BOUNDARY_STOP_TOKENS,
+    NUM_BOUNDARY_CHECKPOINT_SLOTS,
+    PROMPT_CHECKPOINT_SLOT,
+    RESPONSE_CHECKPOINT_SLOT,
+)
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec, iter_layer_specs
 from vllm.v1.worker.mamba_utils import _reinterpret_u64_as_i64
 
@@ -19,6 +25,10 @@ if TYPE_CHECKING:
     from vllm.v1.worker.gpu.model_runner import GPUModelRunner
     from vllm.v1.worker.gpu.model_states.interface import ModelState
     from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
+
+_PROMPT_CHECKPOINT_SLOT = tl.constexpr(PROMPT_CHECKPOINT_SLOT)
+_RESPONSE_CHECKPOINT_SLOT = tl.constexpr(RESPONSE_CHECKPOINT_SLOT)
+_INSTRUCTION_CHECKPOINT_SLOT = tl.constexpr(INSTRUCTION_CHECKPOINT_SLOT)
 
 
 @triton.jit
@@ -40,15 +50,20 @@ def prepare_boundary_capture(
     capture_bias_ptr,
     capture_rows_ptr,
     STOP_CAPACITY: tl.constexpr,
+    NUM_CAPTURES: tl.constexpr,
+    METADATA_WIDTH: tl.constexpr,
 ):
-    enabled = tl.load(metadata_ptr + req_idx * 5)
+    metadata_offset = req_idx * METADATA_WIDTH
+    enabled = tl.load(metadata_ptr + metadata_offset)
     prompt_capture = 0
     response_capture = 0
+    instruction_capture = 0
     if enabled:
-        prompt_len = tl.load(metadata_ptr + req_idx * 5 + 1)
-        min_len = tl.load(metadata_ptr + req_idx * 5 + 2)
-        max_len = tl.load(metadata_ptr + req_idx * 5 + 3)
-        num_stops = tl.load(metadata_ptr + req_idx * 5 + 4)
+        prompt_len = tl.load(metadata_ptr + metadata_offset + 1)
+        instruction_len = tl.load(metadata_ptr + metadata_offset + 2)
+        min_len = tl.load(metadata_ptr + metadata_offset + 3)
+        max_len = tl.load(metadata_ptr + metadata_offset + 4)
+        num_stops = tl.load(metadata_ptr + metadata_offset + 5)
         offsets = tl.arange(0, STOP_CAPACITY)
         stops = tl.load(
             stop_tokens_ptr + req_idx * STOP_CAPACITY + offsets,
@@ -72,25 +87,61 @@ def prepare_boundary_capture(
         if (
             num_computed < prompt_len
             and computed_after == prompt_len
-            and tl.load(seen_ptr + req_idx * 2) == 0
+            and tl.load(seen_ptr + req_idx * NUM_CAPTURES + _PROMPT_CHECKPOINT_SLOT)
+            == 0
         ):
             prompt_capture = prompt_len
-            tl.store(seen_ptr + req_idx * 2, 1)
-        if stopped and tl.load(seen_ptr + req_idx * 2 + 1) == 0:
+            tl.store(seen_ptr + req_idx * NUM_CAPTURES + _PROMPT_CHECKPOINT_SLOT, 1)
+        if (
+            instruction_len > 0
+            and num_computed < instruction_len
+            and computed_after == instruction_len
+            and tl.load(
+                seen_ptr + req_idx * NUM_CAPTURES + _INSTRUCTION_CHECKPOINT_SLOT
+            )
+            == 0
+        ):
+            instruction_capture = instruction_len
+            tl.store(
+                seen_ptr + req_idx * NUM_CAPTURES + _INSTRUCTION_CHECKPOINT_SLOT, 1
+            )
+        if (
+            stopped
+            and tl.load(seen_ptr + req_idx * NUM_CAPTURES + _RESPONSE_CHECKPOINT_SLOT)
+            == 0
+        ):
             response_capture = computed_after
-            tl.store(seen_ptr + req_idx * 2 + 1, 1)
+            tl.store(seen_ptr + req_idx * NUM_CAPTURES + _RESPONSE_CHECKPOINT_SLOT, 1)
 
-    tl.store(capture_tokens_ptr + batch_idx * 2, prompt_capture)
-    tl.store(capture_tokens_ptr + batch_idx * 2 + 1, response_capture)
-    tl.store(capture_bias_ptr + batch_idx * 2, 0)
-    tl.store(capture_bias_ptr + batch_idx * 2 + 1, tl.maximum(num_sampled - 1, 0))
+    output_offset = batch_idx * NUM_CAPTURES
     tl.store(
-        capture_rows_ptr + batch_idx * 2,
+        capture_tokens_ptr + output_offset + _PROMPT_CHECKPOINT_SLOT, prompt_capture
+    )
+    tl.store(
+        capture_tokens_ptr + output_offset + _RESPONSE_CHECKPOINT_SLOT,
+        response_capture,
+    )
+    tl.store(
+        capture_tokens_ptr + output_offset + _INSTRUCTION_CHECKPOINT_SLOT,
+        instruction_capture,
+    )
+    tl.store(capture_bias_ptr + output_offset + _PROMPT_CHECKPOINT_SLOT, 0)
+    tl.store(
+        capture_bias_ptr + output_offset + _RESPONSE_CHECKPOINT_SLOT,
+        tl.maximum(num_sampled - 1, 0),
+    )
+    tl.store(capture_bias_ptr + output_offset + _INSTRUCTION_CHECKPOINT_SLOT, 0)
+    tl.store(
+        capture_rows_ptr + output_offset + _PROMPT_CHECKPOINT_SLOT,
         query_start + prompt_capture - num_computed - 1,
     )
     tl.store(
-        capture_rows_ptr + batch_idx * 2 + 1,
+        capture_rows_ptr + output_offset + _RESPONSE_CHECKPOINT_SLOT,
         query_start + response_capture - num_computed - 1,
+    )
+    tl.store(
+        capture_rows_ptr + output_offset + _INSTRUCTION_CHECKPOINT_SLOT,
+        query_start + instruction_capture - num_computed - 1,
     )
     return num_sampled, num_rejected
 
@@ -111,15 +162,18 @@ def _copy_auxiliary_state_kernel(
     HIDDEN_OFFSET: tl.constexpr,
     HIDDEN_BYTES: tl.constexpr,
     BLOCK: tl.constexpr,
+    NUM_CAPTURES: tl.constexpr,
 ):
-    row = tl.program_id(0) // 2
-    kind = tl.program_id(0) % 2
+    row = tl.program_id(0) // NUM_CAPTURES
+    kind = tl.program_id(0) % NUM_CAPTURES
     state = tl.program_id(1)
-    if tl.load(capture_tokens_ptr + row * 2 + kind) <= 0:
+    if tl.load(capture_tokens_ptr + row * NUM_CAPTURES + kind) <= 0:
         return
     slot = tl.load(idx_mapping_ptr + row)
     block = tl.load(
-        destination_blocks_ptr + (slot * 2 + kind) * (NUM_GROUPS + 1) + NUM_GROUPS
+        destination_blocks_ptr
+        + (slot * NUM_CAPTURES + kind) * (NUM_GROUPS + 1)
+        + NUM_GROUPS
     )
     if state < NUM_STATES:
         base = tl.load(metadata_ptr + state * 4)
@@ -128,7 +182,7 @@ def _copy_auxiliary_state_kernel(
         offset = tl.load(metadata_ptr + state * 4 + 3)
         source = (base + slot.to(tl.int64) * stride).to(tl.pointer_type(tl.uint8))
     else:
-        hidden_row = tl.load(capture_rows_ptr + row * 2 + kind)
+        hidden_row = tl.load(capture_rows_ptr + row * NUM_CAPTURES + kind)
         source = (
             hidden_ptr.to(tl.pointer_type(tl.uint8))
             + hidden_row.to(tl.int64) * hidden_stride
@@ -176,12 +230,13 @@ def _copy_attention_tails_kernel(
     NUM_GROUPS: tl.constexpr,
     BLOCK: tl.constexpr,
     TILES: tl.constexpr,
+    NUM_CAPTURES: tl.constexpr,
 ):
-    row = tl.program_id(0) // 2
-    kind = tl.program_id(0) % 2
+    row = tl.program_id(0) // NUM_CAPTURES
+    kind = tl.program_id(0) % NUM_CAPTURES
     storage = tl.program_id(1)
     tile = tl.program_id(2)
-    count = tl.load(capture_tokens_ptr + row * 2 + kind)
+    count = tl.load(capture_tokens_ptr + row * NUM_CAPTURES + kind)
     if count <= 0:
         return
     slot = tl.load(idx_mapping_ptr + row)
@@ -197,7 +252,7 @@ def _copy_attention_tails_kernel(
     )
     source_block //= block_size // kernel_block_size
     destination_block = tl.load(
-        destination_blocks_ptr + (slot * 2 + kind) * (NUM_GROUPS + 1) + group
+        destination_blocks_ptr + (slot * NUM_CAPTURES + kind) * (NUM_GROUPS + 1) + group
     )
     source = (base + source_block.to(tl.int64) * stride).to(tl.pointer_type(tl.uint8))
     destination = (base + destination_block.to(tl.int64) * stride).to(
@@ -222,7 +277,7 @@ class BoundaryCheckpointState:
         self.max_reqs = model_state.max_num_reqs
         self.num_groups = len(kv_cache_config.kv_cache_groups)
         self.metadata = torch.zeros(
-            (self.max_reqs, 5), dtype=torch.int32, device=self.device
+            (self.max_reqs, 6), dtype=torch.int32, device=self.device
         )
         self.stop_tokens = torch.full(
             (self.max_reqs, MAX_BOUNDARY_STOP_TOKENS),
@@ -231,10 +286,12 @@ class BoundaryCheckpointState:
             device=self.device,
         )
         self.seen = torch.zeros(
-            (self.max_reqs, 2), dtype=torch.int32, device=self.device
+            (self.max_reqs, NUM_BOUNDARY_CHECKPOINT_SLOTS),
+            dtype=torch.int32,
+            device=self.device,
         )
         self.blocks = torch.zeros(
-            (self.max_reqs, 2, self.num_groups + 1),
+            (self.max_reqs, NUM_BOUNDARY_CHECKPOINT_SLOTS, self.num_groups + 1),
             dtype=torch.int32,
             device=self.device,
         )
@@ -283,7 +340,9 @@ class BoundaryCheckpointState:
         self.pool = self._storages[0]
         self.mamba_group_ids = mamba_groups
         self.mamba_blocks = torch.zeros(
-            (self.max_reqs, 2, len(mamba_groups)), dtype=torch.int32, device=self.device
+            (self.max_reqs, NUM_BOUNDARY_CHECKPOINT_SLOTS, len(mamba_groups)),
+            dtype=torch.int32,
+            device=self.device,
         )
         self.storage_metadata = torch.tensor(
             storage_metadata, dtype=torch.int64, device=self.device
@@ -345,6 +404,8 @@ class BoundaryCheckpointState:
     def add_request(self, slot: int, request: "NewRequestData") -> None:
         self.seen[slot].zero_()
         self.metadata[slot].zero_()
+        self.blocks[slot].zero_()
+        self.mamba_blocks[slot].zero_()
         allocation = request.boundary_checkpoint_blocks
         if allocation is None:
             return
@@ -361,6 +422,7 @@ class BoundaryCheckpointState:
                 [
                     1,
                     prompt_len,
+                    request.recurrent_instruction_boundary or 0,
                     prompt_len + params.min_tokens,
                     min(
                         prompt_len + params.max_tokens,
@@ -376,10 +438,10 @@ class BoundaryCheckpointState:
             self.stop_tokens[slot, : len(stops)].copy_(
                 torch.tensor(sorted(stops), dtype=torch.int32, device=self.device)
             )
-        self.blocks[slot].copy_(
+        self.blocks[slot, : len(allocation)].copy_(
             torch.tensor(allocation, dtype=torch.int32, device=self.device)
         )
-        self.mamba_blocks[slot].copy_(
+        self.mamba_blocks[slot, : len(allocation)].copy_(
             torch.tensor(
                 [
                     [kind[group_id] for group_id in self.mamba_group_ids]
@@ -392,7 +454,12 @@ class BoundaryCheckpointState:
         checkpoint = request.boundary_checkpoint
         if checkpoint is not None:
             if checkpoint.num_tokens >= prompt_len:
-                self.seen[slot, 0] = 1
+                self.seen[slot, PROMPT_CHECKPOINT_SLOT] = 1
+            if (
+                request.recurrent_instruction_boundary is not None
+                and checkpoint.num_tokens >= request.recurrent_instruction_boundary
+            ):
+                self.seen[slot, INSTRUCTION_CHECKPOINT_SLOT] = 1
             _restore_auxiliary_state_kernel[(self.auxiliary_metadata.shape[0],)](
                 self.auxiliary_metadata,
                 self.pool,
@@ -435,7 +502,10 @@ class BoundaryCheckpointState:
         self.hidden_dtype = hidden.dtype
         self.spec_hidden_offset = self.hidden_offset + hidden_bytes
         _copy_auxiliary_state_kernel[
-            (idx_mapping.numel() * 2, self.target_metadata.shape[0] + 1)
+            (
+                idx_mapping.numel() * NUM_BOUNDARY_CHECKPOINT_SLOTS,
+                self.target_metadata.shape[0] + 1,
+            )
         ](
             idx_mapping,
             capture[0],
@@ -451,6 +521,7 @@ class BoundaryCheckpointState:
             HIDDEN_OFFSET=self.hidden_offset,
             HIDDEN_BYTES=hidden_bytes,
             BLOCK=1024,
+            NUM_CAPTURES=NUM_BOUNDARY_CHECKPOINT_SLOTS,
         )
         if spec_hidden is not None:
             size = spec_hidden[0].numel() * spec_hidden.element_size()
@@ -458,7 +529,9 @@ class BoundaryCheckpointState:
                 raise RuntimeError("Boundary MTP state exceeds its reserved KV page")
             self.spec_hidden_shape = tuple(spec_hidden.shape[1:])
             self.spec_hidden_dtype = spec_hidden.dtype
-            _copy_auxiliary_state_kernel[(idx_mapping.numel() * 2, 1)](
+            _copy_auxiliary_state_kernel[
+                (idx_mapping.numel() * NUM_BOUNDARY_CHECKPOINT_SLOTS, 1)
+            ](
                 idx_mapping,
                 capture[0],
                 capture[2],
@@ -473,11 +546,15 @@ class BoundaryCheckpointState:
                 HIDDEN_OFFSET=self.spec_hidden_offset,
                 HIDDEN_BYTES=size,
                 BLOCK=1024,
+                NUM_CAPTURES=NUM_BOUNDARY_CHECKPOINT_SLOTS,
             )
 
     def capture_draft(self, idx_mapping: torch.Tensor, capture: torch.Tensor) -> None:
         _copy_auxiliary_state_kernel[
-            (idx_mapping.numel() * 2, self.draft_metadata.shape[0])
+            (
+                idx_mapping.numel() * NUM_BOUNDARY_CHECKPOINT_SLOTS,
+                self.draft_metadata.shape[0],
+            )
         ](
             idx_mapping,
             capture[0],
@@ -493,6 +570,7 @@ class BoundaryCheckpointState:
             HIDDEN_OFFSET=0,
             HIDDEN_BYTES=0,
             BLOCK=1024,
+            NUM_CAPTURES=NUM_BOUNDARY_CHECKPOINT_SLOTS,
         )
 
     def set_draft_replay_anchor(
@@ -575,7 +653,11 @@ class BoundaryCheckpointState:
         block_tables: "BlockTables",
     ) -> None:
         _copy_attention_tails_kernel[
-            (idx_mapping.numel() * 2, self.storage_metadata.shape[0], 16)
+            (
+                idx_mapping.numel() * NUM_BOUNDARY_CHECKPOINT_SLOTS,
+                self.storage_metadata.shape[0],
+                16,
+            )
         ](
             idx_mapping,
             capture[0],
@@ -587,6 +669,7 @@ class BoundaryCheckpointState:
             NUM_GROUPS=self.num_groups,
             BLOCK=4096,
             TILES=16,
+            NUM_CAPTURES=NUM_BOUNDARY_CHECKPOINT_SLOTS,
         )
         self._completion.record()
 

--- a/vllm/v1/worker/gpu/input_batch.py
+++ b/vllm/v1/worker/gpu/input_batch.py
@@ -9,6 +9,7 @@ import torch
 from vllm.triton_utils import tl, triton
 from vllm.utils import random_uuid
 from vllm.utils.math_utils import cdiv
+from vllm.v1.core.boundary_checkpoint import NUM_BOUNDARY_CHECKPOINT_SLOTS
 from vllm.v1.worker.gpu.boundary_checkpoint import (
     BoundaryCheckpointState,
     prepare_boundary_capture,
@@ -565,14 +566,15 @@ def _post_update_kernel(
     boundary_capture_tokens_ptr=None,
     boundary_capture_bias_ptr=None,
     boundary_capture_rows_ptr=None,
+    NUM_CAPTURES: tl.constexpr = 0,
 ):
     req_id = tl.program_id(0)
     req_state_idx = tl.load(idx_mapping_ptr + req_id)
     if req_state_idx < 0:
         # Filter rows with negative index entries.
         if boundary_capture_tokens_ptr is not None:
-            tl.store(boundary_capture_tokens_ptr + req_id * 2, 0)
-            tl.store(boundary_capture_tokens_ptr + req_id * 2 + 1, 0)
+            for kind in range(NUM_CAPTURES):
+                tl.store(boundary_capture_tokens_ptr + req_id * NUM_CAPTURES + kind, 0)
         return
 
     total_len = tl.load(total_len_ptr + req_state_idx)
@@ -605,6 +607,8 @@ def _post_update_kernel(
             boundary_capture_bias_ptr,
             boundary_capture_rows_ptr,
             STOP_CAPACITY=128,
+            NUM_CAPTURES=NUM_CAPTURES,
+            METADATA_WIDTH=6,
         )
         tl.store(num_sampled_ptr + req_id, num_sampled)
         tl.store(num_rejected_ptr + req_id, num_rejected)
@@ -681,6 +685,9 @@ def post_update(
         boundary_capture[0] if boundary_capture is not None else None,
         boundary_capture[1] if boundary_capture is not None else None,
         boundary_capture[2] if boundary_capture is not None else None,
+        NUM_CAPTURES=(
+            NUM_BOUNDARY_CHECKPOINT_SLOTS if boundary_capture is not None else 0
+        ),
         num_warps=1,
     )
 

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -61,6 +61,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
 from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
+from vllm.v1.core.boundary_checkpoint import NUM_BOUNDARY_CHECKPOINT_SLOTS
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.outputs import (
@@ -2003,7 +2004,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             )
         else:
             boundary_capture = torch.empty(
-                (3, input_batch.num_reqs, 2), dtype=torch.int32, device=self.device
+                (3, input_batch.num_reqs, NUM_BOUNDARY_CHECKPOINT_SLOTS),
+                dtype=torch.int32,
+                device=self.device,
             )
 
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -20,6 +20,7 @@ from vllm.triton_utils import tl, triton
 from vllm.utils.gpu_sync_debug import gpu_sync_allowed
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+from vllm.v1.core.boundary_checkpoint import NUM_BOUNDARY_CHECKPOINT_SLOTS
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
@@ -392,23 +393,26 @@ def checkpoint_mamba_states_kernel(
     state_dim_row_count_ptr,
     state_dim_row_stride_ptr,
     NUM_GROUPS: tl.constexpr,
+    NUM_CAPTURES: tl.constexpr,
     CONV_STATE_DIM_FIRST: tl.constexpr,
     TEMPORAL_TILES: tl.constexpr,
 ):
-    batch_idx = tl.program_id(0) // 2
-    kind = tl.program_id(0) % 2
+    batch_idx = tl.program_id(0) // NUM_CAPTURES
+    kind = tl.program_id(0) % NUM_CAPTURES
     state_idx = tl.program_id(1)
     tile_idx = tl.program_id(2)
-    if tl.load(capture_tokens_ptr + batch_idx * 2 + kind) <= 0:
+    if tl.load(capture_tokens_ptr + batch_idx * NUM_CAPTURES + kind) <= 0:
         return
     req_idx = tl.load(idx_mapping_ptr + batch_idx)
     if req_idx < 0:
         return
     src_col = tl.load(state_idx_ptr + req_idx)
-    token_bias = tl.load(capture_bias_ptr + batch_idx * 2 + kind)
+    token_bias = tl.load(capture_bias_ptr + batch_idx * NUM_CAPTURES + kind)
     group_idx = tl.load(state_group_indices_ptr + state_idx)
     destination = tl.load(
-        destination_blocks_ptr + (req_idx * 2 + kind) * NUM_GROUPS + group_idx
+        destination_blocks_ptr
+        + (req_idx * NUM_CAPTURES + kind) * NUM_GROUPS
+        + group_idx
     )
     if destination <= 0:
         return
@@ -1397,12 +1401,26 @@ class MambaSpecDecodeGPUContext:
         """Copy only requested endpoints, selecting the committed spec state."""
         assert self.is_initialized
         num_reqs = idx_mapping.numel()
-        assert capture_tokens.shape == capture_bias.shape == (num_reqs, 2)
-        assert destination_blocks.shape[1:] == (2, self.num_groups)
+        assert (
+            capture_tokens.shape
+            == capture_bias.shape
+            == (
+                num_reqs,
+                NUM_BOUNDARY_CHECKPOINT_SLOTS,
+            )
+        )
+        assert destination_blocks.shape[1:] == (
+            NUM_BOUNDARY_CHECKPOINT_SLOTS,
+            self.num_groups,
+        )
         if not num_reqs:
             return
         checkpoint_mamba_states_kernel[
-            (num_reqs * 2, self.total_states, _TEMPORAL_TILES)
+            (
+                num_reqs * NUM_BOUNDARY_CHECKPOINT_SLOTS,
+                self.total_states,
+                _TEMPORAL_TILES,
+            )
         ](
             idx_mapping,
             state_idx,
@@ -1420,6 +1438,7 @@ class MambaSpecDecodeGPUContext:
             self.state_dim_row_count,
             self.state_dim_row_stride,
             NUM_GROUPS=self.num_groups,
+            NUM_CAPTURES=NUM_BOUNDARY_CHECKPOINT_SLOTS,
             CONV_STATE_DIM_FIRST=is_conv_state_dim_first(),
             TEMPORAL_TILES=_TEMPORAL_TILES,
         )


### PR DESCRIPTION
## Purpose

`--recurrent-checkpoint-policy request_boundaries` currently retains the complete prompt and response endpoint. A later chat request with the same system instructions but a different user message therefore cannot restore the shared recurrent state.

This change adds a checkpoint at the end of the leading `system`/`developer` message segment. It keeps the complete-prompt and response checkpoints unchanged.

## Behavior and invariants

- The OpenAI chat renderer renders the leading instruction segment separately.
- The boundary is forwarded only when the separately rendered token IDs are a nonempty exact prefix of the complete rendered prompt. Conversation-dependent templates that do not preserve that prefix fail closed.
- The scheduler stops prefill exactly at the verified boundary so workers can capture the corresponding recurrent, attention-tail, hidden, and speculative state.
- Prompt and response retain slots 0 and 1. Eligible chat requests allocate slot 2 for the instruction checkpoint; requests without a verified instruction boundary retain the existing two-bundle allocation.
- The extra request field is appended to `EngineCoreRequest` to preserve positional wire compatibility.
- Arbitrary mid-message checkpoints remain disabled. Direct token requests, multimodal requests, resumable requests, and chat templates without an exact instruction prefix retain their existing behavior.

Each eligible chat request reserves one additional evictable endpoint bundle: one block ID per KV cache group plus one auxiliary-state block ID. This is the bounded memory cost for making the shared instruction state reusable.

## Validation

Base: `dev/jovian-judgement` at `858b4912691ed354c0e719871426f8d139f92cbb`.

Automated tests:

- 88 CPU renderer and prefix-cache tests passed.
- 4 CUDA tests passed for three-endpoint metadata, auxiliary and attention-tail restore, committed Mamba-state copies, and async speculative output accounting.
- Formatting, Ruff, mypy, Markdown, SPDX, configuration, and repository pre-commit checks passed.

GLM-5.3-Flash-NVFP4 E2E qualification used TP4/DCP1, MTP3, FP8 KV cache, a 4,096-token scheduler budget, full plus piecewise CUDA graphs, stock RTX PRO 6000 Blackwell clocks, and physical GPUs 4-7.

| Request | Prompt tokens | Cache-hit tokens | Wall time |
|---|---:|---:|---:|
| Cold instructions + user A | 14,861 | 0 | 1.214 s |
| Same instructions + user B | 14,861 | 14,851 | 0.071 s |
| Exact replay of user B | 14,861 | 14,861 | 0.042 s |
| Modified instructions control | 14,868 | 0 | 1.064 s |

A concurrency test kept a 4,096-output-token MTP3 request active while a second request reused the same instructions. The second request restored 11,352 of 11,364 prompt tokens, both requests completed, and the server remained healthy. A separate 1,024-output-token MTP3 request after instruction restore completed at 308.7 output tok/s and 95.6 verifier steps/s; this throughput sample is a runtime health check, not a general performance claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Recurrent prefix caching can now reuse verified leading system and developer instructions across compatible chat requests.
  - Caching also continues to support complete prompts and processed response endpoints.
  - Instruction caching is enabled only when the rendered instruction segment exactly matches the beginning of the full prompt.

- **Documentation**
  - Clarified checkpoint behavior, supported chat templates, and cases where instruction-only caching is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->