### PR TITLE
Fix malformed historical tool-call recovery

### DIFF
--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -16,6 +16,7 @@ from openai.types.responses.response_reasoning_item import (
     Summary,
 )
 
+from vllm.entrypoints.chat_utils import _postprocess_messages
 from vllm.entrypoints.openai.responses.utils import (
     _construct_message_from_response_item,
     construct_chat_messages_with_tool_call,
@@ -173,6 +174,34 @@ class TestResponsesUtils:
         assert (
             message["tool_calls"][0]["function"]["arguments"] == '{"code": "123+456"}'
         )
+
+    def test_malformed_function_call_history_reaches_chat_template_safely(self):
+        raw_arguments = '{"value": '
+        items = [
+            make_function_call(
+                call_id="call_incomplete",
+                name="diagnostic_noop",
+                arguments=raw_arguments,
+            ),
+            make_function_call_output(
+                call_id="call_incomplete",
+                output="The tool was not executed because its arguments were invalid.",
+            ),
+            {"role": "user", "content": "Continue."},
+        ]
+
+        messages = construct_chat_messages_with_tool_call(items)
+        _postprocess_messages(messages)
+
+        assert messages[0]["tool_calls"][0]["function"]["arguments"] == {
+            "__vllm_malformed_json__": raw_arguments
+        }
+        assert messages[1] == {
+            "role": "tool",
+            "content": "The tool was not executed because its arguments were invalid.",
+            "tool_call_id": "call_incomplete",
+        }
+        assert messages[2] == {"role": "user", "content": "Continue."}
 
     def test_construct_chat_messages_preserves_single_item_conversions(self):
         item = ResponseReasoningItem(

--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -2742,3 +2742,31 @@ def test_postprocess_messages_null_arguments_string():
     tool_calls = messages[0]["tool_calls"]
     assert tool_calls is not None
     assert tool_calls[0]["function"]["arguments"] == {}
+
+
+def test_postprocess_messages_recovers_malformed_tool_arguments():
+    raw_arguments = '{"value": '
+    messages: list[ConversationMessage] = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_incomplete",
+                    "type": "function",
+                    "function": {
+                        "name": "diagnostic_noop",
+                        "arguments": raw_arguments,
+                    },
+                }
+            ],
+        }
+    ]
+
+    _postprocess_messages(messages)
+
+    tool_calls = messages[0]["tool_calls"]
+    assert tool_calls is not None
+    assert tool_calls[0]["function"]["arguments"] == {
+        "__vllm_malformed_json__": raw_arguments
+    }

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1851,11 +1851,17 @@ def _postprocess_messages(messages: list[ConversationMessage]) -> None:
                         parameter="tool_calls",
                     )
 
-                # if arguments is None or empty string, set to {}
+                # Keep the existing zero-argument compatibility for None, empty,
+                # and JSON null. Preserve malformed non-empty history in a valid
+                # object so chat templates can render a failed call for recovery.
                 if content := function.get("arguments"):
                     if not isinstance(content, (dict, list)):
-                        parsed = json.loads(content)
-                        function["arguments"] = parsed if parsed is not None else {}
+                        try:
+                            parsed = json.loads(content)
+                        except json.JSONDecodeError:
+                            function["arguments"] = {"__vllm_malformed_json__": content}
+                        else:
+                            function["arguments"] = parsed if parsed is not None else {}
                 else:
                     function["arguments"] = {}
 


### PR DESCRIPTION
## Summary

- recover non-empty malformed historical tool-call arguments as an explicit valid, non-executable record
- preserve the exact raw arguments, call ID, matching tool output, and later conversation turns
- keep valid JSON and existing empty/`null` behavior unchanged
- avoid logging raw argument content
- cover the shared Chat Completions path and Responses history conversion

Closes #684.

Related upstream issue: https://github.com/vllm-project/vllm/issues/43995

## Why this is not duplicate work

Upstream vLLM has since merged https://github.com/vllm-project/vllm/pull/48922, which recovers malformed history by replacing unusable arguments with `{}`. The local-inference-lab `main` targeted here predates that fix and still has the unguarded `json.loads()`, so the integration is still required in this repository.

This focused local fix retains the complete raw historical value inside a namespaced sentinel mapping rather than silently discarding it. It handles incomplete and otherwise invalid JSON without guessing or repairing it, while still giving chat templates the mapping type they require.

## Behavior

An invalid historical string such as:

```json
{"value":
```

is passed to the chat template as a single explicit sentinel mapping:

```json
{"__vllm_malformed_json__": "{\"value\":"}
```

This normalization occurs only while rendering supplied history. It does not execute a tool, synthesize missing JSON, or change valid calls.

## Tests

Passed:

```text
.venv/bin/python -m pytest tests/entrypoints/unit_tests/test_chat_utils.py -k postprocess_messages
2 passed

.venv/bin/python -m pytest tests/entrypoints/openai/responses/test_responses_utils.py -k 'malformed_function_call_history or construct_chat_messages_with_tool_call'
2 passed

uvx ruff format <changed files>
uvx ruff check <changed files>
All checks passed
```

Compatibility checks on the exact R27 source/image lineage:

- Unpatched `/v1/responses` reproduced HTTP 400 for malformed history; valid-history and clean-history controls returned HTTP 200.
- The unpatched GLM-5.3-Flash template path reproduced the same `JSONDecodeError` in `_postprocess_messages()`.
- With this patch, the exact GLM tokenizer/chat template rendered the recovery record, tool output, and continuation successfully.
- The R27-compatible copy of the three shared preprocessing tests passed 3/3.

No model weights, kernels, scheduling, or generation logic are changed. A patched live GPU endpoint test is still pending because the serving node was not interrupted for this frontend-only change.

## AI assistance disclosure

OpenAI Codex was used for incident analysis, implementation, and test execution. The commit records this with an `Assisted-by` trailer. This should receive normal human line-by-line review before merge.
