### PR TITLE
[Worker] Set the serving thread count before warmup, not after

### DIFF
--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -164,3 +164,66 @@ def test_b12x_warmup_precedes_cudagraph_memory_profile(
         "profile_cudagraph_memory",
     ]
     assert available == expected_available_memory
+
+
+def test_serving_thread_count_is_set_before_warmup(monkeypatch):
+    """Dynamo guards compiled functions on torch.get_num_threads(); dropping to
+    the serving count after warmup makes the first real request recompile
+    every torch.compile'd function."""
+    events: list[str] = []
+
+    def capture_model():
+        events.append("capture_model")
+        return 0
+
+    compilation_config = SimpleNamespace(
+        mode=gpu_worker.CompilationMode.NONE,
+        backend="inductor",
+        compilation_time=0.0,
+        encoder_compilation_time=0.0,
+    )
+    worker = SimpleNamespace(
+        vllm_config=SimpleNamespace(compilation_config=compilation_config),
+        compilation_config=compilation_config,
+        model_runner=SimpleNamespace(
+            lora_config=None,
+            maybe_remove_all_loras=lambda lora_config: None,
+            capture_model=capture_model,
+        ),
+        model_config=SimpleNamespace(enforce_eager=False, seed=0),
+        cache_config=SimpleNamespace(kv_cache_memory_bytes=1),
+        observability_config=SimpleNamespace(
+            jit_monitor_mode="off", jit_monitor_verbose=False
+        ),
+        use_v2_model_runner=True,
+        execute_model=None,
+        sample_tokens=None,
+    )
+
+    monkeypatch.setattr(
+        gpu_worker,
+        "set_torch_threads_for_runtime",
+        lambda: events.append("set_torch_threads_for_runtime"),
+    )
+    monkeypatch.setattr(
+        gpu_worker, "kernel_warmup", lambda worker: events.append("kernel_warmup")
+    )
+    monkeypatch.setattr(
+        gpu_worker,
+        "warmup_kernels",
+        lambda *args: events.append("warmup_kernels"),
+    )
+    monkeypatch.setattr(gpu_worker, "set_random_seed", lambda seed: None)
+    monkeypatch.setattr(gpu_worker, "freeze_gc_heap", lambda: None)
+    monkeypatch.setattr(gpu_worker, "maybe_attach_gc_debug_callback", lambda: None)
+    monkeypatch.setattr(gpu_worker, "enable_gpu_sync_check", lambda: None)
+    monkeypatch.setattr("vllm.utils.jit_monitor.activate", lambda mode, verbose: None)
+
+    gpu_worker.Worker.compile_or_warm_up_model(worker)
+
+    assert events == [
+        "set_torch_threads_for_runtime",
+        "kernel_warmup",
+        "capture_model",
+        "warmup_kernels",
+    ]

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -747,6 +747,14 @@ class Worker(WorkerBase):
 
     @instrument(span_name="Warmup (GPU)")
     def compile_or_warm_up_model(self) -> CompilationTimes:
+        # Drop to the serving thread count *before* any warmup: Dynamo guards
+        # every compiled function on torch.get_num_threads(), so compiles done
+        # under the startup count are all invalidated (and redone, ~1s of
+        # TTFT on GLM-5.3-Flash TP4) by the first real request otherwise.
+        # Weight loading, the only startup work that benefits from intra-op
+        # parallelism, has already finished.
+        set_torch_threads_for_runtime()
+
         warmup_sizes: list[int] = []
 
         if self.vllm_config.compilation_config.mode == CompilationMode.VLLM_COMPILE:
@@ -916,10 +924,6 @@ class Worker(WorkerBase):
         # Warmup / first-compile is done — activate the `VLLM_GPU_SYNC_CHECK`
         # gate so subsequent `execute_model` / `sample_tokens` calls enforce it.
         enable_gpu_sync_check()
