### PR TITLE
Fix SM120/121 MLA cuBLAS allocation-boundary reads

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -23,6 +23,37 @@ from vllm.utils.system_utils import update_environment_variables
 mp.set_start_method("spawn", force=True)
 
 
+@pytest.mark.parametrize("rank", range(4))
+def test_ag_rs_preserves_head_major_value_projection_storage(monkeypatch, rank):
+    from vllm.v1.attention.ops import dcp
+
+    partial = torch.arange(3 * 64 * 8, dtype=torch.float32).view(3, 64, 8)
+    lse = torch.zeros((3, 64))
+    monkeypatch.setattr(dcp.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        dcp.current_platform,
+        "is_device_capability_family",
+        lambda family: family == 120,
+    )
+    monkeypatch.setattr(dcp, "_cp_lse_common", lambda *args, **kwargs: (partial, lse))
+
+    class Group:
+        world_size = 4
+        rank_in_group = rank
+
+        def reduce_scatter(self, tensor, dim):
+            assert dim == 0 and tensor.is_contiguous()
+            self.output = tensor.chunk(4, dim=dim)[rank].clone()
+            return self.output
+
+    group = Group()
+    result, result_lse = dcp.cp_lse_ag_out_rs(partial, lse, group, return_lse=True)
+    torch.testing.assert_close(result, partial[:, rank * 16 : (rank + 1) * 16])
+    torch.testing.assert_close(result_lse, lse[:, rank * 16 : (rank + 1) * 16])
+    assert result.transpose(0, 1).is_contiguous()
+    assert result.data_ptr() == group.output.data_ptr()
+
+
 class _FakeCPGroup:
     def __init__(self, world_size: int, device_group: dist.ProcessGroup):
         self.world_size = world_size

