### PR TITLE
[JJ] Preserve DS4 Vision runtime and model-specific launch contracts

### DIFF
--- a/serve-ds4-flash.sh
+++ b/serve-ds4-flash.sh
@@ -34,6 +34,14 @@ require_positive_int() {
   fi
 }
 
+require_max_model_len() {
+  local value=$1
+  if [[ "${value}" != "-1" && ! "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "MAX_MODEL_LEN must be -1 or a positive integer; got '${value}'" >&2
+    exit 2
+  fi
+}
+
 require_nonnegative_int() {
   local name=$1 value=$2
   if [[ ! "${value}" =~ ^[0-9]+$ ]]; then
@@ -68,8 +76,10 @@ esac
 
 standard_model=${STANDARD_MODEL:-deepseek-ai/DeepSeek-V4-Flash}
 dspark_model=${DSPARK_MODEL:-deepseek-ai/DeepSeek-V4-Flash-0731}
+vision_model=${VISION_MODEL:-deepseek-ai/DeepSeek-V4-Flash-Vision-Exp}
 standard_model_revision=${STANDARD_MODEL_REVISION:-60d8d70770c6776ff598c94bb586a859a38244f1}
 dspark_model_revision=${DSPARK_MODEL_REVISION:-9e165c30e2704aec5d9d593cce3eebd58bbef1cb}
+vision_model_revision=${VISION_MODEL_REVISION:-6821d6ad3681a4b137b066b76094fa82ebd0a380}
 if [[ "${mode}" == "dspark" || "${mode}" == "dspark-mtp0" ]]; then
   model=${MODEL_PATH:-${MODEL:-${dspark_model}}}
   spec_model=${SPEC_MODEL_PATH:-${model}}
@@ -82,9 +92,40 @@ else
   default_model_revision=${standard_model_revision}
 fi
 
+model_variant=${DS4_MODEL_VARIANT:-auto}
+case "${model_variant}" in
+  auto)
+    if [[ "${model}" == "${vision_model}" \
+      || "${model}" == *DeepSeek-V4-Flash-Vision-Exp* ]]; then
+      model_variant=vision
+    else
+      model_variant=text
+    fi
+    ;;
+  text|vision) ;;
+  *)
+    echo "DS4_MODEL_VARIANT must be auto, text, or vision; got '${model_variant}'" >&2
+    exit 2
+    ;;
+esac
+if [[ "${model_variant}" == "vision" ]]; then
+  if [[ -z "${MODEL_PATH:-}" && -z "${MODEL:-}" ]]; then
+    model=${vision_model}
+    spec_model=${SPEC_MODEL_PATH:-${model}}
+  fi
+  served_model_name=${SERVED_MODEL_NAME:-DeepSeek-V4-Flash-Vision-Exp}
+  if [[ "${model}" == "${vision_model}" ]]; then
+    default_model_revision=${vision_model_revision}
+  else
+    default_model_revision=
+  fi
+fi
+
 model_revision=${MODEL_REVISION:-}
 if [[ -z "${model_revision}" ]]; then
-  if [[ "${model}" == "${standard_model}" || "${model}" == "${dspark_model}" ]]; then
+  if [[ "${model}" == "${standard_model}" \
+    || "${model}" == "${dspark_model}" \
+    || "${model}" == "${vision_model}" ]]; then
     model_revision=${default_model_revision}
   fi
 fi
@@ -97,9 +138,43 @@ host=${HOST:-0.0.0.0}
 port=${PORT:-8000}
 tp_size=${TP_SIZE:-${TP:-4}}
 dcp_size=${DCP_SIZE:-${DCP:-1}}
+lmcache_mode=${LMCACHE_MODE:-off}
+lmcache_mode=${lmcache_mode,,}
+lmcache_transfer_mode=${LMCACHE_TRANSFER_MODE:-auto}
+lmcache_transfer_mode=${lmcache_transfer_mode,,}
+direct_lmcache=0
+if [[ "${lmcache_mode}" != "off" \
+  && "${lmcache_mode}" != "0" \
+  && "${lmcache_transfer_mode}" != "engine_driven" ]]; then
+  direct_lmcache=1
+fi
+engine_driven_lmcache=0
+if [[ "${lmcache_mode}" != "off" \
+  && "${lmcache_mode}" != "0" \
+  && "${lmcache_transfer_mode}" == "engine_driven" ]]; then
+  engine_driven_lmcache=1
+fi
+vision_direct_lmcache=0
+text_direct_lmcache=0
+if [[ "${direct_lmcache}" == "1" && "${model_variant}" == "vision" ]]; then
+  vision_direct_lmcache=1
+elif [[ "${direct_lmcache}" == "1" ]]; then
+  text_direct_lmcache=1
+fi
 if [[ "${mode}" == "dspark" || "${mode}" == "dspark-mtp0" ]]; then
   max_num_seqs=${MAX_NUM_SEQS:-16}
