### PR TITLE
[JJ] Account for DeepSeek V4 prefill peak in KV admission

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1827,10 +1827,14 @@ def test_glm_dcp_attention_profile_skips_non_glm_and_dcp1():
     "architecture",
     ["DeepseekV4ForCausalLM", "DeepseekV4ForConditionalGeneration"],
 )
-@pytest.mark.parametrize("dummy_run_fails", [False, True])
+@pytest.mark.parametrize(
+    ("init_fails", "dummy_run_fails"),
+    [(False, False), (False, True), (True, False)],
+)
 def test_deepseek_v4_attention_profile_uses_reachable_prefill_and_cleans_up(
     monkeypatch: pytest.MonkeyPatch,
     architecture: str,
+    init_fails: bool,
     dummy_run_fails: bool,
 ):
     runner = GPUModelRunner.__new__(GPUModelRunner)
@@ -1839,7 +1843,12 @@ def test_deepseek_v4_attention_profile_uses_reachable_prefill_and_cleans_up(
     runner.max_num_tokens = 4096
     events: list[object] = []
 
-    runner._init_minimal_kv_cache_for_profiling = lambda: events.append("init-kv")
+    def init_kv():
+        events.append("init-kv")
+        if init_fails:
+            raise RuntimeError("expected DeepSeek V4 KV initialization failure")
+
+    runner._init_minimal_kv_cache_for_profiling = init_kv
 
     def dummy_run(*args, **kwargs):
         events.append(("dummy-run", args, kwargs))
@@ -1857,25 +1866,33 @@ def test_deepseek_v4_attention_profile_uses_reachable_prefill_and_cleans_up(
         lambda _: nullcontext(),
     )
 
-    if dummy_run_fails:
+    if init_fails:
+        with pytest.raises(
+            RuntimeError, match="expected DeepSeek V4 KV initialization failure"
+        ):
+            runner._profile_deepseek_v4_attention()
+    elif dummy_run_fails:
         with pytest.raises(RuntimeError, match="expected DeepSeek V4 profile failure"):
             runner._profile_deepseek_v4_attention()
     else:
         runner._profile_deepseek_v4_attention()
 
     assert events[0] == "init-kv"
-    assert events[1] == (
-        "dummy-run",
-        (4096,),
-        {
-            "force_attention": True,
-            "skip_eplb": True,
-            "is_profile": True,
-            "single_request_prefill": True,
-        },
-    )
+    if init_fails:
+        assert events == ["init-kv", "cleanup"]
+    else:
+        assert events[1] == (
+            "dummy-run",
+            (4096,),
+            {
+                "force_attention": True,
+                "skip_eplb": True,
+                "is_profile": True,
+                "single_request_prefill": True,
+            },
+        )
     assert events[-1] == "cleanup"
-    if not dummy_run_fails:
+    if not init_fails and not dummy_run_fails:
         assert events[-2] == "sync"
 
 

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1912,6 +1912,7 @@ def test_profile_run_releases_generic_outputs_before_deepseek_profile(monkeypatc
     runner.supports_mm_inputs = False
     runner.max_num_tokens = 4096
     runner.is_pooling_model = False
+    runner.compilation_config = SimpleNamespace(static_forward_context={})
     events: list[object] = []
     output_refs: list[ref] = []
 

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1823,6 +1823,103 @@ def test_glm_dcp_attention_profile_skips_non_glm_and_dcp1():
     runner._init_minimal_kv_cache_for_profiling.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "architecture",
+    ["DeepseekV4ForCausalLM", "DeepseekV4ForConditionalGeneration"],
+)
+@pytest.mark.parametrize("dummy_run_fails", [False, True])
+def test_deepseek_v4_attention_profile_uses_reachable_prefill_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+    architecture: str,
+    dummy_run_fails: bool,
+):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.model_config = SimpleNamespace(architecture=architecture)
+    runner.vllm_config = object()
+    runner.max_num_tokens = 4096
+    events: list[object] = []
+
+    runner._init_minimal_kv_cache_for_profiling = lambda: events.append("init-kv")
+
+    def dummy_run(*args, **kwargs):
+        events.append(("dummy-run", args, kwargs))
+        if dummy_run_fails:
+            raise RuntimeError("expected DeepSeek V4 profile failure")
+        return torch.empty(1), torch.empty(1)
+
+    runner._dummy_run = dummy_run
+    runner._sync_device = lambda: events.append("sync")
+    runner._cleanup_profiling_kv_cache = lambda: events.append("cleanup")
+
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "set_current_vllm_config",
+        lambda _: nullcontext(),
+    )
+
+    if dummy_run_fails:
+        with pytest.raises(RuntimeError, match="expected DeepSeek V4 profile failure"):
+            runner._profile_deepseek_v4_attention()
+    else:
+        runner._profile_deepseek_v4_attention()
+
+    assert events[0] == "init-kv"
+    assert events[1] == (
+        "dummy-run",
+        (4096,),
+        {
+            "force_attention": True,
+            "skip_eplb": True,
+            "is_profile": True,
+            "single_request_prefill": True,
+        },
+    )
+    assert events[-1] == "cleanup"
+    if not dummy_run_fails:
+        assert events[-2] == "sync"
+
+
+def test_deepseek_v4_attention_profile_skips_other_architectures():
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.model_config = SimpleNamespace(architecture="OtherArchitecture")
+    runner._init_minimal_kv_cache_for_profiling = Mock()
+
+    runner._profile_deepseek_v4_attention()
+
+    runner._init_minimal_kv_cache_for_profiling.assert_not_called()
+
+
+def test_profile_run_profiles_attention_before_releasing_encoder_cache(monkeypatch):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.supports_mm_inputs = False
+    runner.max_num_tokens = 4096
+    runner.is_pooling_model = False
+    events: list[object] = []
+
+    runner._dummy_run = lambda *args, **kwargs: (
+        events.append(("dummy-run", args, kwargs)) or (torch.empty(1), torch.empty(1))
+    )
+    runner._profile_deepseek_v4_attention = lambda: events.append("profile-attention")
+    runner._sync_device = lambda: events.append("sync")
+    runner.encoder_cache = SimpleNamespace(
+        clear=lambda: events.append("clear-encoder-cache")
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_last_rank=False),
+    )
+
+    runner.profile_run()
+
+    assert events == [
+        ("dummy-run", (4096,), {"is_profile": True}),
+        "profile-attention",
+        "sync",
+        "clear-encoder-cache",
+    ]
+
+
 class TestInitFp8KvScalesHybridModels:
     """Verify init_fp8_kv_scales handles heterogeneous kv_caches entries.
 

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -5,6 +5,7 @@ import gc
 from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import Mock
+from weakref import ref
 
 import numpy as np
 import pytest
@@ -1906,17 +1907,29 @@ def test_deepseek_v4_attention_profile_skips_other_architectures():
     runner._init_minimal_kv_cache_for_profiling.assert_not_called()
 
 
-def test_profile_run_profiles_attention_before_releasing_encoder_cache(monkeypatch):
+def test_profile_run_releases_generic_outputs_before_deepseek_profile(monkeypatch):
     runner = GPUModelRunner.__new__(GPUModelRunner)
     runner.supports_mm_inputs = False
     runner.max_num_tokens = 4096
     runner.is_pooling_model = False
     events: list[object] = []
+    output_refs: list[ref] = []
 
-    runner._dummy_run = lambda *args, **kwargs: (
-        events.append(("dummy-run", args, kwargs)) or (torch.empty(1), torch.empty(1))
-    )
-    runner._profile_deepseek_v4_attention = lambda: events.append("profile-attention")
+    class ProfileOutput:
+        pass
+
+    def dummy_run(*args, **kwargs):
+        events.append(("dummy-run", args, kwargs))
+        outputs = (ProfileOutput(), ProfileOutput())
+        output_refs.extend(ref(output) for output in outputs)
+        return outputs
+
+    def profile_attention():
+        assert all(output_ref() is None for output_ref in output_refs)
+        events.append("profile-attention")
+
+    runner._dummy_run = dummy_run
+    runner._profile_deepseek_v4_attention = profile_attention
     runner._sync_device = lambda: events.append("sync")
     runner.encoder_cache = SimpleNamespace(
         clear=lambda: events.append("clear-encoder-cache")
@@ -1931,8 +1944,8 @@ def test_profile_run_profiles_attention_before_releasing_encoder_cache(monkeypat
 
     assert events == [
         ("dummy-run", (4096,), {"is_profile": True}),
-        "profile-attention",
         "sync",
+        "profile-attention",
         "clear-encoder-cache",
     ]
 

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1844,8 +1844,8 @@ def test_deepseek_v4_attention_profile_uses_reachable_prefill_and_cleans_up(
     runner.max_num_tokens = 4096
     events: list[object] = []
 
-    def init_kv():
-        events.append("init-kv")
+    def init_kv(*, num_blocks=None):
+        events.append(("init-kv", num_blocks))
         if init_fails:
             raise RuntimeError("expected DeepSeek V4 KV initialization failure")
 
@@ -1878,9 +1878,9 @@ def test_deepseek_v4_attention_profile_uses_reachable_prefill_and_cleans_up(
     else:
         runner._profile_deepseek_v4_attention()
 
-    assert events[0] == "init-kv"
+    assert events[0] == ("init-kv", 1)
     if init_fails:
-        assert events == ["init-kv", "cleanup"]
+        assert events == [("init-kv", 1), "cleanup"]
     else:
         assert events[1] == (
             "dummy-run",

--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -225,8 +225,8 @@ def test_deepseek_v4_attention_profile_uses_reachable_prefill_and_cleans_up(
     runner.max_num_tokens = 4096
     events: list[object] = []
 
-    def init_kv(_):
-        events.append("init-kv")
+    def init_kv(_, *, num_blocks=None):
+        events.append(("init-kv", num_blocks))
         if init_fails:
             raise RuntimeError("expected DeepSeek V4 KV initialization failure")
 
@@ -259,9 +259,9 @@ def test_deepseek_v4_attention_profile_uses_reachable_prefill_and_cleans_up(
     else:
         runner._profile_deepseek_v4_attention()
 
-    assert events[0] == "init-kv"
+    assert events[0] == ("init-kv", 1)
     if init_fails:
-        assert events == ["init-kv", "cleanup"]
+        assert events == [("init-kv", 1), "cleanup"]
     else:
         assert events[1] == (
             "dummy-run",

--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -203,3 +203,108 @@ def test_glm_dcp_attention_profile_skips_irrelevant_configurations(
     runner.profile_glm_dcp_attention()
 
     assert not initialized
+
+
+@pytest.mark.parametrize(
+    "architecture",
+    ["DeepseekV4ForCausalLM", "DeepseekV4ForConditionalGeneration"],
+)
+@pytest.mark.parametrize("dummy_run_fails", [False, True])
+def test_deepseek_v4_attention_profile_uses_reachable_prefill_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+    architecture: str,
+    dummy_run_fails: bool,
+):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.model_config = SimpleNamespace(architecture=architecture)
+    runner.max_num_tokens = 4096
+    events: list[object] = []
+
+    monkeypatch.setattr(
+        model_runner_module,
+        "_init_minimal_kv_cache_for_profiling",
+        lambda _: events.append("init-kv"),
+    )
+    monkeypatch.setattr(
+        model_runner_module,
+        "_teardown_profiling_state",
+        lambda _: events.append("cleanup"),
+    )
+
+    def dummy_run(*args, **kwargs):
+        events.append(("dummy-run", args, kwargs))
+        if dummy_run_fails:
+            raise RuntimeError("expected DeepSeek V4 profile failure")
+        return torch.empty(1), torch.empty(1)
+
+    runner._dummy_run = dummy_run
+    monkeypatch.setattr(torch.accelerator, "synchronize", lambda: events.append("sync"))
+
+    if dummy_run_fails:
+        with pytest.raises(RuntimeError, match="expected DeepSeek V4 profile failure"):
+            runner._profile_deepseek_v4_attention()
+    else:
+        runner._profile_deepseek_v4_attention()
+
+    assert events[0] == "init-kv"
+    assert events[1] == (
+        "dummy-run",
+        (4096,),
+        {
+            "skip_eplb": True,
+            "is_profile": True,
+            "single_request_prefill": True,
+            "profile_all_kv_cache_groups": True,
+        },
+    )
+    assert events[-1] == "cleanup"
+    if not dummy_run_fails:
+        assert events[-2] == "sync"
+
+
+def test_deepseek_v4_attention_profile_skips_other_architectures(monkeypatch):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.model_config = SimpleNamespace(architecture="OtherArchitecture")
+    initialized = False
+
+    def record_initialization(_):
+        nonlocal initialized
+        initialized = True
+
+    monkeypatch.setattr(
+        model_runner_module,
+        "_init_minimal_kv_cache_for_profiling",
+        record_initialization,
+    )
+
+    runner._profile_deepseek_v4_attention()
+
+    assert not initialized
+
+
+def test_profile_run_profiles_attention_before_releasing_encoder_cache(monkeypatch):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.supports_mm_inputs = False
+    runner.max_num_tokens = 4096
+    runner.is_last_pp_rank = False
+    events: list[object] = []
+
+    runner._dummy_run = lambda *args, **kwargs: (
+        events.append(("dummy-run", args, kwargs)) or (None, None)
+    )
+    runner._profile_deepseek_v4_attention = lambda: events.append("profile-attention")
+    runner.reset_encoder_cache = lambda: events.append("reset-encoder-cache")
+    monkeypatch.setattr(torch.accelerator, "synchronize", lambda: events.append("sync"))
+
+    runner.profile_run()
+
+    assert events == [
+        (
+            "dummy-run",
+            (4096,),
+            {"skip_attn": True, "is_profile": True},
+        ),
+        "profile-attention",
+        "sync",
+        "reset-encoder-cache",
+    ]

--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from types import SimpleNamespace
+from weakref import ref
 
 import pytest
 import torch
@@ -297,17 +298,29 @@ def test_deepseek_v4_attention_profile_skips_other_architectures(monkeypatch):
     assert not initialized
 
 
-def test_profile_run_profiles_attention_before_releasing_encoder_cache(monkeypatch):
+def test_profile_run_releases_generic_outputs_before_deepseek_profile(monkeypatch):
     runner = GPUModelRunner.__new__(GPUModelRunner)
     runner.supports_mm_inputs = False
     runner.max_num_tokens = 4096
     runner.is_last_pp_rank = False
     events: list[object] = []
+    output_refs: list[ref] = []
 
-    runner._dummy_run = lambda *args, **kwargs: (
-        events.append(("dummy-run", args, kwargs)) or (None, None)
-    )
-    runner._profile_deepseek_v4_attention = lambda: events.append("profile-attention")
+    class ProfileOutput:
+        pass
+
+    def dummy_run(*args, **kwargs):
+        events.append(("dummy-run", args, kwargs))
+        outputs = (ProfileOutput(), ProfileOutput())
+        output_refs.extend(ref(output) for output in outputs)
+        return outputs
+
+    def profile_attention():
+        assert all(output_ref() is None for output_ref in output_refs)
+        events.append("profile-attention")
+
+    runner._dummy_run = dummy_run
+    runner._profile_deepseek_v4_attention = profile_attention
     runner.reset_encoder_cache = lambda: events.append("reset-encoder-cache")
     monkeypatch.setattr(torch.accelerator, "synchronize", lambda: events.append("sync"))
 
@@ -319,7 +332,7 @@ def test_profile_run_profiles_attention_before_releasing_encoder_cache(monkeypat
             (4096,),
             {"skip_attn": True, "is_profile": True},
         ),
-        "profile-attention",
         "sync",
+        "profile-attention",
         "reset-encoder-cache",
     ]

--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -209,10 +209,14 @@ def test_glm_dcp_attention_profile_skips_irrelevant_configurations(
     "architecture",
     ["DeepseekV4ForCausalLM", "DeepseekV4ForConditionalGeneration"],
 )
-@pytest.mark.parametrize("dummy_run_fails", [False, True])
+@pytest.mark.parametrize(
+    ("init_fails", "dummy_run_fails"),
+    [(False, False), (False, True), (True, False)],
+)
 def test_deepseek_v4_attention_profile_uses_reachable_prefill_and_cleans_up(
     monkeypatch: pytest.MonkeyPatch,
     architecture: str,
+    init_fails: bool,
     dummy_run_fails: bool,
 ):
     runner = GPUModelRunner.__new__(GPUModelRunner)
@@ -220,10 +224,13 @@ def test_deepseek_v4_attention_profile_uses_reachable_prefill_and_cleans_up(
     runner.max_num_tokens = 4096
     events: list[object] = []
 
+    def init_kv(_):
+        events.append("init-kv")
+        if init_fails:
+            raise RuntimeError("expected DeepSeek V4 KV initialization failure")
+
     monkeypatch.setattr(
-        model_runner_module,
-        "_init_minimal_kv_cache_for_profiling",
-        lambda _: events.append("init-kv"),
+        model_runner_module, "_init_minimal_kv_cache_for_profiling", init_kv
     )
     monkeypatch.setattr(
         model_runner_module,
@@ -240,25 +247,33 @@ def test_deepseek_v4_attention_profile_uses_reachable_prefill_and_cleans_up(
     runner._dummy_run = dummy_run
     monkeypatch.setattr(torch.accelerator, "synchronize", lambda: events.append("sync"))
 
-    if dummy_run_fails:
+    if init_fails:
+        with pytest.raises(
+            RuntimeError, match="expected DeepSeek V4 KV initialization failure"
+        ):
+            runner._profile_deepseek_v4_attention()
+    elif dummy_run_fails:
         with pytest.raises(RuntimeError, match="expected DeepSeek V4 profile failure"):
             runner._profile_deepseek_v4_attention()
     else:
         runner._profile_deepseek_v4_attention()
 
     assert events[0] == "init-kv"
-    assert events[1] == (
-        "dummy-run",
-        (4096,),
-        {
-            "skip_eplb": True,
-            "is_profile": True,
-            "single_request_prefill": True,
-            "profile_all_kv_cache_groups": True,
-        },
-    )
+    if init_fails:
+        assert events == ["init-kv", "cleanup"]
+    else:
+        assert events[1] == (
+            "dummy-run",
+            (4096,),
+            {
+                "skip_eplb": True,
+                "is_profile": True,
+                "single_request_prefill": True,
+                "profile_all_kv_cache_groups": True,
+            },
+        )
     assert events[-1] == "cleanup"
-    if not dummy_run_fails:
+    if not init_fails and not dummy_run_fails:
         assert events[-2] == "sync"
 
 

--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -303,6 +303,7 @@ def test_profile_run_releases_generic_outputs_before_deepseek_profile(monkeypatc
     runner.supports_mm_inputs = False
     runner.max_num_tokens = 4096
     runner.is_last_pp_rank = False
+    runner.compilation_config = SimpleNamespace(static_forward_context={})
     events: list[object] = []
     output_refs: list[ref] = []
 

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -1094,8 +1094,15 @@ def _extrapolate_full_graph_memory(
     return estimate
 
 
-def _init_minimal_kv_cache_for_profiling(runner: "GPUModelRunner") -> None:
-    """Allocate the smallest KV cache that still lets every graph be captured."""
+def _init_minimal_kv_cache_for_profiling(
+    runner: "GPUModelRunner", *, num_blocks: int | None = None
+) -> None:
+    """Allocate the smallest KV cache required by a profiling workload.
+
+    Graph capture needs one block per padded sequence. A caller that executes
+    one eager request can request one block explicitly, avoiding temporary KV
+    storage that would otherwise be included in activation headroom.
+    """
     from vllm.v1.core.kv_cache_utils import (
         get_kv_cache_config_from_groups,
         get_kv_cache_groups,
@@ -1104,12 +1111,18 @@ def _init_minimal_kv_cache_for_profiling(runner: "GPUModelRunner") -> None:
     kv_cache_spec = runner.get_kv_cache_spec()
     kv_cache_groups = get_kv_cache_groups(runner.vllm_config, kv_cache_spec)
     # At least one block per sequence is required to capture the graphs.
-    min_blocks = (
-        min(runner.max_num_reqs, runner.compilation_config.max_cudagraph_capture_size)
-        or 1
-    )
+    if num_blocks is None:
+        num_blocks = (
+            min(
+                runner.max_num_reqs,
+                runner.compilation_config.max_cudagraph_capture_size,
+            )
+            or 1
+        )
+    if num_blocks < 1:
+        raise ValueError("Profiling KV cache requires at least one block")
     saved_override = runner.cache_config.num_gpu_blocks_override
-    runner.cache_config.num_gpu_blocks_override = min_blocks
+    runner.cache_config.num_gpu_blocks_override = num_blocks
     try:
         minimal_config = get_kv_cache_config_from_groups(
             runner.vllm_config, kv_cache_groups, available_memory=0

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -912,8 +912,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         }:
             return
 
-        _init_minimal_kv_cache_for_profiling(self)
         try:
+            _init_minimal_kv_cache_for_profiling(self)
             self._dummy_run(
                 self.max_num_tokens,
                 skip_eplb=True,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -916,7 +916,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             return
 
         try:
-            _init_minimal_kv_cache_for_profiling(self)
+            _init_minimal_kv_cache_for_profiling(self, num_blocks=1)
             self._dummy_run(
                 self.max_num_tokens,
                 skip_eplb=True,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -889,10 +889,41 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             else:
                 self._dummy_pooler_run(hidden_states)
 
+        self._profile_deepseek_v4_attention()
         torch.accelerator.synchronize()
         del hidden_states, sample_hidden_states
         self.reset_encoder_cache()
         gc.collect()
+
+    @torch.inference_mode()
+    def _profile_deepseek_v4_attention(self) -> None:
+        """Include the maximum DeepSeek V4 prefill peak in KV admission.
+
+        The generic profile omits attention and distributes its token budget
+        across requests. DeepSeek V4 can execute the complete scheduler token
+        budget as one prefill, where query projection and auxiliary-stream
+        indexer work overlap. Run that reachable shape while multimodal encoder
+        outputs from ``profile_run`` remain resident. A minimal temporary cache
+        makes attention executable without reserving the production KV pool.
+        """
+        if self.model_config.architecture not in {
+            "DeepseekV4ForCausalLM",
+            "DeepseekV4ForConditionalGeneration",
+        }:
+            return
+
+        _init_minimal_kv_cache_for_profiling(self)
+        try:
+            self._dummy_run(
+                self.max_num_tokens,
+                skip_eplb=True,
+                is_profile=True,
+                single_request_prefill=True,
+                profile_all_kv_cache_groups=True,
+            )
+            torch.accelerator.synchronize()
+        finally:
+            _teardown_profiling_state(self)
 
     @torch.inference_mode()
     def profile_glm_dcp_attention(self) -> None:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -889,9 +889,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             else:
                 self._dummy_pooler_run(hidden_states)
 
-        self._profile_deepseek_v4_attention()
+        # The generic and DeepSeek-specific passes represent separate scheduler
+        # steps. Release the generic outputs so KV admission uses the larger
+        # transient peak instead of an unreachable sum of both passes.
         torch.accelerator.synchronize()
         del hidden_states, sample_hidden_states
+        self._profile_deepseek_v4_attention()
         self.reset_encoder_cache()
         gc.collect()
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6640,9 +6640,12 @@ class GPUModelRunner(
                 output = self._dummy_sampler_run(last_hidden_states)
         else:
             output = None
-        self._profile_deepseek_v4_attention()
+        # The generic and DeepSeek-specific passes represent separate scheduler
+        # steps. Release the generic outputs so KV admission uses the larger
+        # transient peak instead of an unreachable sum of both passes.
         self._sync_device()
         del hidden_states, output
+        self._profile_deepseek_v4_attention()
         self.encoder_cache.clear()
         gc.collect()
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6640,10 +6640,46 @@ class GPUModelRunner(
                 output = self._dummy_sampler_run(last_hidden_states)
         else:
             output = None
+        self._profile_deepseek_v4_attention()
         self._sync_device()
         del hidden_states, output
         self.encoder_cache.clear()
         gc.collect()
+
+    @torch.inference_mode()
+    def _profile_deepseek_v4_attention(self) -> None:
+        """Include the maximum DeepSeek V4 prefill peak in KV admission.
+
+        The generic profile does not create attention metadata and distributes
+        its token budget across requests. DeepSeek V4 can execute the complete
+        scheduler token budget as one prefill, where query projection and
+        auxiliary-stream indexer work overlap. Run that reachable shape while
+        multimodal encoder outputs from ``profile_run`` remain resident. A
+        minimal temporary cache makes attention executable without reserving
+        the production KV pool.
+        """
+        if self.model_config.architecture not in {
+            "DeepseekV4ForCausalLM",
+            "DeepseekV4ForConditionalGeneration",
+        }:
+            return
+
+        with set_current_vllm_config(self.vllm_config):
+            self._init_minimal_kv_cache_for_profiling()
+
+        model_output: tuple[torch.Tensor, torch.Tensor] | None = None
+        try:
+            model_output = self._dummy_run(
+                self.max_num_tokens,
+                force_attention=True,
+                skip_eplb=True,
+                is_profile=True,
+                single_request_prefill=True,
+            )
+            self._sync_device()
+        finally:
+            del model_output
+            self._cleanup_profiling_kv_cache()
 
     @torch.inference_mode()
     def profile_glm_dcp_attention(self) -> None:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6664,11 +6664,10 @@ class GPUModelRunner(
         }:
             return
 
-        with set_current_vllm_config(self.vllm_config):
-            self._init_minimal_kv_cache_for_profiling()
-
         model_output: tuple[torch.Tensor, torch.Tensor] | None = None
         try:
+            with set_current_vllm_config(self.vllm_config):
+                self._init_minimal_kv_cache_for_profiling()
             model_output = self._dummy_run(
                 self.max_num_tokens,
                 force_attention=True,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6644,7 +6644,7 @@ class GPUModelRunner(
         # steps. Release the generic outputs so KV admission uses the larger
         # transient peak instead of an unreachable sum of both passes.
         self._sync_device()
-        del hidden_states, output
+        del hidden_states, last_hidden_states, output
         self._profile_deepseek_v4_attention()
         self.encoder_cache.clear()
         gc.collect()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6670,7 +6670,7 @@ class GPUModelRunner(
         model_output: tuple[torch.Tensor, torch.Tensor] | None = None
         try:
             with set_current_vllm_config(self.vllm_config):
-                self._init_minimal_kv_cache_for_profiling()
+                self._init_minimal_kv_cache_for_profiling(num_blocks=1)
             model_output = self._dummy_run(
                 self.max_num_tokens,
                 force_attention=True,
@@ -6716,7 +6716,9 @@ class GPUModelRunner(
             del model_output
             self._cleanup_profiling_kv_cache()
 
-    def _init_minimal_kv_cache_for_profiling(self) -> None:
+    def _init_minimal_kv_cache_for_profiling(
+        self, *, num_blocks: int | None = None
+    ) -> None:
         from vllm.v1.core.kv_cache_utils import (
             get_kv_cache_config_from_groups,
             get_kv_cache_groups,
@@ -6726,14 +6728,20 @@ class GPUModelRunner(
         KVCacheSpecRegistry.check_kv_cache_spec_registry(kv_cache_spec)
         kv_cache_groups = get_kv_cache_groups(self.vllm_config, kv_cache_spec)
         # the minimum number of blocks required is 1 block *per sequence*
-        min_blocks = (
-            min(self.max_num_reqs, self.compilation_config.max_cudagraph_capture_size)
-            or 1
-        )
+        if num_blocks is None:
+            num_blocks = (
+                min(
+                    self.max_num_reqs,
+                    self.compilation_config.max_cudagraph_capture_size,
+                )
+                or 1
+            )
+        if num_blocks < 1:
+            raise ValueError("Profiling KV cache requires at least one block")
 
         # Temporarily change num_gpu_blocks_override to allocate a minimal KV cache
         saved_override = self.cache_config.num_gpu_blocks_override
-        self.cache_config.num_gpu_blocks_override = min_blocks
+        self.cache_config.num_gpu_blocks_override = num_blocks
         try:
             minimal_config = get_kv_cache_config_from_groups(
                 self.vllm_config, kv_cache_groups, available_memory=0


### PR DESCRIPTION
## Purpose

vLLM must reserve enough non-KV GPU memory for every execution shape that the configured scheduler can produce. DeepSeek V4 text and Vision can execute the complete `max_num_batched_tokens` budget as one prefill request. The generic startup profile skips attention and distributes its token budget across requests, so it does not measure the full DeepSeek V4 query projection and sparse-indexer peak.

Without that measurement, GPU KV admission can consume memory needed by a valid request. Reproduced failures included:

- DeepSeek-V4-Flash-Vision-Exp, MNB4096, MNS4, utilization 0.975: an 86 MiB `wq_b` allocation failed with 72 MiB free.
- DeepSeek-V4-Flash-0731, MNB4096, MNS6, utilization 0.970, engine-driven LMCache: a 128 MiB `wq_b` allocation failed with 109 MiB free.

The release and source merge contract is tracked in [rtx6kpro issue #95](https://github.com/local-inference-lab/rtx6kpro/issues/95).

## Resulting behavior

The legacy and modular GPU model runners perform an architecture-gated DeepSeek V4 attention profile during standard memory profiling.

The profile:

- releases generic-profile outputs because the generic and DeepSeek-specific passes represent mutually exclusive scheduler steps;
- retains multimodal encoder outputs, so Vision accounting includes their scheduler-reachable residency;
- initializes a minimal temporary KV cache with one block per hybrid KV group;
- executes all configured scheduler tokens as one prefill request;
- synchronizes before reading the peak;
- releases temporary KV, attention, and graph state after success or failure, including partial initialization failure.

CUDA peak-memory accounting therefore observes the larger reachable transient instead of summing mutually exclusive passes. GPU KV admission receives every remaining byte after the measured peak. The implementation does not add a fixed reserve, lower `gpu_memory_utilization`, alter attention arithmetic, or retain a persistent projection workspace.

## Compatibility

The additional profile runs only for:

- `DeepseekV4ForCausalLM`
- `DeepseekV4ForConditionalGeneration`

Other architectures retain their existing profiling behavior. DeepSeek V4 startup performs one additional full-token profile; request-time execution and scheduling are unchanged.

## Validation

### Source tests

- Ruff format and lint: passed
- Python bytecode compilation: passed
- whitespace validation: passed
- legacy model runner focused tests: 8 passed, 47 deselected
- modular model runner memory-profile tests: 15 passed
- Docker source-composition and runtime contracts: passed
- Docker Compose profile contracts: 24 passed

### Qualified artifact

```text
image: voipmonitor/vllm:jovian-judgement-vllmd267ca7-b12xe58515a-fi803c466-cu133-torch213-20260906-r8
registry digest: sha256:7f4de2bb4faf58d9b05c508037de57415dc4e5b7d53a24588db0ed0bcb7f8968
image ID: sha256:7e533ec88bcd04979f05c737768f75de0fb16fa80391c1b5d104565092f85579
vLLM integration tree: d267ca78d0d07e3993093b023844619af41a5e11
```

Hardware: two 96 GiB RTX PRO 6000 Blackwell Workstation Edition GPUs connected through one PCIe switch. Runtime: CUDA 13.3, PyTorch 2.13.0, NCCL 2.31.2.

| Profile | Configuration | GPU KV capacity | Memory-pressure result |
|---|---|---:|---|
| Text | TP2, K5, MNS8, MNB4096, utilization 0.975 | 1,185,524 tokens; 7.86 GiB/rank | 4,096-token and 810,000-token requests passed |
| Vision | TP2, K3, MNS4, MNB4096, utilization 0.975 | 1,206,495 tokens; 8.00 GiB/rank | 810,000-token prefill overlapped with ten 2048x2048 image requests; both passed |
| Text + engine-driven LMCache | TP2, K5, MNS8, MNB4096, utilization 0.970 | 1,113,883 tokens; 7.39 GiB/rank | 810,000-token request and cache restore after GPU eviction passed |

Text captured and executed 9/9 PIECEWISE target graphs, 7/7 FULL target graphs, and 6/6 FULL DSpark graphs. Vision captured and executed 5/5 PIECEWISE target graphs, 3/3 FULL target graphs, and 3/3 FULL DSpark graphs. No qualified decode request used an eager fallback.

The complete machine-readable receipt is [`validation/jovian-judgement-ds4-r8.json`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/main/validation/jovian-judgement-ds4-r8.json). The serving specification is [`models/ds4-jovian-judgement-r8.md`](https://github.com/local-inference-lab/rtx6kpro/blob/master/models/ds4-jovian-judgement-r8.md).

## Scope

**Qualified:** the recorded TP2/DCP1 text, Vision, and engine-driven LMCache profiles on 96 GiB SM120 GPUs.

**Not qualified:** TP1, TP greater than two, DCP greater than one, GPUs with less than 96 GiB, comparative throughput, and task-level model quality.