--- a/tests/kernels/attention/test_mla_bmm_storage.py
+++ b/tests/kernels/attention/test_mla_bmm_storage.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MLA GEMMs must not read outside small, interleaved input allocations."""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.attention.mla_attention import (
+    _bmm_with_disjoint_batches,
+)
+from vllm.platforms import current_platform
+
+
+@pytest.mark.parametrize("rows", [1, 2, 4, 8, 32])
+@pytest.mark.parametrize("projection", ["query", "value"])
+@torch.inference_mode()
+def test_mla_bmm_at_mapped_allocation_end(rows, projection):
+    if (
+        not current_platform.is_cuda()
+        or not current_platform.is_device_capability_family(120)
+    ):
+        pytest.skip("Regression requires the SM120/121 cuBLAS path")
+    if not hasattr(torch.cuda.MemPool, "snapshot"):
+        pytest.skip("Allocator boundary inspection requires MemPool.snapshot")
+
+    k, n = (256, 512) if projection == "query" else (512, 256)
+    pool = torch.cuda.MemPool()
+    with torch.cuda.use_mem_pool(pool):
+        owner = torch.ones(10 * 1024 * 1024, device="cuda", dtype=torch.bfloat16)
+    end = owner.data_ptr() + owner.numel() * owner.element_size()
+    assert any(s["address"] + s["total_size"] == end for s in pool.snapshot())
+    source = owner[-rows * 16 * k :].view(rows, 16, k)
+    lhs = source.transpose(0, 1)
+    rhs = torch.ones((16, k, n), device="cuda", dtype=torch.bfloat16)
+    result = torch.empty((rows, 16, n), device="cuda", dtype=torch.bfloat16)
+    out = result.transpose(0, 1)
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            _bmm_with_disjoint_batches(lhs, rhs, out=out)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            _bmm_with_disjoint_batches(lhs, rhs, out=out)
+    torch.cuda.current_stream().wait_stream(stream)
+    for value in (1, 3, -5):
+        source.fill_(value)
+        graph.replay()
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(
+            result, torch.full_like(result, value * k), rtol=0, atol=0
+        )
+    graph.reset()
+
+
+@pytest.mark.parametrize("rows", [1, 4, 8, 32, 128, 4096])
+@pytest.mark.parametrize("projection", ["query", "value"])
+@torch.inference_mode()
+def test_mla_bmm_random_values_and_graph_replay(rows, projection):
+    if not current_platform.is_cuda():
+        pytest.skip("CUDA GEMM qualification")
+    torch.manual_seed(42)
+    k, n = (256, 512) if projection == "query" else (512, 256)
+    source = torch.randn((rows, 16, k), device="cuda", dtype=torch.bfloat16)
+    lhs = source.transpose(0, 1)
+    rhs = torch.randn((16, k, n), device="cuda", dtype=torch.bfloat16)
+    result = torch.empty((rows, 16, n), device="cuda", dtype=torch.bfloat16)
+    out = result.transpose(0, 1)
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        _bmm_with_disjoint_batches(lhs, rhs, out=out)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            _bmm_with_disjoint_batches(lhs, rhs, out=out)
+    torch.cuda.current_stream().wait_stream(stream)
+    for sign in (1, -1):
+        source.mul_(sign)
+        graph.replay()
+        reference = torch.bmm(lhs.float().contiguous(), rhs.float()).bfloat16()
+        torch.testing.assert_close(out, reference, rtol=0.02, atol=0.25)
+    graph.reset()

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -417,6 +417,13 @@ def _detect_output_quant_key(
 def _bmm_with_disjoint_batches(
     lhs: torch.Tensor, rhs: torch.Tensor, *, out: torch.Tensor
 ) -> None:
+    """Write a batched product using disjoint input matrices on SM120/121.
+
+    Args:
+        lhs: Input with shape (heads, rows, reduction).
+        rhs: Input with shape (heads, reduction, columns).
+        out: Caller-owned result with shape (heads, rows, columns).
+    """
     # cuBLAS issues 6040940/5996751: on SM120/121, interleaved input
     # matrices can read past their allocation. Disjoint matrices avoid that
     # access without changing logical values. Contiguous inputs remain aliases.

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -414,6 +414,18 @@ def _detect_output_quant_key(
     return kFp8StaticTensorSym
 
 
+def _bmm_with_disjoint_batches(
+    lhs: torch.Tensor, rhs: torch.Tensor, *, out: torch.Tensor
+) -> None:
+    # cuBLAS issues 6040940/5996751: on SM120/121, interleaved input
+    # matrices can read past their allocation. Disjoint matrices avoid that
+    # access without changing logical values. Contiguous inputs remain aliases.
+    if current_platform.is_cuda() and current_platform.is_device_capability_family(120):
+        lhs = lhs.contiguous()
+        rhs = rhs.contiguous()
+    torch.bmm(lhs, rhs, out=out)
+
+
 def _select_mqa_query(
     q: torch.Tensor,
     q_dcp_replicated: torch.Tensor | None,
@@ -1167,7 +1179,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                     mqa_ql_nope = mqa_q_nope.new_empty((N, B, L))
 
                 # Multiply (N, B, P) x (N, P, L) -> (N, B, L)
-                torch.bmm(mqa_q_nope, W_UK_T, out=mqa_ql_nope)
+                _bmm_with_disjoint_batches(mqa_q_nope, W_UK_T, out=mqa_ql_nope)
 
                 # Convert from (N, B, L) to (B, N, L)
                 mqa_ql_nope = mqa_ql_nope.transpose(0, 1)
@@ -1538,7 +1550,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             )
         else:
             # Multiply + Transpose (N, B, L) x (N, L, V)->(N, B, V)->(B, N, V)
-            torch.bmm(x, self.W_UV, out=out.transpose(0, 1))
+            _bmm_with_disjoint_batches(x, self.W_UV, out=out.transpose(0, 1))
 
 
 def unified_mla_kv_cache_update(

--- a/vllm/v1/attention/ops/dcp.py
+++ b/vllm/v1/attention/ops/dcp.py
@@ -15,6 +15,7 @@ import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.distributed import get_dcp_group
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.ops.cp_common import (
     DirectCPWorkspace,
@@ -295,7 +296,14 @@ def cp_lse_ag_out_rs(
         seq_lens=seq_lens,
         query_start_loc=query_start_loc,
     )
-    out = cp_group.reduce_scatter(out, dim=1)
+    if current_platform.is_cuda() and current_platform.is_device_capability_family(120):
+        # Preserve the head-major collective output for the following MLA
+        # value GEMM. Its batch matrices are disjoint, avoiding cuBLAS's
+        # SM120/121 overlapping-stride read defect and a redundant transpose copy.
+        out = cp_group.reduce_scatter(out.transpose(0, 1).contiguous(), dim=0)
+        out = out.transpose(0, 1)
+    else:
+        out = cp_group.reduce_scatter(out, dim=1)
 
     if return_lse:
         cp_num_heads = lse.shape[1] // cp_group.world_size


### PR DESCRIPTION
## Behavior

MLA query/value projection supplies disjoint batch matrices to cuBLAS on
SM120/121. DCP reduce-scatter retains head-major storage so the value projection
can consume its output without another transpose copy. Other device families
are unchanged. Quantization, logical head ownership and CUDA graph execution
are unchanged.

## Reason

A native GLM TP4/DCP4 DFlash startup fault was reduced to plain PyTorch/cuBLAS:
`[16,4,512] @ [16,512,256]`, with left-hand strides `[512,8192,1]` at the end of
a strongly owned, isolated 20-MiB allocation. Tensor elements are disjoint,
but head matrices have overlapping bounding spans. cuBLAS reads exactly the
first unmapped address. The standalone reproducer and server CUDA cores select
the same TMA GEMM kernel and launch geometry. No profiler, sanitizer, B12X or
vLLM is required to reproduce the standalone fault.

This matches NVIDIA's documented SM120/121 batched-GEMM bounds defect,
issues 6040940/5996751, still listed for cuBLAS 13.6.0:
[CUDA release notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cublas-release-13-3-update-1).

Already contiguous inputs remain aliases. Required copies are CUDA-graph
captured; graph replay does not allocate. This is independent of the
shared-expert output lifetime correction in #706.

## Validation

Status: **implemented; component-qualified; serving qualification pending**.
RTX PRO 6000 Blackwell Workstation, PyTorch 2.13, CUDA 13.3, cuBLAS 13.6.0:

- Native allocation-boundary fault reproduced twice before correction.
- 10 query/value mapped-end cases pass with changed-input CUDA graph replay.
- 12 random query/value cases, 1–4096 rows, pass FP32-accumulation reference
  checks at BF16 output tolerance.
- Four DCP rank cases pass exact logical values, head ownership and no-copy
  storage checks.
- All 26 scoped tests and pre-commit checks pass on the composed source; the
  two runtime files are identical to this standalone PR.

Tests: `tests/kernels/attention/test_mla_bmm_storage.py` and the head-major
cases in `tests/distributed/test_dcp_a2a.py`. No complete-model performance
claim is made by the component results. Full no-spec/MTP3/DFlash2 validation
is tracked in #651.

Implementation and validation were AI-assisted. Maintainer review is requested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MLA attention reliability on newer NVIDIA GPU architectures (SM120/121), preventing potential incorrect results during batched matrix multiplications.
  - Preserved the expected output layout during distributed attention processing, ensuring compatibility with downstream value projections.
  - Added safeguards for varied batch sizes, input patterns, CUDA graph replay, and memory-boundary scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->