### PR TITLE
perf(attention): compact GLM DCP indices in one stable row tile

### DIFF
--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -929,7 +929,95 @@ def test_b12x_selected_indices_use_physical_slots(record_bytes: int) -> None:
 
 def test_sparse_index_remap_tiling_covers_glm5_next_width() -> None:
     assert _remap_tiling(2048, 128, True) == (True, 2048, 1, 8)
-    assert _remap_tiling(2051, 128, True) == (False, 128, 17, 4)
+    assert _remap_tiling(2051, 128, True) == (True, 4096, 1, 8)
+    assert _remap_tiling(384, 128, True) == (False, 128, 3, 4)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA metadata kernel")
+@pytest.mark.parametrize("gathered", [False, True])
+@pytest.mark.parametrize("dcp_rank", range(4))
+def test_glm_dcp_compaction_preserves_tail_order_on_graph_replay(
+    gathered: bool, dcp_rank: int
+) -> None:
+    """A C4 tail cannot race the history into a different attention order."""
+    from vllm.v1.attention.backends.mla.sparse_utils import (
+        triton_filter_and_convert_dcp_index,
+    )
+
+    rows, width, page_size = 4, 2051, 2048
+    # Remapping only reads metadata. This physical page would lie above 2 GiB
+    # in a 528-byte packed-record pool; no KV payload is allocated here.
+    page_id = 4097
+    req_ids = torch.zeros(rows, dtype=torch.int32, device="cuda")
+    block_table = torch.full((1, 1), page_id, dtype=torch.int32, device="cuda")
+    starts = torch.zeros((4, 1), dtype=torch.int32, device="cuda")
+    lengths = torch.full_like(starts, page_size)
+    indices = torch.full((rows, width), -1, dtype=torch.int32, device="cuda")
+    out, counts = torch.empty_like(indices), torch.empty_like(req_ids)
+
+    def run():
+        if gathered:
+            b12x_mla_sparse._map_global_topk_to_gathered_ckv(
+                req_ids,
+                indices,
+                starts,
+                lengths,
+                out,
+                counts,
+                dcp_size=4,
+                cp_kv_cache_interleave_size=4,
+                padded_rank_tokens=page_size,
+            )
+            return out, counts
+        return triton_filter_and_convert_dcp_index(
+            req_ids,
+            block_table,
+            indices,
+            dcp_size=4,
+            dcp_rank=dcp_rank,
+            cp_kv_cache_interleave_size=4,
+            BLOCK_SIZE=page_size,
+            NUM_TOPK_TOKENS=width,
+            return_valid_counts=True,
+        )
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        run()
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        result, valid_counts = run()
+
+    for tail_count in (3, 0, 1):
+        source = torch.full((rows, width), -1, dtype=torch.int32)
+        source[1, 2048 : 2048 + tail_count] = torch.arange(tail_count)
+        source[2, :24] = torch.arange(24)
+        source[2, 2048 : 2048 + tail_count] = torch.arange(24, 24 + tail_count)
+        source[3] = torch.arange(width)
+        expected = torch.full_like(source, -1)
+        expected_counts = torch.zeros(rows, dtype=torch.int32)
+        for row in range(rows):
+            token = source[row].to(torch.int64)
+            owner = token // 4 % 4
+            local = token // 16 * 4 + token % 4
+            valid = (token >= 0) & (local < page_size)
+            if gathered:
+                slots = owner * page_size + local
+            else:
+                valid &= owner == dcp_rank
+                slots = page_id * page_size + local
+            selected = slots[valid].to(torch.int32)
+            expected_counts[row] = selected.numel()
+            expected[row, : selected.numel()] = selected
+        indices.copy_(source)
+        for _ in range(4):
+            result.fill_(123456)
+            valid_counts.fill_(-123456)
+            graph.replay()
+            assert torch.equal(result.cpu(), expected)
+            assert torch.equal(valid_counts.cpu(), expected_counts)
 
 
 def test_b12x_glm5_next_cache_writer_ignores_empty_rope() -> None:

--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -1251,8 +1251,7 @@ def test_split_indexer_prefill_chunks_single_request_overflow():
     assert out == expected
 
 
