### PR TITLE
[BugFix] Reuse partial attention pages below their published boundary

### DIFF
--- a/tests/v1/core/test_partial_attention_rewind.py
+++ b/tests/v1/core/test_partial_attention_rewind.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Reuse a cached attention tail below its published hash boundary."""
+
+import pytest
+import torch
+
+from tests.v1.core.test_prefix_caching import make_request
+from vllm.utils.hashing import sha256
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import init_none_hash
+from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager
+from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.mark.parametrize("dcp,replicated", [(1, False), (4, False), (4, True)])
+@pytest.mark.parametrize("leading_blocks", [0, 1])
+@pytest.mark.parametrize("drop_eagle", [False, True])
+def test_replay_below_published_attention_tail(
+    dcp, replicated, leading_blocks, drop_eagle
+):
+    init_none_hash(sha256)
+    unit = 256
+    spec = FullAttentionSpec(
+        block_size=2048,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        dcp_replicated=replicated,
+    )
+    effective = spec.block_size * (1 if replicated else dcp)
+    boundary = leading_blocks * effective + 2048
+    producer = make_request("producer", list(range(boundary)), unit, sha256)
+    pool = BlockPool(num_gpu_blocks=8, enable_caching=True, hash_block_size=unit)
+    blocks = pool.get_new_blocks(leading_blocks + 1)
+    full_blocks = boundary // effective
+    pool.cache_full_blocks(producer, blocks, 0, full_blocks, effective, 0)
+    if boundary % effective:
+        pool.cache_partial_block(producer, blocks[-1], boundary, 0, effective)
+    pool.free_blocks(blocks)
+
+    def lookup(tokens):
+        request = make_request("consumer", tokens, unit, sha256)
+        return FullAttentionManager.find_longest_cache_hit(
+            request.block_hashes,
+            max_length=boundary - 1,
+            kv_cache_group_ids=[0],
+            block_pool=pool,
+            kv_cache_spec=spec,
+            drop_eagle_block=drop_eagle,
+            alignment_tokens=unit,
+            dcp_world_size=dcp,
+        )
+
+    found, hit = lookup(list(range(boundary)))
+    expected = boundary - unit * (1 + int(drop_eagle))
+    assert hit == expected
+    assert list(found[0]) == blocks
+
+    divergent = list(range(boundary))
+    divergent[-1] += 1
+    _, hit = lookup(divergent)
+    assert hit == max(0, leading_blocks * effective - unit * int(drop_eagle))

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -933,7 +933,15 @@ class FullAttentionManager(SingleTypeKVCacheManager):
                     computed.append(cached)
                 hit_length = max_partial_idx * alignment_tokens
             else:
-                for fine_idx in range(max_partial_idx - 1, first_partial_idx - 1, -1):
+                # A published partial tail also covers earlier boundaries in
+                # this page. Its chained hash must match the request before we
+                # can rewind it, just as for a cached full page above.
+                lookup_end = (
+                    min(first_partial_idx + scale_factor - 1, len(block_hashes))
+                    if max_partial_idx > first_partial_idx
+                    else first_partial_idx
+                )
+                for fine_idx in range(lookup_end - 1, first_partial_idx - 1, -1):
                     cached_tail = block_pool.get_cached_block(
                         block_hashes[fine_idx], kv_cache_group_ids
                     )
@@ -941,7 +949,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
                         continue
                     for computed, cached in zip(computed_blocks, cached_tail):
                         computed.append(cached)
-                    hit_length = (fine_idx + 1) * alignment_tokens
+                    hit_length = min(fine_idx + 1, max_partial_idx) * alignment_tokens
                     break
 
         # Eagle needs the tokens right before the generation point recomputed:


### PR DESCRIPTION
A 2,048-token GLM-5.3 prompt under TP4/DCP4 returned correct answers but reused zero tokens on an identical warm request. The target attention page covers 8,192 tokens and publishes a partial hash at token 2,048. Replay excludes the final prompt token, so the old lookup never examines that published hash.

Allow a matching later partial hash in the same attention page to prove an earlier prefix. Cap the returned length at the requested aligned limit, then preserve the existing EAGLE rewind. This mirrors the full-page fallback. Replicated groups and DCP1 block scaling remain unchanged.

Validation so far:

- Original image source 63bd2b9aa6b9a5ffb4040dd5af17a55f7a64bb43: four focused DCP4 failures, with eight DCP1 and replicated-cache controls passing.
- Fixed lookup: 122 tests passed with the patched manager overlay. All 124 affected CPU tests passed in the complete source-verified image, including divergent-prefix and EAGLE controls.
- Public source head: 74cf9209092b3b8d986aecd0d55983ed6f9d8724, based on current dev/jovian-judgement.
- Source-verified candidate image: sha256:75af98309b5778c95d89fc197a30823efa62cf615168e07488ed935a2e2f5545.
- Original GPU response: cold cached=0, warm cached=0, appended cached=1792; all three answers were correct.
- Baseline DCP1 retained 4,723,200 tokens in two pressure runs with zero errors/preemptions and at least 4.02 GiB free per GPU.

Fixed-image GPU validation:

- DCP1 control: correct canary answers, shared-prefix reuse, and C1/C8/C16 decode and mixed screens passed; zero runtime errors or preemptions.
- DCP4: all 12 boundary cases and 16 shared-prefix requests passed with per-request token and cache-metric reconciliation. The original 2048-token reproduction now reuses 1792 tokens on warm replay.
- Cold/warm retrieval: exactly 491520 input tokens; warm reuse is 491264 tokens and matches the metric delta.
- All 64 agent turns passed, with individual cached-prefix reuse checked from raw responses.
- Pressure repeats 1 and 2: all three targets passed in each repeat, totaling 288 requests. Retained-prefix lower bound is 6119424 tokens. Minimum free GiB per GPU: [2.9755859375, 2.8193359375, 2.8193359375, 3.4443359375]. Preemptions, OOMs, restarts, and fatal errors were all zero.
- Reported capacity is 14843551 tokens. The 12-sequence cap limits this workload to 6120000 rendered tokens, so the remaining reported capacity is not labeled validated.

Independent source review found no blocking defect. A fresh Astra reviewer verified the changed-file hashes and checked 13680 CPU oracle cases; the old finder disagreed in 1704 cases.

Qualification scope is VRAM-only. The pre-existing per-group connector caller omits DCP/PCP arguments, so this PR makes no live connector-transfer qualification claim.

All required local CPU, GPU correctness, pressure, and independent source-review gates passed on the public head. The exact original LP27 service was restored with its unchanged container ID, image, and configuration fingerprint. LP26 remained stopped and no candidate was promoted. A separate intermittent illegal-access failure during original-image graph startup is preserved and unresolved; this lookup patch does not claim to fix it.

Rechecked current upstream work before readiness, including #644, #654, #677, #678, #482, #519, #533, #524, #670, #674, and #675. PRs #654 and #678 change alignment semantics in the same finder but retain the old search bounded by max_partial_idx. They do not contain this later-tail proof. The public head is unchanged and GitHub reports the PR mergeable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attention cache reuse when matching requests share a cached tail below its published boundary.
  * Corrected cache-hit length calculation across supported attention configurations.

* **Tests**
  * Added coverage for replaying cached attention tails with matching and divergent request prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->