-  max_model_len=${MAX_MODEL_LEN:-131072}
+  if [[ "${model_variant}" == "vision" ]]; then
+    if [[ "${vision_direct_lmcache}" == "1" ]]; then
+      # Direct LMCache creates CUDA transfer buffers after vLLM profiles the
+      # model. A 900k-token KV pool leaves enough physical memory for those
+      # buffers and the maximum profiled vision batch on a 96 GiB GPU.
+      max_model_len=${MAX_MODEL_LEN:-900000}
+    else
+      max_model_len=${MAX_MODEL_LEN:-1048576}
+    fi
+  else
+    max_model_len=${MAX_MODEL_LEN:-131072}
+  fi
 else
   max_num_seqs=${MAX_NUM_SEQS:-64}
   max_model_len=${MAX_MODEL_LEN:-262144}
@@ -107,7 +182,7 @@ fi
 max_num_batched_tokens=${MAX_NUM_BATCHED_TOKENS:-8192}
 gpu_memory_utilization=${GPU_MEMORY_UTILIZATION:-}
 block_size=${BLOCK_SIZE:-256}
-load_format=${LOAD_FORMAT:-fastsafetensors}
+load_format=${LOAD_FORMAT:-instanttensor}
 kv_offloading_size=${KV_OFFLOADING_SIZE:-}
 native_l2_path=${NATIVE_L2_PATH:-}
 native_l2_size=${NATIVE_L2_GB:-}
@@ -119,8 +194,23 @@ rejection_sample_method=${REJECTION_SAMPLE_METHOD:-standard}
 require_positive_int TP_SIZE "${tp_size}"
 require_positive_int DCP_SIZE "${dcp_size}"
 require_positive_int MAX_NUM_SEQS "${max_num_seqs}"
+require_max_model_len "${max_model_len}"
 require_positive_int MAX_NUM_BATCHED_TOKENS "${max_num_batched_tokens}"
 require_positive_int BLOCK_SIZE "${block_size}"
+# vLLM interprets -1 as the model-derived maximum length. DS4 checkpoints
+# declare a 1,048,576-token limit, so launcher memory guards must evaluate the
+# sentinel against that capacity while preserving -1 on the vLLM command line.
+policy_max_model_len=${max_model_len}
+if [[ "${max_model_len}" == "-1" ]]; then
+  policy_max_model_len=1048576
+fi
+if [[ "${vision_direct_lmcache}" == "1" \
+  && -n "${MAX_MODEL_LEN:-}" \
+  && "${policy_max_model_len}" -gt 900000 \
+  && -z "${GPU_MEMORY_UTILIZATION:-}" ]]; then
+  echo "Vision direct LMCache with MAX_MODEL_LEN above 900000 requires an explicit GPU_MEMORY_UTILIZATION override; the qualified 96 GiB default is MAX_MODEL_LEN=900000 with GPU_MEMORY_UTILIZATION=0.951" >&2
+  exit 2
+fi
 if [[ -n "${kv_offloading_size}" \
   && ! "${kv_offloading_size}" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]]; then
   echo "KV_OFFLOADING_SIZE must be a non-negative GiB value; got '${kv_offloading_size}'" >&2
@@ -176,6 +266,7 @@ export NCCL_PROTO=${NCCL_PROTO:-LL,LL128,Simple}
 export OMP_NUM_THREADS=${OMP_NUM_THREADS:-16}
 export LLM_WORKER_MULTIPROC_METHOD=${LLM_WORKER_MULTIPROC_METHOD:-spawn}
 export SAFETENSORS_FAST_GPU=${SAFETENSORS_FAST_GPU:-1}
+export INSTANTTENSOR_BACKEND=${INSTANTTENSOR_BACKEND:-BUFFERED}
 
 export VLLM_USE_AOT_COMPILE=${VLLM_USE_AOT_COMPILE:-1}
 export VLLM_USE_BREAKABLE_CUDAGRAPH=${VLLM_USE_BREAKABLE_CUDAGRAPH:-0}
@@ -250,7 +341,12 @@ if [[ "${mode}" == "mtp2" || "${mode}" == "mtp3" ]]; then
   spec_args=(--speculative-config "${spec_json}")
   graph_multiplier=8
 elif [[ "${mode}" == "dspark" ]]; then
