### PR TITLE
[Backport][Responses] Handle additional_tools input items

### DIFF
--- a/tests/entrypoints/openai/responses/test_function_call_parsing.py
+++ b/tests/entrypoints/openai/responses/test_function_call_parsing.py
@@ -6,8 +6,97 @@ import json
 
 import pytest
 from openai.types.responses import ResponseFunctionToolCall, ResponseOutputMessage
+from openai.types.responses.response_item import AdditionalTools
 
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+
+def make_function_tool(name: str) -> dict:
+    return {
+        "type": "function",
+        "name": name,
+        "description": f"Call {name}.",
+        "parameters": {
+            "type": "object",
+            "properties": {},
+        },
+    }
+
+
+def test_additional_tools_are_promoted_out_of_input():
+    """Additional tools configure the request and are not chat messages."""
+    request = ResponsesRequest(
+        model="gpt-oss",
+        input=[
+            {
+                "id": "at_123",
+                "type": "additional_tools",
+                "role": "developer",
+                "tools": [make_function_tool("exec")],
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Run pwd"}],
+            },
+        ],
+        tool_choice="required",
+    )
+
+    assert len(request.input) == 1
+    assert request.input[0]["type"] == "message"
+    assert [tool.name for tool in request.tools] == ["exec"]
+    assert request.tool_choice == "required"
+
+
+def test_additional_tools_extend_top_level_tools_in_input_order():
+    request = ResponsesRequest(
+        model="gpt-oss",
+        tools=[make_function_tool("top_level")],
+        input=[
+            {
+                "id": "at_123",
+                "type": "additional_tools",
+                "role": "developer",
+                "tools": [make_function_tool("first_additional")],
+            },
+            {
+                "id": "at_456",
+                "type": "additional_tools",
+                "role": "developer",
+                "tools": [make_function_tool("second_additional")],
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Hello"}],
+            },
+        ],
+    )
+
+    assert len(request.input) == 1
+    assert [tool.name for tool in request.tools] == [
+        "top_level",
+        "first_additional",
+        "second_additional",
+    ]
+
+
+def test_typed_additional_tools_are_promoted():
+    additional_tools = AdditionalTools(
+        id="at_123",
+        type="additional_tools",
+        role="developer",
+        tools=[make_function_tool("exec")],
+    )
+
+    request = ResponsesRequest(
+        model="gpt-oss",
+        input=[additional_tools, {"role": "user", "content": "Run pwd"}],
+    )
+
+    assert len(request.input) == 1
+    assert [tool.name for tool in request.tools] == ["exec"]
 
 
 def test_function_call_dict_converted_to_object():

--- a/tests/entrypoints/openai/responses/test_function_call_parsing.py
+++ b/tests/entrypoints/openai/responses/test_function_call_parsing.py
@@ -12,6 +12,7 @@ from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 
 def make_function_tool(name: str) -> dict:
