### PR TITLE
Fix Codex tool-call poisoning and fatal KV completion races

### DIFF
--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -16,6 +16,7 @@ from openai.types.responses.response_reasoning_item import (
     Summary,
 )
 
+from vllm.entrypoints.chat_utils import _postprocess_messages
 from vllm.entrypoints.openai.responses.utils import (
     _construct_message_from_response_item,
     construct_chat_messages_with_tool_call,
@@ -152,6 +153,32 @@ class TestResponsesUtils:
         assert (
             message["tool_calls"][0]["function"]["arguments"] == '{"code": "123+456"}'
         )
+
+    def test_malformed_function_call_history_remains_replayable(self):
+        """Malformed Responses history must not poison later turns."""
+        malformed = (
+            '{"cmd": "sed -n 155,180p test.py", "workdir": "'
+            "/workspace/L</think><tool_call>exec_command<arg_key>cmd"
+        )
+        items = [
+            make_function_call(
+                call_id="call_incomplete",
+                name="exec_command",
+                arguments=malformed,
+            ),
+            make_function_call_output(
+                call_id="call_incomplete",
+                output="The tool call was not executed.",
+            ),
+            {"role": "user", "content": "Continue."},
+        ]
+
+        messages = construct_chat_messages_with_tool_call(items)
+        _postprocess_messages(messages)
+
+        assert messages[0]["tool_calls"][0]["function"]["arguments"] == {}
+        assert messages[1]["tool_call_id"] == "call_incomplete"
+        assert messages[2] == {"role": "user", "content": "Continue."}
 
     def test_construct_chat_messages_preserves_single_item_conversions(self):
         item = ResponseReasoningItem(

--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -2806,3 +2806,120 @@ async def test_resolve_items_does_not_leak_tasks_on_partial_failure():
         f"resolve_items left {len(leaked_tasks)} task(s) running after "
         f"raising: {leaked_tasks}"
     )
+
+
+def _assistant_tool_call(arguments, name="write"):
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_0",
+                    "type": "function",
+                    "function": {"name": name, "arguments": arguments},
+                }
+            ],
+        }
+    ]
+
+
+def _assistant_tool_calls(calls):
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": calls,
+        }
+    ]
+
+
+def test_tool_call_arguments_dict_passthrough(caplog):
+    messages = _assistant_tool_call({"a": 1})
+    _postprocess_messages(messages)
+    args = messages[0]["tool_calls"][0]["function"]["arguments"]
+    assert args == {"a": 1}
+    assert not caplog.records
+
+
+def test_tool_call_arguments_valid_object_string(caplog):
+    messages = _assistant_tool_call('{"a": 1}')
+    _postprocess_messages(messages)
+    args = messages[0]["tool_calls"][0]["function"]["arguments"]
+    assert args == {"a": 1}
+    assert not caplog.records
+
+
+def test_tool_call_arguments_malformed_json_small(caplog):
+    bad = '{"cmd": "mkdir -p /tmp/mmadtest && cat > /tmp/mmadtest'
+    messages = _assistant_tool_call(bad, name="exec")
+    _postprocess_messages(messages)
+    args = messages[0]["tool_calls"][0]["function"]["arguments"]
+    assert args == {}
+
+    assert len(caplog.records) == 1
+    assert "exec" in caplog.records[0].message
+    assert "coercing to an empty object" in caplog.records[0].message
+
+
+def test_tool_call_arguments_malformed_json_large(caplog):
+    bad = '{"filepath": "src/main.py", "contents": "' + ("x" * 18000)
+    messages = _assistant_tool_call(bad, name="write")
+    _postprocess_messages(messages)
+    args = messages[0]["tool_calls"][0]["function"]["arguments"]
+    assert args == {}
+
+    assert len(caplog.records) == 1
+    assert "write" in caplog.records[0].message
+    assert "coercing to an empty object" in caplog.records[0].message
+
+
+@pytest.mark.parametrize("non_obj", ["[]", "42", "true", '"hello"', "null"])
+def test_tool_call_arguments_valid_json_non_object(caplog, non_obj):
+    messages = _assistant_tool_call(non_obj, name="bad_tool")
+    _postprocess_messages(messages)
+    args = messages[0]["tool_calls"][0]["function"]["arguments"]
+    assert args == {}
+
+    if non_obj == "null":
+        # null parses to None, so no warning is emitted according to requirements
+        assert not caplog.records
+    else:
+        assert len(caplog.records) == 1
+        assert "bad_tool" in caplog.records[0].message
+        assert "not a JSON object" in caplog.records[0].message
+
+
+@pytest.mark.parametrize("missing", [None, ""])
+def test_tool_call_arguments_missing_or_empty(caplog, missing):
+    messages = _assistant_tool_call(missing)
+    if missing is None:
+        del messages[0]["tool_calls"][0]["function"]["arguments"]
+    _postprocess_messages(messages)
+    args = messages[0]["tool_calls"][0]["function"]["arguments"]
+    assert args == {}
+    assert not caplog.records
+
+
+def test_tool_call_arguments_multiple_independent(caplog):
+    calls = [
+        {
+            "id": "call_0",
+            "type": "function",
+            "function": {"name": "good", "arguments": '{"a": 1}'},
+        },
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "bad", "arguments": '{"cmd": "'},
+        },
+    ]
+    messages = _assistant_tool_calls(calls)
+    _postprocess_messages(messages)
+
+    tool_calls = messages[0]["tool_calls"]
+    assert tool_calls[0]["function"]["arguments"] == {"a": 1}
+    assert tool_calls[1]["function"]["arguments"] == {}
+
+    assert len(caplog.records) == 1
+    assert "bad" in caplog.records[0].message

