### PR TITLE
[JJ] Preserve auxiliary-stream output allocation lifetimes

### DIFF
--- a/tests/utils_/test_multi_stream_utils.py
+++ b/tests/utils_/test_multi_stream_utils.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+import torch
+
+from vllm.utils.multi_stream_utils import (
+    execute_in_parallel,
+    maybe_execute_in_parallel,
+)
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is required"
+)
+
+
+_ALLOCATION_BYTES = 16 * 1024 * 1024
+_CONSUMER_DELAY_CYCLES = 500_000_000
+
+
+def _assert_aux_output_lifetime(
+    invoke: Callable[[torch.cuda.Stream], Any], extract: Callable[[Any], torch.Tensor]
+) -> None:
+    torch.accelerator.synchronize()
+    torch.accelerator.empty_cache()
+
+    consumer_stream = torch.cuda.current_stream()
+    producer_stream = torch.cuda.Stream(priority=-1)
+    copied = torch.empty(_ALLOCATION_BYTES, dtype=torch.uint8, device="cuda")
+
+    # Resolve imports, events, and copy kernels before delaying the consumer.
+    warmup = invoke(producer_stream)
+    copied.copy_(extract(warmup))
+    torch.cuda._sleep(1)
+    torch.accelerator.synchronize()
+    del warmup
+    torch.accelerator.empty_cache()
+
+    result = invoke(producer_stream)
+    tensor = extract(result)
+    consumer_done = torch.cuda.Event()
+
+    torch.cuda._sleep(_CONSUMER_DELAY_CYCLES)
+    copied.copy_(tensor)
+    consumer_done.record()
+    del tensor, result
+
+    with torch.cuda.stream(producer_stream):
+        replacement = torch.full(
+            (_ALLOCATION_BYTES,), 93, dtype=torch.uint8, device="cuda"
+        )
+
+    producer_stream.synchronize()
+    consumer_was_pending = not consumer_done.query()
+    torch.accelerator.synchronize()
+    assert consumer_was_pending, "The test must overwrite while the consumer is pending"
+    assert torch.all(copied == 17)
+    assert torch.all(replacement == 93)
+    assert torch.cuda.current_stream() == consumer_stream
+
+
+@requires_cuda
+def test_maybe_execute_in_parallel_preserves_aux_output_lifetime() -> None:
+    event0 = torch.cuda.Event()
+    event1 = torch.cuda.Event()
+
+    def invoke(producer_stream: torch.cuda.Stream) -> tuple[None, torch.Tensor]:
+        return maybe_execute_in_parallel(
+            lambda: None,
+            lambda: torch.full(
+                (_ALLOCATION_BYTES,), 17, dtype=torch.uint8, device="cuda"
+            ),
+            event0,
+            event1,
+            producer_stream,
+        )
+
+    _assert_aux_output_lifetime(invoke, lambda result: result[1])
+
+
+@requires_cuda
+def test_execute_in_parallel_preserves_nested_aux_output_lifetime() -> None:
+    start_event = torch.cuda.Event()
+    done_event = torch.cuda.Event()
+
+    def invoke(producer_stream: torch.cuda.Stream) -> tuple[None, list[Any]]:
+        return execute_in_parallel(
+            lambda: None,
+            [
+                lambda: {
+                    "output": (
+                        torch.full(
+                            (_ALLOCATION_BYTES,),
+                            17,
+                            dtype=torch.uint8,
+                            device="cuda",
+                        ),
+                    )
+                }
+            ],
+            start_event,
+            [done_event],
+            [producer_stream],
+            enable=True,
+        )
+
+    _assert_aux_output_lifetime(invoke, lambda result: result[1][0]["output"][0])
+
+
+@pytest.mark.parametrize("helper", ["pair", "fanout"])
+def test_sequential_execution_preserves_results_and_order(helper: str) -> None:
+    calls = []
+
+    def call(value):
+        calls.append(value)
+        return value
+
+    if helper == "pair":
+        result = maybe_execute_in_parallel(lambda: call(1), lambda: call(2), None, None)
+        assert result == (1, 2)
+    else:
+        result = execute_in_parallel(
+            lambda: call(1), [lambda: call(2), None, lambda: call(3)], None, []
+        )
+        assert result == (1, [2, None, 3])
+    assert calls == ([1, 2] if helper == "pair" else [1, 2, 3])
+
+
+@requires_cuda
+@pytest.mark.parametrize("helper", ["pair", "fanout"])
+def test_parallel_cuda_graph_replay_preserves_outputs(helper: str) -> None:
+    source = torch.arange(1024, device="cuda", dtype=torch.float32)
+    producer = torch.cuda.Stream()
+    start, done = torch.cuda.Event(), torch.cuda.Event()
+
+    def operation():
+        if helper == "pair":
+            main, aux = maybe_execute_in_parallel(
+                lambda: source + 1, lambda: {"value": source * 2}, start, done, producer
+            )
+        else:
+            main, aux_results = execute_in_parallel(
+                lambda: source + 1,
+                [lambda: {"value": source * 2}],
+                start,
+                [done],
+                [producer],
+                enable=True,
+            )
+            aux = aux_results[0]
+        return main + aux["value"]
+
+    operation()
+    torch.accelerator.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        output = operation()
+    for value in (3, 17, -5):
+        source.fill_(value)
+        graph.replay()
+        torch.testing.assert_close(output, torch.full_like(output, value * 3 + 1))

