### PR TITLE
연구용 Kimi worker allocator-history 및 snapshot 진단 보존

### DIFF
--- a/tests/tools/test_kimi_memory_audit_patch.py
+++ b/tests/tools/test_kimi_memory_audit_patch.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GPU나 실제 신호 없이 메모리 감사 패치의 설치 계약을 검증한다."""
+
+import importlib.util
+import pickle
+import signal
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2] / "tools/profiler/kimi_memory_audit_patch.py"
+)
+SOURCE = """class Worker:
+    def init_device(self):
+        if self.device_config.device_type == "cuda":
+            return "ready"
+"""
+
+
+@pytest.fixture
+def installer(tmp_path, monkeypatch):
+    spec = importlib.util.spec_from_file_location("memory_audit_patch", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    target = tmp_path / "worker.py"
+    target.write_text(SOURCE)
+    monkeypatch.setattr(module, "PATH", target)
+    return module, target
+
+
+def test_install_is_idempotent_and_preserves_worker_method(installer):
+    module, target = installer
+    assert module.main() == 0
+    patched = target.read_text()
+    compile(patched, str(target), "exec")
+    assert 'return "ready"' in patched
+    assert patched.count("self._k3_memory_audit_install()") == 1
+    assert module.main() == 0
+    assert target.read_text() == patched
+
+
+@pytest.mark.parametrize("source", ["class Worker: pass\n", SOURCE + SOURCE])
+def test_missing_or_ambiguous_anchor_never_overwrites_source(installer, source):
+    module, target = installer
+    target.write_text(source)
+    with pytest.raises(SystemExit):
+        module.main()
+    assert target.read_text() == source
+
+
+def test_invalid_generated_source_is_not_written(installer, monkeypatch):
+    module, target = installer
+    monkeypatch.setattr(module, "NEW", "invalid syntax !!!")
+    with pytest.raises(SyntaxError):
+        module.main()
+    assert target.read_text() == SOURCE
+
+
+def test_disabled_audit_does_not_touch_cuda_or_signal(installer, monkeypatch):
+    module, target = installer
+    module.main()
+    fake_torch = ModuleType("torch")
+    fake_cuda = Mock()
+    monkeypatch.setattr(fake_torch, "cuda", fake_cuda, raising=False)
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    install_signal = Mock()
+    monkeypatch.setattr(signal, "signal", install_signal)
+    monkeypatch.delenv("K3_MEMORY_AUDIT", raising=False)
+    namespace = {"logger": Mock()}
+    exec(compile(target.read_text(), str(target), "exec"), namespace)
+    namespace["Worker"]()._k3_memory_audit_install()
+    assert fake_cuda.mock_calls == []
+    install_signal.assert_not_called()
+
+
+def test_enabled_audit_writes_mocked_rank_snapshot(installer, monkeypatch, tmp_path):
+    module, target = installer
+    module.main()
+    fake_torch = ModuleType("torch")
+    fake_cuda = Mock()
+    fake_cuda.mem_get_info.return_value = (10, 20)
+    fake_cuda.memory_stats.return_value = {"allocated": 7}
+    fake_cuda.memory._snapshot.return_value = {"segments": []}
+    monkeypatch.setattr(fake_torch, "cuda", fake_cuda, raising=False)
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    install_signal = Mock()
+    monkeypatch.setattr(signal, "signal", install_signal)
+    monkeypatch.setenv("K3_MEMORY_AUDIT", "1")
+    monkeypatch.setenv("K3_MEMORY_AUDIT_MAX_ENTRIES", "32")
+    monkeypatch.setenv("K3_MEMORY_AUDIT_DIR", str(tmp_path / "snapshots"))
+    namespace = {"logger": Mock()}
+    exec(compile(target.read_text(), str(target), "exec"), namespace)
+    worker = namespace["Worker"]()
+    worker.rank = 3
+    worker.device_config = SimpleNamespace(device_type="cuda")
+    assert worker.init_device() == "ready"
+    fake_cuda.memory._record_memory_history.assert_called_once_with(max_entries=32)
+    install_signal.assert_called_once()
+    signum, handler = install_signal.call_args.args
+    assert signum == signal.SIGUSR1
+    handler(None, None)
+    files = list((tmp_path / "snapshots").glob("rank3-*.pickle"))
+    assert len(files) == 1
+    with files[0].open("rb") as stream:
+        payload = pickle.load(stream)
+    assert payload["rank"] == 3
+    assert payload["mem_get_info"] == {"free": 10, "total": 20}
+    assert payload["snapshot"] == {"segments": []}

--- a/tools/pre_commit/check_forbidden_imports.py
+++ b/tools/pre_commit/check_forbidden_imports.py
@@ -56,6 +56,9 @@ CHECK_IMPORTS = {
             "tests/utils_/test_hashing.py",
             "tests/compile/test_aot_compile.py",
             "benchmarks/kernels/graph_machete_bench.py",
+            # 로컬 allocator snapshot 형식 및 신뢰된 테스트 출력만 처리한다.
+            "tools/profiler/kimi_memory_audit_patch.py",
+            "tests/tools/test_kimi_memory_audit_patch.py",
             "benchmarks/kernels/benchmark_lora.py",
             "benchmarks/kernels/benchmark_machete.py",
             "benchmarks/fused_kernels/layernorm_rms_benchmarks.py",

--- a/tools/profiler/kimi_memory_audit_patch.py
+++ b/tools/profiler/kimi_memory_audit_patch.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""격리된 Kimi worker 소스에 선택적 메모리 감사 훅을 설치한다.
+
+연구용으로 준비된 소스 패치를 보존한다. K3PATCH_GPU_WORKER로 지정한 파일의
+정확한 init_device 앵커만 수정하며, 현재 프로세스나 GPU에는 접근하지 않는다.
+설치된 worker가 K3_MEMORY_AUDIT=1로 시작할 때만 allocator history와 SIGUSR1
+처리를 활성화한다. 출력 디렉터리는 K3_MEMORY_AUDIT_DIR로 지정한다.
+
+이 훅은 CUDA의 비공개 snapshot API를 사용하고 신호 처리 중 GPU API를 호출한다.
+메모리 사용량과 타이밍에 영향을 주므로 유휴 상태의 격리된 진단 서버에서만
+사용한다. SIGUSR1 재진입과 실제 CUDA 실행은 별도 검증 대상이다. pickle에는
+스택 경로가 들어갈 수 있으며, 신뢰하지 않는 snapshot은 역직렬화하지 않는다.
+"""
+
+import os
+from pathlib import Path
+
+PATH = Path(
+    os.environ.get(
+        "K3PATCH_GPU_WORKER",
+        "/opt/infernal-invocation/vllm/vllm/v1/worker/gpu_worker.py",
+    )
+)
+MARKER = "kimi-k3-memory-audit"
+
+OLD = """    def init_device(self):
+        if self.device_config.device_type == "cuda":
+"""
+
+NEW = '''    def _k3_memory_audit_install(self):
+        """kimi-k3-memory-audit: allocator 이력과 SIGUSR1 snapshot을 기록한다."""
+        import os as _os
+        import pickle as _pickle
+        import signal as _signal
+        import time as _time
+
+        import torch as _torch
+
+        if _os.environ.get("K3_MEMORY_AUDIT", "0") != "1":
+            return
+        out_dir = _os.environ.get("K3_MEMORY_AUDIT_DIR", "/cache/memory-audit")
+        try:
+            _torch.cuda.memory._record_memory_history(
+                max_entries=int(
+                    _os.environ.get("K3_MEMORY_AUDIT_MAX_ENTRIES", "400000")
+                )
+            )
+        except Exception as exc:  # pragma: no cover
+            logger.warning("메모리 감사 이력 기록을 사용할 수 없습니다: %s", exc)
+
+        def _dump(signum, frame):
+            try:
+                _os.makedirs(out_dir, exist_ok=True)
+                rank = getattr(self, "rank", _os.environ.get("RANK", "x"))
+                stamp = _time.strftime("%Y%m%d-%H%M%S")
+                free, total = _torch.cuda.mem_get_info()
+                payload = {
+                    "rank": rank,
+                    "time": stamp,
+                    "mem_get_info": {"free": int(free), "total": int(total)},
+                    "memory_stats": dict(_torch.cuda.memory_stats()),
+                    "snapshot": _torch.cuda.memory._snapshot(),
+                }
+                path = _os.path.join(out_dir, f"rank{rank}-{stamp}.pickle")
+                with open(path, "wb") as fh:
+                    _pickle.dump(payload, fh)
+                logger.info("메모리 감사 snapshot 기록: %s (여유 %.2f / 전체 %.2f GiB)",
+                            path, free / 2**30, total / 2**30)
+            except Exception as exc:  # pragma: no cover
+                logger.warning("메모리 감사 snapshot 기록 실패: %s", exc)
+
+        _signal.signal(_signal.SIGUSR1, _dump)
+        logger.info("메모리 감사 활성화: SIGUSR1 -> %s", out_dir)
+
+    def init_device(self):
+        self._k3_memory_audit_install()
+        if self.device_config.device_type == "cuda":
+'''
+
+
+def main() -> int:
+    """대상 소스의 앵커를 검증하고 한 번만 감사 훅을 삽입한다.
+
+    Returns:
+        패치 완료 또는 이미 패치된 경우 0.
+
+    Raises:
+        SystemExit: 대상 앵커가 정확히 하나가 아닌 경우.
+        SyntaxError: 패치된 소스가 Python 문법에 맞지 않는 경우.
+        OSError: 대상 파일을 읽거나 쓸 수 없는 경우.
+    """
+    text = PATH.read_text()
+    if MARKER in text:
+        print(f"이미 설치된 worker 메모리 감사: {MARKER}")
+        return 0
+    if text.count(OLD) != 1:
+        raise SystemExit(f"대상 앵커가 정확히 하나가 아닙니다: {PATH}")
+    patched = text.replace(OLD, NEW, 1)
+    compile(patched, str(PATH), "exec")
+    PATH.write_text(patched)
+    print(f"worker 메모리 감사 설치 완료: {MARKER}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Worker 메모리 감사 도구

상태: **research-only, 기본 비활성**. 운영자가 요청한 미게시 작업 보존을 위해 기존 Kimi 진단 패치를 검토용 PR로 게시한다. 실제 서빙 파일·GPU·신호 처리 상태는 변경하지 않았다.

`tools/profiler/kimi_memory_audit_patch.py`는 지정된 worker 소스에 allocator history와 SIGUSR1 snapshot 훅을 설치한다. `K3PATCH_GPU_WORKER`가 대상 파일을 지정하며, 설치된 worker가 `K3_MEMORY_AUDIT=1`로 시작할 때만 훅이 활성화된다. 출력은 `K3_MEMORY_AUDIT_DIR` 아래 rank별 파일로 저장된다.

기존 준비본 `kimi-k3-production/bin/patch-worker-memory-audit.py`의 진단 동작을 보존한다. 설치기는 정확한 `init_device` 앵커, 중복 설치 및 생성 소스의 문법을 검사한다. 새로운 실행 경로가 아니라 격리된 진단 환경의 소스 패치 도구다.

## 안전성과 한계

- 기본 실행에서는 CUDA API나 신호 핸들러를 호출하지 않는다.
- 활성화하면 비공개 PyTorch allocator snapshot API를 사용하고 SIGUSR1 핸들러에서 GPU API를 호출한다. 실제 CUDA 신호 처리·재진입·성능 영향은 검증되지 않았다.
- 유휴 상태의 격리된 연구 서버에서만 검증해야 하며, production 기본 기능으로 사용하면 안 된다.
- pickle은 기존 snapshot 소비 도구와의 형식 호환을 위해 사용한다. 도구는 로컬 snapshot을 쓰며, 외부 요청이나 업로드 파일을 역직렬화하는 경로는 추가하지 않는다. 테스트가 읽는 파일도 해당 테스트가 생성한 파일뿐이다.
- import 정책의 예외는 도구와 테스트 두 파일에만 명시했다. 신뢰하지 않는 snapshot을 역직렬화하지 않는다.

## 검증

```text
격리된 uv 환경에서:
.venv/bin/python -m pytest --noconftest -q -p no:cacheprovider \
  tests/tools/test_kimi_memory_audit_patch.py
6 passed
```

검증 범위: 반복 설치, 앵커 누락·중복 시 원본 보존, 잘못된 생성 소스의 쓰기 거부, 기본 비활성 경로, mocked rank snapshot의 스키마와 값. CUDA와 SIGUSR1 전송은 mock이며 실제 GPU 검증을 주장하지 않는다.

pre-commit의 Ruff·형식·mypy·금지 import·CUDA API 정책 검사까지 통과했다. 커밋은 `f888bfeefe`이며 기준은 `dev/infernal-invocation` 계보다.

## 기존 PR과 구분

lab와 upstream에서 memory-audit/SIGUSR1 중복 PR을 검색했으나 동일 도구는 확인되지 않았다. rank-0 profiler 제한과 그래프 동기화 진단은 이미 lab #654/#687에 포함되어 있어 재게시하지 않는다. 이 allocator-history 진단은 해당 소스 스냅샷에 없던 별도 도구다.

AI 지원으로 기존 소스를 검토·보존하고 테스트했다. non-draft는 검토 가능 상태이며, 사람의 승인·병합·배포 승인을 의미하지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbbhUVVnUp9AZZ5uprpb8j


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional GPU memory-audit hook for isolated Kimi workers.
  * Supports collecting allocator history, memory statistics, and snapshots on demand, with results saved to a configurable directory.
  * Audit behavior remains inactive unless explicitly enabled.

* **Bug Fixes**
  * Patch installation now avoids modifying sources when the expected insertion point is missing or ambiguous.
  * Generated code is validated before changes are written.

* **Tests**
  * Added coverage for installation safety and enabled/disabled audit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->