--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -2835,6 +2835,7 @@ def _assistant_tool_calls(calls):
 
 
 def test_tool_call_arguments_dict_passthrough(caplog):
+    """Dictionary arguments pass through without warnings."""
     messages = _assistant_tool_call({"a": 1})
     _postprocess_messages(messages)
     args = messages[0]["tool_calls"][0]["function"]["arguments"]
@@ -2843,6 +2844,7 @@ def test_tool_call_arguments_dict_passthrough(caplog):
 
 
 def test_tool_call_arguments_valid_object_string(caplog):
+    """A valid object string becomes the mapping templates require."""
     messages = _assistant_tool_call('{"a": 1}')
     _postprocess_messages(messages)
     args = messages[0]["tool_calls"][0]["function"]["arguments"]
@@ -2851,6 +2853,7 @@ def test_tool_call_arguments_valid_object_string(caplog):
 
 
 def test_tool_call_arguments_malformed_json_small(caplog):
+    """A short malformed call is redacted and reported once."""
     bad = '{"cmd": "mkdir -p /tmp/mmadtest && cat > /tmp/mmadtest'
     messages = _assistant_tool_call(bad, name="exec")
     _postprocess_messages(messages)
@@ -2863,6 +2866,7 @@ def test_tool_call_arguments_malformed_json_small(caplog):
 
 
 def test_tool_call_arguments_malformed_json_large(caplog):
+    """A cap-truncated large call is redacted without logging its body."""
     bad = '{"filepath": "src/main.py", "contents": "' + ("x" * 18000)
     messages = _assistant_tool_call(bad, name="write")
     _postprocess_messages(messages)
@@ -2876,6 +2880,7 @@ def test_tool_call_arguments_malformed_json_large(caplog):
 
 @pytest.mark.parametrize("non_obj", ["[]", "42", "true", '"hello"', "null"])
 def test_tool_call_arguments_valid_json_non_object(caplog, non_obj):
+    """Valid JSON values that are not objects are not sent to templates."""
     messages = _assistant_tool_call(non_obj, name="bad_tool")
     _postprocess_messages(messages)
     args = messages[0]["tool_calls"][0]["function"]["arguments"]
@@ -2892,6 +2897,7 @@ def test_tool_call_arguments_valid_json_non_object(caplog, non_obj):
 
 @pytest.mark.parametrize("missing", [None, ""])
 def test_tool_call_arguments_missing_or_empty(caplog, missing):
+    """Missing and empty arguments retain zero-argument compatibility."""
     messages = _assistant_tool_call(missing)
     if missing is None:
         del messages[0]["tool_calls"][0]["function"]["arguments"]
@@ -2902,6 +2908,7 @@ def test_tool_call_arguments_missing_or_empty(caplog, missing):
 
 
 def test_tool_call_arguments_multiple_independent(caplog):
