### PR TITLE
perf(qwen3.8): overlap GDN input projections through 64 graph rows

### DIFF
--- a/tests/models/test_qwen3_8_flash_next_model.py
+++ b/tests/models/test_qwen3_8_flash_next_model.py
@@ -140,7 +140,7 @@ def test_mtp_compaction_preserves_attention_rows_and_selected_outputs(indices):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-@pytest.mark.parametrize("num_tokens", [1, 4, 16, 32])
+@pytest.mark.parametrize("num_tokens", [1, 4, 16, 32, 64, 65])
 @pytest.mark.parametrize("kind", ["gdn", "qsa"])
 def test_attention_projection_overlap_replays_with_changed_inputs(
     monkeypatch, num_tokens: int, kind: str

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -2353,7 +2353,7 @@ def qwen_gdn_input_projections(
     layer_name: LayerNameType,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     layer = get_forward_context().no_compile_layers[_resolve_layer_name(layer_name)]
-    if hidden_states.shape[0] > 16 or not torch.cuda.is_current_stream_capturing():
+    if hidden_states.shape[0] > 64 or not torch.cuda.is_current_stream_capturing():
         qkvz, _ = layer.in_proj_qkvz(hidden_states)
         ba, _ = layer.in_proj_ba(hidden_states)
         return qkvz, ba


### PR DESCRIPTION
## Purpose

Status: **implemented**. Correctness is **qualified only for the tests and TP1/MTP3 configuration below**. E2E performance remains **research-only**: these samples do not establish a net throughput improvement or absence of regressions.

Capture Qwen Gated DeltaNet's independent QKVZ and BA input projections on separate CUDA streams for batches through **64 rows**, instead of 16. MTP3 verification at concurrency 8/16 can use 32/64 rows, which are covered by the extended overlap limit. Rows refer to a captured execution batch, not the total request sequence length.

This extends Luke Alonso's existing `qwen_gdn_input_projections` operation, retaining its stream fork/join and downstream-consumer ordering. Execution through 16 rows is unchanged; eager execution and batches above 64 rows remain serial. No precision, sampling, cache, B12X kernel or public API changes.

Not a revival of #636: that closed proposal introduced a paired B12X API and compared against serial projections. This PR measures the existing JJ operation with only its row limit changed. **B12X #307 is not required.** Open-PR checks found no equivalent extension.

## Test Result

Conditions: TP1/MTP3 on one stock RTX PRO 6000 Blackwell Workstation, `local-inference-lab/Qwen3.8-Flash-Next-NVFP4`, temperature 1, top-p 0.95, top-k 20.

A/B/A on the same GPU: limit 16 → 64 → 16. Each server start received three warmed 30-second C1/C8/C16 sweeps; medians pool six reference windows versus three candidate windows. No samples were discarded.

| Measurement | Limit 16 | Limit 64 | Observed change |
| --- | ---: | ---: | ---: |
| C1 output, tok/s | 178.92 | 175.42 | -1.96% |
| C8 aggregate output, tok/s | 635.35 | 645.10 | +1.54% |
| C16 aggregate output, tok/s | 944.99 | 948.84 | +0.41% |
| Uncached 32k prefill, tok/s | 15,102.30 | 15,065.54 | -0.24% |

Interpretation:

- **C1: lower measured output; a regression has neither been established nor ruled out.** Both variants execute the same projection path. Normalized steps/s are 84.773 versus 84.760 (-0.02%); lower output throughput accompanies lower sampled acceptance. Output ranges are 168.60–184.88 versus 168.09–191.77 tok/s. This supports sampling variability as an explanation, but does not prove the absence of a regression.
- **C8/C16: small observed output gains, not established repeatable E2E improvements.** Acceptance-normalized steps/s improve by 2.21% / 1.66%, which is supporting evidence, not a substitute for actual output tok/s. At concurrency above one, normalized steps sum request-level work, not GPU batch forwards.
- **32k prefill: a measured -0.24%, not a claimed improvement.** The sample set does not establish whether this difference is noise or a regression.

Only three candidate windows per concurrency were measured. **Repeat alternating A/B runs before recommending a merge on performance grounds**, using the same GPU, source boundary, serving configuration and temperature-1 workload. Retain all valid samples and report output tok/s, acceptance and normalized steps together. A confirmed C1 or prefill regression must not be dismissed because another concurrency improves.

The independent evidence supporting review of this optimization is:

- All **12** changed-input GDN/QSA CUDA-graph replay cases pass, including the 64/65 boundary.
- Packed B12X projection probes produce bit-identical outputs and verify downstream-consumer visibility at 1/4/16/32/64/65 rows.
- Isolated projection intervals: **20.458 → 14.416 µs at 32 rows (-29.5%)**, **28.448 → 20.954 µs at 64 rows (-26.3%)**. These are not full-model speedups.
- Cold/cache-hit JSON checks at C1/C8/C16 and post-prefill logprobs checks pass. All 27 decode cells pass loop/error/concurrency checks; no preemptions. This is serving correctness evidence, not a general model-quality evaluation.
- Pre-commit checks, including mypy, pass for both modified files.

## Test Plan

Executed in the qualification image's Python environment:

```bash
/opt/venv/bin/python -m pytest \
  tests/models/test_qwen3_8_flash_next_model.py \
  -k attention_projection_overlap_replays_with_changed_inputs -q
```

```bash
uv run --no-project --with pre-commit pre-commit run --files \
  vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py \
  tests/models/test_qwen3_8_flash_next_model.py
```

<details>
<summary>Source boundary and serving protocol</summary>

Measured vLLM base: [99c94361](https://github.com/local-inference-lab/vllm/commit/99c94361d1f1b369d2cdab3ada9a4728a59c1f81), with this PR's commit as the candidate. B12X is identical in both images: [64839632](https://github.com/local-inference-lab/b12x/commit/6483963275dcf32eb2eec6d100e644d1ea647ed6). JJ commit `f9dc27dde5d501d96cd477b25ae87634179cc90b` does not modify either changed file; E2E numbers above are for the stated measured boundary, not a retest including that commit.

Checkpoint revision: `b797d2e1160b9596b2570e56c1d3590faa09d4ed`. Private NVFP4 draft vocabulary head; BF16 target vocabulary head; FP8 KV, FP32 recurrent state, CPU PLE offload. B12X linear/MoE/GDN decode, FlashInfer GDN prefill, V2 `FULL_AND_PIECEWISE`. Maximum context 262144, maximum requests 16, scheduler budget 6019, graph capture through 64 rows. No source-code mounts; source manifests checked before and after each arm.

llmbench 0.6.1, context 0 (119 rendered prompt tokens), 10-second C1 prewarm plus per-cell concurrency readiness, EOS respected, repetition detection enabled, cancelled requests drained between cells. Prefill uses 32768 explicit token IDs, two warmups and three measured requests per arm, one output token and verified zero cache hits. Its engine request-prefill timer includes first-token work; it is not a pure GPU timer.

Isolated projection test: synthetic packed MXFP8 weights with automatic activation policy, K=2560, N=16384/96; 20 warmups, 100 alternating CUDA-event samples, ten graph replays per sample, five changed-input correctness replays per shape.

No TP2, vision or other-hardware qualification is claimed. Additional validation is also recorded in [the #636 qualification comment](https://github.com/local-inference-lab/vllm/pull/636#issuecomment-5577573345).

</details>

AI-assisted implementation and validation, published at Martin Vit's request. Existing Luke Alonso implementation and attribution are retained. Human maintainer review is required before merging; the test execution reported here was performed by the assistant.
