### PR TITLE
Fix Mamba recurrent cleanup across null gaps (backport #55450)

### DIFF
--- a/tests/v1/core/test_mamba_sparse_cleanup.py
+++ b/tests/v1/core/test_mamba_sparse_cleanup.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.single_type_kv_cache_manager import MambaManager
+from vllm.v1.kv_cache_interface import MambaSpec
+
+
+class CountedBlocks(list):
+    reads = 0
+
+    def __getitem__(self, index):
+        self.reads += 1
+        return super().__getitem__(index)
+
+
+def make_manager(draft_slots):
+    return MambaManager(
+        MambaSpec(block_size=16, shapes=((1,),), dtypes=(torch.float32,),
+                  mamba_cache_mode="align", num_speculative_blocks=draft_slots),
+        BlockPool(128, enable_caching=True, hash_block_size=16),
+        enable_caching=True, kv_cache_group_id=0, scheduler_block_size=64,
+    )
+
+
+@pytest.mark.parametrize("draft_slots", [0, 3, 7])
+@pytest.mark.parametrize("chunk", [64, 256])
+def test_async_sparse_cleanup(draft_slots, chunk):
+    manager = make_manager(draft_slots)
+    pool = manager.block_pool
+    rid = "async"
+    endpoints = []
+    for step in range(1, 7):
+        computed = (step - 1) * chunk
+        processed = max(0, computed - chunk)
+        manager.remove_skipped_blocks(rid, processed)
+        before = list(manager.req_to_blocks[rid])
+        limit = max(0, (processed - 1) // 16)
+        assert all(b.is_null for b in before[:limit])
+        for index, block in endpoints:
+            if index >= limit:
+                assert before[index] is block and block.ref_cnt == 1
+            else:
+                assert before[index].is_null
+        manager.get_num_blocks_to_allocate(
+            rid, step * chunk, (), computed, computed, step * chunk)
+        manager.allocate_new_blocks(rid, step * chunk, step * chunk)
+        table = manager.req_to_blocks[rid]
+        index = step * chunk // 16 - 1
+        endpoints = [(i, b) for i, b in endpoints if i >= limit]
+        endpoints.append((index, table[index]))
+        assert all(not b.is_null and b.ref_cnt == 1 for b in table[index:])
+        assert sum(not b.is_null for b in table) <= 3 + draft_slots
+    manager.free(rid)
+    assert pool.get_num_free_blocks() == 127
+    # Reusing an ID after teardown must not inherit its old cleanup cursor.
+    manager.get_num_blocks_to_allocate(rid, chunk, (), 0, 0, chunk)
+    manager.allocate_new_blocks(rid, chunk, chunk)
+    manager.remove_skipped_blocks(rid, chunk + 16)
+    assert all(b.is_null for b in manager.req_to_blocks[rid][:chunk // 16])
+    manager.free(rid)
+    assert pool.get_num_free_blocks() == 127
+
+
+def test_cleanup_does_not_rescan_history_or_advance_past_table():
+    manager = make_manager(3)
+    rid = "bounded"
+    manager.remove_skipped_blocks(rid, 16000)
+    blocks = CountedBlocks([manager.block_pool.null_block] * 1000)
+    old, current = manager.block_pool.get_new_blocks(2)
+    blocks[10], blocks[999] = old, current
+    manager.req_to_blocks[rid] = blocks
+    manager.remove_skipped_blocks(rid, 16000)
+    assert old.ref_cnt == 0
+    assert current.ref_cnt == 1
+    blocks.reads = 0
+    for _ in range(100):
+        manager.remove_skipped_blocks(rid, 16000)
+        manager.remove_skipped_blocks(rid, 15999)
+    assert blocks.reads == 0
+    manager.free(rid)
+    assert manager.block_pool.get_num_free_blocks() == 127

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -101,6 +101,82 @@ def test_mamba_speculative_block_relocation_requires_exclusive_ownership():
         manager._relocate_speculative_block([pinned_block], 0)
 
 
+def test_mamba_retirement_crosses_null_gaps():
+    spec = MambaSpec(
+        block_size=4,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    pool = BlockPool(num_gpu_blocks=8, enable_caching=False, hash_block_size=4)
+    manager = MambaManager(
+        spec,
+        block_pool=pool,
+        enable_caching=False,
+        kv_cache_group_id=0,
+        scheduler_block_size=4,
+    )
+    old, committed, in_flight = pool.get_new_blocks(3)
+    manager.req_to_blocks["r"] = [old, pool.null_block, committed, in_flight]
+
+    # The state at token 12 and the following in-flight state must survive.
+    for _ in range(2):
+        manager.remove_skipped_blocks("r", processed_computed_tokens=12)
+        assert manager.req_to_blocks["r"] == [
+            pool.null_block,
+            pool.null_block,
+            committed,
+            in_flight,
+        ]
+        assert old.ref_cnt == 0
+        assert committed.ref_cnt == in_flight.ref_cnt == 1
+        assert pool.get_num_free_blocks() == 5
+
+    manager.free("r")
+    manager.req_to_blocks["r"] = pool.get_new_blocks(2)
+    manager.remove_skipped_blocks("r", processed_computed_tokens=5)
+    assert manager.req_to_blocks["r"][0].is_null
+    assert manager.req_to_blocks["r"][1].ref_cnt == 1
+
+
+@pytest.mark.parametrize("block_size", [3584, 4608])
+@pytest.mark.parametrize("in_flight_chunks", [0, 1, 2])
+def test_mamba_retirement_bounds_prefill_states(block_size, in_flight_chunks):
+    spec = MambaSpec(
+        block_size=block_size,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+        num_speculative_blocks=5,
+    )
+    pool = BlockPool(num_gpu_blocks=1000, enable_caching=True, hash_block_size=256)
+    manager = MambaManager(
+        spec,
+        block_pool=pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        scheduler_block_size=block_size,
+    )
+    initial_free = pool.get_num_free_blocks()
+    chunk = 8192 // block_size * block_size
+    peak_held = 0
+    # Replay full prefill chunks with an async committed-token lag.
+    for target in range(chunk, 480031 + 1, chunk):
+        computed = target - chunk
+        committed = max(0, computed - in_flight_chunks * chunk)
+        manager.remove_skipped_blocks("r", committed)
+        manager.get_num_blocks_to_allocate(
+            "r", target + 5, [], computed, computed, target
+        )
+        manager.allocate_new_blocks("r", target + 5, target)
+        peak_held = max(peak_held, initial_free - pool.get_num_free_blocks())
+
+    # Five speculative blocks, current/previous states, and bounded in-flight states.
+    assert peak_held == 7 + in_flight_chunks
+    manager.free("r")
+    assert pool.get_num_free_blocks() == initial_free
+
+
 def get_sliding_window_manager(
     sliding_window_spec,
     block_pool,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1637,6 +1637,7 @@ class MambaManager(SingleTypeKVCacheManager):
             # Mapping from request ID to the index of the block
             # allocated in the previous step
             self.last_state_block_idx: dict[str, int] = {}
+            self._num_retired_blocks: dict[str, int] = {}
             # The set of the requests that have been allocated blocks
             self._allocated_block_reqs: set[str] = set()
             # Number of internal checkpoint blocks required by each request's
@@ -1789,6 +1790,27 @@ class MambaManager(SingleTypeKVCacheManager):
                     mask[boundary_block - start_block] = True
 
         return mask
+
+    def _remove_blocks_in_range(
+        self, request_id: str, first_block: int, last_block: int
+    ) -> None:
+        if self.mamba_cache_mode != "align":
+            return super()._remove_blocks_in_range(request_id, first_block, last_block)
+        blocks = self.req_to_blocks.get(request_id, [])
+        first_block = max(first_block, self._num_retired_blocks.get(request_id, 0))
+        last_block = min(last_block, len(blocks))
+        if first_block >= last_block:
+            return
+        freed: list[KVCacheBlock] = []
+        # Mamba prefill leaves null gaps between states awaiting retirement.
+        for i in range(last_block - 1, first_block - 1, -1):
+            if blocks[i].is_null:
+                continue
+            freed.append(blocks[i])
+            blocks[i] = self._null_block
+        if freed:
+            self.block_pool.free_blocks(freed)
+        self._num_retired_blocks[request_id] = last_block
 
     def remove_skipped_blocks(
         self,
@@ -2057,6 +2079,7 @@ class MambaManager(SingleTypeKVCacheManager):
         if self.mamba_cache_mode == "align":
             self._allocated_block_reqs.discard(request_id)
             self.last_state_block_idx.pop(request_id, None)
+            self._num_retired_blocks.pop(request_id, None)
             self._num_checkpoint_blocks.pop(request_id, None)
             self._producer_partial_tail_reqs.pop(request_id, None)
             # An offer is only guaranteed to hold committed bytes until the end


### PR DESCRIPTION
Backport [Luca Motz's upstream fix, vllm-project/vllm#55450](https://github.com/vllm-project/vllm/pull/55450) at 98ae7c068d7894346cfcfdb9a92b17a9308fcdc9. Mamba align cleanup currently stops at a null gap and can retain obsolete recurrent states. This adds a bounded per-request retirement cursor that crosses gaps, preserves the processed-token fence and reverse free order, and resets on teardown.

The change contains 23 added runtime lines, the upstream regression tests, and seven focused sparse cleanup cases. No scheduler or FIFO change is included. Only patch context was adapted from LP29 to the target.

Validation and inclusion:

- Standalone base: dev/jovian-judgement at aba94d396d27ea92a2044ad024c003b36da505d3. Its cleanup still breaks at null gaps. All 59 open PR diffs targeting this branch were checked for the cleanup helper, retirement cursor, and upstream reference. Related #525 retains the same null-gap break; #556 and #557 do not implement this fix.
- Full standalone source checkout mounted read-only into the existing LP29 dependency container, with CPU platform, no GPU devices, no network, two CPUs and 6 GiB RAM: 193 tests passed across test_single_type_kv_cache_manager.py, test_prefix_caching.py, test_mamba_align_chunk_split.py, and test_mamba_sparse_cleanup.py. All seven focused cases fail with the original target manager. Changed Python files compile and git diff --check passes. The source checkout has no generated vllm._version, producing a commit-hash warning.
- Earlier exact LP29 base c4578d4b9b6bc0a9eafd2dc8a97baf348237d9e4 and candidate 5801b1d04f9a14a78292dec78683260fc3710656: seven original failures become seven passes, and 198 manager/cache tests pass. Broader suites have the same 35 baseline failures on both sources (offline model config and missing fixture attribute). These broader results belong to LP29, not this standalone base. Independent review found no blockers.
- Earlier GPU diagnostic: the candidate manager was a single-file overlay on exact LP29, campaign cleanup-01. All 21 cold/warm/appended results were correct, with full warm/appended reuse. Baseline dcp1-stress-01 had a first-warm miss. Warm wall time was 62.04 seconds baseline versus 6.477 seconds candidate in one diagnostic run, not a general benchmark.

This standalone head and its image have not been GPU-tested. DCP4 warm-needle failure remains unresolved and also occurs without MTP. This is a recurrent cleanup backport, not a corruption fix or production qualification.

Local evidence is archived in the station repository under glm53-jovian/results/lp29-recurrent-cleanup, lp29-recurrent-cleanup-review, and lp29-recurrent-cleanup-publication; GPU campaign evidence is under /data/lp29-retention-diagnostic/campaigns/cleanup-01. The original LP29 source checkout and services were left unchanged during publication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mamba cache block retirement across sparse or empty block regions.
  * Ensured cache cleanup correctly handles incremental updates, speculative slots, and in-flight prefill states.
  * Improved resource reclamation so completed requests fully release cache blocks and request identifiers can be safely reused.

* **Tests**
  * Added coverage for sparse cleanup, block-boundary handling, repeated cleanup calls, request reuse, and bounded cache usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->