### PR TITLE
Enable GLM recurrent boundary restore with DCP and DFlash

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -141,12 +141,14 @@ def make_full_mamba_manager(
 
 @pytest.mark.parametrize("prompt_len", [3, 4, 5, 7, 8, 9])
 @pytest.mark.parametrize("use_eagle", [False, True])
+@pytest.mark.parametrize("dcp", [1, 4])
 def test_request_boundaries_reuse_exact_prompt_and_response_with_private_state(
     prompt_len,
     use_eagle,
+    dcp,
 ):
     manager = make_full_mamba_manager(
-        dcp_world_size=1,
+        dcp_world_size=dcp,
         hash_block_size=4,
         num_blocks=64,
         enable_boundary_checkpoints=True,
@@ -175,10 +177,12 @@ def test_request_boundaries_reuse_exact_prompt_and_response_with_private_state(
     blocks, hit, _ = manager.get_computed_blocks(repeat)
     assert hit == prompt_len
     assert manager.allocate_slots(repeat, 1, hit, blocks) is not None
-    if use_eagle or prompt_len % 4:
+    if use_eagle or prompt_len % (4 * dcp):
         # MTP replays the last row even at a physical page boundary.
         attention = manager.get_blocks(repeat.request_id).blocks[0]
-        assert attention[(prompt_len - 1) // 4].block_id != prompt.block_ids[0][-1]
+        assert (
+            attention[(prompt_len - 1) // (4 * dcp)].block_id != prompt.block_ids[0][-1]
+        )
     state_blocks = manager.get_blocks(repeat.request_id).blocks[1]
     # An unaligned restore has a private working copy; aligned restores
     # append a fresh running block after the cached state.
@@ -192,6 +196,99 @@ def test_request_boundaries_reuse_exact_prompt_and_response_with_private_state(
     assert hit == prompt_len + 1
     assert manager.allocate_slots(continuation, 2, hit, blocks) is not None
     manager.free(continuation)
+    _, retained = manager.take_kv_cache_block_copies()
+    manager.block_pool.free_blocks(retained)
+    assert manager.reset_prefix_cache()
+
+
+@pytest.mark.parametrize("dcp", [1, 4])
+@pytest.mark.parametrize("missing_group", [None, 2, 3])
+def test_request_boundary_retains_complete_dflash_windows(dcp, missing_group):
+    """Evicted draft prefixes are valid only before every required window."""
+    config = KVCacheConfig(
+        num_blocks=128,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["target"],
+                FullAttentionSpec(4, num_kv_heads=1, head_size=1, dtype=torch.float32),
+            ),
+            KVCacheGroupSpec(
+                ["recurrent"],
+                MambaSpec(
+                    4,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["draft_window"],
+                SlidingWindowSpec(
+                    4,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=8,
+                    dcp_replicated=True,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["draft_full"],
+                FullAttentionSpec(
+                    4,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    dcp_replicated=True,
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        config,
+        max_model_len=128,
+        enable_caching=True,
+        dcp_world_size=dcp,
+        scheduler_block_size=4 * dcp,
+        hash_block_size=4,
+        enable_boundary_checkpoints=True,
+    )
+    tokens = list(range(29))
+    producer = make_request("producer", tokens, 4, sha256)
+    manager.get_computed_blocks(producer)
+    assert manager.allocate_slots(producer, len(tokens)) is not None
+    manager.remove_skipped_blocks(producer.request_id, len(tokens) - 1)
+    groups = manager.get_blocks(producer.request_id).blocks
+    assert groups[2][0].is_null
+    if missing_group is not None:
+        block = groups[missing_group][-2]
+        manager.block_pool.free_blocks([block])
+        groups[missing_group][-2] = manager.block_pool.null_block
+
+    checkpoint = manager.publish_boundary_checkpoint(
+        producer, len(tokens), kind="prompt"
+    )
+    if missing_group is not None:
+        assert checkpoint is None
+        manager.free(producer)
+        assert len(manager.boundary_checkpoints) == 0
+        return
+    assert checkpoint is not None
+    assert checkpoint.draft_prefix_len == len(tokens)
+    assert checkpoint.block_ids[2][:5] == (0,) * 5
+    assert all(checkpoint.block_ids[2][5:])
+    assert all(checkpoint.block_ids[3])
+    manager.free(producer)
+
+    consumer = make_request("consumer", tokens + [100], 4, sha256)
+    blocks, hit, _ = manager.get_computed_blocks(consumer)
+    assert hit == len(tokens)
+    assert manager.allocate_slots(consumer, 1, hit, blocks) is not None
+    working = manager.get_blocks(consumer.request_id).blocks
+    for group in (0, 2, 3):
+        assert working[group][-1].block_id != checkpoint.block_ids[group][-1]
+    manager.free(consumer)
     _, retained = manager.take_kv_cache_block_copies()
     manager.block_pool.free_blocks(retained)
     assert manager.reset_prefix_cache()

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
@@ -2,10 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Callable
+from types import SimpleNamespace
 
 import pytest
 
 import vllm.v1.core.kv_cache_utils as kv_cache_utils
+from vllm.config import VllmConfig
 from vllm.distributed.kv_events import BlockRemoved, BlockStored
 from vllm.sampling_params import SamplingParams
 from vllm.utils.hashing import sha256
@@ -129,6 +131,52 @@ def test_request_boundaries_fall_back_for_oversized_stop_sets():
     assert BoundaryCheckpointCache.supports_request(request)
     request.sampling_params.stop_token_ids = list(range(256))
     assert not BoundaryCheckpointCache.supports_request(request)
+
+
+@pytest.mark.parametrize("method", [None, "mtp", "dflash"])
+@pytest.mark.parametrize("dcp", [1, 2, 4])
+@pytest.mark.parametrize("external_cache", [False, True])
+def test_glm_boundary_adapter_requires_gpu_resident_atomic_state(
+    monkeypatch, method, dcp, external_cache
+):
+    """DCP and DFlash are supported; external checkpoint persistence is not."""
+    monkeypatch.setattr(
+        "vllm.platforms.current_platform",
+        SimpleNamespace(is_cuda=lambda: True),
+    )
+    config = SimpleNamespace(
+        cache_config=SimpleNamespace(
+            recurrent_checkpoint_policy="auto",
+            enable_prefix_caching=True,
+            mamba_cache_mode="align",
+            kv_cache_layout=None,
+            kv_offloading_size=None,
+        ),
+        model_config=SimpleNamespace(
+            enable_sleep_mode=False,
+            enable_return_routed_experts=False,
+            hf_text_config=SimpleNamespace(model_type="glm5_next_text"),
+        ),
+        parallel_config=SimpleNamespace(
+            pipeline_parallel_size=1,
+            data_parallel_size=1,
+            decode_context_parallel_size=dcp,
+            prefill_context_parallel_size=1,
+        ),
+        speculative_config=(
+            None
+            if method is None
+            else SimpleNamespace(
+                method=method,
+                uses_dynamic_speculative_decoding=lambda: False,
+            )
+        ),
+        use_v2_model_runner=True,
+        lora_config=None,
+        kv_transfer_config=object() if external_cache else None,
+    )
+    adapter_enabled = VllmConfig.use_request_boundary_checkpoints.fget(config)
+    assert adapter_enabled is not external_cache
 
 
 def test_request_boundary_branches_deduplicate_and_survive_sibling_eviction():

--- a/tests/v1/spec_decode/test_dflash_dcp.py
+++ b/tests/v1/spec_decode/test_dflash_dcp.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 import vllm.v1.worker.gpu.spec_decode.dflash.speculator as dflash_speculator
@@ -62,7 +63,11 @@ def test_dflash_sliding_window_cache_is_replicated_under_dcp():
     assert spec.dcp_replicated is True
 
 
-def test_dflash_uses_draft_group_dcp_slot_parameters(monkeypatch):
+@pytest.mark.parametrize("context_kv_is_restored", [False, True])
+@pytest.mark.parametrize("use_full_graph", [False, True])
+def test_dflash_uses_draft_group_dcp_slot_parameters(
+    monkeypatch, context_kv_is_restored, use_full_graph
+):
     """A sharded DSpark-style draft group must retain the real DCP mapping."""
     cp_args = []
 
@@ -79,7 +84,7 @@ def test_dflash_uses_draft_group_dcp_slot_parameters(monkeypatch):
             SimpleNamespace(
                 num_reqs=1,
                 num_tokens=1,
-                cg_mode=CUDAGraphMode.NONE,
+                cg_mode=(CUDAGraphMode.FULL if use_full_graph else CUDAGraphMode.NONE),
             ),
             None,
         ),
@@ -96,14 +101,18 @@ def test_dflash_uses_draft_group_dcp_slot_parameters(monkeypatch):
         kernel_block_sizes=[16],
         get_group_cp_parameters=lambda _gid: (2, 4, 8),
     )
-    model = SimpleNamespace(precompute_and_store_context_kv=lambda *_args: None)
+    context_writes = []
+    query_runs = []
+    model = SimpleNamespace(
+        precompute_and_store_context_kv=lambda *args: context_writes.append(args)
+    )
     speculator = SimpleNamespace(
         num_query_per_req=1,
         num_speculative_steps=1,
         max_model_len=128,
         max_num_reqs=1,
         max_num_tokens=1,
-        hidden_states=torch.zeros((1, 1)),
+        hidden_states=torch.full((1, 1), -99.0),
         context_positions=torch.zeros(1, dtype=torch.int64),
         sample_indices=torch.zeros(1, dtype=torch.int64),
         sample_pos=torch.zeros(1, dtype=torch.int64),
@@ -119,7 +128,9 @@ def test_dflash_uses_draft_group_dcp_slot_parameters(monkeypatch):
         parallel_drafting_token_id=0,
         sample_from_anchor=False,
         model=model,
-        query_cudagraph_manager=None,
+        query_cudagraph_manager=SimpleNamespace(
+            run_fullgraph=lambda *_args: query_runs.append("graph")
+        ),
         dp_size=1,
         dp_rank=0,
         _group_causal=False,
@@ -127,7 +138,7 @@ def test_dflash_uses_draft_group_dcp_slot_parameters(monkeypatch):
         draft_tokens=torch.zeros((1, 1), dtype=torch.int64),
         _build_draft_attn_metadata=lambda **_kwargs: {},
         _prepare_eplb_forward=lambda *_args: None,
-        _generate_draft=lambda *_args, **_kwargs: None,
+        _generate_draft=lambda *_args, **_kwargs: query_runs.append("eager"),
     )
     input_batch = SimpleNamespace(
         num_reqs=1,
@@ -143,7 +154,7 @@ def test_dflash_uses_draft_group_dcp_slot_parameters(monkeypatch):
         input_batch=input_batch,
         attn_metadata={},
         slot_mappings={},
-        last_hidden_states=torch.zeros((1, 1)),
+        last_hidden_states=torch.full((1, 1), 5.0),
         aux_hidden_states=None,
         num_sampled=one_i32,
         num_rejected=one_i32,
@@ -151,9 +162,13 @@ def test_dflash_uses_draft_group_dcp_slot_parameters(monkeypatch):
         next_prefill_tokens=one_i64,
         temperature=one_f32,
         seeds=one_i64,
+        context_kv_is_restored=context_kv_is_restored,
     )
 
     assert cp_args == [(2, 4, 8)]
+    assert len(context_writes) == (0 if context_kv_is_restored else 1)
+    assert speculator.hidden_states.item() == (-99.0 if context_kv_is_restored else 5.0)
+    assert query_runs == ["graph" if use_full_graph else "eager"]
 
 
 def test_replicated_draft_metadata_uses_full_sequence_lengths(monkeypatch):

--- a/tests/v1/worker/test_boundary_checkpoint_attention.py
+++ b/tests/v1/worker/test_boundary_checkpoint_attention.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Snapshot the same logical attention endpoint in sharded and replicated groups."""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.worker.gpu.boundary_checkpoint import _copy_attention_tails_kernel
+
+pytestmark = pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+
+
+@pytest.mark.parametrize("dcp", [1, 2, 4])
+@pytest.mark.parametrize("kernel_block_size", [2, 8])
+@pytest.mark.parametrize("endpoint", [1, 8, 9, 16, 17, 32, 33])
+def test_attention_snapshot_uses_group_virtual_page(dcp, kernel_block_size, endpoint):
+    page_size = 8
+    bytes_per_page = 37
+    num_groups = 2
+    num_captures = 3
+    device = "cuda"
+    sources = [
+        (torch.arange(8 * bytes_per_page).reshape(8, bytes_per_page) + group)
+        .to(torch.uint8)
+        .to(device)
+        for group in range(num_groups)
+    ]
+    pools = [torch.cat((source, torch.full_like(source, 165))) for source in sources]
+    metadata = torch.tensor(
+        [
+            [pool.data_ptr(), bytes_per_page, group, page_size]
+            for group, pool in enumerate(pools)
+        ],
+        dtype=torch.int64,
+        device=device,
+    )
+    blocks_per_page = page_size // kernel_block_size
+    tables = []
+    for group in range(num_groups):
+        pages = torch.arange(8, dtype=torch.int32, device=device)
+        if group == 1:
+            pages = pages.flip(0)
+        expanded = (
+            pages[:, None] * blocks_per_page
+            + torch.arange(blocks_per_page, dtype=torch.int32, device=device)
+        ).flatten()
+        tables.append(torch.stack((torch.zeros_like(expanded), expanded)))
+    table_ptrs = torch.tensor(
+        [t.data_ptr() for t in tables], dtype=torch.uint64, device=device
+    )
+    table_strides = torch.tensor(
+        [t.stride(0) for t in tables], dtype=torch.int64, device=device
+    )
+    kernel_sizes = torch.full(
+        (num_groups,), kernel_block_size, dtype=torch.int32, device=device
+    )
+    cp_sizes = torch.tensor([dcp, 1], dtype=torch.int32, device=device)
+    slots = torch.tensor([1], dtype=torch.int32, device=device)
+    counts = torch.tensor([[endpoint, 0, 0]], dtype=torch.int32, device=device)
+    destinations = torch.full(
+        (2, num_captures, num_groups + 1), 9, dtype=torch.int32, device=device
+    )
+
+    _copy_attention_tails_kernel[(num_captures, num_groups, 2)](
+        slots,
+        counts,
+        destinations,
+        metadata,
+        table_ptrs,
+        table_strides,
+        kernel_sizes,
+        cp_sizes,
+        NUM_GROUPS=num_groups,
+        BLOCK=32,
+        TILES=2,
+        NUM_CAPTURES=num_captures,
+    )
+
+    for group, cp_size in enumerate((dcp, 1)):
+        page = (endpoint - 1) // (page_size * cp_size)
+        source_page = page if group == 0 else 7 - page
+        torch.testing.assert_close(pools[group][9], sources[group][source_page])
+        torch.testing.assert_close(pools[group][:8], sources[group])
+        assert torch.all(pools[group][8] == 165)
+        assert torch.all(pools[group][10:] == 165)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -611,13 +611,23 @@ class VllmConfig:
             and (
                 self.speculative_config is None
                 or (
-                    self.speculative_config.method == "mtp"
+                    (
+                        self.speculative_config.method == "mtp"
+                        or (
+                            self.speculative_config.method == "dflash"
+                            and model.hf_text_config.model_type
+                            in ("glm5_next_text", "glm5_next")
+                        )
+                    )
                     and not self.speculative_config.uses_dynamic_speculative_decoding()
                 )
             )
             and parallel.pipeline_parallel_size == 1
             and parallel.data_parallel_size == 1
-            and parallel.decode_context_parallel_size == 1
+            and (
+                parallel.decode_context_parallel_size == 1
+                or model.hf_text_config.model_type in ("glm5_next_text", "glm5_next")
+            )
             and parallel.prefill_context_parallel_size == 1
             and self.kv_transfer_config is None
             and cache.kv_offloading_size is None

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -726,12 +726,23 @@ class KVCacheManager:
             ):
                 blocks = [0] * (count - 1)
             else:
-                blocks = [
+                # A sliding-window group can legitimately evict its leading
+                # pages. Retain the window required to replay the final row,
+                # and reject holes only inside that reachable range.
+                skipped = min(
+                    manager.get_num_skipped_tokens(num_tokens - 1)
+                    // manager.block_size,
+                    count - 1,
+                )
+                tail = [
                     block.block_id
-                    for block in manager.req_to_blocks[request.request_id][: count - 1]
+                    for block in manager.req_to_blocks[request.request_id][
+                        skipped : count - 1
+                    ]
                 ]
-                if len(blocks) != count - 1 or 0 in blocks:
+                if len(tail) != count - 1 - skipped or 0 in tail:
                     return None
+                blocks = [0] * skipped + tail
             blocks.append(allocation[slot][group_id])
             grouped_blocks.append(tuple(blocks))
         checkpoint = BoundaryCheckpoint(

--- a/vllm/v1/worker/gpu/boundary_checkpoint.py
+++ b/vllm/v1/worker/gpu/boundary_checkpoint.py
@@ -227,6 +227,7 @@ def _copy_attention_tails_kernel(
     block_table_ptrs,
     table_strides_ptr,
     kernel_block_sizes_ptr,
+    group_cp_sizes_ptr,
     NUM_GROUPS: tl.constexpr,
     BLOCK: tl.constexpr,
     TILES: tl.constexpr,
@@ -245,12 +246,15 @@ def _copy_attention_tails_kernel(
     group = tl.load(storage_metadata_ptr + storage * 4 + 2)
     block_size = tl.load(storage_metadata_ptr + storage * 4 + 3)
     kernel_block_size = tl.load(kernel_block_sizes_ptr + group)
+    cp_size = tl.load(group_cp_sizes_ptr + group)
     table_stride = tl.load(table_strides_ptr + group)
     table = tl.load(block_table_ptrs + group).to(tl.pointer_type(tl.int32))
-    source_block = tl.load(
-        table + slot * table_stride + (count - 1) // kernel_block_size
-    )
-    source_block //= block_size // kernel_block_size
+    # A DCP page covers cp_size times as many global tokens as local tokens.
+    # Every rank snapshots its own allocation of that same virtual page.
+    blocks_per_page = block_size // kernel_block_size
+    page_index = (count - 1) // (block_size * cp_size)
+    source_block = tl.load(table + slot * table_stride + page_index * blocks_per_page)
+    source_block //= blocks_per_page
     destination_block = tl.load(
         destination_blocks_ptr + (slot * NUM_CAPTURES + kind) * (NUM_GROUPS + 1) + group
     )
@@ -590,14 +594,16 @@ class BoundaryCheckpointState:
         token: int | None = None,
         num_speculative_tokens: int = 1,
     ) -> torch.Tensor:
-        """Rebuild the lookahead-dependent draft row using its saved target hidden."""
+        """Prepare the first proposal after restoring a committed target prefix."""
         from vllm.config.compilation import CUDAGraphMode
         from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
         from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+        from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
         from vllm.v1.worker.workspace import use_workspace_lane
 
         speculator = runner.speculator
         assert speculator is not None and runner.sampler is not None
+        is_dflash = isinstance(speculator, DFlashSpeculator)
         slot = runner.req_states.req_id_to_index[req_id]
         batch = InputBatch.make_dummy(1, 1, InputBuffers(1, 1, self.device))
         batch.req_ids = [req_id]
@@ -619,20 +625,28 @@ class BoundaryCheckpointState:
         zeros = torch.zeros_like(ones)
         try:
             tables, slots = runner.prepare_attn(batch)
-            metadata = runner.model_state.prepare_attn(
-                batch,
-                CUDAGraphMode.NONE,
-                tables,
-                slots,
-                speculator.attn_groups,
-                runner.kv_cache_config,
+            metadata = (
+                None
+                if is_dflash
+                else runner.model_state.prepare_attn(
+                    batch,
+                    CUDAGraphMode.NONE,
+                    tables,
+                    slots,
+                    speculator.attn_groups,
+                    runner.kv_cache_config,
+                )
             )
+            # DFlash's restored prefix already contains context KV through
+            # count. Re-inserting row count-1 would mutate a shared full page;
+            # only the bonus-and-mask query block is needed for the proposal.
+            replay_kwargs = {"context_kv_is_restored": True} if is_dflash else {}
             with use_workspace_lane(runner._draft_workspace_lane):
                 return speculator.propose(
                     batch,
                     metadata,
                     build_slot_mappings_by_layer(slots, runner.kv_cache_config),
-                    self.get_hidden_states(block_id, draft=True),
+                    self.get_hidden_states(block_id, draft=not is_dflash),
                     None,
                     ones,
                     zeros,
@@ -641,7 +655,10 @@ class BoundaryCheckpointState:
                     runner.sampler.sampling_states.temperature.gpu,
                     runner.sampler.sampling_states.seeds.gpu,
                     num_speculative_tokens=num_speculative_tokens,
-                    is_profile=True,
+                    # DFlash uses its ordinary fixed-size query block; its
+                    # graph reads the persistent buffers prepared by propose.
+                    is_profile=not is_dflash,
+                    **replay_kwargs,
                 )
         finally:
             self.set_draft_replay_anchor(slot, count, 1)
@@ -666,6 +683,7 @@ class BoundaryCheckpointState:
             block_tables.block_table_ptrs,
             block_tables.block_table_strides,
             block_tables.kernel_block_sizes_tensor,
+            block_tables.group_cp_sizes,
             NUM_GROUPS=self.num_groups,
             BLOCK=4096,
             TILES=16,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -145,6 +145,7 @@ from vllm.v1.worker.gpu.spec_decode.adaptive_verification import (
     AdaptiveVerificationManager,
     maybe_create_adaptive_verification_manager,
 )
+from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
 from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
     set_eagle3_aux_hidden_state_layers,
 )
@@ -1582,6 +1583,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if (
                 self.boundary_checkpoint_state is not None
                 and self.speculator is not None
+                and not isinstance(self.speculator, DFlashSpeculator)
             ):
                 for new_req in scheduler_output.scheduled_new_reqs:
                     checkpoint = new_req.boundary_checkpoint
@@ -2038,7 +2040,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if boundary_state is not None:
             assert boundary_capture is not None
             spec_hidden = None
-            if self.speculator is not None:
+            if self.speculator is not None and not isinstance(
+                self.speculator, DFlashSpeculator
+            ):
                 spec_hidden = hidden_states
                 if hasattr(self.model, "get_mtp_target_hidden_states"):
                     spec_hidden = self.model.get_mtp_target_hidden_states()

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -371,6 +371,7 @@ class DFlashSpeculator(DraftModelSpeculator):
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
+        context_kv_is_restored: bool = False,
     ) -> torch.Tensor:
         del num_speculative_tokens
         num_reqs = input_batch.num_reqs
@@ -385,13 +386,16 @@ class DFlashSpeculator(DraftModelSpeculator):
         # number of rejected tokens, we maintain the size of input_ids and
         # hidden_states the same as the target model's. This means, we pad each
         # request's query length to include any rejected positions.
-        if aux_hidden_states:
-            hidden_states = self.model.combine_hidden_states(
-                torch.cat(aux_hidden_states, dim=-1)
+        if not context_kv_is_restored:
+            if aux_hidden_states:
+                hidden_states = self.model.combine_hidden_states(
+                    torch.cat(aux_hidden_states, dim=-1)
+                )
+            else:
+                hidden_states = last_hidden_states
+            self.hidden_states[:num_target_tokens].copy_(
+                hidden_states[:num_target_tokens]
             )
-        else:
-            hidden_states = last_hidden_states
-        self.hidden_states[:num_target_tokens].copy_(hidden_states[:num_target_tokens])
 
         if dummy_run and skip_attn_for_dummy_run:
             # Memory profiling path: block_tables / kv_cache_config are not initialized.
@@ -466,11 +470,12 @@ class DFlashSpeculator(DraftModelSpeculator):
             ]
         else:
             context_slots = self._context_slot_mappings[0][:num_target_tokens]
-        self.model.precompute_and_store_context_kv(
-            self.hidden_states[:num_target_tokens],
-            self.context_positions[:num_target_tokens],
-            context_slots,
-        )
+        if not context_kv_is_restored:
+            self.model.precompute_and_store_context_kv(
+                self.hidden_states[:num_target_tokens],
+                self.context_positions[:num_target_tokens],
+                context_slots,
+            )
 
         # Every DFlash step has exactly num_query_per_req tokens, so we can use FULL CGs
         batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(


### PR DESCRIPTION
## Purpose

Enable GLM-5.3-Flash semantic recurrent checkpoints with static DFlash2 and
decode context parallelism. Shared leading instructions, completed prompts,
and committed response endpoints can be reused without retaining a recurrent
state every 256 tokens.

## Restore contract

- Attention snapshots use each cache group's context-parallel geometry.
  Target pages are sharded under DCP; DFlash draft pages remain replicated.
- DFlash restores its projected context KV and generates the first proposal
  through its ordinary query graph. It must not rewrite the last context row
  into an immutable shared page.
- Evicted draft pages are allowed only before the sliding window required by
  the checkpoint. A hole inside that window invalidates the checkpoint.
- The existing collective worker wait completes all rank-local copies before
  the scheduler publishes the checkpoint. No additional handshake is introduced.

External KV connectors, dynamic speculation, and unsupported parallel layouts
continue to select aligned retention. This PR does not implement semantic
checkpoint persistence in LMCache or change physical serving-page defaults.

## Dependencies and scope

The serving qualification stack includes #674 for scalar-safe recurrent
restoration and #664 for isolated logits-only scheduler steps. It also includes
#676, which fixes partial physical attention-page lookup independently.

This does not duplicate those changes: it supplies the missing DCP address
mapping and DFlash context/window restore contract. Open-PR searches in this
fork and upstream found no equivalent request-boundary implementation.

## Validation

Status: implemented; GPU-resident cache correctness is qualified for the
configurations below. Matched release-performance qualification is in progress.

Four RTX PRO 6000 Blackwell Workstation Edition GPUs, TP4, stock clocks,
4,096-token scheduler budget, 2,048-token target/recurrent pages, and full plus
piecewise CUDA graphs:

- 42 CUDA attention snapshot cases cover DCP1/2/4, replicated draft groups,
  logical page edges, exact copied bytes, and untouched neighboring pages.
- 18 CUDA scalar-restore cases pass with #674.
- 260 scheduler/prefix-cache/DFlash CPU cases, 128 prefix-manager cases, and
  12 partial-attention-rewind cases pass.
- DFlash2/DCP1 and DFlash2/DCP4 with NVFP4 target KV restore all 8,191,
  8,192, 8,193, and 32,768 prompt tokens and preserve all 256 greedy output
  token IDs. Response continuations match independent cold controls.
- MTP3/DCP4 passes the exact, instruction, response, and eight-conversation
  matrix. Five seeded 4,096-token coding requests show no acceptance collapse
  after restoration: median accepted draft tokens/step is 2.095 cold and
  2.157 restored; verifier throughput is 92.32 and 92.45 steps/s.
- No-speculation/DCP4 with FP8 target KV passes 32 packaged-image scenarios,
  including actual assistant/user continuation, tool history, and divergent
  instructions. The assistant continuation restores 11,385 tokens; the tool
  history replays all 11,520 prompt tokens.
- DFlash2/DCP4 with NVFP4 target KV passes the same 32-scenario packaged-image
  matrix, including the first restored proposal through the query CUDA graph.
- 18 CPU configuration cases verify automatic GLM no-spec/MTP/DFlash boundary
  selection under DCP1/2/4 and fail-closed external-cache selection. The complete
  prefix-primitive test file passes all 46 cases.
- `llama-benchy` 0.4.0 at depth 8,192 passes coherence and prefix reuse with
  DFlash2/DCP1, DFlash2/DCP4, and MTP3/DCP4.

Representative reproduction commands, in a built vLLM environment:

```bash
uv run .venv/bin/python -m pytest -q \
  tests/v1/worker/test_boundary_checkpoint_attention.py \
  tests/v1/spec_decode/test_dflash_dcp.py \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py

uvx llama-benchy --base-url http://127.0.0.1:5051/v1 \
  --model GLM-5.3-Flash-NVFP4 --depth 8192 --enable-prefix-caching --runs 3
```

Serving probes use `/v1/completions` with token-ID prompts, `temperature=0`,
`max_tokens=256`, `ignore_eos=true`, `return_token_ids=true`, and an unchanged
`cache_salt`. Each exact prompt is sent three times. The two replays must report
the entire prompt as cached and return the same output token IDs as the first
request. Appended-response probes are compared with separately salted cold
controls. Chat probes check literal record values through instruction branches,
assistant continuations, and tool histories.

Matched release-performance and external-cache qualification remain required
before recommending the image for deployment. The stochastic acceptance medians
above are not a speedup claim.

AI assistance was used for implementation, review, and validation. Human
maintainer review is required before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for DFlash speculative decoding with GLM5 models.
  - Enabled decode context parallelism across multiple workers for GLM5.
  - Improved reuse of request-boundary checkpoints across distributed configurations.

- **Bug Fixes**
  - Improved checkpoint handling for sliding-window attention after pages are evicted.
  - Preserved correct context and attention state reuse during DFlash decoding.
  - Improved isolation when reusing partial checkpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->