-  spec_tokens=${DSPARK_TOKENS:-${NUM_SPECULATIVE_TOKENS:-7}}
+  if [[ "${model_variant}" == "vision" ]]; then
+    default_dspark_tokens=3
+  else
+    default_dspark_tokens=7
+  fi
+  spec_tokens=${DSPARK_TOKENS:-${NUM_SPECULATIVE_TOKENS:-${default_dspark_tokens}}}
   require_positive_int DSPARK_TOKENS "${spec_tokens}"
   # Target verification schedules at most one sampled token plus K drafts per
   # request. Capturing beyond that physical row count only consumes graph
@@ -320,11 +416,30 @@ if [[ "${sp_async_tp}" == "1" ]]; then
 fi
 
 if [[ -z "${gpu_memory_utilization}" ]]; then
-  # The 0731 DSpark draft head is larger than the historical MTP head. Its
-  # B12X TP2 profile needs 0.975 to retain the default 131k serving limit after
-  # attention and FULL-graph allocations are accounted for. At 0.97 the r15
-  # stack exposed 7.11 GiB of KV storage while this profile needs 7.37 GiB.
-  if [[ "${mode}" == "dspark" ]]; then
+  if [[ "${engine_driven_lmcache}" == "1" \
+    && "${mode}" == "dspark" \
+    && "${tp_size}" == "2" \
+    && "${policy_max_model_len}" -ge 1048576 ]]; then
+    # Engine-driven transfer performs GPU gathers in the existing vLLM
+    # workers and keeps the standalone cache server CPU-only. A 0.970 budget
+    # provides more than one million GPU KV tokens on 96 GiB TP2 GPUs while
+    # retaining measured runtime headroom during a one-million-token store.
+    gpu_memory_utilization=0.970
+  elif [[ "${vision_direct_lmcache}" == "1" ]]; then
+    # Direct LMCache transfer opens one CUDA IPC client per TP rank after the
+    # vLLM memory estimate. The TP2 profile reserves enough physical memory for
+    # those late allocations and an uncached 810k-token plus ten-image overlap.
+    gpu_memory_utilization=0.951
+  elif [[ "${text_direct_lmcache}" == "1" ]]; then
+    # Direct LMCache allocates transfer buffers after vLLM sizes the GPU KV
+    # pool. A 0.965 budget preserves a one-million-token TP2 DSpark KV pool on
+    # 96 GiB GPUs while retaining memory for the runtime transfer allocation.
+    gpu_memory_utilization=0.965
+  elif [[ "${model_variant}" == "vision" ]]; then
+    gpu_memory_utilization=0.975
+  elif [[ "${mode}" == "dspark" ]]; then
+    # The 0731 DSpark draft head needs 0.975 to retain its serving limit after
+    # attention and FULL-graph allocations are accounted for.
     if [[ "${backend}" == "lucifer-default" ]]; then
       # The default DeepGEMM MoE path retains more model/runtime memory than
       # FlashInfer CUTLASS. At 0.9465 only 7.35 GiB remained for the 7.89 GiB
@@ -350,6 +465,35 @@ if [[ -z "${gpu_memory_utilization}" ]]; then
     gpu_memory_utilization=0.912
   else
     gpu_memory_utilization=0.91
+  fi
+fi
+
+allow_unqualified_lmcache_memory=$(bool_value \
+  LMCACHE_ALLOW_UNQUALIFIED_MEMORY_PROFILE \
+  "${LMCACHE_ALLOW_UNQUALIFIED_MEMORY_PROFILE:-0}")
+lmcache_memory_profile=standard
+if [[ "${engine_driven_lmcache}" == "1" \
+  && "${mode}" == "dspark" \
+  && "${tp_size}" == "2" \
+  && "${policy_max_model_len}" -ge 1048576 ]]; then
+  if awk -v value="${gpu_memory_utilization}" \
+    'BEGIN { exit !((value + 0) <= 0.970) }'; then
+    lmcache_memory_profile=qualified
+  else
+    lmcache_memory_profile=unqualified
+  fi
+elif [[ "${text_direct_lmcache}" == "1" \
+  && "${mode}" == "dspark" \
+  && "${tp_size}" == "2" \
+  && "${policy_max_model_len}" -ge 1048576 ]]; then
+  lmcache_memory_profile=qualified
+  if awk -v value="${gpu_memory_utilization}" \
+    'BEGIN { exit !((value + 0) > 0.965) }'; then
+    if [[ "${allow_unqualified_lmcache_memory}" == "0" ]]; then
+      echo "Text DS4 TP2 DSpark with direct LMCache and MAX_MODEL_LEN at or above 1048576 requires GPU_MEMORY_UTILIZATION at or below 0.965 on 96 GiB GPUs; set LMCACHE_ALLOW_UNQUALIFIED_MEMORY_PROFILE=1 only after qualifying a different memory profile" >&2
+      exit 2
+    fi
+    lmcache_memory_profile=unqualified
   fi
 fi
 
