### PR TITLE
[JJ] Count graph memory once in post-capture KV recommendations

### DIFF
--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -175,3 +175,62 @@ def test_b12x_warmup_precedes_cudagraph_memory_profile(
     assert worker.peak_activation_memory == 5
     assert worker.total_consumed == 10 + (90 - final_free_memory)
     assert worker.cudagraph_memory_estimate == graph_estimate
+
+
+@pytest.mark.parametrize("estimated_gib", [0, 4])
+@pytest.mark.parametrize("measured_gib", [3, 7])
+def test_post_capture_recommendation_counts_measured_graph_memory_once(
+    monkeypatch, estimated_gib, measured_gib
+):
+    """The saved KV budget uses measured graph storage, not its estimate."""
+    compilation = SimpleNamespace(
+        mode=gpu_worker.CompilationMode.NONE,
+        compilation_time=0.0,
+        encoder_compilation_time=0.0,
+    )
+    worker = SimpleNamespace(
+        vllm_config=SimpleNamespace(compilation_config=compilation),
+        compilation_config=compilation,
+        model_runner=SimpleNamespace(
+            lora_config=None,
+            maybe_remove_all_loras=lambda config: None,
+            capture_model=lambda: measured_gib * GiB_bytes,
+        ),
+        model_config=SimpleNamespace(enforce_eager=False, seed=0),
+        cache_config=SimpleNamespace(
+            kv_cache_memory_bytes=None, gpu_memory_utilization=0.9
+        ),
+        init_snapshot=SimpleNamespace(
+            free_memory=100 * GiB_bytes, total_memory=100 * GiB_bytes
+        ),
+        requested_memory=90 * GiB_bytes,
+        total_consumed=10 * GiB_bytes,
+        peak_activation_memory=5 * GiB_bytes,
+        cudagraph_memory_estimate=estimated_gib * GiB_bytes,
+        available_kv_cache_memory_bytes=(75 - estimated_gib) * GiB_bytes,
+        use_v2_model_runner=False,
+        observability_config=SimpleNamespace(
+            jit_monitor_mode="off", jit_monitor_verbose=False
+        ),
+    )
+    saved = []
+    monkeypatch.setattr(
+        gpu_worker, "maybe_save_startup_plan", lambda w, budget: saved.append(budget)
+    )
+    monkeypatch.setattr(
+        gpu_worker, "get_pp_group", lambda: SimpleNamespace(is_last_rank=False)
+    )
+    for name in (
+        "kernel_warmup",
+        "set_random_seed",
+        "freeze_gc_heap",
+        "maybe_attach_gc_debug_callback",
+        "enable_gpu_sync_check",
+        "set_torch_threads_for_runtime",
+    ):
+        monkeypatch.setattr(gpu_worker, name, lambda *args: None)
+    monkeypatch.setattr("vllm.utils.jit_monitor.activate", lambda **kwargs: None)
+
+    gpu_worker.Worker.compile_or_warm_up_model(worker)
+
+    assert saved == [(90 - 10 - 5 - measured_gib) * GiB_bytes - 150 * (1 << 20)]

--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -82,19 +82,23 @@ def test_startup_plan_apply_gate(plan_env):
 
 @pytest.mark.parametrize(
     "final_free_memory,expected_available_memory",
-    [(80, 80), (75, 75)],
+    [(90, 75), (85, 70)],
 )
+@pytest.mark.parametrize("graph_estimate", [0, 4])
+@pytest.mark.parametrize("estimate_graphs", [False, True])
 def test_b12x_warmup_precedes_cudagraph_memory_profile(
     monkeypatch,
     final_free_memory,
     expected_available_memory,
+    graph_estimate,
+    estimate_graphs,
 ):
     """B12X launch modules must be resolved before descriptor capture begins."""
     events: list[object] = []
 
     def profile_cudagraph_memory():
         events.append("profile_cudagraph_memory")
-        return 0
+        return graph_estimate
 
     model_runner = SimpleNamespace(
         model_memory_usage=0,
@@ -105,8 +109,8 @@ def test_b12x_warmup_precedes_cudagraph_memory_profile(
     profile_result = SimpleNamespace(
         total_consumed=10,
         transient_peak_headroom=5,
-        after_profile=SimpleNamespace(free_memory=80),
-        non_kv_cache_memory=10,
+        after_profile=SimpleNamespace(free_memory=90),
+        non_kv_cache_memory=15,
     )
 
     @contextmanager
@@ -133,6 +137,9 @@ def test_b12x_warmup_precedes_cudagraph_memory_profile(
     )
 
     monkeypatch.setattr(gpu_worker, "maybe_apply_startup_plan", lambda worker: None)
+    monkeypatch.setenv(
+        "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS", str(int(estimate_graphs))
+    )
     monkeypatch.setattr(gpu_worker, "memory_profiling", fake_memory_profiling)
     monkeypatch.setattr(
         gpu_worker,
@@ -163,4 +170,8 @@ def test_b12x_warmup_precedes_cudagraph_memory_profile(
         ("b12x_warmup", (8, 4)),
         "profile_cudagraph_memory",
     ]
-    assert available == expected_available_memory
+    applied_graph_estimate = graph_estimate if estimate_graphs else 0
+    assert available == expected_available_memory - applied_graph_estimate
+    assert worker.peak_activation_memory == 5
+    assert worker.total_consumed == 10 + (90 - final_free_memory)
+    assert worker.cudagraph_memory_estimate == graph_estimate

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -588,9 +588,9 @@ class Worker(WorkerBase):
             0,
         )
         self.total_consumed = profile_result.total_consumed + late_persistent_memory
-        self.peak_activation_memory = (
-            profile_result.transient_peak_headroom + cudagraph_memory_estimate_applied
-        )
+        # KV admission subtracts the graph estimate separately. Post-capture
+        # recommendations add measured graph memory to this activation peak.
+        self.peak_activation_memory = profile_result.transient_peak_headroom
         self.cudagraph_memory_estimate = cudagraph_memory_estimate
 
         free_gpu_memory = final_profile_snapshot.free_memory


### PR DESCRIPTION
## Behavior

Keep transient activation memory separate from estimated CUDA graph memory in the worker's accounting fields. The post-capture KV budget recommendation combines persistent memory, the activation peak, and **measured** graph memory exactly once.

The admission calculation already subtracts the graph estimate separately. Adding that estimate to `peak_activation_memory` also made the post-capture recommendation subtract both the estimate and the actual graph allocation.

## Compatibility

Initial GPU KV admission and runtime allocation behavior are unchanged. This corrects a too-small post-capture recommendation; it is not a fix for a late-serving OOM, and does not add a reserve or change `gpu_memory_utilization`.

## Validation

- The focused worker suite covers graph estimates 0 and 4, the estimate flag enabled/disabled, and two final free-memory observations.
- Activation-accounting reference: 8 passed / 2 failed. Corrected: 10 passed.
- Four direct `compile_or_warm_up_model` tests combine estimated graph memory of 0/4 GiB with measured graph memory of 3/7 GiB. They assert the emitted KV recommendation and saved budget. The complete focused suite passes all 14 cases on commit `d84208d424a16b15edc5f6e7e4326ec9d3409b1e`.
- Assertions check available KV memory, persistent memory accounting, the activation-only peak, and the saved graph estimate.
- Command: `uv run --no-project --python /opt/venv/bin/python python -m pytest -q /tests/test_gpu_worker.py` in the DS4 Jovian Judgement r8 runtime, mounting the host's uv binary and only the worker module for the corrected arm. A CUDA device must be visible for module imports; the accounting assertions use mocked memory observations.
- Ruff and `git diff --check` pass.

AI assistance: implementation and tests prepared with OpenAI Codex. Maintainer review is requested before merge.