+    """One malformed call does not alter a valid sibling call."""
     calls = [
         {
             "id": "call_0",

--- a/tests/parser/engine/test_glm47_moe.py
+++ b/tests/parser/engine/test_glm47_moe.py
@@ -197,6 +197,32 @@ class TestStreaming:
         assert json.loads(collect_tool_arguments(results)) == EXPECTED_ARGS
         assert collect_content(results) == ""
 
+    def test_reopened_tool_markup_inside_unclosed_value_stays_valid_json(
+        self, parser, mock_request, tools
+    ):
+        """A captured malformed-call shape must still finish as valid JSON."""
+        mock_request.tools = tools
+        nested_markup = (
+            f"/workspace/L{THINK_END}{TOOL_CALL_START}record_value"
+            f"{ARG_KEY_START}value{ARG_KEY_END}{ARG_VALUE_START}second"
+        )
+        output = (
+            f"{THINK_END}{TOOL_CALL_START}record_value"
+            f"{ARG_KEY_START}value{ARG_KEY_END}{ARG_VALUE_START}first"
+            f"{ARG_VALUE_END}{ARG_KEY_START}path{ARG_KEY_END}"
+            f"{ARG_VALUE_START}{nested_markup}"
+        )
+
+        results = simulate_tool_streaming(parser, mock_request, _tag_chunks(output))
+        finish = parser.finish_streaming()
+        if finish is not None:
+            results.append((finish, output))
+
+        assert json.loads(collect_tool_arguments(results)) == {
+            "value": "first",
+            "path": nested_markup,
+        }
+
     def test_stop_token_id_without_text_in_final_delta(self, mock_request, tools):
         """Speculative decoding can deliver the whole call plus the stop
         token in one step; serving strips the stop text but keeps its ID.

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -1593,29 +1593,88 @@ class TestArgDeltaWithConverter:
 
 
 class TestSafeArgPrefix:
-    """Unit tests for ParserEngine._safe_arg_prefix."""
+    """Unit tests for ParserEngine._safe_arg_prefix.
+
+    A trailing value that cannot stream (non-string, or a string for a key the
+    schema may coerce) is withheld together with its ``"key": `` separator:
+    the flush can drop an unfinished parameter, and a prefix ending on the
+    separator then has no valid completion.
+    """
 
     @pytest.mark.parametrize(
         "json_str, expected",
         [
-            ('{"a": 1}', '{"a": '),
-            ('{"a": 1, "b": 2}', '{"a": 1, "b": '),
+            ('{"a": 1}', ""),
+            ('{"a": 1, "b": 2}', '{"a": 1'),
             ('{"a": "hello", "b": "world"}', '{"a": "hello", "b": "world'),
-            ('{"obj": {"x": 1}, "b": 2}', '{"obj": {"x": 1}, "b": '),
-            ('{"url": "http://x:80", "b": 1}', '{"url": "http://x:80", "b": '),
-            ('{"a": 1', '{"a": '),
+            ('{"obj": {"x": 1}, "b": 2}', '{"obj": {"x": 1}'),
+            ('{"url": "http://x:80", "b": 1}', '{"url": "http://x:80"'),
+            ('{"a": 1', ""),
             ("{}", ""),
             ("{", ""),
             ("", ""),
-            ('{"k":1}', '{"k":'),
-            ('{"k": 1, "v":2}', '{"k": 1, "v":'),
+            ('{"k":1}', ""),
+            ('{"k": 1, "v":2}', '{"k": 1'),
             ('{"k":"value"}', '{"k":"value'),
             ('{"k":"unterminated', '{"k":"unterminated'),
             (r'{"k":"escaped \" quote"}', r'{"k":"escaped \" quote'),
+            # A complete trailing value followed by a separator is kept whole.
+            ('{"a": "x", "b": 2, ', '{"a": "x", "b": 2'),
+            # Unfinished containers are withheld with their key.
+            ('{"a": "x", "obj": {"b": ', '{"a": "x"'),
+            ('{"a": "x", "items": [1, ', '{"a": "x"'),
+            # A streamed string never ends inside an escape sequence.
+            ('{"t": "ab\\', '{"t": "ab'),
+            ('{"t": "ab\\u12', '{"t": "ab'),
+            ('{"t": "ab\\u12ab', '{"t": "ab\\u12ab'),
+            ('{"t": "ab\\n', '{"t": "ab\\n'),
         ],
     )
     def test_safe_arg_prefix(self, json_str, expected):
         assert ParserEngine._safe_arg_prefix(json_str) == expected
+
+    def test_schema_typed_trailing_string_is_withheld_with_its_key(self):
+        # ``count`` may be coerced to a number, so its value cannot stream and
+        # the separator must not be left dangling either.
+        json_str = '{"path": "README.md", "count": "1'
+        assert (
+            ParserEngine._safe_arg_prefix(json_str, {"path"}) == '{"path": "README.md"'
+        )
+
+
+class TestJsonPrefixTerminator:
+    """Unit tests for ParserEngine._json_prefix_terminator.
+
+    Every non-empty suffix must make the prefix parse; a prefix with no valid
+    completion yields "" so the caller can decline to close it.
+    """
+
+    @pytest.mark.parametrize(
+        "prefix, expected",
+        [
+            ('{"a": "x', '"}'),
+            ('{"a": "x\\', '\\"}'),
+            ('{"a": [', "]}"),
+            ('{"a": {"b": "x', '"}}'),
+            # A dangling separator is completed with null, the one value every
+            # schema type accepts.
+            ('{"count": ', "null}"),
+            ('{"a": "x", "b": ', "null}"),
+            ('{"a": {"b": ', "null}}"),
+            ('{"a": "x", "items": [1, ', "null]}"),
+            # An object after a comma cannot be completed without inventing a key.
+            ('{"a": 1, ', ""),
+            # A partial escape cannot be completed without inventing characters.
+            ('{"t": "ab\\u12', ""),
+            ('{"flag": tr', ""),
+            ("", ""),
+        ],
+    )
+    def test_json_prefix_terminator(self, prefix, expected):
+        suffix = ParserEngine._json_prefix_terminator(prefix)
+        assert suffix == expected
+        if suffix:
+            json.loads(prefix + suffix)
 
 
 # ── Coercion instability regression tests ────────────────────────

--- a/tests/parser/engine/test_qwen3.py
+++ b/tests/parser/engine/test_qwen3.py
@@ -44,6 +44,67 @@ def parser(mock_tokenizer):
     )
 
 
+class TestUnclosedParameterFlush:
+    def test_unclosed_parameter_still_streams_valid_json(self, parser, mock_request):
+        """A tool call cut off mid-parameter must not stream unparseable JSON.
+
+        ``_safe_arg_prefix`` streams unterminated string values on the
+        understanding that the flush closes them. When the model reopens a tool
+        call without closing the current parameter, the non-partial
+        re-derivation drops that parameter, so it is neither longer than nor a
+        prefix of what was already streamed. ``_flush_arg_converter`` then had
+        nothing to append and the stream ended with ``finish_reason`` set while
+        ``arguments`` was still cut off mid-string, which no JSON parser
+        accepts. Observed in production on Qwen3.8-27B at temperature 1.0.
+
+        Fed one character at a time because that is the worst case for the
+        prefix invariant, and because the boundary that triggers this lands
+        inside a literal the incremental lexer would otherwise hold.
+        """
+        raw = (
+            "<tool_call>\n<function=write_file>\n"
+            "<parameter=path>\nREADME.md\n</parameter>\n"
+            "<parameter=content>\n# Title\n\n"
+            "body text that continues for a while\n\n"
+            # The model reopens a tool call without closing <parameter=content>.
+            "<tool_call>\n<function=write_file>"
+        )
+        results = simulate_tool_streaming(parser, mock_request, list(raw))
+        finish = parser.finish_streaming()
+        if finish is not None:
+            results.append((finish, ""))
+
+        args = collect_tool_arguments(results)
+        assert args, "no arguments were streamed"
+        assert args.startswith('{"path": "README.md"'), args[:60]
+        json.loads(args)
+
+    def test_truncated_parameter_still_streams_valid_json(self, parser, mock_request):
+        """The same defect with no stray markup: generation simply stops.
+
+        This is the common trigger. A length stop, a stop string or a client
+        disconnect ends the stream partway through a parameter value, with no
+        second ``<tool_call>`` and nothing malformed in the model output. The
+        flush re-derives without the still-open parameter and again has nothing
+        to append, so the client is handed a string that was never closed.
+        """
+        raw = (
+            "<tool_call>\n<function=write_file>\n"
+            "<parameter=path>\nREADME.md\n</parameter>\n"
+            "<parameter=content>\n# Title\n\n"
+            "body text that stops mid-sen"
+        )
+        results = simulate_tool_streaming(parser, mock_request, list(raw))
+        finish = parser.finish_streaming()
+        if finish is not None:
+            results.append((finish, ""))
+
+        args = collect_tool_arguments(results)
+        assert args, "no arguments were streamed"
+        assert args.startswith('{"path": "README.md"'), args[:60]
+        json.loads(args)
+
+
 class TestNonStreaming:
     def test_no_tool_calls(self, parser, mock_request):
         result = parser.extract_tool_calls(

--- a/tests/parser/engine/test_qwen3.py
+++ b/tests/parser/engine/test_qwen3.py
@@ -46,7 +46,7 @@ def parser(mock_tokenizer):
 
 class TestUnclosedParameterFlush:
     def test_unclosed_parameter_still_streams_valid_json(self, parser, mock_request):
-        """A tool call cut off mid-parameter must not stream unparseable JSON.
+        """A tool call cut off mid-parameter must not stream unparsable JSON.
 
         ``_safe_arg_prefix`` streams unterminated string values on the
         understanding that the flush closes them. When the model reopens a tool

--- a/tests/parser/engine/test_qwen3.py
+++ b/tests/parser/engine/test_qwen3.py
@@ -104,6 +104,55 @@ class TestUnclosedParameterFlush:
         assert args.startswith('{"path": "README.md"'), args[:60]
         json.loads(args)
 
+    @pytest.fixture
+    def tools(self):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "write_file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "count": {"type": "integer"},
+                        },
+                    },
+                },
+            }
+        ]
+
+    @pytest.fixture
+    def parser_with_tools(self, mock_tokenizer, tools):
+        return ParserEngine(
+            mock_tokenizer,
+            tools=tools,
+            parser_engine_config=qwen3_config(thinking=False),
+        )
+
+    def test_truncated_typed_parameter_still_streams_valid_json(
+        self, parser_with_tools, mock_request
+    ):
+        """Truncation inside a schema-typed (non-string) parameter.
+
+        The number cannot stream, so before the fix the prefix ended on the
+        separator, ``{"path": "README.md", "count": ``, and the flush had no
+        completion for it.
+        """
+        raw = (
+            "<tool_call>\n<function=write_file>\n"
+            "<parameter=path>\nREADME.md\n</parameter>\n"
+            "<parameter=count>\n12"
+        )
+        results = simulate_tool_streaming(parser_with_tools, mock_request, list(raw))
+        finish = parser_with_tools.finish_streaming()
+        if finish is not None:
+            results.append((finish, ""))
+
+        args = collect_tool_arguments(results)
+        assert args, "no arguments were streamed"
+        assert json.loads(args)["path"] == "README.md"
+
 
 class TestNonStreaming:
     def test_no_tool_calls(self, parser, mock_request):

--- a/tests/parser/engine/test_qwen3.py
+++ b/tests/parser/engine/test_qwen3.py
@@ -46,20 +46,11 @@ def parser(mock_tokenizer):
 
 class TestUnclosedParameterFlush:
     def test_unclosed_parameter_still_streams_valid_json(self, parser, mock_request):
-        """A tool call cut off mid-parameter must not stream unparsable JSON.
+        """A tool call reopened mid-parameter must still stream parsable JSON.
 
-        ``_safe_arg_prefix`` streams unterminated string values on the
-        understanding that the flush closes them. When the model reopens a tool
-        call without closing the current parameter, the non-partial
-        re-derivation drops that parameter, so it is neither longer than nor a
-        prefix of what was already streamed. ``_flush_arg_converter`` then had
-        nothing to append and the stream ended with ``finish_reason`` set while
-        ``arguments`` was still cut off mid-string, which no JSON parser
-        accepts. Observed in production on Qwen3.8-27B at temperature 1.0.
-
-        Fed one character at a time because that is the worst case for the
-        prefix invariant, and because the boundary that triggers this lands
-        inside a literal the incremental lexer would otherwise hold.
+        The flush re-derives without the open parameter, so it cannot extend
+        the streamed prefix; the prefix has to be closed instead. Fed one
+        character at a time, the worst case for the prefix invariant.
         """
         raw = (
             "<tool_call>\n<function=write_file>\n"
@@ -80,14 +71,7 @@ class TestUnclosedParameterFlush:
         json.loads(args)
 
     def test_truncated_parameter_still_streams_valid_json(self, parser, mock_request):
-        """The same defect with no stray markup: generation simply stops.
-
-        This is the common trigger. A length stop, a stop string or a client
-        disconnect ends the stream partway through a parameter value, with no
-        second ``<tool_call>`` and nothing malformed in the model output. The
-        flush re-derives without the still-open parameter and again has nothing
-        to append, so the client is handed a string that was never closed.
-        """
+        """The common trigger: generation simply stops inside a parameter."""
         raw = (
             "<tool_call>\n<function=write_file>\n"
             "<parameter=path>\nREADME.md\n</parameter>\n"

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -5301,6 +5301,8 @@ def test_ec_connector_update_connector_output_called():
     scheduler.ec_connector.update_connector_output.assert_called_once_with(
         ec_connector_output
     )
+
+
 # ==============================================================================
 # Variable-length encoder cross-attention block allocation tests
 # ==============================================================================

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -5060,7 +5060,95 @@ def test_abort_request_finished_recving():
     assert not scheduler.finished_recving_kv_req_ids
 
 
+def test_ignore_late_finished_recving_after_abort_cleanup():
+    """A late receive completion must not revive or crash a cleaned request."""
+    scheduler = create_scheduler(use_kv_connector=True)
+
+    # add a single request
+    request = create_requests(num_requests=1)[0]
+    scheduler.add_request(request)
+
+    # abort after recv completed but before the scheduler promotes the request
+    request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+    scheduler.finished_recving_kv_req_ids.add(request.request_id)
+    scheduler.finish_requests((request.request_id,), RequestStatus.FINISHED_ABORTED)
+
+    assert request.request_id not in scheduler.requests
+
+    # a late worker callback should be ignored rather than crashing
+    scheduler_output = scheduler.schedule()
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[],
+        req_id_to_index={},
+        kv_connector_output=KVConnectorOutput(finished_recving={request.request_id}),
+    )
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert request.request_id not in scheduler.requests
+    assert not scheduler.finished_recving_kv_req_ids
+
+
+def test_ignore_late_finished_sending_after_request_cleanup():
+    """A late send completion must not crash after request cleanup."""
+    scheduler = create_scheduler(use_kv_connector=True)
+
+    # add and finish a single request so it is fully removed
+    request = create_requests(num_requests=1)[0]
+    scheduler.add_request(request)
+    scheduler.finish_requests((request.request_id,), RequestStatus.FINISHED_ABORTED)
+
+    assert request.request_id not in scheduler.requests
+
+    # a stale async send completion should also be ignored
+    scheduler_output = scheduler.schedule()
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[],
+        req_id_to_index={},
+        kv_connector_output=KVConnectorOutput(finished_sending={request.request_id}),
+    )
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert request.request_id not in scheduler.requests
+
+
+def test_same_step_recv_and_send_completion_after_abort():
+    """Dual completion frees an aborted request once without crashing."""
+    scheduler = create_scheduler(use_kv_connector=True)
+    request = create_requests(num_requests=1)[0]
+    scheduler.add_request(request)
+    request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+    scheduler.finish_requests((request.request_id,), RequestStatus.FINISHED_ABORTED)
+
+    assert request.request_id in scheduler.requests
+
+    scheduler._update_from_kv_xfer_finished(
+        KVConnectorOutput(
+            finished_recving={request.request_id},
+            finished_sending={request.request_id},
+        )
+    )
+
+    assert request.request_id not in scheduler.requests
+    assert not scheduler.finished_recving_kv_req_ids
+
+
+@pytest.mark.parametrize("direction", ["finished_recving", "finished_sending"])
+def test_unexpected_kv_completion_does_not_free_active_request(direction):
+    """An out-of-order completion must not delete an active request."""
+    scheduler = create_scheduler(use_kv_connector=True)
+    request = create_requests(num_requests=1)[0]
+    scheduler.add_request(request)
+
+    scheduler._update_from_kv_xfer_finished(
+        KVConnectorOutput(**{direction: {request.request_id}})
+    )
+
+    assert scheduler.requests[request.request_id] is request
+    assert not scheduler.finished_recving_kv_req_ids
+
+
 def test_delayed_kv_connector_free_keeps_scheduler_active():
+    """A delayed send keeps the scheduler active until blocks are freed."""
     scheduler = create_scheduler(use_kv_connector=True)
     queued_request, request = create_requests(
         num_requests=2, req_ids=["queued", "finished"]
@@ -5213,8 +5301,6 @@ def test_ec_connector_update_connector_output_called():
     scheduler.ec_connector.update_connector_output.assert_called_once_with(
         ec_connector_output
     )
-
-
 # ==============================================================================
 # Variable-length encoder cross-attention block allocation tests
 # ==============================================================================

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1944,9 +1944,43 @@ def _postprocess_messages(messages: list[ConversationMessage]) -> None:
 
                 # if arguments is None or empty string, set to {}
                 if content := function.get("arguments"):
-                    if not isinstance(content, (dict, list)):
-                        parsed = json.loads(content)
-                        function["arguments"] = parsed if parsed is not None else {}
+                    if isinstance(content, dict):
+                        parsed = content
+                    else:
+                        if isinstance(content, str):
+                            try:
+                                parsed = json.loads(content)
+                            except json.JSONDecodeError:
+                                # A malformed `arguments` string lives in
+                                # conversation history, so failing the request
+                                # here would fail every subsequent turn too and
+                                # leave the conversation unrecoverable. Coerce
+                                # to an empty object so the turn can proceed.
+                                logger.warning(
+                                    "Tool call %r has arguments that are not valid "
+                                    "JSON (%d chars); coercing to an empty object "
+                                    "so the conversation can continue.",
+                                    function.get("name"),
+                                    len(content),
+                                )
+                                parsed = None
+                        else:
+                            parsed = content
+
+                        if not isinstance(parsed, dict):
+                            if parsed is not None:
+                                # Valid JSON, but not an object (e.g. "[]",
+                                # "42", "true").
+                                # Chat templates require a mapping.
+                                logger.warning(
+                                    "Tool call %r arguments decoded to %s, not a "
+                                    "JSON object; coercing to an empty object.",
+                                    function.get("name"),
+                                    type(parsed).__name__,
+                                )
+                            parsed = {}
+
+                    function["arguments"] = parsed
                 else:
                     function["arguments"] = {}
 

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -978,11 +978,70 @@ class ParserEngine(Parser):
         prev = slot.streamed_json
         if final_json and len(final_json) > len(prev):
             if prev and not final_json.startswith(prev):
-                return None
+                return self._close_streamed_json(slot, prev)
             diff = final_json[len(prev) :]
             slot.streamed_json = final_json
             return diff
+        if prev:
+            return self._close_streamed_json(slot, prev)
         return None
+
+    def _close_streamed_json(self, slot: ToolCallSlot, prev: str) -> str | None:
+        """Terminate an argument prefix the flush cannot extend.
+
+        ``_safe_arg_prefix`` deliberately streams unterminated string values for
+        prefix-stable keys, on the understanding that the flush completes them.
+        If the model never closes a parameter, the non-partial re-derivation
+        drops that parameter entirely, so it is neither longer than nor a prefix
+        of what was already sent. Returning ``None`` there ends the stream with
+        ``finish_reason`` set while the client holds a half-written string, which
+        no JSON parser accepts. Close what was already sent instead: the client
+        gets the truncated value rather than an unparseable message.
+        """
+        suffix = self._json_prefix_terminator(prev)
+        if not suffix:
+            return None
+        slot.streamed_json = prev + suffix
+        return suffix
+
+    @staticmethod
+    def _json_prefix_terminator(prefix: str) -> str:
+        """Return the shortest suffix that makes ``prefix`` parse, or ``""``."""
+        in_string = False
+        escape = False
+        stack: list[str] = []
+        for c in prefix:
+            if escape:
+                escape = False
+                continue
+            if in_string:
+                if c == "\\":
+                    escape = True
+                elif c == '"':
+                    in_string = False
+                continue
+            if c == '"':
+                in_string = True
+            elif c == "{":
+                stack.append("}")
+            elif c == "[":
+                stack.append("]")
+            elif c in "}]" and stack:
+                stack.pop()
+        suffix = ""
+        if escape:
+            # A trailing escape would swallow the quote that closes the string.
+            suffix += "\\"
+        if in_string:
+            suffix += '"'
+        suffix += "".join(reversed(stack))
+        if not suffix:
+            return ""
+        try:
+            json.loads(prefix + suffix)
+        except (json.JSONDecodeError, ValueError):
+            return ""
+        return suffix
 
     _NAME_RE = re.compile(r'"name"\s*:\s*"([^"]*)"')
 

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -996,7 +996,7 @@ class ParserEngine(Parser):
         of what was already sent. Returning ``None`` there ends the stream with
         ``finish_reason`` set while the client holds a half-written string, which
         no JSON parser accepts. Close what was already sent instead: the client
-        gets the truncated value rather than an unparseable message.
+        gets the truncated value rather than an unparsable message.
         """
         suffix = self._json_prefix_terminator(prev)
         if not suffix:

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -292,6 +292,7 @@ class ParserEngine(Parser):
         the closing tag arrives.
         """
         last_colon = -1
+        last_comma = -1
         last_key: str | None = None
         pending_key: str | None = None
         in_string = False
@@ -321,27 +322,50 @@ class ParserEngine(Parser):
                 last_colon = i
                 last_key = pending_key
                 pending_key = None
+            elif c == "," and depth == 1:
+                last_comma = i
         if last_colon < 0:
             return ""
         end = last_colon + 1
         while end < len(json_str) and json_str[end] in (" ", "\t", "\n", "\r"):
             end += 1
-        if end >= len(json_str) or json_str[end] != '"':
-            return json_str[:end]
-        if string_keys is not None and last_key not in string_keys:
-            return json_str[:end]
+        if (
+            end >= len(json_str)
+            or json_str[end] != '"'
+            or (string_keys is not None and last_key not in string_keys)
+        ):
+            # The trailing value cannot stream. Stop after the last complete
+            # top-level value rather than after ``"key": ``: the flush can
+            # drop an unfinished parameter, and a prefix that ends on the
+            # separator then has no valid completion.
+            return json_str[:last_comma] if last_comma >= 0 else ""
 
         escape = False
+        escape_start = -1
+        hex_left = 0
         for i in range(end + 1, len(json_str)):
             c = json_str[i]
+            if hex_left:
+                hex_left -= 1
+                if hex_left == 0:
+                    escape_start = -1
+                continue
             if escape:
                 escape = False
+                if c == "u":
+                    hex_left = 4
+                else:
+                    escape_start = -1
                 continue
             if c == "\\":
                 escape = True
+                escape_start = i
                 continue
             if c == '"':
                 return json_str[:i]
+        if escape_start >= 0:
+            # Never end on a partial escape: ``\u12`` has no valid completion.
+            return json_str[:escape_start]
         return json_str
 
     @staticmethod
@@ -1034,6 +1058,16 @@ class ParserEngine(Parser):
             suffix += "\\"
         if in_string:
             suffix += '"'
+        else:
+            # A dangling separator has no value to close; ``null`` is the one
+            # placeholder every schema type accepts. An object cannot be
+            # completed after a comma without inventing a key, so that case
+            # falls through to the parse check below and yields no suffix.
+            tail = prefix.rstrip()
+            if tail.endswith(":") or (
+                tail.endswith(",") and stack and stack[-1] == "]"
+            ):
+                suffix += "null"
         suffix += "".join(reversed(stack))
         if not suffix:
             return ""

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -1059,10 +1059,13 @@ class ParserEngine(Parser):
         if in_string:
             suffix += '"'
         else:
-            # A dangling separator has no value to close; ``null`` is the one
-            # placeholder every schema type accepts. An object cannot be
-            # completed after a comma without inventing a key, so that case
-            # falls through to the parse check below and yields no suffix.
+            # A dangling separator has no value to close. ``null`` is used
+            # purely to make the prefix PARSE: the client is being handed a
+            # truncated call either way, and a null placeholder may still fail
+            # the tool's schema, which is strictly better than arguments no
+            # JSON parser accepts. An object cannot be completed after a comma
+            # without inventing a key, so that case falls through to the parse
+            # check below and yields no suffix.
             tail = prefix.rstrip()
             if tail.endswith(":") or (
                 tail.endswith(",") and stack and stack[-1] == "]"

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -3719,18 +3719,44 @@ class Scheduler(SchedulerInterface):
 
         # KV Connector:: update recv and send status from last step.
         for req_id in kv_connector_output.finished_recving or ():
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.warning(
+                    "Ignoring late KV receive completion for unknown request %s",
+                    req_id,
+                )
+                self.finished_recving_kv_req_ids.discard(req_id)
+                continue
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            req = self.requests[req_id]
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
+            elif RequestStatus.is_finished(req.status):
+                self._free_blocks(req)
             else:
-                assert RequestStatus.is_finished(req.status)
-                self._free_blocks(self.requests[req_id])
+                logger.warning(
+                    "Ignoring KV receive completion for request %s in "
+                    "unexpected status %s",
+                    req_id,
+                    req.status.name,
+                )
         for req_id in kv_connector_output.finished_sending or ():
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.warning(
+                    "Ignoring late KV send completion for unknown request %s",
+                    req_id,
+                )
+                continue
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            self._free_blocks(self.requests[req_id])
+            if RequestStatus.is_finished(req.status):
+                self._free_blocks(req)
+            else:
+                logger.warning(
+                    "Ignoring KV send completion for request %s in unexpected "
+                    "status %s",
+                    req_id,
+                    req.status.name,
+                )
 
     def _update_requests_with_invalid_blocks(
         self,


### PR DESCRIPTION
## Summary

This hardens the `dev/jovian-judgement` serving stack against the two production failures observed on GLM-5.3-Flash:

1. A streamed tool call can end with an incomplete JSON argument prefix. The parser now emits the shortest valid JSON suffix when normal finalization cannot extend the streamed prefix, while withholding unsafe separators and partial escapes.
2. If malformed arguments already exist in Responses or Chat Completions history, shared message preprocessing replaces them with `{}` and logs only the tool name and payload length. The malformed payload is never logged, reparsed by the chat template, or executed.
3. A late, duplicate, or out-of-order KV-transfer completion can no longer assert or delete an active request. Expected callbacks retain their existing behavior; stale callbacks are logged and ignored.

The target branch already contains the GLM delimiter-state fix from `9b38d88081`. This PR adds a regression using the captured GLM failure shape (a second `<tool_call>` beginning inside an unclosed argument) to verify the combined behavior.

Closes #684.

## Incident coverage

| Failure | Result after this PR |
|---|---|
| GLM emits/reopens tool markup before closing a streamed argument | Client receives parseable JSON containing the truncated/raw value, not a half-written JSON string |
| Codex replays a malformed `function_call.arguments` item | History is normalized before template rendering; later turns remain usable |
| LMCache engine-driven completion arrives after abort/cleanup | Scheduler ignores the unknown request instead of killing EngineCore |
| `finished_recving` and `finished_sending` arrive for the same aborted request in one step | Request is freed once; the second completion is treated as stale |
| Connector reports a completion for a still-active request | Callback is ignored and the active request is not freed |

## Upstream provenance and non-duplication

- Replay recovery is the adopted upstream behavior from vllm-project/vllm#48922 (merged). It is needed here because `dev/jovian-judgement` predates that merge.
- Streaming JSON finalization is a backport of vllm-project/vllm#53739, including its subsequent review fixes. That PR remains open upstream and its Qwen regression is parser-engine-wide; this PR adds the GLM production shape.
- Stale KV callback handling preserves the approach and authorship from vllm-project/vllm#37859, then extends it to validate request status and cover the same-step receive/send race reported in #46240. Related upstream attempts include #43265, #46304, #47499, and #49278; none is merged into this hardware branch.
- This supersedes local-inference-lab/vllm#685. That PR targets `main` and uses a local sentinel representation. This PR targets the branch used for these builds and follows the subsequently merged upstream `{}` behavior.

## Tests

Passed locally on macOS arm64 / Python 3.12 using an isolated `uv` environment:

```text
pytest tests/parser/engine/test_glm47_moe.py \
       tests/parser/engine/test_qwen3.py \
       tests/parser/engine/test_parser_engine.py -q
191 passed

pytest tests/entrypoints/unit_tests/test_chat_utils.py \
       tests/entrypoints/openai/responses/test_responses_utils.py \
       --confcutdir=tests/entrypoints \
       -k 'tool_call_arguments or malformed_function_call_history' -q
13 passed

VLLM_TARGET_DEVICE=cpu pytest tests/v1/core/test_scheduler.py \
       --confcutdir=tests/v1 \
       -k 'ignore_late_finished or same_step_recv_and_send_completion_after_abort or unexpected_kv_completion_does_not_free_active_request or abort_request_waiting_for_remote_kvs or abort_request_finished_recving or delayed_kv_connector_free_keeps_scheduler_active' -q
8 passed

pre-commit run --files <all 9 changed files>
All applicable checks passed, including ruff, formatting, typos, mypy, SPDX, forbidden imports, and configuration validation.
```

The `--confcutdir` options avoid vLLM's global macOS teardown fixture, whose `torch.accelerator.memory.empty_host_cache()` currently segfaults on this host; the tests themselves pass. Linux CI should run with the normal repository configuration.

Upstream #53739 also reports a forced-truncation live-model evaluation: 40/40 malformed tool calls before the parser fix and 0/40 after it.

## Model evaluation

No model-quality evaluation is applicable: this changes frontend history normalization, parser finalization, and scheduler lifecycle validation, not weights, kernels, sampling, or logits. The parser regression uses the captured GLM markup shape, and the scheduler regression reproduces the exact assertion ordering from the production report.

## AI assistance disclosure

OpenAI Codex was used for incident analysis, upstream research, implementation, and test execution. AI assistance is recorded in commit trailers. Upstream commits retain their original authorship. Per repository policy, the submitter must review every changed line before merge; normal human review is still required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed, missing, or non-object tool-call arguments by normalizing them safely instead of raising errors.
  - Preserved tool-call history and identifiers when replaying conversations containing malformed arguments.
  - Improved streaming tool-call output so interrupted or incomplete values are completed as valid JSON while retaining completed data and embedded content.
  - Prevented stale or unexpected KV-transfer completions from crashing or incorrectly reviving requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->