@@ -498,11 +642,13 @@ if [[ -n "${EXTRA_VLLM_ARGS:-}" ]]; then
 fi
 command+=("$@")
 
-printf 'DS4 launch: mode=%s depth=%s backend=%s allreduce=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s native_l2=%s allocator=%s model=%s\n' \
-  "${mode}" "${dspark_depth_mode}" \
+printf 'DS4 launch: variant=%s mode=%s depth=%s backend=%s allreduce=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s lmcache_transfer=%s direct_lmcache=%s lmcache_memory_profile=%s native_l2=%s allocator=%s model=%s\n' \
+  "${model_variant}" "${mode}" "${dspark_depth_mode}" \
   "${backend}" "${allreduce_mode}" \
   "${tp_size}" "${dcp_size}" "${max_num_seqs}" \
-  "${graph_cap}" "${load_format}" \
+  "${graph_cap}" "${load_format}" "${INSTANTTENSOR_BACKEND}" \
+  "${lmcache_transfer_mode}" \
+  "${direct_lmcache}" "${lmcache_memory_profile}" \
   "${native_l2_enabled}" \
   "${PYTORCH_CUDA_ALLOC_CONF:-<unset>}" "${model}" >&2
 printf 'Command:' >&2

--- a/tests/models/test_deepseek_v4_vision.py
+++ b/tests/models/test_deepseek_v4_vision.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.models.common.ops import sequence_parallel
+from vllm.models.deepseek_v4.common.mm_preprocess import (
+    IMAGE_PLACEHOLDER,
+    DeepseekV4VLProcessingInfo,
+)
+from vllm.models.deepseek_v4.nvidia import mtp, vl_model
+
+
+@pytest.mark.parametrize("vocabulary", [{}, {IMAGE_PLACEHOLDER: 42}])
+def test_image_placeholder_requires_exact_vocabulary_entry(vocabulary):
+    tokenizer = SimpleNamespace(
+        get_vocab=lambda: vocabulary,
+        convert_tokens_to_ids=lambda token: vocabulary.get(token, 17),
+    )
+    info = SimpleNamespace(get_tokenizer=lambda: tokenizer)
+    if not vocabulary:
+        with pytest.raises(ValueError, match="Token not found in tokenizer"):
+            DeepseekV4VLProcessingInfo.get_image_placeholder_token_id(info)
+    else:
+        assert DeepseekV4VLProcessingInfo.get_image_placeholder_token_id(info) == 42
+
+
+def test_interleaved_vision_weights_are_streamed_and_finalized_once(monkeypatch):
+    events = []
+    language_model = SimpleNamespace(process_weights_after_loading=Mock())
+    model = SimpleNamespace(
+        language_model=language_model,
+        hf_to_vllm_mapper=SimpleNamespace(apply=iter),
+    )
+    finalize = vl_model.DeepseekV4ForConditionalGeneration.process_weights_after_loading
+    model.process_weights_after_loading = lambda: finalize(model)
+
+    class Loader:
+        def __init__(self, module):
+            self.module = module
+
+        def load_weights(self, weights):
+            loaded = set()
+            for name, _ in weights:
+                events.append(("load", name))
+                loaded.add(name)
+            return loaded
+
+    monkeypatch.setattr(vl_model, "AutoWeightsLoader", Loader)
+    names = (
+        "vision.patch_embed.weight",
+        "language_model.model.embed.weight",
+        "aligner.w1.weight",
+        "language_model.model.layers.0.weight",
+    )
+
+    def weights():
+        for name in names:
+            events.append(("yield", name))
+            yield name, torch.empty(1)
+
+    loaded = vl_model.DeepseekV4ForConditionalGeneration.load_weights(model, weights())
+    assert loaded == set(names)
+    assert events == [
+        event
+        for name in names
+        for event in (("yield", name), ("load", name.removeprefix("language_model.")))
+    ]
+    model.process_weights_after_loading()
+    language_model.process_weights_after_loading.assert_called_once_with()
+
+
+@pytest.mark.parametrize("num_tokens", [3, 4])
+@pytest.mark.parametrize("rank", [0, 1])
+@pytest.mark.parametrize("use_sp", [False, True])
+def test_mtp_routing_ids_match_local_hidden_rows(monkeypatch, num_tokens, rank, use_sp):
+    monkeypatch.setattr(
+        sequence_parallel, "get_tensor_model_parallel_world_size", lambda: 2
+    )
+    monkeypatch.setattr(
+        sequence_parallel, "get_tensor_model_parallel_rank", lambda: rank
+    )
+    monkeypatch.setattr(mtp.envs, "VLLM_MOE_SKIP_PADDING", False)
+    monkeypatch.setattr(mtp, "fused_mtp_input_rmsnorm", lambda e, p, h, *args: (e, h))
+    monkeypatch.setattr(mtp, "sp_all_gather", lambda x: torch.cat([x, x]))
+    ids = torch.arange(1, num_tokens + 1)
+    expected = sequence_parallel.sp_shard(ids) if use_sp else ids
+
+    class Block:
+        use_sequence_parallel = use_sp
+
+        def __call__(self, *, positions, x, input_ids):
+            torch.testing.assert_close(input_ids, expected)
+            assert input_ids.shape[0] == x.shape[0]
+            torch.testing.assert_close(x[:, 0, 0], input_ids.float())
+            return x, None, None, None
+
+        @staticmethod
+        def mhc_post(x, *args):
+            return x
+
+    norm = SimpleNamespace(weight=torch.ones(2), variance_epsilon=1e-6)
+    layer = SimpleNamespace(
+        config=SimpleNamespace(hidden_size=2),
+        hc_mult=1,
+        enorm=norm,
+        hnorm=norm,
+        h_proj=lambda x: x,
+        e_proj=lambda x: x,
+        mtp_block=Block(),
+    )
+    result = mtp.DeepSeekV4MultiTokenPredictorLayer.forward(
+        layer,
+        input_ids=ids,
+        positions=torch.arange(num_tokens),
+        previous_hidden_states=ids.float().view(-1, 1).expand(-1, 2),
+        inputs_embeds=torch.zeros(num_tokens, 2),
+    )
+    assert result.shape == (num_tokens, 2)

