### PR TITLE
fix(recurrent cache): admit exact checkpoint hits during active decode

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -29,6 +29,7 @@ from vllm.v1.core.boundary_checkpoint import BoundaryCheckpointCache
 from vllm.v1.core.encoder_cache_manager import EncoderCacheManager
 from vllm.v1.core.kv_cache_coordinator import HybridKVCacheCoordinator
 from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
+from vllm.v1.core.sched.interface import PauseState
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.core.single_type_kv_cache_manager import register_all_kvcache_specs
@@ -85,6 +86,68 @@ def test_full_boundary_hit_preserves_async_speculative_decode_token_count():
     decode_step = scheduler.schedule()
     assert not decode_step.boundary_logits_only
     assert decode_step.num_scheduled_tokens == {"repeat": 4}
+
+
+@pytest.mark.parametrize("admission_blocker", [None, "capacity", "allocation", "pause"])
+def test_full_boundary_hit_is_admitted_while_another_request_decodes(
+    admission_blocker, monkeypatch
+):
+    """A saved-logits hit needs one isolated step, not an empty running queue."""
+    scheduler = create_scheduler(
+        enable_prefix_caching=True,
+        use_v2_model_runner=True,
+        async_scheduling=True,
+        num_speculative_tokens=3,
+        speculative_method="ngram_gpu",
+    )
+    manager = scheduler.kv_cache_manager
+    manager.boundary_checkpoints = BoundaryCheckpointCache(manager.block_pool)
+    producer, first, second = create_requests(
+        num_requests=3,
+        num_tokens=32,
+        same_prompt=True,
+        req_ids=["producer", "first", "second"],
+    )
+    manager.get_computed_blocks(producer)
+    assert manager.allocate_slots(producer, 32) is not None
+    manager.publish_boundary_checkpoint(producer, 32, kind="prompt")
+    manager.free(producer)
+    scheduler.add_request(first)
+    assert scheduler.schedule().boundary_logits_only
+    scheduler.add_request(second)
+
+    discovery_step = scheduler.schedule()
+    assert discovery_step.num_scheduled_tokens == {"first": 4}
+    assert second.boundary_checkpoint is not None
+    if admission_blocker is not None:
+        with monkeypatch.context() as patch:
+            if admission_blocker == "capacity":
+                patch.setattr(scheduler, "max_num_running_reqs", 1)
+            elif admission_blocker == "allocation":
+                allocate = manager.allocate_slots
+
+                def allocate_without_waiter(request, *args, **kwargs):
+                    if request is second:
+                        return None
+                    return allocate(request, *args, **kwargs)
+
+                patch.setattr(manager, "allocate_slots", allocate_without_waiter)
+            else:
+                scheduler.set_pause_state(PauseState.PAUSED_NEW)
+            blocked_step = scheduler.schedule()
+            assert not blocked_step.boundary_logits_only
+            assert blocked_step.num_scheduled_tokens == {"first": 4}
+            assert second.status == RequestStatus.WAITING
+        scheduler.set_pause_state(PauseState.UNPAUSED)
+    admission_step = scheduler.schedule()
+    assert admission_step.boundary_logits_only
+    assert admission_step.num_scheduled_tokens == {"second": 1}
+    assert first in scheduler.running and second in scheduler.running
+    assert second.num_computed_tokens == 32
+    assert second.num_output_placeholders == 1
+    decode_step = scheduler.schedule()
+    assert not decode_step.boundary_logits_only
+    assert decode_step.num_scheduled_tokens == {"first": 4, "second": 4}
 
 
 def test_make_scheduled_encoder_input_stats_output_embeddings():

--- a/tests/v1/worker/test_gpu_input_batch_v2.py
+++ b/tests/v1/worker/test_gpu_input_batch_v2.py
@@ -24,7 +24,10 @@ DEVICE = current_platform.device_type
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_boundary_auxiliary_restore_survives_slot_reuse_and_virtual_attention_pages():
+@pytest.mark.parametrize("restore_slot", [0, 1])
+def test_boundary_auxiliary_restore_survives_slot_reuse_and_virtual_attention_pages(
+    restore_slot: int,
+):
     """Raw selector state, saved hidden states and attention tails form one bundle."""
     device = torch.device("cuda")
     raw_state = torch.arange(6, dtype=torch.float32, device=device).reshape(2, 3)
@@ -124,13 +127,13 @@ def test_boundary_auxiliary_restore_survives_slot_reuse_and_virtual_attention_pa
         boundary_checkpoint=BoundaryCheckpoint(1, 7, ((6,),), (10,)),
         boundary_checkpoint_blocks=((12, 13), (14, 15)),
     )
-    state.add_request(0, request)
-    torch.testing.assert_close(raw_state[0], expected_state)
-    assert anchors[0].item() == 6
-    assert accepted[0].item() == 1
+    state.add_request(restore_slot, request)
+    torch.testing.assert_close(raw_state[restore_slot], expected_state)
+    assert anchors[restore_slot].item() == 6
+    assert accepted[restore_slot].item() == 1
     torch.testing.assert_close(state.get_hidden_states(10), hidden[:1])
     torch.testing.assert_close(state.get_hidden_states(10, draft=True), spec_hidden[:1])
-    torch.testing.assert_close(draft_state[0], expected_draft)
+    torch.testing.assert_close(draft_state[restore_slot], expected_draft)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -603,7 +603,7 @@ class Scheduler(SchedulerInterface):
             if self.mamba_partial_cache_hit
             else 0
         )