--- a/vllm/utils/multi_stream_utils.py
+++ b/vllm/utils/multi_stream_utils.py
@@ -8,6 +8,19 @@ from typing import Any
 import torch
 
 
+def _record_stream_recursive(obj: Any, stream: torch.cuda.Stream) -> None:
+    """Prevent auxiliary storage reuse while consumer work remains queued."""
+    if isinstance(obj, torch.Tensor):
+        if obj.is_cuda:
+            obj.record_stream(stream)
+    elif isinstance(obj, (list, tuple)):
+        for item in obj:
+            _record_stream_recursive(item, stream)
+    elif isinstance(obj, dict):
+        for item in obj.values():
+            _record_stream_recursive(item, stream)
+
+
 class EventType(Enum):
     Main = 0
     Attention = 1
@@ -26,6 +39,9 @@ def maybe_execute_in_parallel(
     fn1 runs on aux_stream, synchronized via CUDA events. When aux_stream is
     None or a breakable CUDA graph capture is active, both functions execute
     sequentially on the current stream.
+
+    Returned CUDA tensors, including values nested in lists, tuples, and dicts,
+    retain auxiliary allocation storage until queued current-stream reads finish.
 
     This design follows TensorRT-LLM's maybe_execute_in_parallel pattern
     (tensorrt_llm/_torch/modules/multi_stream_utils.py).
@@ -56,6 +72,10 @@ def maybe_execute_in_parallel(
             result1 = fn1()
             event1.record()
         event1.wait()
+        # The join orders reads, but eager allocations also need their consumer
+        # registered with the allocator. Captured outputs use graph-pool storage.
+        if not torch.cuda.is_current_stream_capturing():
+            _record_stream_recursive(result1, torch.cuda.current_stream())
     else:
         result0 = fn0()
         result1 = fn1()
@@ -82,6 +102,9 @@ def execute_in_parallel(
     before returning. Falls back to sequential execution on the current stream
     when aux_streams is None or enable is False; in that case default_fn runs
     first, then aux_fns in order.
+
+    Returned CUDA tensors, including values nested in lists, tuples, and dicts,
+    retain auxiliary allocation storage until queued current-stream reads finish.
 
     Args:
         default_fn: Callable for the default (current) stream.
@@ -128,5 +151,8 @@ def execute_in_parallel(
 
     for ev in pending:
         ev.wait()
+
+    if not torch.cuda.is_current_stream_capturing():
+        _record_stream_recursive(aux_results, torch.cuda.current_stream())
 
     return default_result, aux_results


### PR DESCRIPTION
## Behavior

Register auxiliary-stream tensor outputs with the calling CUDA stream before returning from `maybe_execute_in_parallel` and `execute_in_parallel`. Traverse tensors nested in lists, tuples, and dictionaries. Preserve event ordering, concurrent execution, graph capture, tensor values, and return structures. No CPU/GPU synchronization is added.

## Correctness contract

A returned tensor must remain readable by work queued on the calling stream after its last Python reference is released. The event join orders kernel execution but does not register the consumer with the CUDA caching allocator. Without that registration, the producer can reuse an allocation while the consumer still reads it.

The regression test produces byte value 17 on an auxiliary stream, queues a delayed copy on the calling stream, releases the output, and requests a same-sized producer allocation containing 93. The consumer is verified to remain pending during the allocation. Unmodified code copies 93; the correction preserves 17. This is an allocator-lifetime test, not a test of model arithmetic.

The related shared-expert lifetime correction in [#93](https://github.com/local-inference-lab/vllm/pull/93) fixes a different helper. It does not protect these generic parallel-execution helpers.

## Validation

Qualified on RTX PRO 6000 Blackwell SM120, CUDA 13.3, PyTorch 2.13.0, native caching allocator with `expandable_segments:True`:

- Reference: 2 failed / 4 passed; three repetitions: 6 failed / 12 passed.
- Corrected: 6 passed; three repetitions: 18 passed.
- Coverage: direct and nested outputs, sequential execution order, pair/fan-out CUDA graph capture and replay with changed input values.
- Command: `uv run --no-project --python /opt/venv/bin/python python -m pytest -q /tests/test_multi_stream_utils.py`. The test file is mounted read-only; the corrected arm also replaces only the installed `vllm/utils/multi_stream_utils.py` module. The baseline imports the unchanged module from the published DS4 Jovian Judgement r8 image.
- Ruff and `git diff --check` pass.

Graph-pool allocation lifetimes remain unchanged during capture; `record_stream` applies to non-captured allocation lifetimes.

## Scope and limitations

This fixes a demonstrated generic helper contract violation. It is **not a demonstrated root-cause fix** for the community's long-running DeepSeek V4 crash: the reported C128 compressor callback returns `None`, and the reported exact prefix-resume shape also passes on unmodified r8. The release qualification must report those production failures separately.

AI assistance: implementation and tests prepared with OpenAI Codex. Maintainer review is requested before merge.
