### PR TITLE
fix(moe): retain shared-expert output through consumer-stream reads

### DIFF
--- a/tests/model_executor/layers/test_shared_experts_stream.py
+++ b/tests/model_executor/layers/test_shared_experts_stream.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Check shared-expert output ownership across asynchronous CUDA streams.
+
+The shared-expert wrapper must return storage that remains valid until the
+caller's queued consumer completes, even after Python releases the output and
+the producer stream allocates another equally sized tensor. The test exercises
+the wrapper interface without loading a language model.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
+    SharedExperts,
+    SharedExpertsOrder,
+)
+
+
+def shared_wrapper(layer, monkeypatch):
+    monkeypatch.setenv("VLLM_DISABLE_SHARED_EXPERTS_STREAM", "0")
+    config = SimpleNamespace(
+        moe_parallel_config=SimpleNamespace(
+            enable_eplb=False,
+            all2all_backend="allgather_reducescatter",
+            use_fi_nvl_two_sided_kernels=False,
+        )
+    )
+    return SharedExperts(layer, config, False, lambda: False)
+
+
+class ConstantBytes(torch.nn.Module):
+    def forward(self, hidden_states):
+        return torch.full(
+            (16 * 1024 * 1024,), 17, dtype=torch.uint8, device=hidden_states.device
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_shared_output_survives_producer_reuse(monkeypatch):
+    torch.accelerator.synchronize()
+    torch.accelerator.empty_cache()
+    wrapper = shared_wrapper(ConstantBytes(), monkeypatch)
+    hidden = torch.ones((1, 16), device="cuda")
+    copied = torch.empty(16 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+
+    def invoke():
+        wrapper.maybe_sync_shared_experts_stream(hidden)
+        wrapper(hidden, SharedExpertsOrder.MULTI_STREAM_OVERLAPPED)
+        return wrapper.output
+
+    warmup = invoke()
+    copied.copy_(warmup)
+    torch.cuda._sleep(1)
+    torch.accelerator.synchronize()
+    del warmup
+    torch.accelerator.empty_cache()
+
+    result = invoke()
+    producer = wrapper._stream
+    pointer = result.data_ptr()
+    consumer_done = torch.cuda.Event()
+    torch.cuda._sleep(500_000_000)
+    copied.copy_(result)
+    consumer_done.record()
+    del result
+    with torch.cuda.stream(producer):
+        replacement = torch.full_like(copied, 93)
+    producer.synchronize()
+    pending = not consumer_done.query()
+    torch.accelerator.synchronize()
+    print(
+        {
+            "producer_reused_output": replacement.data_ptr() == pointer,
+            "consumer_was_pending": pending,
+            "copied_values": copied.unique().tolist(),
+        },
+        flush=True,
+    )
+    assert pending, "The producer must allocate while the consumer is pending"
+    assert torch.all(copied == 17), "Shared output was reused before its consumer"
+    assert torch.all(replacement == 93)
+
+
+class DoubleInput(torch.nn.Module):
+    def forward(self, hidden_states):
+        return hidden_states * 2
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_shared_output_cuda_graph_replay(monkeypatch):
+    wrapper = shared_wrapper(DoubleInput(), monkeypatch)
+    hidden = torch.ones((1, 1024), device="cuda")
+
+    def invoke():
+        wrapper.maybe_sync_shared_experts_stream(hidden)
+        wrapper(hidden, SharedExpertsOrder.MULTI_STREAM_OVERLAPPED)
+        return wrapper.output + 1
+
+    invoke()
+    torch.accelerator.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        output = invoke()
+    for value in (3, 17, -5):
+        hidden.fill_(value)
+        graph.replay()
+        torch.testing.assert_close(output, torch.full_like(output, value * 2 + 1))

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -130,8 +130,6 @@ class SharedExperts(torch.nn.Module):
             # Record that the clone will be used by shared_experts_stream
             # to avoid gc issue from deallocation of hidden_states_clone
             # For more details: https://docs.pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html # noqa: E501
-            # NOTE: We don't need shared_output.record_stream(current_stream())
-            # because we synch the streams before using shared_output.
             shared_experts_input.record_stream(self._stream)
 
             # Mark sync start point for the aux stream since we will
@@ -148,6 +146,9 @@ class SharedExperts(torch.nn.Module):
         with torch.cuda.stream(self._stream):
             output = self._layer(shared_experts_input)
         current_stream().wait_stream(self._stream)
+        # The wait orders execution, but does not prevent producer-side reuse
+        # after the caller releases this tensor with consumer work still queued.
+        output.record_stream(current_stream())
 
         return output
 


### PR DESCRIPTION
## Behavior

`SharedExperts` records its auxiliary-stream output on the consumer stream.
The existing stream wait orders execution, but does not prevent the allocator
from recycling the output after Python releases it while a consumer is queued.
This can corrupt a subsequent read or unmap an expandable CUDA segment too early.

The change preserves arithmetic, overlap, dispatch and CUDA graph replay. It
adds no GPU kernel or serving synchronization barrier.

## Validation

Status: **implemented; stream-lifetime contract qualified**.

On an RTX PRO 6000 Blackwell Workstation GPU, a delayed consumer copies a
16 MiB shared-expert output containing 17 while the producer allocates an
equally sized tensor containing 93. The uncorrected implementation returns 93;
the corrected implementation returns 17. Both the ordinary allocator and
`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` reproduce that distinction.
Three changed-input graph replays also pass.

```bash
pytest -q tests/model_executor/layers/test_shared_experts_stream.py
PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
  pytest -q tests/model_executor/layers/test_shared_experts_stream.py
```

A separate 32 MiB expandable-segment reproducer releases the last Python
reference and calls `empty_cache` while a delayed consumer is pending.
Without this correction it exits 139 with an Xid13 MMU fault; with the
correction it waits for the consumer, copies 17 and exits successfully.
This proves the lifetime defect, not the cause of every GLM startup fault.

Packaged GLM TP4/DCP1 MTP3, FP8 KV, stock GPUs4–7, budget4096, OMP1,
NCCL16/2MiB and full/piecewise graphs retain three 30-second samples per cell:

| Measurement | Without ownership correction | With correction |
|---|---:|---:|
| 32K prefill, tok/s | 14,498 | 14,495 |
| C1 output / verifier, tok/s / steps/s | 250.79 / 103.22 | 254.97 / 103.37 |
| C8 aggregate output, tok/s | 902.56 | 888.63 |

The corrected composition also passes a million-token request, 12 public-chat
checks and tool scenarios TC-01–TC-15 at seed42. This scoped comparison does
not qualify every serving mode or isolate all historical startup failures.
Repository pre-commit and Python 3.10/3.12 type checks pass.

## Review boundary

Merged #695 protects `maybe_execute_in_parallel` and `execute_in_parallel`.
`SharedExperts` uses its own handoff and does not call those helpers, so this
is not a duplicate. The corrected module and test are byte-identical in the
source-locked serving composition at `f21c11418eb`.

AI assistance: OpenAI Codex prepared and tested this change under Martin Vít's
direction. Human source review is requested; this is a fork contribution, not
an upstream submission or a release approval.
