### PR TITLE
Kimi KDA: preserve stateless first-token prefill classification backport

### DIFF
--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -222,6 +222,59 @@ def test_non_spec_one_token_state_classification(
         assert actual.has_initial_state is None
 
 
+def test_non_spec_mixed_batch_masks_only_stateless_first_token():
+    batch = BatchSpec(seq_lens=[100, 50, 1], query_lens=[1, 1, 1])
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, DEVICE
+    ).replace(is_prefilling=torch.tensor([False, False, True]))
+    actual = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=0,
+        full_cuda_graph=False,
+    ).build(0, common_attn_metadata)
+
+    assert actual.num_decodes == 2
+    assert actual.num_decode_tokens == 2
+    assert actual.num_prefills == 1
+    assert actual.num_prefill_tokens == 1
+    assert actual.has_initial_state is not None
+    assert actual.has_initial_state.tolist() == [True, True, False]
+
+
+def test_non_spec_without_prefill_flags_keeps_decode_classification():
+    common_attn_metadata = create_common_attn_metadata(
+        BatchSpec(seq_lens=[100, 50, 1], query_lens=[1, 1, 1]),
+        BLOCK_SIZE,
+        DEVICE,
+    )
+    assert common_attn_metadata.is_prefilling is None
+    actual = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=0,
+        full_cuda_graph=False,
+    ).build(0, common_attn_metadata)
+
+    assert actual.num_decodes == 3
+    assert actual.num_prefills == 0
+    assert actual.has_initial_state is None
+
+
+def test_non_spec_zero_length_padding_is_not_promoted_to_prefill():
+    batch = BatchSpec(seq_lens=[100, 50, 0], query_lens=[1, 1, 0])
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, DEVICE
+    ).replace(is_prefilling=torch.tensor([False, False, True]))
+    actual = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=0,
+        full_cuda_graph=False,
+    ).build(0, common_attn_metadata)
+
+    assert actual.num_decodes == 3
+    assert actual.num_prefills == 0
+    assert actual.has_initial_state is None
+
+
 def test_mixed_regular_and_spec_decode_uses_packed_decode_metadata():
     batch = BatchSpec(seq_lens=[100, 65, 20], query_lens=[1, 1, 3])
     common_attn_metadata = create_common_attn_metadata(

--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -188,6 +188,40 @@ def test_kimi_k3_kda_metadata_matches_shared_gdn(
     _assert_matches_shared_gdn(reference, actual)
 
 
+@pytest.mark.parametrize(
+    ("seq_len", "is_prefilling", "expected_prefill"),
+    [
+        pytest.param(1, True, True, id="stateless-first-token"),
+        pytest.param(65, True, False, id="stateful-one-token-extend"),
+        pytest.param(1, False, False, id="decode-capture-row"),
+    ],
+)
+def test_non_spec_one_token_state_classification(
+    seq_len: int,
+    is_prefilling: bool,
+    expected_prefill: bool,
+):
+    batch = BatchSpec(seq_lens=[seq_len], query_lens=[1])
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, DEVICE
+    ).replace(is_prefilling=torch.tensor([is_prefilling], dtype=torch.bool))
+    actual = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=0,
+        full_cuda_graph=False,
+    ).build(0, common_attn_metadata)
+
+    assert actual.num_prefills == int(expected_prefill)
+    assert actual.num_prefill_tokens == int(expected_prefill)
+    assert actual.num_decodes == int(not expected_prefill)
+    assert actual.num_decode_tokens == int(not expected_prefill)
+    if expected_prefill:
+        assert actual.has_initial_state is not None
+        assert actual.has_initial_state.tolist() == [False]
+    else:
+        assert actual.has_initial_state is None
+
+
 def test_mixed_regular_and_spec_decode_uses_packed_decode_metadata():
     batch = BatchSpec(seq_lens=[100, 65, 20], query_lens=[1, 1, 3])
     common_attn_metadata = create_common_attn_metadata(

--- a/vllm/models/kimi_k3/nvidia/kda_metadata.py
+++ b/vllm/models/kimi_k3/nvidia/kda_metadata.py
@@ -272,9 +272,23 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
                 num_spec_decodes = spec_sequence_masks_cpu.sum().item()
 
         if num_spec_decodes == 0:
-            # The runner orders ordinary decodes before prefills.
+            # A one-token first chunk has no valid KDA state, while a one-token
+            # continuation does. Only the prefill path masks an unowned state slot.
+            assert m.seq_lens_cpu_upper_bound is not None
+            query_lens_cpu = query_start_loc_cpu.diff()
+            no_prior_state = (query_lens_cpu > 0) & (
+                m.seq_lens_cpu_upper_bound <= query_lens_cpu
+            )
+            if m.is_prefilling is not None:
+                no_prior_state &= m.is_prefilling
+            else:
+                no_prior_state = torch.zeros_like(no_prior_state)
             num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
-                split_decodes_and_prefills(m, decode_threshold=1)
+                split_decodes_and_prefills(
+                    m.replace(is_prefilling=no_prior_state),
+                    decode_threshold=1,
+                    treat_short_extends_as_decodes=False,
+                )
             )
             num_spec_decode_tokens = 0
             spec_token_indx = None


### PR DESCRIPTION
## Stateless one-token KDA prefill classification

Status: **historical integration backport, published for review; not newly deployed**.

A new non-speculative one-token request has no valid recurrent state. The Kimi KDA metadata builder must route it through prefill so the initial-state mask is applied, while retaining decode classification for stateful one-token extends, dummy capture rows and zero-length padding.

This prepared branch contains `15458f7a84` and `ffe189252b7e`. It is a local-inference-lab backport of upstream [vllm-project/vllm#51483](https://github.com/vllm-project/vllm/pull/51483), with credit retained in the original commit. It does not duplicate a lab PR; upstream and lab use different integration bases.

## Scope and limitations

The metadata guard compares CPU sequence length with active query length and intersects with the prefill flag before calling the shared prefill/decode splitter. Added tests cover a stateless first token, stateful one-token extension, capture rows, reordered mixed requests, absent prefill flags and zero-query padding.

This is distinct from lab #687, which fixes model-runner-v2 FULL graph selection before attention execution. The historical commit assumed runner-side graph selection already rejected prefills. That assumption does not replace the #687 guard, and publishing this old branch does not authorize reverting it or changing the active serving stack.

## Validation and publication

The publication audit inspected both source and tests and ran `git diff --check`, which passes. No CUDA or full-model test was rerun for this older branch, so current-lineage qualification remains required before merge or deployment. The prepared tests are in `tests/models/kimi_k3/test_kda_metadata.py`.

The operator requested all prepared local changes be exposed in local-inference-lab, including research-only candidates. The branch is therefore non-draft for visibility, not a statement of human merge approval. AI assistance was used for the publication audit. Original commit authorship and attribution remain unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxvNwugeU8RJFd7WRYwNLG
