### PR TITLE
fix(qwen3.8): integrate complete B12X QSA operations for MTP

### DIFF
--- a/tests/models/test_qwen3_8_flash_next_qsa.py
+++ b/tests/models/test_qwen3_8_flash_next_qsa.py
@@ -1291,8 +1291,8 @@ def test_projected_qsa_uses_complete_run_with_ready_event(monkeypatch) -> None:
         torch.empty(rows, 1),
     )
     ready = object()
-    events = []
-    bindings = []
+    events: list[str] = []
+    bindings: list[SimpleNamespace] = []
 
     def bind(context, live, out, *, overlap):
         assert live is staged and overlap

--- a/tests/models/test_qwen3_8_flash_next_qsa.py
+++ b/tests/models/test_qwen3_8_flash_next_qsa.py
@@ -264,6 +264,7 @@ def test_qsa_bind_uses_shared_workspace_with_smaller_profile_cache(
     owner.max_seq_len = max_seq_len
     owner.max_speculative_tokens = 2
     owner.max_decode_rows = 6
+    owner._share_mtp_indices = False
     owner.compress_ratio = 4
     owner.raw_ring_capacity = 8
     owner.budget = 2048
@@ -478,6 +479,7 @@ def test_qsa_warmup_runs_every_context_with_only_padded_requests(
         max_tokens=max_tokens,
         max_speculative_tokens=2,
         max_decode_rows=6,
+        overlap_input_projections=False,
     )
     calls = []
 
@@ -1238,68 +1240,98 @@ def _require_qsa_gpu() -> torch.device:
 
 
 @pytest.mark.parametrize("source_dtype", [torch.int32, torch.int64])
-def test_mtp_selection_capture_reorders_errors_and_replaces_causal_tail_on_replay(
+def test_mtp_anchor_row_map_follows_compaction_during_graph_replay(
     source_dtype: torch.dtype,
 ) -> None:
-    """A draft round owns its anchor selection; padding cannot inherit errors."""
+    """Only row ownership is supplied by vLLM; B12X owns anchor/tail evaluation."""
     device = _require_qsa_gpu()
     layer = Qwen3_8FlashNextQSAAttention.__new__(Qwen3_8FlashNextQSAAttention)
     torch.nn.Module.__init__(layer)
     layer._share_mtp_indices = True
     layer.max_tokens, layer.max_seqs, layer.max_speculative_tokens = 16, 4, 3
-    layer._native_selection_width = 2051
-    layer._selected_positions = torch.arange(
-        16 * 2051, device=device, dtype=torch.int32
-    ).view(16, 2051)
-    layer._mtp_source_positions = (
-        torch.arange(16, device=device, dtype=torch.int64) + 63
+    layer._selected_positions = torch.empty(
+        (16, 2051), device=device, dtype=torch.int32
     )
-    layer._mtp_source_errors = torch.zeros(16, device=device, dtype=torch.int32)
-    layer._mtp_source_errors[7] = 512
-    layer._mtp_shared_selected_positions = torch.full(
-        (4, 2054), -1, device=device, dtype=torch.int32
-    )
-    layer._mtp_captured_lengths = torch.empty(4, device=device, dtype=torch.int64)
-    layer._mtp_captured_errors = torch.empty(4, device=device, dtype=torch.int32)
-    layer._mtp_read_errors = torch.empty(4, device=device, dtype=torch.int32)
-    source_rows = torch.tensor([7, 3, 0, -1], device=device, dtype=source_dtype)
-    request_ids = torch.tensor([0, 1, -1, -1], device=device, dtype=torch.int32)
-    positions = torch.tensor([72, 67, -1, -1], device=device, dtype=torch.int64)
-
-    def capture_and_read():
-        layer.compact_topk_indices(source_rows)
-        layer._append_mtp_selection_tail(positions, request_ids)
-
-    capture_and_read()
+    layer._mtp_source_rows = torch.full((4,), -1, device=device, dtype=torch.int64)
+    source_rows = torch.tensor([7, 3, 0], device=device, dtype=source_dtype)
+    pointer = layer._mtp_source_rows.data_ptr()
+    layer.compact_topk_indices(source_rows)
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        capture_and_read()
-    for shift in (0, 100):
-        layer._selected_positions.add_(shift)
+        layer.compact_topk_indices(source_rows)
+    for mapping in ([7, 3, 0], [1, -1, 15]):
+        source_rows.copy_(torch.tensor(mapping, device=device, dtype=source_dtype))
+        layer._mtp_source_rows.fill_(99)
         graph.replay()
-        torch.testing.assert_close(
-            layer._mtp_shared_selected_positions[:3, :2051],
-            layer._selected_positions[source_rows[:3].long()],
-            rtol=0,
-            atol=0,
-        )
-        assert layer._mtp_shared_selected_positions[:, 2051:].tolist() == [
-            [71, 72, -1],
-            [67, -1, -1],
-            [-1, -1, -1],
-            [-1, -1, -1],
-        ]
-        assert layer._mtp_read_errors.tolist() == [512, 0, 0, 0]
-        # Rejection can shorten a speculative tail; no future column may survive.
-        immutable = layer._mtp_shared_selected_positions[:, :2051].clone()
-        positions[0] = 71
-        layer._append_mtp_selection_tail(positions, request_ids)
-        assert layer._mtp_shared_selected_positions[0, 2051:].tolist() == [71, -1, -1]
-        assert torch.equal(layer._mtp_shared_selected_positions[:, :2051], immutable)
-        positions[0] = 75
-        layer._append_mtp_selection_tail(positions, request_ids)
-        assert layer._mtp_read_errors[0].item() != 0
-        positions[0] = 72
+        assert layer._mtp_source_rows.tolist() == [*mapping, -1]
+        assert layer._mtp_source_rows.data_ptr() == pointer
+
+
+def test_projected_qsa_uses_complete_run_with_ready_event(monkeypatch) -> None:
+    """The projection consumer needs only B12X run, never split QSA exports."""
+    rows = 2
+    metadata = SimpleNamespace(
+        num_actual_tokens=rows,
+        max_seq_len=8,
+        slot_mapping=torch.arange(rows),
+        request_ids=torch.arange(rows, dtype=torch.int32),
+    )
+    staged = SimpleNamespace(
+        request_ids=torch.arange(rows, dtype=torch.int32),
+        logical_positions=torch.arange(rows, dtype=torch.int64),
+        sequence_lengths=torch.ones(rows, dtype=torch.int32),
+        query_start_loc=torch.arange(rows + 1, dtype=torch.int32),
+        num_accepted_tokens=torch.ones(rows, dtype=torch.int32),
+        is_prefilling=torch.zeros(rows, dtype=torch.bool),
+    )
+    output = torch.empty(rows, 2, 4)
+    index_query, raw_key, rope = (
+        torch.empty(rows, 2, 4),
+        torch.empty(rows, 4),
+        torch.empty(rows, 1),
+    )
+    ready = object()
+    events = []
+    bindings = []
+
+    def bind(context, live, out, *, overlap):
+        assert live is staged and overlap
+        binding = SimpleNamespace(output=out)
+        bindings.append(binding)
+        return binding
+
+    def run(binding, **inputs):
+        assert events == ["kv"]
+        assert inputs["index_ready"] is ready
+        assert inputs["index_query"] is index_query
+        assert inputs["raw_index_key"] is raw_key
+        assert inputs["rope_positions"] is rope
+        assert inputs["query_positions"] is staged.logical_positions
+        binding.output.fill_(7)
+
+    layer = SimpleNamespace(
+        skip_topk=False,
+        _parallel_selector_metadata=lambda _: metadata,
+        _qsa_binding_for_workload=lambda **_: object(),
+        _selector_metadata_views=staged,
+        _selector_index_inputs=(index_query, raw_key, rope),
+        _index_ready=ready,
+        _bind_qsa_context=bind,
+        kv_cache=None,
+        impl=SimpleNamespace(do_kv_cache_update=lambda *_: events.append("kv")),
+    )
+    monkeypatch.setattr(qsa_module, "get_b12x_qsa", lambda: SimpleNamespace(run=run))
+    Qwen3_8FlashNextQSAAttention._run_projected_qsa(
+        layer,
+        torch.arange(rows),
+        torch.empty(rows, 8),
+        torch.empty_like(output),
+        torch.empty_like(output),
+        torch.empty_like(output),
+        output,
+    )
+    assert len(bindings) == 1
+    assert torch.all(output == 7)
 
 
 def test_qsa_rope_staging_masks_graph_padding() -> None:

--- a/vllm/models/qwen3_8_flash_next/nvidia/qsa.py
+++ b/vllm/models/qwen3_8_flash_next/nvidia/qsa.py
@@ -1778,6 +1778,7 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
         )
         stream = aux_stream()
         assert stream is not None and self._selector_done is not None
+        assert self._index_ready is not None
         main_stream = current_stream()
         stream.wait_stream(main_stream)
         hidden_states.record_stream(stream)

--- a/vllm/models/qwen3_8_flash_next/nvidia/qsa.py
+++ b/vllm/models/qwen3_8_flash_next/nvidia/qsa.py
@@ -81,7 +81,7 @@ _QSA_INDEX_HEAD_DIM = 128
 _QSA_MANAGER_BLOCK_ALIGNMENT = 8
 _QSA_MAX_SPECULATIVE_TOKENS = 4
 _QSA_SPLITTING_OP = "vllm::qwen3_8_flash_next_qsa_with_output"
-_QSA_PROJECTED_READ_OP = "vllm::qwen3_8_flash_next_qsa_read_projected"
+_QSA_PROJECTED_READ_OP = "vllm::qwen3_8_flash_next_qsa_run_projected"
 
 
 def _qsa_prefill_context_capacities(
@@ -238,13 +238,18 @@ class _B12xQSAWarmup:
             }
 
             def compile_rows(context: _QSAContextPlan, rows: int) -> None:
-                qsa.run(
-                    layer._bind_qsa_context(context),
-                    **{
-                        key: value[:rows] if key in row_inputs else value
-                        for key, value in inputs.items()
-                    },
-                )
+                dynamic = {
+                    key: value[:rows] if key in row_inputs else value
+                    for key, value in inputs.items()
+                }
+                qsa.run(layer._bind_qsa_context(context), **dynamic)
+                if layer.overlap_input_projections and rows <= 16:
+                    layer._index_ready.record(current_stream())
+                    qsa.run(
+                        layer._bind_qsa_context(context, overlap=True),
+                        **dynamic,
+                        index_ready=layer._index_ready,
+                    )
 
             for context in live_contexts:
                 compile_rows(context, prefill_rows)
@@ -255,13 +260,12 @@ class _B12xQSAWarmup:
                         compile_rows(decode_context, rows)
                 if getattr(layer, "_share_mtp_indices", False):
                     rows = int(layer.max_seqs)
-                    qsa.run_selected(
+                    qsa.run(
                         layer._bind_qsa_context(decode_context),
                         query=inputs["query"][:rows],
                         request_ids=inputs["request_ids"][:rows],
                         query_positions=inputs["query_positions"][:rows],
-                        selected_positions=layer._mtp_shared_selected_positions,
-                        selection_errors=layer._mtp_read_errors,
+                        reuse_draft_selection=True,
                     )
 
         return B12xWarmupUnit(
@@ -790,88 +794,6 @@ def _stage_qsa_rope_positions_kernel(
     )
 
 
-@triton.jit
-def _record_mtp_selection_metadata_kernel(
-    positions,
-    errors,
-    saved_positions,
-    saved_errors,
-    rows,
-    BLOCK: tl.constexpr,
-):
-    row = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
-    mask = row < rows
-    tl.store(saved_positions + row, tl.load(positions + row, mask, other=-1), mask)
-    tl.store(saved_errors + row, tl.load(errors + row, mask, other=0), mask)
-
-
-@triton.jit
-def _compact_mtp_selection_kernel(
-    source_rows,
-    source_positions,
-    source_errors,
-    source_selection,
-    captured_lengths,
-    captured_errors,
-    captured_selection,
-    source_capacity,
-    source_stride,
-    destination_stride,
-    WIDTH: tl.constexpr,
-    TAIL: tl.constexpr,
-    BLOCK: tl.constexpr,
-):
-    row = tl.program_id(0).to(tl.int64)
-    source = tl.load(source_rows + row).to(tl.int64)
-    valid = (source >= 0) & (source < source_capacity)
-    column = tl.arange(0, BLOCK)
-    position = tl.load(source_positions + source, valid, other=-1)
-    error = tl.load(source_errors + source, valid, other=1)
-    selected = tl.load(
-        source_selection + source * source_stride + column,
-        valid & (column < WIDTH),
-        other=-1,
-    )
-    tl.store(
-        captured_selection + row * destination_stride + column,
-        selected,
-        column < WIDTH + TAIL,
-    )
-    tl.store(captured_lengths + row, position + 1)
-    tl.store(captured_errors + row, error)
-
-
-@triton.jit
-def _append_mtp_selection_tail_kernel(
-    captured_lengths,
-    captured_errors,
-    positions,
-    request_ids,
-    selection,
-    errors,
-    selection_stride,
-    max_requests,
-    WIDTH: tl.constexpr,
-    TAIL: tl.constexpr,
-    BLOCK: tl.constexpr,
-):
-    row = tl.program_id(0).to(tl.int64)
-    column = tl.arange(0, BLOCK)
-    start = tl.load(captured_lengths + row)
-    end = tl.load(positions + row)
-    request = tl.load(request_ids + row)
-    active = (request >= 0) & (request < max_requests)
-    valid = active & (start > 0) & (end >= start) & (end < start + TAIL)
-    tail = start + column
-    tl.store(
-        selection + row * selection_stride + WIDTH + column,
-        tl.where(valid & (tail <= end), tail, -1),
-        column < TAIL,
-    )
-    error = tl.load(captured_errors + row)
-    tl.store(errors + row, tl.where(active, error | tl.where(valid, 0, 1), 0))
-
-
 class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
     """Merged main attention, selector state, and b12x QSA transaction."""
 
@@ -1038,6 +960,12 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
         self._selector_done = (
             torch.cuda.Event() if self.overlap_input_projections else None
         )
+        self._index_ready = (
+            torch.cuda.Event() if self.overlap_input_projections else None
+        )
+        if self._selector_done is not None:
+            self._selector_done.record(aux_stream())
+        self._selector_index_inputs: tuple[torch.Tensor, ...] | None = None
         self._selector_metadata_views: _StagedQSAMetadata | None = None
         self._native_selection_width = self.budget + self.compress_ratio - 1
         self._share_mtp_indices = bool(
@@ -1050,8 +978,8 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
             for name, shape, dtype in (
                 ("_mtp_source_positions", (self.max_tokens,), torch.int64),
                 ("_mtp_source_errors", (self.max_tokens,), torch.int32),
-                ("_mtp_captured_lengths", (self.max_seqs,), torch.int64),
-                ("_mtp_captured_errors", (self.max_seqs,), torch.int32),
+                ("_mtp_source_rows", (self.max_seqs,), torch.int64),
+                ("_mtp_num_source_rows", (1,), torch.int32),
                 ("_mtp_read_errors", (self.max_seqs,), torch.int32),
                 (
                     "_mtp_shared_selected_positions",
@@ -1068,6 +996,7 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
                     persistent=False,
                 )
             self._mtp_shared_selected_positions.fill_(-1)
+            self._mtp_source_rows.fill_(-1)
 
         self.register_buffer(
             "_raw_k_ring",
@@ -1411,11 +1340,27 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
         context: _QSAContextPlan,
         staged: _StagedQSAMetadata | None = None,
         output: torch.Tensor | None = None,
+        *,
+        overlap: bool = False,
     ):
         impl = cast(Qwen3_8FlashNextQSAImpl, self.impl)
         main_k_cache, main_v_cache = impl._kv_cache_views(self.kv_cache)
         rope_cos, rope_sin = self.rotary_emb.cos_sin_cache.chunk(2, dim=-1)
         rows = context.plan.caps.max_q_rows
+        draft_selection = None
+        if self._share_mtp_indices:
+            qsa = get_b12x_qsa()
+            if qsa is None:
+                raise RuntimeError("b12x QSA is unavailable for draft state binding")
+            draft_selection = qsa.DraftSelectionState(
+                selected_positions=self._selected_positions,
+                logical_positions=self._mtp_source_positions,
+                errors=self._mtp_source_errors,
+                source_rows=self._mtp_source_rows,
+                num_source_rows=self._mtp_num_source_rows,
+                work_positions=self._mtp_shared_selected_positions,
+                work_errors=self._mtp_read_errors,
+            )
         return context.plan.bind(
             scratch=context.scratch,
             main_block_table=context.main_block_table,
@@ -1438,6 +1383,9 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
             rope_sin=rope_sin,
             output=self._qsa_output[:rows] if output is None else output,
             selected_positions=self._selected_positions[:rows],
+            selection_stream=aux_stream() if overlap else None,
+            selection_done=self._selector_done if overlap else None,
+            draft_selection=draft_selection,
         )
 
     def unbind_kv_cache(self) -> None:
@@ -1687,7 +1635,7 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
         self.skip_topk = bool(skip and self._share_mtp_indices)
 
     def compact_topk_indices(self, source_rows: torch.Tensor) -> None:
-        """Capture accepted-token-aligned draft rows and their selector errors."""
+        """Map compacted requests to their accepted draft-selection anchors."""
         if not self._share_mtp_indices:
             return
         rows = int(source_rows.numel())
@@ -1701,50 +1649,9 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
             or not source_rows.is_contiguous()
         ):
             raise TypeError("QSA MTP source rows must be contiguous CUDA int32/int64")
-        _compact_mtp_selection_kernel[(rows,)](
-            source_rows,
-            self._mtp_source_positions,
-            self._mtp_source_errors,
-            self._selected_positions,
-            self._mtp_captured_lengths,
-            self._mtp_captured_errors,
-            self._mtp_shared_selected_positions,
-            self.max_tokens,
-            self._selected_positions.stride(0),
-            self._mtp_shared_selected_positions.stride(0),
-            WIDTH=self._native_selection_width,
-            TAIL=self.max_speculative_tokens,
-            BLOCK=triton.next_power_of_2(
-                self._native_selection_width + self.max_speculative_tokens
-            ),
-        )
-
-    def _record_mtp_selection_metadata(self, binding, staged, rows: int) -> None:
-        if self._share_mtp_indices:
-            _record_mtp_selection_metadata_kernel[(triton.cdiv(rows, 128),)](
-                staged.logical_positions,
-                binding.state_errors,
-                self._mtp_source_positions,
-                self._mtp_source_errors,
-                rows,
-                BLOCK=128,
-            )
-
-    def _append_mtp_selection_tail(self, positions, request_ids) -> None:
-        _append_mtp_selection_tail_kernel[(int(positions.shape[0]),)](
-            self._mtp_captured_lengths,
-            self._mtp_captured_errors,
-            positions,
-            request_ids,
-            self._mtp_shared_selected_positions,
-            self._mtp_read_errors,
-            self._mtp_shared_selected_positions.stride(0),
-            self.max_seqs,
-            WIDTH=self._native_selection_width,
-            TAIL=self.max_speculative_tokens,
-            BLOCK=triton.next_power_of_2(self.max_speculative_tokens),
-            num_warps=1,
-        )
+        self._mtp_source_rows[:rows].copy_(source_rows)
+        if rows < self.max_seqs:
+            self._mtp_source_rows[rows:].fill_(-1)
 
     def _run_reused_qsa(self, query, key, value, output) -> None:
         raw = get_forward_context().attn_metadata
@@ -1791,17 +1698,15 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
         impl.do_kv_cache_update(
             self, key[:rows], value[:rows], self.kv_cache, metadata.slot_mapping[:rows]
         )
-        self._append_mtp_selection_tail(staged.logical_positions, staged.request_ids)
         qsa = get_b12x_qsa()
         if qsa is None:
             raise RuntimeError("b12x QSA is unavailable for MTP selection reuse")
-        qsa.run_selected(
+        qsa.run(
             self._bind_qsa_context(context, staged, output[:rows]),
             query=query[:rows],
             request_ids=staged.request_ids,
             query_positions=staged.logical_positions,
-            selected_positions=self._mtp_shared_selected_positions[:rows],
-            selection_errors=self._mtp_read_errors[:rows],
+            reuse_draft_selection=True,
         )
         if rows < output.shape[0]:
             output[rows:].zero_()
@@ -1856,7 +1761,7 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
             return None
         return metadata
 
-    def _project_and_select(
+    def _project_qsa_inputs(
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
@@ -1890,29 +1795,17 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
                 positions, staged.request_ids, rows
             )
             index_query, raw_index_key = self.indexer.project(hidden_states)
-            qsa = get_b12x_qsa()
-            if qsa is None:
-                raise RuntimeError("b12x QSA disappeared after cache binding")
-            binding = self._bind_qsa_context(context, staged)
-            qsa.select(
-                binding,
-                index_query=index_query[:rows],
-                raw_index_key=raw_index_key[:rows],
-                request_ids=staged.request_ids,
-                query_positions=staged.logical_positions,
-                rope_positions=rope_positions,
-                sequence_lengths=staged.sequence_lengths,
-                query_start_loc=staged.query_start_loc,
-                num_accepted_tokens=staged.num_accepted_tokens,
-                is_prefilling=staged.is_prefilling,
+            self._selector_index_inputs = (
+                index_query[:rows],
+                raw_index_key[:rows],
+                rope_positions,
             )
-            self._record_mtp_selection_metadata(binding, staged, rows)
-            self._selector_done.record(stream)
-        # Only QKV is exposed as a returned tensor. Selector storage is private
-        # until _read_projected_qsa joins its producer before reading attention.
+            self._index_ready.record(stream)
+        # The complete B12X run consumes these inputs and joins its selection
+        # stream after the independent main Q/K/V producer has been enqueued.
         return self.qkv_proj(hidden_states)[0]
 
-    def _read_projected_qsa(
+    def _run_projected_qsa(
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
@@ -1944,19 +1837,26 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
             self.kv_cache,
             metadata.slot_mapping[:rows],
         )
-        assert self._selector_done is not None
-        current_stream().wait_event(self._selector_done)
         qsa = get_b12x_qsa()
         if qsa is None or metadata.request_ids is None:
             raise RuntimeError("b12x QSA selection metadata is unavailable")
         staged = self._selector_metadata_views
-        if staged is None:
+        if staged is None or self._selector_index_inputs is None:
             raise RuntimeError("QSA attention has no matching selector metadata")
-        qsa.run_selected(
-            self._bind_qsa_context(context, staged, output[:rows]),
+        index_query, raw_index_key, rope_positions = self._selector_index_inputs
+        qsa.run(
+            self._bind_qsa_context(context, staged, output[:rows], overlap=True),
             query=query[:rows],
+            index_query=index_query,
+            raw_index_key=raw_index_key,
             request_ids=staged.request_ids,
             query_positions=staged.logical_positions,
+            rope_positions=rope_positions,
+            sequence_lengths=staged.sequence_lengths,
+            query_start_loc=staged.query_start_loc,
+            num_accepted_tokens=staged.num_accepted_tokens,
+            is_prefilling=staged.is_prefilling,
+            index_ready=self._index_ready,
         )
         if rows < output.shape[0]:
             output[rows:].zero_()
@@ -2015,7 +1915,6 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
             num_accepted_tokens=staged.num_accepted_tokens,
             is_prefilling=staged.is_prefilling,
         )
-        self._record_mtp_selection_metadata(binding, staged, rows)
         if rows < output.shape[0]:
             output[rows:].zero_()
 
@@ -2080,7 +1979,7 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
     ) -> torch.Tensor:
         if self.overlap_input_projections or self._share_mtp_indices:
             layer_name = _encode_layer_name(self.layer_name)
-            qkv = torch.ops.vllm.qwen3_8_flash_next_qsa_project_and_select(
+            qkv = torch.ops.vllm.qwen3_8_flash_next_qsa_project_inputs(
                 positions,
                 hidden_states,
                 self._selected_positions,
@@ -2093,7 +1992,7 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
             key = key.view(rows, self.num_kv_heads, self.head_dim)
             value = value.view(rows, self.num_kv_heads, self.head_dim)
             output = torch.empty_like(query)
-            torch.ops.vllm.qwen3_8_flash_next_qsa_read_projected(
+            torch.ops.vllm.qwen3_8_flash_next_qsa_run_projected(
                 positions,
                 hidden_states,
                 query,
@@ -2141,7 +2040,7 @@ class Qwen3_8FlashNextQSAAttention(nn.Module, AttentionLayerBase):
         return projected
 
 
-def _qsa_project_and_select(
+def _qsa_project_inputs(
     positions: torch.Tensor,
     hidden_states: torch.Tensor,
     selected_positions: torch.Tensor,
@@ -2151,10 +2050,10 @@ def _qsa_project_and_select(
     layer = get_forward_context().no_compile_layers[_resolve_layer_name(layer_name)]
     if selected_positions.data_ptr() != layer._selected_positions.data_ptr():
         raise ValueError("QSA selection must use its bound caller-owned buffer")
-    return layer._project_and_select(positions, hidden_states)
+    return layer._project_qsa_inputs(positions, hidden_states)
 
 
-def _qsa_project_and_select_fake(
+def _qsa_project_inputs_fake(
     positions: torch.Tensor,
     hidden_states: torch.Tensor,
     selected_positions: torch.Tensor,
@@ -2165,14 +2064,15 @@ def _qsa_project_and_select_fake(
 
 
 direct_register_custom_op(
-    op_name="qwen3_8_flash_next_qsa_project_and_select",
-    op_func=_qsa_project_and_select,
+    op_name="qwen3_8_flash_next_qsa_project_inputs",
+    op_func=_qsa_project_inputs,
+    # This buffer is also the ordering token for the hidden selector inputs.
     mutates_args=["selected_positions"],
-    fake_impl=_qsa_project_and_select_fake,
+    fake_impl=_qsa_project_inputs_fake,
 )
 
 
-def _qsa_read_projected(
+def _qsa_run_projected(
     positions: torch.Tensor,
     hidden_states: torch.Tensor,
     query: torch.Tensor,
@@ -2185,10 +2085,10 @@ def _qsa_read_projected(
     layer = get_forward_context().no_compile_layers[_resolve_layer_name(layer_name)]
     if selected_positions.data_ptr() != layer._selected_positions.data_ptr():
         raise ValueError("QSA attention must consume the matching selector buffer")
-    layer._read_projected_qsa(positions, hidden_states, query, key, value, output)
+    layer._run_projected_qsa(positions, hidden_states, query, key, value, output)
 
 
-def _qsa_read_projected_fake(
+def _qsa_run_projected_fake(
     positions: torch.Tensor,
     hidden_states: torch.Tensor,
     query: torch.Tensor,
@@ -2202,10 +2102,10 @@ def _qsa_read_projected_fake(
 
 
 direct_register_custom_op(
-    op_name="qwen3_8_flash_next_qsa_read_projected",
-    op_func=_qsa_read_projected,
-    mutates_args=["output"],
-    fake_impl=_qsa_read_projected_fake,
+    op_name="qwen3_8_flash_next_qsa_run_projected",
+    op_func=_qsa_run_projected,
+    mutates_args=["output", "selected_positions"],
+    fake_impl=_qsa_run_projected_fake,
 )
 
 


### PR DESCRIPTION
## Fix

Use the complete B12X QSA operation for Qwen sparse attention. Merged #658
calls `qsa.select` and `qsa.run_selected`, which merged B12X #321 no longer
exports; that mismatch raises `AttributeError` during CUDA capture.

Index projection and metadata preparation run on the auxiliary stream. vLLM
passes their readiness event to `qsa.run` after enqueueing the independent
main QKV producer. B12X owns selection, the stream join and attention.

MTP still reuses its own first-draft selection. vLLM supplies an accepted-row
map and fresh caller-owned bindings; B12X owns anchor gathering, causal tails
and error propagation. The target continues selecting independently. This
does not disable overlap, introduce a workspace cache, change precision or
switch serving to eager mode.

## Dependency and scope

Requires local-inference-lab/b12x#337 for `DraftSelectionState` and caller-owned
completion events. Merge that API change first. This PR repairs the
consumer of the complete-operation interface; it does not duplicate #606,
#659, #660 or #661. No equivalent open local or upstream PR was found.

## Validation

Status: **qualified for TP1/TP2 MTP3** with the composed Qwen stack.

```text
B12X_QSA_GPU_TEST=1 pytest -q tests/models/test_qwen3_8_flash_next_qsa.py
```

41 focused QSA cases pass. The complete image passes 123 QSA/model/GDN tests
and 40 focused router cases. Repository pre-commit checks, including mypy,
pass on every changed vLLM file in the composition.

RTX PRO 6000 Workstation stock, MTP3, temperature 1, top-p .95, top-k 20,
private NVFP4 draft vocabulary, BF16 target vocabulary and V2 full/piecewise
graphs: 32k prefill 14,947 → 14,920 tok/s (-0.18%). Median reasoning C1 output
is 170.6 → 182.8 tok/s over three warmed windows; verifier execution improves
about 1.7%. Output also varies with acceptance; this is a composition A/B, not
an isolated kernel-speed claim. Cold/warmed JSON and post-32k logprobs pass.

On the same stock TP2 GPU pair: median C1 198.6 → 200.2 output tok/s,
92.74 → 93.17 verifier steps/s, and 32k prefill 16,684 → 16,836 tok/s.
The C1/2/4/8/16 sweep has no errors or detected loops. C8 measures
831.7 → 936.5 output tok/s and C16 1288.7 → 1367.2 in single warmed windows.
Cold/restored JSON through C16, post-prefill logprobs and system/developer
instruction-prefix reuse pass. The performance A/B boundary is the complete
source pair, not this PR alone.

[Source-locked serving A/B, commands, raw results and limitations](https://gist.github.com/voipmonitor/48312f245e310174039d9d478d2e5e30#file-qwen38-qsa-api-qualification-md).
The unmerged Qwen checklist is #662.

AI assistance was used. Maintainer review is required before merge.