--- a/tests/scripts/test_serve_ds4_flash.sh
+++ b/tests/scripts/test_serve_ds4_flash.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+launcher="${repo_root}/serve-ds4-flash.sh"
+vision_model=deepseek-ai/DeepSeek-V4-Flash-Vision-Exp
+
+capture() {
+  env -i \
+    PATH="${PATH}" \
+    HOME="${HOME}" \
+    PYTHON_BIN=/bin/true \
+    DRY_RUN=1 \
+    MODE=dspark \
+    MODEL="${vision_model}" \
+    "$@" \
+    "${launcher}" 2>&1
+}
+
+assert_contains() {
+  local output=$1 expected=$2
+  if [[ "${output}" != *"${expected}"* ]]; then
+    printf 'Missing expected launcher fragment: %s\n%s\n' \
+      "${expected}" "${output}" >&2
+    exit 1
+  fi
+}
+
+default_output="$(capture)"
+assert_contains "${default_output}" 'variant=vision mode=dspark'
+assert_contains "${default_output}" 'DeepSeek-V4-Flash-Vision-Exp'
+assert_contains "${default_output}" '--revision 6821d6ad3681a4b137b066b76094fa82ebd0a380'
+assert_contains "${default_output}" 'num_speculative_tokens\":3'
+assert_contains "${default_output}" '--gpu-memory-utilization 0.975'
+assert_contains "${default_output}" '--max-model-len 1048576'
+assert_contains "${default_output}" '--load-format instanttensor'
+assert_contains "${default_output}" 'load_format=instanttensor'
+assert_contains "${default_output}" 'instanttensor_backend=BUFFERED'
+
+variant_output="$(env -i PATH="${PATH}" HOME="${HOME}" PYTHON_BIN=/bin/true \
+  DRY_RUN=1 MODE=dspark DS4_MODEL_VARIANT=vision "${launcher}" 2>&1)"
+assert_contains "${variant_output}" 'model=deepseek-ai/DeepSeek-V4-Flash-Vision-Exp'
+assert_contains "${variant_output}" '--revision 6821d6ad3681a4b137b066b76094fa82ebd0a380'
+
+local_output="$(capture MODEL=/model DS4_MODEL_VARIANT=vision)"
+assert_contains "${local_output}" 'model=/model'
+if [[ "${local_output}" == *'--revision '* ]]; then
+  echo 'A local model path must not inherit a Hugging Face revision.' >&2
+  exit 1
+fi
+
+fastsafetensors_output="$(capture LOAD_FORMAT=fastsafetensors)"
+assert_contains "${fastsafetensors_output}" '--load-format fastsafetensors'
+assert_contains "${fastsafetensors_output}" 'load_format=fastsafetensors'
+
+text_output="$(capture \
+  MODEL=deepseek-ai/DeepSeek-V4-Flash-0731 DS4_MODEL_VARIANT=text)"
+assert_contains "${text_output}" 'variant=text mode=dspark'
+assert_contains "${text_output}" '--max-model-len 131072'
+
+text_auto_length_output="$(capture \
+  MODEL=deepseek-ai/DeepSeek-V4-Flash-0731 DS4_MODEL_VARIANT=text \
+  MAX_MODEL_LEN=-1)"
+assert_contains "${text_auto_length_output}" '--max-model-len -1'
+
+text_engine_auto_length_output="$(capture \
+  MODEL=deepseek-ai/DeepSeek-V4-Flash-0731 DS4_MODEL_VARIANT=text \
+  LMCACHE_MODE=disk LMCACHE_TRANSFER_MODE=engine_driven \
+  MAX_MODEL_LEN=-1 TP_SIZE=2)"
+assert_contains "${text_engine_auto_length_output}" '--max-model-len -1'
+assert_contains "${text_engine_auto_length_output}" '--gpu-memory-utilization 0.970'
+assert_contains "${text_engine_auto_length_output}" 'lmcache_memory_profile=qualified'
+
+if invalid_auto_length_output="$(capture \
+    MODEL=deepseek-ai/DeepSeek-V4-Flash-0731 DS4_MODEL_VARIANT=text \
+    MAX_MODEL_LEN=0)"; then
+  printf 'Launcher accepted an invalid zero MAX_MODEL_LEN:\n%s\n' \
+    "${invalid_auto_length_output}" >&2
+  exit 1
+fi
+assert_contains "${invalid_auto_length_output}" \
+  "MAX_MODEL_LEN must be -1 or a positive integer"
+
+text_lmcache_output="$(capture \
+  MODEL=deepseek-ai/DeepSeek-V4-Flash-0731 DS4_MODEL_VARIANT=text \
+  LMCACHE_MODE=disk)"
+assert_contains "${text_lmcache_output}" '--gpu-memory-utilization 0.965'
+assert_contains "${text_lmcache_output}" 'direct_lmcache=1'
+
+text_engine_driven_output="$(capture \
+  MODEL=deepseek-ai/DeepSeek-V4-Flash-0731 DS4_MODEL_VARIANT=text \
+  LMCACHE_MODE=disk LMCACHE_TRANSFER_MODE=engine_driven \
+  MAX_MODEL_LEN=1048576 TP_SIZE=2)"
+assert_contains "${text_engine_driven_output}" '--gpu-memory-utilization 0.970'
+assert_contains "${text_engine_driven_output}" 'direct_lmcache=0'
+assert_contains "${text_engine_driven_output}" 'lmcache_transfer=engine_driven'
+assert_contains "${text_engine_driven_output}" 'lmcache_memory_profile=qualified'
+
+text_engine_override_output="$(capture \
+  MODEL=deepseek-ai/DeepSeek-V4-Flash-0731 DS4_MODEL_VARIANT=text \
+  LMCACHE_MODE=disk LMCACHE_TRANSFER_MODE=engine_driven \
+  MAX_MODEL_LEN=1048576 TP_SIZE=2 GPU_MEMORY_UTILIZATION=0.975)"
+assert_contains "${text_engine_override_output}" '--gpu-memory-utilization 0.975'
+assert_contains "${text_engine_override_output}" 'lmcache_memory_profile=unqualified'
+
+text_qualified_output="$(capture \
+  MODEL=deepseek-ai/DeepSeek-V4-Flash-0731 DS4_MODEL_VARIANT=text \
+  LMCACHE_MODE=disk TP_SIZE=2 DSPARK_TOKENS=5 MAX_MODEL_LEN=1048576)"
+assert_contains "${text_qualified_output}" '--gpu-memory-utilization 0.965'
+assert_contains "${text_qualified_output}" 'lmcache_memory_profile=qualified'
+
+if text_unsafe_output="$(capture \
+    MODEL=deepseek-ai/DeepSeek-V4-Flash-0731 DS4_MODEL_VARIANT=text \
+    LMCACHE_MODE=disk TP_SIZE=2 DSPARK_TOKENS=5 MAX_MODEL_LEN=1048576 \
+    GPU_MEMORY_UTILIZATION=0.975)"; then
+  printf 'Text direct LMCache accepted an unqualified memory profile:\n%s\n' \
+    "${text_unsafe_output}" >&2
+  exit 1
+fi
+assert_contains "${text_unsafe_output}" \
+  'requires GPU_MEMORY_UTILIZATION at or below 0.965'
+
+text_override_output="$(capture \
+  MODEL=deepseek-ai/DeepSeek-V4-Flash-0731 DS4_MODEL_VARIANT=text \
+  LMCACHE_MODE=disk TP_SIZE=2 DSPARK_TOKENS=5 MAX_MODEL_LEN=1048576 \
+  GPU_MEMORY_UTILIZATION=0.975 \
+  LMCACHE_ALLOW_UNQUALIFIED_MEMORY_PROFILE=1)"
+assert_contains "${text_override_output}" '--gpu-memory-utilization 0.975'
+assert_contains "${text_override_output}" 'lmcache_memory_profile=unqualified'
+
+lmcache_output="$(capture LMCACHE_MODE=ram)"
+assert_contains "${lmcache_output}" '--gpu-memory-utilization 0.951'
+assert_contains "${lmcache_output}" '--max-model-len 900000'
+
+engine_driven_output="$(capture \
+  LMCACHE_MODE=ram LMCACHE_TRANSFER_MODE=engine_driven TP_SIZE=2)"
+assert_contains "${engine_driven_output}" '--gpu-memory-utilization 0.970'
+assert_contains "${engine_driven_output}" '--max-model-len 1048576'
+assert_contains "${engine_driven_output}" 'lmcache_memory_profile=qualified'
+
+explicit_output="$(capture \
+  LMCACHE_MODE=ram GPU_MEMORY_UTILIZATION=0.965 DSPARK_TOKENS=2)"
+assert_contains "${explicit_output}" '--gpu-memory-utilization 0.965'
+assert_contains "${explicit_output}" 'num_speculative_tokens\":2'
+
+explicit_high_capacity_output="$(capture \
+  LMCACHE_MODE=ram GPU_MEMORY_UTILIZATION=0.96 MAX_MODEL_LEN=1048576)"
+assert_contains "${explicit_high_capacity_output}" '--gpu-memory-utilization 0.96'
+assert_contains "${explicit_high_capacity_output}" '--max-model-len 1048576'
+
+if unsafe_high_capacity_output="$(capture \
+    LMCACHE_MODE=ram MAX_MODEL_LEN=1048576)"; then
+  printf 'Vision direct LMCache accepted an unqualified 1M memory profile:\n%s\n' \
+    "${unsafe_high_capacity_output}" >&2
+  exit 1
+fi
+assert_contains "${unsafe_high_capacity_output}" \
+  'MAX_MODEL_LEN above 900000 requires an explicit GPU_MEMORY_UTILIZATION override'