+    """Build a minimal Responses function tool."""
     return {
         "type": "function",
         "name": name,
@@ -50,6 +51,7 @@ def test_additional_tools_are_promoted_out_of_input():
 
 
 def test_additional_tools_extend_top_level_tools_in_input_order():
+    """Additional tools follow top-level tools and preserve input order."""
     request = ResponsesRequest(
         model="gpt-oss",
         tools=[make_function_tool("top_level")],
@@ -82,7 +84,8 @@ def test_additional_tools_extend_top_level_tools_in_input_order():
     ]
 
 
-def test_typed_additional_tools_are_promoted():
+def test_typed_additional_tools_in_tuple_are_promoted():
+    """Typed additional tools are promoted from non-list iterables."""
     additional_tools = AdditionalTools(
         id="at_123",
         type="additional_tools",
@@ -90,10 +93,11 @@ def test_typed_additional_tools_are_promoted():
         tools=[make_function_tool("exec")],
     )
 
-    request = ResponsesRequest(
-        model="gpt-oss",
-        input=[additional_tools, {"role": "user", "content": "Run pwd"}],
-    )
+    request_data = {
+        "model": "gpt-oss",
+        "input": (additional_tools, {"role": "user", "content": "Run pwd"}),
+    }
+    request = ResponsesRequest(**request_data)
 
     assert len(request.input) == 1
     assert [tool.name for tool in request.tools] == ["exec"]

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -593,10 +593,18 @@ class ResponsesRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def check_tool_usage(cls, data):
+        """Promote input tools and validate tool choice against effective tools."""
         if not isinstance(data, dict):
             return data
 
         input_data = data.get("input")
+        if input_data is not None and not isinstance(input_data, (list, str, bytes)):
+            try:
+                input_data = list(input_data)
+            except TypeError:
+                pass
+            else:
+                data["input"] = input_data
         if isinstance(input_data, list):
             input_items = []
             additional_tools = []

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -42,6 +42,7 @@ from openai.types.responses import (
     ResponseInProgressEvent as OpenAIResponseInProgressEvent,
 )
 from openai.types.responses.response import IncompleteDetails, ToolChoice
+from openai.types.responses.response_item import AdditionalTools
 from openai.types.responses.response_reasoning_item import (
     Content as ResponseReasoningTextContent,
 )
@@ -594,6 +595,25 @@ class ResponsesRequest(OpenAIBaseModel):
     def check_tool_usage(cls, data):
         if not isinstance(data, dict):
             return data
+
+        input_data = data.get("input")
+        if isinstance(input_data, list):
+            input_items = []
+            additional_tools = []
+            for item in input_data:
+                if isinstance(item, AdditionalTools):
+                    additional_tools.extend(item.tools)
+                elif isinstance(item, dict) and item.get("type") == "additional_tools":
+                    try:
+                        additional_tools.extend(AdditionalTools(**item).tools)
+                    except ValidationError:
+                        input_items.append(item)
+                else:
+                    input_items.append(item)
+
+            if len(input_items) != len(input_data):
+                data["input"] = input_items
+                data["tools"] = [*(data.get("tools") or []), *additional_tools]
 
         tools = data.get("tools")
         tool_choice = data.get("tool_choice", "auto")


### PR DESCRIPTION
## Purpose

Backport vllm-project/vllm#55662 to the active
`dev/jovian-judgement` hardware branch so local GLM and other Codex deployments
can use native Responses `additional_tools` handling before the upstream change
is merged and synchronized.

The root cause and reproducer are documented in vllm-project/vllm#55659.

The change treats `additional_tools` input items as structural request
configuration: it appends their definitions to the effective tool list and
removes the items from conversation input before chat or Harmony rendering.

## Why this is not a duplicate

- No open local-inference-lab/vllm PR mentions `additional_tools`.
- vllm-project/vllm#55662 targets upstream `main`; it does not flow into the
  divergent `dev/jovian-judgement` hardware branch until a future sync.
- The backport contains only the two-file upstream change, with no unrelated
  upstream commits.

## Test Plan

Run the focused Responses request-parsing and message-construction tests and
all pre-commit hooks applicable to the changed files.

No model evaluation is needed because this only normalizes request protocol
data; it does not change model execution or output algorithms.

## Test Result

```text
PYTHONPATH=. /tmp/vllm-additional-tools/.venv/bin/python -m pytest \
  --confcutdir=tests/entrypoints/openai/responses \
  tests/entrypoints/openai/responses/test_function_call_parsing.py \
  tests/entrypoints/openai/responses/test_responses_utils.py -q

57 passed, 15 warnings in 0.07s
```

`--confcutdir` bypasses this older branch's unrelated global cleanup fixture,
which segfaults on macOS in `torch.accelerator.memory.empty_host_cache()` after
the first test. The first regression assertion passed before that teardown;
the isolated run completed all 57 tests.

```text
/tmp/vllm-additional-tools/.venv/bin/pre-commit run --files \
  vllm/entrypoints/openai/responses/protocol.py \
  tests/entrypoints/openai/responses/test_function_call_parsing.py

All hooks passed.
```

The minimal request was also exercised directly against the patched request
and message constructors. It produced one user chat message and an effective
tool list containing `exec`.

## AI assistance

This backport was prepared with OpenAI Codex assistance. The human submitter
reviewed and approved the identical upstream change before submission and
understands the request-normalization behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Responses requests now correctly promote valid additional tools from the input list into the top-level tools list.
  - Additional tools are merged in input order while preserving existing tool selections.
  - Invalid additional-tool entries remain available for standard validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->