### PR TITLE
Frontend: preserve server-default repetition detection backport

### DIFF
--- a/tests/entrypoints/openai/test_repetition_detection_defaults.py
+++ b/tests/entrypoints/openai/test_repetition_detection_defaults.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Unit tests for repetition_detection propagation from default_sampling_params
+to SamplingParams in ChatCompletionRequest and CompletionRequest.
+
+Operators can set repetition_detection server-side via the model generation
+config or --override-generation-config to guard against degenerate repetition
+loops; the serving layer must apply it when a request does not set its own.
+"""
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.completion.protocol import (
+    CompletionRequest,
+)
+from vllm.sampling_params import RepetitionDetectionParams
+
+SERVER_DEFAULT = RepetitionDetectionParams(max_pattern_size=8, min_count=4)
+REQUEST_OVERRIDE = RepetitionDetectionParams(max_pattern_size=1, min_count=10)
+
+
+class TestCompletionRepetitionDetection:
+    """repetition_detection fallback in CompletionRequest.to_sampling_params()."""
+
+    def test_server_default_applied(self):
+        """Server-default repetition_detection applies when request sends none."""
+        request = CompletionRequest(model="test-model", prompt="hello")
+
+        sampling_params = request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={"repetition_detection": SERVER_DEFAULT},
+        )
+
+        assert sampling_params.repetition_detection == SERVER_DEFAULT
+
+    def test_request_value_wins(self):
+        """Request-specified repetition_detection overrides the server default."""
+        request = CompletionRequest(
+            model="test-model",
+            prompt="hello",
+            repetition_detection=REQUEST_OVERRIDE,
+        )
+
+        sampling_params = request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={"repetition_detection": SERVER_DEFAULT},
+        )
+
+        assert sampling_params.repetition_detection == REQUEST_OVERRIDE
+
+    def test_no_repetition_detection_anywhere(self):
+        """With no server default and no request value, it stays disabled."""
+        request = CompletionRequest(model="test-model", prompt="hello")
+
+        sampling_params = request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={},
+        )
+
+        assert sampling_params.repetition_detection is None
+
+
+class TestChatCompletionRepetitionDetection:
+    """repetition_detection fallback in ChatCompletionRequest.to_sampling_params()."""
+
+    def test_server_default_applied(self):
+        """Server-default repetition_detection applies when request sends none."""
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+        sampling_params = request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={"repetition_detection": SERVER_DEFAULT},
+        )
+
+        assert sampling_params.repetition_detection == SERVER_DEFAULT
+
+    def test_request_value_wins(self):
+        """Request-specified repetition_detection overrides the server default."""
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            repetition_detection=REQUEST_OVERRIDE,
+        )
+
+        sampling_params = request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={"repetition_detection": SERVER_DEFAULT},
+        )
+
+        assert sampling_params.repetition_detection == REQUEST_OVERRIDE
+
+    def test_no_repetition_detection_anywhere(self):
+        """With no server default and no request value, it stays disabled."""
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+        sampling_params = request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={},
+        )
+
+        assert sampling_params.repetition_detection is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,6 +33,7 @@ from vllm.config.load import LoadConfig
 from vllm.config.utils import get_field
 from vllm.config.vllm import OPTIMIZATION_LEVEL_TO_CONFIG, OptimizationLevel
 from vllm.platforms import current_platform
+from vllm.sampling_params import RepetitionDetectionParams
 from vllm.v1.attention.backend import AttentionCGSupport
 
 DEVICE_TYPE = current_platform.device_type
@@ -901,6 +902,22 @@ def test_generation_config_loading():
     )
 
     assert model_config.get_diff_sampling_param() == override_generation_config
+
+    # repetition_detection is accepted as a server-side default and converted
+    # from the raw JSON dict into typed params for the serving layers.
+    model_config = ModelConfig(
+        model_id,
+        generation_config="vllm",
+        override_generation_config={
+            "repetition_detection": {"max_pattern_size": 8, "min_count": 4}
+        },
+    )
+
+    assert model_config.get_diff_sampling_param() == {
+        "repetition_detection": RepetitionDetectionParams(
+            max_pattern_size=8, min_count=4
+        )
+    }
 
 
 @pytest.mark.parametrize(

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1705,6 +1705,7 @@ class ModelConfig:
             "top_p",
             "min_p",
             "max_new_tokens",
+            "repetition_detection",
         ]
         if any(p in config for p in available_params):
             diff_sampling_param = {
@@ -1715,6 +1716,14 @@ class ModelConfig:
             if "max_new_tokens" in diff_sampling_param:
                 diff_sampling_param["max_tokens"] = diff_sampling_param.pop(
                     "max_new_tokens"
+                )
+            # repetition_detection arrives as a raw dict from JSON configs
+            repetition_detection = diff_sampling_param.get("repetition_detection")
+            if isinstance(repetition_detection, dict):
+                from vllm.sampling_params import RepetitionDetectionParams
+
+                diff_sampling_param["repetition_detection"] = RepetitionDetectionParams(
+                    **repetition_detection
                 )
         else:
             diff_sampling_param = {}

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -739,7 +739,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
             allowed_token_ids=self.allowed_token_ids,
             extra_args=extra_args or None,
             skip_clone=True,  # Created fresh per request, safe to skip clone
-            repetition_detection=self.repetition_detection,
+            repetition_detection=self.repetition_detection
+            or default_sampling_params.get("repetition_detection"),
         )
 
     @model_validator(mode="before")

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -391,7 +391,8 @@ class CompletionRequest(OpenAIBaseModel):
             bad_words=self.bad_words,
             extra_args=extra_args or None,
             skip_clone=True,  # Created fresh per request, safe to skip clone
-            repetition_detection=self.repetition_detection,
+            repetition_detection=self.repetition_detection
+            or default_sampling_params.get("repetition_detection"),
             thinking_token_budget=self.thinking_token_budget,
         )
 


### PR DESCRIPTION
## Operator-configurable repetition-detection defaults

Status: **historical upstream backport, not enabled in the active Kimi service**. Published for review at the operator's request; no new serving behavior is introduced by publication.

Prepared commit `95b96696e702` preserves the server-default plumbing from upstream [vllm-project/vllm#51036](https://github.com/vllm-project/vllm/pull/51036). Original authorship and attribution are retained.

The change admits `repetition_detection` from model generation configuration, converts its JSON object to `RepetitionDetectionParams`, and lets chat/completion requests inherit that default when they do not supply their own setting. Request values still take precedence. Without an operator-configured default or request value the detector remains disabled.

## Important distinction

This configuration feature is not the fix for corrupted four-token prefill tails. Lab #687 corrects the underlying graph-selection defect. This branch only exposes an optional output-stopping policy and is not being used to conceal that defect or presented as a precision-preserving model optimization.

## Validation and compatibility

The corresponding upstream PR records six protocol-default tests, generation-config conversion coverage and eight neighboring stop-token default tests. The prepared branch includes the protocol and model-config test additions. The publication audit inspected those changes and ran `git diff --check`; it did not rerun the historical full test matrix or model evaluation.

The branch targets the local-inference-lab integration line. It is a backport record of existing upstream work, not a duplicate upstream proposal. Open lab searches found no separate server-default repetition-detection PR.

Current-base review and tests are required before merge. No active generation configuration, repetition penalty, stopping policy, server or cache was changed. AI assistance was used for publication; human merge approval is not asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxvNwugeU8RJFd7WRYwNLG