--- a/tests/v1/attention/test_deepseek_v4_swa_visible.py
+++ b/tests/v1/attention/test_deepseek_v4_swa_visible.py
@@ -8,7 +8,9 @@ The reference semantics are a torch port of the official
 ``min(pos - span_start, max_image_tokens - 1)`` extra tokens to the left and
 ``min(span_end - pos, max_image_tokens)`` to the right; the window then starts
 at ``max(pos - (window - 1) - max(left - (window - 1), 0), 0)`` and ends at
-``pos + right`` (inclusive).
+``pos + right`` (inclusive), capped at the materialized sequence endpoint.
+For complete image spans this is identical to the reference. Metadata naming
+future image positions must not expose KV rows that have not been written.
 """
 
 import pytest
@@ -51,7 +53,11 @@ def ref_left_right(
             for span_start, span_end in spans:
                 if span_start <= pos <= span_end:
                     left = min(pos - span_start, max_image_tokens - 1)
-                    right = min(span_end - pos, max_image_tokens)
+                    right = min(
+                        span_end - pos,
+                        max_image_tokens,
+                        max(seq_len - pos - 1, 0),
+                    )
             lefts.append(left)
             rights.append(right)
     return lefts, rights
@@ -197,6 +203,12 @@ CASES: list[_Case] = [
         "seq_lens": [40, 9],
         "query_lens": [16, 9],
         "spans": [[(30, 38)], []],
+    },
+    # Metadata naming future image tokens must not expose unwritten KV rows.
+    {
+        "seq_lens": [35],
+        "query_lens": [11],
+        "spans": [[(30, 38)]],
     },
     # span ending exactly at the prompt end; tiny request
     {

--- a/vllm/models/deepseek_v4/common/mm_preprocess.py
+++ b/vllm/models/deepseek_v4/common/mm_preprocess.py
@@ -345,10 +345,10 @@ class DeepseekV4VLProcessingInfo(BaseProcessingInfo):
         }
 
     def get_image_placeholder_token_id(self) -> int:
-        token_id = self.get_tokenizer().convert_tokens_to_ids(IMAGE_PLACEHOLDER)
-        if token_id is None:
+        vocabulary = self.get_tokenizer().get_vocab()
+        if IMAGE_PLACEHOLDER not in vocabulary:
             raise ValueError(f"Token not found in tokenizer: {IMAGE_PLACEHOLDER}")
-        return token_id
+        return vocabulary[IMAGE_PLACEHOLDER]
 
     def get_image_size_with_most_features(self) -> ImageSize:
         hf_config = self.get_hf_config()

--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -180,6 +180,7 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
                 )
             inputs_embeds = sp_shard(inputs_embeds)
             previous_hidden_states = sp_shard(previous_hidden_states)
+            input_ids = sp_shard(input_ids)
         hidden_states = self.h_proj(previous_hidden_states) + self.e_proj(
             inputs_embeds
         ).unsqueeze(-2)

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -934,7 +934,9 @@ def _compute_image_visibility_kernel(
         left = tl.where(
             in_span, tl.minimum(pos - span_start, max_image_tokens - 1), left
         )
-        right = tl.where(in_span, tl.minimum(span_end - pos, max_image_tokens), right)
+        materialized_right = tl.maximum(seq_len - pos - 1, 0)
+        span_right = tl.minimum(span_end - pos, max_image_tokens)
+        right = tl.where(in_span, tl.minimum(span_right, materialized_right), right)
     tl.store(left_visible_ptr + token_idx, left)
     tl.store(right_visible_ptr + token_idx, right)
 


### PR DESCRIPTION
## Behavior

Preserve the canonical DeepSeek V4 Vision model and loader while enforcing
three serving invariants:

- Resolve the image placeholder by exact vocabulary membership. An unknown
  token ID must not masquerade as a valid image placeholder.
- Shard MTP input IDs together with hidden states under sequence parallelism.
- Limit bidirectional image visibility to KV positions materialized by the
  actual sequence length, including a prefill chunk ending inside an image.

The native launcher selects text or Vision checkpoint identity, K3 for Vision,
buffered InstantTensor, and transport-aware memory profiles. Explicit model,
loader and memory choices remain available; `MAX_MODEL_LEN=-1` remains valid.
The shared image's separate DS4 wrapper selects text K5 and isolates its graph
and CPU defaults from the GLM launcher.

## Relationship to #634

This is a reduced port of #634 onto Jovian Judgement with the canonical Vision
implementation already present. It must replace, not stack with, the full
model-import PR. The model implementation and lazy loading from Isotr0py's
upstream contribution remain in the base. Martin Vit's runtime and launcher
contracts from #634 are credited in both commits. This PR does not reimport
an alternate Vision model or overwrite GLM/Qwen cache machinery.

Duplicate checks found no separate open PR for these three remaining contracts.
The upstream SM12x enablement PR is broader and is not duplicated here.

## Validation

- Focused Vision, routing, visible-span and launcher contracts: 30 passed.
- Installed shared image: 236 native/model/warmup/runner tests, 82 LMCache
  transfer tests, 113 Qwen tests (5 skips), and 7 DS4 functionalization/profile
  tests pass.
- RTX PRO 6000 Workstation, stock TP2/DCP1: text K5 and Vision K3 load, capture
  FULL_AND_PIECEWISE graphs and complete 810K-token admission probes.
- Text answers/tools and Vision image/prefix checks pass. Engine-driven RAM
  and filesystem restore after both services restart are byte-exact for all
  eight cache groups on both TP ranks. Each restore supplies 32,768 external
  tokens with zero GPU-prefix hits; the remaining prompt tail is computed.
- Warmed 30-second C1/32K observations: text 212.30 tok/s, 75.59 steps/s,
  14,220 prefill tok/s; Vision 170.40 tok/s, 80.47 steps/s, 11,074 prefill tok/s.
  Single cells and variable control rates do not establish a universal gain.

Focused commands (isolated image Python/dependencies):

```bash
uv run --no-project --python /opt/venv/bin/python python -m pytest -q \
  tests/models/test_deepseek_v4_vision.py \
  tests/v1/attention/test_deepseek_v4_swa_visible.py
bash tests/scripts/test_serve_ds4_flash.sh
git diff --check
```

Full composition and release boundaries are recorded in the
[shared serving report](https://github.com/local-inference-lab/rtx6kpro/blob/master/models/glm-5.3-flash/validation/shared-serving-r29.md).
TP8, NVFP4 target KV and multi-hour Vision stability are not qualified here.
The Vision change is not claimed as a demonstrated fix for Unat's Xid report.

AI assistance: Codex performed the reduced port and validation under Martin
Vit's direction. Human review of the changed lines remains required before
merging; no human-review approval is asserted by these test results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved serving support for DeepSeek V4 Vision models, including automatic model and variant detection, revision handling, vision-specific defaults, and InstantTensor loading.
  - Added model-aware sequence-length, memory, GPU utilization, and speculative-token settings.
  - Expanded launch diagnostics and configuration checks for high-capacity and LMCache deployments.

- **Bug Fixes**
  - Corrected image placeholder token resolution and sequence-parallel processing.
  - Prevented image-attention visibility from extending beyond materialized sequence data.
  - Added clearer rejection of invalid model-length and memory-profile configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->