-        stops = (
+        stops: tuple[int, ...] = (
             # Same invariant: a chunk starting mid-block stops at the boundary
             # rather than running past it.
             next_block_boundary if start % block_size != 0 else 0,
@@ -719,6 +719,28 @@ class Scheduler(SchedulerInterface):
     def num_active_local_partial_prefills(self) -> int:
         """Count model-compute partials, excluding async KV-only restores."""
         return sum(request.is_prefill_chunk for request in self.running)
+
+    def _has_waiting_boundary_logits(self) -> bool:
+        """Whether the queue head needs an isolated saved-logits step."""
+        if (
+            not (self.waiting or self.skipped_waiting)
+            or self._pause_state != PauseState.UNPAUSED
+            or len(self.running) + self.num_waiting_for_streaming_input
+            >= self.max_num_running_reqs
+        ):
+            return False
+        queue = self._select_waiting_queue_for_scheduling()
+        if queue is None:
+            return False
+        request = queue.peek_request()
+        checkpoint = request.boundary_checkpoint
+        return (
+            request.status in (RequestStatus.WAITING, RequestStatus.PREEMPTED)
+            and request.num_computed_tokens == 0
+            and checkpoint is not None
+            and checkpoint.num_tokens == request.num_tokens
+            and (request.num_stale_output_tokens == 0 or request.drop_stale_output)
+        )
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         self.current_step += 1
@@ -1175,7 +1197,12 @@ class Scheduler(SchedulerInterface):
             if micro_mixed_step
             else ("prefill" if adaptive_prefill_turn else None)
         )
-        schedule_running_requests(initial_service_class)
+        # A full recurrent-cache hit cannot share a model step with forwards.
+        # Its cache lookup in the waiting pass records that requirement. Give
+        # it an isolated admission step instead of waiting for decodes to end.
+        reserve_boundary_logits_step = self._has_waiting_boundary_logits()
+        if not reserve_boundary_logits_step:
+            schedule_running_requests(initial_service_class)
 
         # Record the LoRAs in scheduled_running_reqs
         scheduled_loras: set[int] = set()
@@ -1678,6 +1705,11 @@ class Scheduler(SchedulerInterface):
             # record whether it was capacity-bound.
             if not defer_prefills:
                 self.prefill_capacity_bound = bool(self.waiting)
+
+        if reserve_boundary_logits_step and not num_scheduled_tokens:
+            # Cache eviction, admission limits, or deferred input can prevent
+            # the isolated step. Running requests must still make progress.
+            schedule_running_requests(initial_service_class)
 
         # In a micro-sliced mixed step, waiting admission gets the first
         # prefill quantum after decodes. Any unused portion is immediately


### PR DESCRIPTION
## Behavior and contract

Admit an exact recurrent checkpoint hit even while other requests are decoding.
The restored hidden state needs one isolated logits-only step; resident decodes
remain allocated and resume together with the admitted request on the following
step. Running-first scheduling otherwise makes the cached request wait until
all resident decodes finish.

Reserve that step only for a known complete checkpoint at the waiting queue
head. Capacity limits and admission pauses retain their existing behavior.
If allocation or admission cannot progress, schedule resident requests instead
of leaving the device idle. Partial checkpoint hits use the ordinary path.

The public boundary-state test also covers request slots zero and one, including
selector state, saved hidden states, draft state and partial attention pages.
The scalar-safe restore implementation comes from #674 by @logprobz; it is not
duplicated here. Merge #674 as well to run the slot-one integration case.

## Validation

Status: **qualified** for the scheduler invariant and composed serving cases
below, not a general language-model quality certification.

- The minimal scheduler test fails without the admission change. The fixed
  suite passes 199 scheduler, fairness and micro-slicing cases, including full
  capacity, allocation failure and admission pause controls.
- Seven boundary/input-state GPU tests pass with scalar-safe restoration.
- In a composed Qwen3.8-Flash-Next-NVFP4 MTP3 server, cold and exact-checkpoint
  batches at C1, C2, C3, C4, C8 and C16 return the required JSON on TP1 and TP2.
  Scheduler gauges reach each requested concurrency. All requests use
  temperature 1, top-p .95 and top-k 20. V2 FULL_AND_PIECEWISE remains enabled.
- A 32,768-token prefill followed by C3/C4/C8/C16 cold and restored batches
  also passes. These serving checks include the separate padded-QSA fix in
  #658; they are composition results, not an isolated speedup claim.

Reproduce in a built CUDA vLLM environment:

```bash
uv run .venv/bin/python -m pytest -q \
  tests/v1/core/test_scheduler.py \
  tests/v1/core/test_prefill_compute_share_scheduler.py \
  tests/v1/core/test_micro_slicing.py
uv run .venv/bin/python -m pytest -q \
  tests/v1/worker/test_gpu_input_batch_v2.py -k boundary
```

## Scope and review

Targets `dev/jovian-judgement`. #664 controls prefill compute sharing and keeps
logits-only steps isolated; it does not admit a waiting full checkpoint while
running requests continually consume the scheduling step. Searches in this fork
and upstream found no equivalent cached-waiter admission fix. #674 supplies the
independent scalar-restore fix. #682 adds GLM DCP/DFlash restore geometry.

AI assistance was used for implementation, inspection and tests. Human
maintainer review is required before merge. The assembly and evidence are
tracked in #662.