-
-        # Startup is done; steady-state serving gets no benefit from torch
-        # intra-op parallelism.
-        set_torch_threads_for_runtime()
 
         return CompilationTimes(
             language_model=self.compilation_config.compilation_time,


### PR DESCRIPTION
## Summary

`Worker.compile_or_warm_up_model()` called `set_torch_threads_for_runtime()` (startup thread count → 1) **after** kernel warmup and cudagraph capture. Dynamo guards every compiled function on `torch.get_num_threads()`, so every `torch.compile`'d helper compiled during warmup (`SiluAndMul.forward_native`, `grouped_topk` ×3, `_swiglu_limit_torch`, `get_masked_input_and_mask`) was invalidated the moment the thread count changed, and the first real request recompiled all of them. No warmup at any shape could cover it, because the global state changed after warmup finished.

This moves the call to the top of the method. Weight loading, the only startup phase that benefits from intra-op parallelism, has already completed by then.

## Evidence

GLM-5.3-Flash NVFP4, TP4 across four DGX Spark nodes, MTP k=3, `--no-enable-flashinfer-autotune`, `max_num_batched_tokens=8192`.

`TORCH_LOGS=recompiles` on the first real 8192-token prefill after startup (rank 0):

```
Recompiling function forward_native in .../layers/activation.py:236
    - 0/2: GLOBAL_STATE changed: num_threads
Recompiling function grouped_topk in .../fused_moe/router/grouped_topk_router.py:75
    - 1/1: GLOBAL_STATE changed: num_threads
Recompiling function fused_grouped_topk in .../fused_moe/router/grouped_topk_router.py:28
Recompiling function grouped_topk in .../_custom_ops.py:2470
Recompiling function _swiglu_limit_torch in .../fused_moe/utils.py:535
Recompiling function get_masked_input_and_mask in .../vocab_parallel_embedding.py:212
    (all: GLOBAL_STATE changed: num_threads)
```

Startup log ordering that caused it: `Reducing Torch threads from 20 to 1 for serving` is printed at 13:28:32, after `Graph capturing finished` at 13:28:29 and kernel warmup at 13:28:13.

A rank-0 torch profiler trace of that first request shows the corresponding GPU-idle gaps attributed to `torch/_dynamo/convert_frame.py` compiles: 570 ms (swiglu limit), 387 ms (grouped top-k), 364 ms + 270 ms (`CustomOp.forward` compile wrapper).

First 8192-token prefill after a fresh start, then a second distinct 8192-token prompt as the steady-state reference (client-observed, single request):

| build | first prefill | second prefill | cold penalty |
|---|---|---|---|
| `dev/jovian-judgement` @ db7a65e29 | 4.38 s | 3.35 s | +1.03 s |
| + this change | 3.59 s | 3.37 s | +0.22 s |

Engine-side `vllm:request_prefill_time_seconds_sum` matches the client numbers to within 20 ms, so the cost is inside the engine step, not the API server.

Also measured and **not** included: an extra `_dummy_run(max_num_batched_tokens, single_request_prefill=True)` in `kernel_warmup` when FlashInfer autotune is disabled. On its own it recovered 0.1 s of the 1.03 s (the recompiles happened anyway); on top of this change it made no measurable difference (3.56 s vs 3.59 s first prefill).

The remaining ~0.2 s is a second recompile wave for the size-1 specialisation (`2 <= hidden_states.size()[0]` guards) plus a Triton JIT of `_gather_shared_paged_supertile_kernel` that the JIT monitor flags; both are independent of this change.

## Test

`tests/v1/worker/test_gpu_worker.py::test_serving_thread_count_is_set_before_warmup` asserts the call order `set_torch_threads_for_runtime → kernel_warmup → capture_model → warmup_kernels`. Ran the file inside the SM121 image on a GB10 node: 5 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Applied the configured serving thread count before model compilation and warmup.
  - Prevented unnecessary recompilation on the first real request.
  - Improved consistency during CUDA graph capture and kernel warmup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->