### PR TITLE
fix(router): synchronize clustered BF16 reduction ownership

### DIFF
--- a/tests/kernels/test_ll_bf16_gemm.py
+++ b/tests/kernels/test_ll_bf16_gemm.py
@@ -2,6 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for cuteDSL low-latency router GEMM (dot-product + split-K)."""
 
+import shutil
+import subprocess
+import sys
+import textwrap
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -141,6 +146,44 @@ def test_splitk_K_sweep(K):
     a = torch.randn(8, K, dtype=torch.bfloat16, device="cuda")
     b = torch.randn(64, K, dtype=torch.bfloat16, device="cuda")
     _assert_close(_gemm(a, b), _ref(a, b), context=f"splitk K={K}")
+
+
+def test_splitk_producer_consumer_barriers():
+    """Partial-block MMA barriers must not rendezvous with DMA exit barriers."""
+    sanitizer = shutil.which("compute-sanitizer")
+    if sanitizer is None:
+        pytest.skip("compute-sanitizer is required to check barrier participation")
+    assert sanitizer is not None
+    code = textwrap.dedent("""
+        import torch
+        from vllm.model_executor.kernels.linear.cute_dsl.ll_bf16 import ll_bf16_gemm
+
+        for rows, width, experts in ((5, 2048, 17), (16, 4096, 256)):
+            a = torch.ones((rows, width), device="cuda", dtype=torch.bfloat16)
+            b = torch.ones((experts, width), device="cuda", dtype=torch.bfloat16)
+            output = ll_bf16_gemm(a, b)
+            torch.accelerator.synchronize()
+            torch.testing.assert_close(
+                output, torch.full_like(output, width), rtol=0, atol=0
+            )
+    """)
+    result = subprocess.run(
+        [
+            sanitizer,
+            "--tool",
+            "synccheck",
+            "--error-exitcode",
+            "86",
+            sys.executable,
+            "-c",
+            code,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ERROR SUMMARY: 0 errors" in result.stdout + result.stderr
 
 
 # =================================================================

--- a/vllm/model_executor/kernels/linear/cute_dsl/_ll_bf16_splitk.py
+++ b/vllm/model_executor/kernels/linear/cute_dsl/_ll_bf16_splitk.py
@@ -357,6 +357,19 @@ class LLBf16SplitK:
             consumer_group=consumer_group,
         )
 
+        num_elems: cutlass.Constexpr = self.num_epilogue_elems
+        elems_per_thread: cutlass.Constexpr = self.epilogue_elems_per_thread
+        partials = cute.make_tensor(
+            cute.arch.alloc_smem(
+                cutlass.Float32, num_elems * self.split_k, alignment=16
+            ),
+            cute.make_layout((self.split_k, num_elems), stride=(num_elems, 1)),
+        )
+        cta_rank = cute.arch.block_idx_in_cluster()
+        # A peer's DSMEM may be accessed only after that CTA has started.
+        cute.arch.cluster_arrive()
+        cute.arch.cluster_wait()
+
         # Round-robin split-K: split z handles tiles z, z+split_k, ...
         K_total = cute.size(mA, mode=[1])
         k_tile_count = cute.size(gA, mode=[2])
@@ -497,8 +510,6 @@ class LLBf16SplitK:
 
             # Cluster reduction epilogue.
             # Reduce per-warp accumulators within this CTA.
-            num_elems: cutlass.Constexpr = self.num_epilogue_elems
-            elems_per_thread: cutlass.Constexpr = self.epilogue_elems_per_thread
             # Map MMA threads to linear CTA output elements.
             epilogue_thread_layout = cute.make_layout(
                 (elems_per_thread, self.num_mma_threads),
@@ -519,16 +530,8 @@ class LLBf16SplitK:
             )
             tCsC_partial = thr_mma.partition_C(smem_warp)
             cute.autovec_copy(tCrC, tCsC_partial)
-            cute.arch.sync_threads()
-
-            # Layout: (split-K rank, linear MN element).
-            partials = cute.make_tensor(
-                cute.arch.alloc_smem(
-                    cutlass.Float32, num_elems * self.split_k, alignment=16
-                ),
-                cute.make_layout((self.split_k, num_elems), stride=(num_elems, 1)),
-            )
-            cta_rank = cute.arch.block_idx_in_cluster()
+            # DMA warps drain the copy pipeline independently of MMA reduction.
+            cute.arch.barrier(barrier_id=1, number_of_threads=self.num_mma_threads)
 
             for ei in cutlass.range_constexpr(elems_per_thread):
                 elem_idx = epilogue_slots[ei, mma_tidx]
@@ -547,7 +550,7 @@ class LLBf16SplitK:
                     total = total * scale
                 partials[cta_rank, elem_idx] = total
 
-            cute.arch.sync_threads()
+            cute.arch.barrier(barrier_id=1, number_of_threads=self.num_mma_threads)
 
             # Broadcast this CTA's partials to peer DSMEM.
             for ei in cutlass.range_constexpr(elems_per_thread):
@@ -558,28 +561,31 @@ class LLBf16SplitK:
                     remote = set_block_rank(my_slot, cutlass.Int32(peer))
                     st_shared_remote_f32(remote, my_val)
 
-            cute.arch.cluster_arrive()
-            cute.arch.cluster_wait()  # peer DSMEM stores are now visible
+        # All producer and consumer warps participate. No CTA can exit while a
+        # peer still writes its partials into that CTA's distributed shared memory.
+        cute.arch.cluster_arrive()
+        cute.arch.cluster_wait()
 
+        if not is_dma_warp:
             if const_expr(self.use_pdl) and mma_tidx == 0:
                 cute.arch.griddepcontrol_launch_dependents()
-            cute.arch.sync_threads()
 
-            # Reduce split-K partials and write global output.
-            for ei in cutlass.range_constexpr(elems_per_thread):
-                elem_idx = epilogue_slots[ei, mma_tidx]
-                local_coord = cute.select(epilogue_slot_coords[elem_idx], mode=[1, 0])
-                global_coord = cC[local_coord]
-                if cute.elem_less(global_coord, mC.shape):
-                    acc = (
-                        partials[None, elem_idx]
-                        .load()
-                        .reduce(
-                            cute.ReductionOp.ADD,
-                            init_val=cutlass.Float32(0.0),
-                            reduction_profile=0,
+            # One CTA owns each global output; peer CTAs must not race its stores.
+            if cta_rank == 0:
+                for ei in cutlass.range_constexpr(elems_per_thread):
+                    elem_idx = ei * self.num_mma_threads + mma_tidx
+                    local_coord = (elem_idx // bN, elem_idx % bN)
+                    global_coord = cC[local_coord]
+                    if cute.elem_less(global_coord, mC.shape):
+                        acc = (
+                            partials[None, elem_idx]
+                            .load()
+                            .reduce(
+                                cute.ReductionOp.ADD,
+                                init_val=cutlass.Float32(0.0),
+                                reduction_profile=0,
+                            )
                         )
-                    )
-                    gC[local_coord] = acc
+                        gC[local_coord] = acc
 
         cute.arch.sync_threads()


### PR DESCRIPTION
## Behavior and reason

Fix synchronization in `LLBf16SplitK`, the clustered BF16-input/FP32-output
expert-router matrix product used for batches larger than four rows.

- Use a named 128-thread barrier for consumer-only reduction. Whole-CTA
  barriers inside the consumer branch cannot safely rendezvous with the
  producer branch's exit barrier.
- Rendezvous the complete cluster before peer shared-memory writes, and again
  after both producer and consumer branches finish. Peer storage must exist
  before access and remain alive until all remote writes complete.
- Give cluster rank zero sole ownership of global output stores.

The public API, BF16 operands, FP32 reduction order, shape dispatch, copy
pipeline and programmatic dependent launch remain unchanged. No backend
fallback, quantization change or feature switch is added.

## Validation

RTX PRO 6000 Workstation, SM120, CUDA 13.3, Compute Sanitizer 2026.2.1:

| Check | Unmodified | Corrected |
|---|---|---|
| Standalone `(M,K,N)=(16,4096,256)` synccheck | 8,000 divergent-barrier errors on first warmup | Zero errors; exact output |
| Same shape, memcheck, eager and graph replay | Not a claimed control | Zero errors; exact output |
| Router shape/API/graph suite plus barrier regression | Regression fails | 136 passed, also repeated in the baked image |
| DS4 Vision, TP2/DCP1, FP8, C4/four images, engine-driven LMCache | Two production-clock runs failed with `CTA Not Present`, after 259 s and 55 s | Two separate 600 s runs: 529 and 501 HTTP 200 completions, zero HTTP errors, healthy server |

Kernel suite command in the image's isolated environment:

```bash
/opt/venv/bin/python -m pytest --noconftest -q tests/kernels/test_ll_bf16_gemm.py
```

`test_splitk_producer_consumer_barriers` invokes synccheck in an independent
process and checks exact products. Root-level pytest collection requires
additional repository-wide test dependencies; `--noconftest` isolates this
self-contained kernel suite.

The serving tests use stock GPUs0/1, a 4096-token budget, full-and-piecewise
graphs and separate empty external-cache tiers. The second run uses baked
vLLM `45361846`, without source mounts or CUDA exception-wait instrumentation.
They do not establish long-duration stability or general response quality.
No fault-PC trace was captured, so they do not prove every launch failure has
this cause. This is a correctness fix, not a claimed speedup.

Racecheck separately reports asynchronous operand-stage hazards. The report
also reproduces in an independent CUDA-only four-stage producer/consumer
copy program, without CuTe, GEMM, DSMEM, vLLM or LMCache; generation-specific
copied values are exact. Scalar loads and reassembled PTX reproduce it too.
The producer/consumer ordering follows the documented mbarrier visibility
contract, supporting a sanitizer-tracking limitation, but vendor confirmation
is absent. Those runs are retained as failed diagnostics, not advertised as
passing racecheck. No pipeline fallback or sanitizer suppression is included.

## Scope and attribution

The kernel originates in Roberto L. Castro's upstream vLLM #42562. Its history
is retained. Open-PR searches for the kernel and clustered router synchronization
found no duplicate fix; upstream #50091/#50177 concern warmup, not these barriers.

AI-assisted implementation and validation by Codex. This is a review request
for the Local Inference Lab fork, not an upstream submission or a claim that
human line-by-line review has already occurred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved split-K BF16 GEMM reliability for both partial-block and full-block workloads.
  - Fixed synchronization issues that could cause incorrect results during parallel matrix multiplication.
  - Ensured outputs are written consistently and accurately across supported split-K execution paths.

- **Tests**
  - Added regression coverage that validates exact GEMM results and checks for synchronization errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->