-# 384 and 2051 count via tiled atomic accumulation rather than the single-tile
-# path 128 takes. 2051 also exercises a masked final tile.
+# Width 384 exercises tiled counting; 2051 exercises a masked single-row tile.
 @pytest.mark.parametrize("num_topk_tokens", [128, 384, 2051])
 def test_triton_convert_returns_valid_counts(num_topk_tokens: int):
     """Test that return_valid_counts correctly counts non-negative indices."""

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -34,6 +34,7 @@ from vllm.v1.attention.backend import (
     MultipleOf,
 )
 from vllm.v1.attention.backends.mla.sparse_utils import (
+    _remap_tiling,
     triton_convert_req_index_to_global_index,
     triton_filter_and_convert_dcp_index,
 )
@@ -398,7 +399,16 @@ def _map_global_topk_to_gathered_ckv_kernel(
     valid_i32 = valid.to(tl.int32)
     local_offset = tl.cumsum(valid_i32) - valid_i32
     tile_valid_count = tl.sum(valid_i32)
-    output_base = tl.atomic_add(valid_count_ptr + row, tile_valid_count)
+    if tl.constexpr(BLOCK_N >= NUM_TOPK_TOKENS):
+        output_base = 0
+        tl.store(valid_count_ptr + row, tile_valid_count)
+        tl.store(
+            out_ptr + row * out_stride0 + cols * out_stride1,
+            -1,
+            mask=col_mask & (cols >= tile_valid_count),
+        )
+    else:
+        output_base = tl.atomic_add(valid_count_ptr + row, tile_valid_count)
     tl.store(
         out_ptr + row * out_stride0 + (output_base + local_offset) * out_stride1,
         gathered_slot,
@@ -437,12 +447,13 @@ def _map_global_topk_to_gathered_ckv(
     ):
         raise TypeError("CKV gather index metadata must be int32")
 
-    block_n = 128
-    out.fill_(-1)
-    valid_counts.zero_()
-    _map_global_topk_to_gathered_ckv_kernel[
-        (token_indices.shape[0], triton.cdiv(token_indices.shape[1], block_n))
-    ](
+    single_tile, block_n, tiles_per_row, num_warps = _remap_tiling(
+        token_indices.shape[1], 128, True
+    )
+    if not single_tile:
+        out.fill_(-1)
+        valid_counts.zero_()
+    _map_global_topk_to_gathered_ckv_kernel[(token_indices.shape[0], tiles_per_row)](
         req_ids,
         token_indices,
         rank_req_starts,
@@ -462,6 +473,7 @@ def _map_global_topk_to_gathered_ckv(
         DCP_INTERLEAVE=cp_kv_cache_interleave_size,
         NUM_TOPK_TOKENS=token_indices.shape[1],
         BLOCK_N=block_n,
+        num_warps=num_warps,
     )
 
 

--- a/vllm/v1/attention/backends/mla/sparse_utils.py
+++ b/vllm/v1/attention/backends/mla/sparse_utils.py
@@ -47,7 +47,7 @@ def _convert_req_index_to_global_index_kernel(
     BLOCK_N: tl.constexpr,  # tile width along columns
     HAS_PREFILL: tl.constexpr,
     COUNT_VALID: tl.constexpr,  # whether to count valid indices
-    # BLOCK_N == NUM_TOPK_TOKENS: one program owns the row, so the valid count
+    # BLOCK_N >= NUM_TOPK_TOKENS: one program owns the row, so the valid count
     # is an in-register reduction and needs no atomic.
     SINGLE_TILE: tl.constexpr,
     # When set, scatter valid slots to a contiguous prefix [0, valid_count) using
@@ -134,6 +134,13 @@ def _convert_req_index_to_global_index_kernel(
         if SINGLE_TILE:
             base = 0
             tl.store(valid_count_ptr + token_id, tile_valid_count)
+            # The row owner initializes only the tail. These stores cannot
+            # overlap the compacted prefix written by valid lanes below.
+            tl.store(
+                out_ptr + token_id * out_stride0 + indice_id * out_stride1,
+                -1,
+                mask=in_bounds & (indice_id >= tile_valid_count),
+            )
         else:
             base = tl.atomic_add(valid_count_ptr + token_id, tile_valid_count)
         dest = base + local_offset
@@ -162,8 +169,10 @@ def _remap_tiling(
     Counting the valid slots per row is the only reason the column tiles have to
     talk to each other, so when counting give one program the whole row: the
     count becomes an in-register reduction plus a plain store, needing neither
-    atomics nor a zero-initialized counter. The row is one ``tl.arange``, so this
-    needs a power-of-two width; other top-k sizes stay tiled and atomic.
+    atomics nor a zero-initialized counter. GLM's 2051-column layout includes
+    three incomplete-pool tokens after 2048 history columns. A padded row tile
+    keeps that tail in input-relative order instead of racing a history tile.
+    Other non-power-of-two widths retain tiled counting.
 
     Returns:
         (single_tile, block_n, tiles_per_row, num_warps)
@@ -172,9 +181,11 @@ def _remap_tiling(
     assert BLOCK_N > 0 and BLOCK_N & (BLOCK_N - 1) == 0, (
         f"BLOCK_N ({BLOCK_N}) must be a positive power of two"
     )
-    single_tile = count_valid and NUM_TOPK_TOKENS & (NUM_TOPK_TOKENS - 1) == 0
+    single_tile = count_valid and (
+        NUM_TOPK_TOKENS & (NUM_TOPK_TOKENS - 1) == 0 or NUM_TOPK_TOKENS == 2051
+    )
     if single_tile:
-        return True, NUM_TOPK_TOKENS, 1, 8
+        return True, triton.next_power_of_2(NUM_TOPK_TOKENS), 1, 8
     return False, BLOCK_N, (NUM_TOPK_TOKENS + BLOCK_N - 1) // BLOCK_N, 4
 
 
@@ -322,8 +333,10 @@ def triton_filter_and_convert_dcp_index(
     leaves the rest ``-1``. DCP filtering marks non-owned slots ``-1`` and so
     creates interior gaps; the trtllm-gen sparse kernel reads the first
     ``valid_count`` entries of each row, so they must be a contiguous prefix.
-    Compaction is fused into the kernel (atomic slot allocator) rather than a
-    separate sort/gather pass. Prefix order is unspecified (only the set matters).
+    Compaction is fused into the kernel rather than a separate sort/gather
+    pass. Counted power-of-two widths and GLM's 2051 columns preserve input
+    order with one row owner. Other widths use an atomic tile allocator and
+    provide the same selected set without an ordering guarantee.
     """
     assert dcp_size >= 1
     assert 0 <= dcp_rank < dcp_size
@@ -358,8 +371,8 @@ def triton_filter_and_convert_dcp_index(
     block_table_c = block_table.contiguous()
     token_indices_c = token_indices.contiguous()
 
-    # The compaction uses the valid-count buffer as a slot allocator, so it
-    # requires counting. Pre-fill out with -1 so the unwritten tail stays -1.
+    # Compaction requires counting. A single row owner writes its own -1 tail;
+    # racing tiles require the output to be initialized before reservation.
     count_valid = return_valid_counts or compact_valid_to_front
 
     # The compaction builds on the counting, so it shares the tiling.
@@ -367,7 +380,7 @@ def triton_filter_and_convert_dcp_index(
         NUM_TOPK_TOKENS, BLOCK_N, count_valid
     )
 
-    if compact_valid_to_front:
+    if compact_valid_to_front and not single_tile:
         out = torch.full_like(token_indices_c, -1)
     else:
         out = torch.empty_like(token_indices_c)

--- a/vllm/v1/attention/backends/mla/sparse_utils.py
+++ b/vllm/v1/attention/backends/mla/sparse_utils.py
@@ -174,6 +174,11 @@ def _remap_tiling(
     keeps that tail in input-relative order instead of racing a history tile.
     Other non-power-of-two widths retain tiled counting.
 
+    Args:
+        NUM_TOPK_TOKENS: Number of selection columns per token row.
+        BLOCK_N: Power-of-two column width for the tiled implementation.
+        count_valid: Whether the operation must produce a valid-entry count.
+
     Returns:
         (single_tile, block_n, tiles_per_row, num_warps)
     """
@@ -337,6 +342,24 @@ def triton_filter_and_convert_dcp_index(
     pass. Counted power-of-two widths and GLM's 2051 columns preserve input
     order with one row owner. Other widths use an atomic tile allocator and
     provide the same selected set without an ordering guarantee.
+
+    Args:
+        req_id: Request-row index for each token row.
+        block_table: Per-request mapping from logical blocks to physical blocks.
+        token_indices: Global per-request token positions, with negative padding.
+        dcp_size: Number of decode-context-parallel ranks.
+        dcp_rank: Rank whose owned positions are retained.
+        cp_kv_cache_interleave_size: Number of consecutive positions per stripe.
+        BLOCK_SIZE: Number of token positions in a logical KV block.
+        BLOCK_STRIDE_ROWS: Physical row stride between blocks; defaults to BLOCK_SIZE.
+        NUM_TOPK_TOKENS: Number of selection columns per token row.
+        BLOCK_N: Power-of-two column width for tiled remapping.
+        return_valid_counts: Whether to return per-row counts alongside indices.
+        compact_valid_to_front: Whether valid indices must form a contiguous prefix.
+
+    Returns:
+        Physical indices with invalid entries set to -1, optionally paired with
+        the per-row valid counts.
     """
     assert dcp_size >= 1
     assert 0 <= dcp_rank < dcp_size


### PR DESCRIPTION
## Behavior

Compact GLM's 2051-column sparse-attention selection with one GPU program per
row. It preserves the selected token set, input-relative order, valid count
and `-1` padding without atomic reservations or separate initialization
kernels. Other non-power-of-two widths keep their tiled implementation.

The 2051 columns contain 2048 selected complete-pool entries and three
reserved incomplete-pool entries. DCP rank filtering and full-CKV index
translation must consume only valid entries. Racing tiles preserve the set
but can change floating-point attention reduction order between executions.

## Validation

Status: **implemented; index and kernel-performance contracts qualified**.
Against `dev/jovian-judgement` at `f9dc27dde5d`, the branch passes 26 GPU tests
on stock RTX PRO 6000 GPU12:

```bash
pytest -q tests/v1/attention/test_b12x_sparse_mla_api.py \
  tests/v1/attention/test_sparse_mla_backends.py \
  -k 'glm_dcp_compaction or sparse_index_remap_tiling or triton_convert'
```

Coverage includes poisoned outputs/counts, changing occupancy across graph
replays, all four DCP ranks and high physical page IDs. The high-page test
validates index metadata, not a multi-gigabyte KV allocation. Pre-commit passes.

Alternating same-process measurements of the production helpers:

| Operation | Tiled implementation | Single-row implementation |
|---|---:|---:|
| DCP rank filtering, 4096 rows | 46.92 µs | 20.49 µs |
| Full-CKV translation, 4096 rows | 44.57 µs | 24.61 µs |
| Small DCP batches | approximately 4.11 µs | approximately 4.11 µs |

These are metadata-kernel times, not an end-to-end speedup claim. The DCP1
column-preserving helper also passes 32 changed-input graph replays at each
of four row counts. It measures 4.09 → 2.07 µs for small rows and
32.79 → 14.35 µs at 4096 rows.

Packaged TP4/DCP4, FP8 KV, budget4096, OMP1, NCCL16/2MiB, full/piecewise
graphs and matched stock quartets retain three samples per image:

| Mode | 32K prefill before → after, tok/s | C1 output before → after, tok/s |
|---|---:|---:|
| No speculation | 13,587 → 13,574 | 141.97 → 141.91 |
| MTP3 | 13,293 → 13,259 | 224.33 → 223.08 |
| DFlash2 K7 | 13,210 → 13,214 | 192.83 → 197.34 |

Each mode also passes a million-token request, 12 chat/cache checks and
TC-01–TC-15 at seed42. **The separate DCP1 complete-image comparison is not
qualified:** MTP verifier throughput was 109.37 → 103.28 steps/s between
boots. Identical-source boots also exhibit that graph-execution variation;
its cause is not established. No sample is discarded or gain generalized.

This does not make automatic atomic MoE deterministic or prove restored-draft
acceptance parity. No fixed-order MoE or sorting diagnostic is shipped.

## Review boundary

No open PR found in the fork implements this single-row GLM compaction.
PR #561's draft-metadata refresh is a separate change in the same backend
module; the source-locked serving composition includes both.
Original commit authorship is preserved. OpenAI Codex assisted with the
implementation and validation under Martin Vít's direction. Human review is
requested; complete-image release qualification remains separate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sparse attention handling for 2,051-column layouts, preserving the correct ordering of tail tokens.
  * Fixed output initialization and token compaction behavior for single-tile processing.
  * Improved reliability of gathered and non-gathered index-mapping paths during CUDA graph replay.

* **Tests**
  * Added coverage for additional tiling configurations and CUDA graph replay scenarios.
  * Clarified test coverage for tiled and masked token-counting cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->