### PR TITLE
Reuse B12X warmup buffers across route-id dtypes

### DIFF
--- a/tests/kernels/moe/test_b12x.py
+++ b/tests/kernels/moe/test_b12x.py
@@ -740,6 +740,7 @@ def test_b12x_moe_warmup_runs_each_planner_regime_once(
     planned_tokens = []
     launched_tokens = []
     launched_dtypes = []
+    launched_buffers = []
     launched_resources = []
     synchronized = []
 
@@ -769,6 +770,12 @@ def test_b12x_moe_warmup_runs_each_planner_regime_once(
     def fake_run(**kwargs):
         launched_tokens.append(kwargs["hidden_states"].shape[0])
         launched_dtypes.append(kwargs["topk_ids"].dtype)
+        launched_buffers.append(
+            tuple(
+                kwargs[name].data_ptr()
+                for name in ("hidden_states", "output", "topk_weights", "scratch")
+            )
+        )
         launched_resources.append(
             tuple(
                 weakref.ref(kwargs[name])
@@ -801,6 +808,12 @@ def test_b12x_moe_warmup_runs_each_planner_regime_once(
     assert planned_tokens == [1, 3, 8]
     assert launched_tokens == [1, 1, 3, 3, 8, 8]
     assert launched_dtypes == [torch.int32, torch.int64] * 3
+    # Both route-id dtypes of one regime run on the same input, output,
+    # weight and scratch buffers; regimes do not share buffers.
+    assert launched_buffers[0] == launched_buffers[1]
+    assert launched_buffers[2] == launched_buffers[3]
+    assert launched_buffers[4] == launched_buffers[5]
+    assert len({launched_buffers[0], launched_buffers[2], launched_buffers[4]}) == 3
     assert synchronized == [True]
 
 

--- a/vllm/model_executor/layers/fused_moe/b12x.py
+++ b/vllm/model_executor/layers/fused_moe/b12x.py
@@ -672,18 +672,31 @@ class B12xExperts(mk.FusedMoEExpertsModular):
                 activation=activation,
                 apply_router_weight_on_input=apply_router_weight_on_input,
             )
+            # One buffer set per token count serves both route-id dtypes: the
+            # launches are stream-ordered, so the second reads the same zero
+            # input and overwrites the same output and scratch after the
+            # first completes. The retained set stays one input, one output
+            # and one scratch per regime instead of doubling with the dtypes;
+            # its allocator footprint bounds the KV budget of launches that
+            # retain the warmed allocator high-water.
+            scratch = torch.empty(
+                (_b12x_scratch_nbytes(plan),),
+                dtype=torch.uint8,
+                device=device,
+            )
+            hidden_states = torch.zeros(
+                (tokens, int(prepared.hidden_size)),
+                dtype=dtype,
+                device=device,
+            )
+            output = torch.empty_like(hidden_states)
+            topk_weights = torch.full(
+                (tokens, topk),
+                1.0 / topk,
+                dtype=torch.float32,
+                device=device,
+            )
             for route_ids_dtype in (torch.int32, torch.int64):
-                scratch = torch.empty(
-                    (_b12x_scratch_nbytes(plan),),
-                    dtype=torch.uint8,
-                    device=device,
-                )
-                hidden_states = torch.zeros(
-                    (tokens, int(prepared.hidden_size)),
-                    dtype=dtype,
-                    device=device,
-                )
-                output = torch.empty_like(hidden_states)
                 topk_ids = (
                     torch.arange(topk, device=device, dtype=route_ids_dtype)
                     .unsqueeze(0)
@@ -691,12 +704,6 @@ class B12xExperts(mk.FusedMoEExpertsModular):
                     .contiguous()
                 )
                 topk_ids.remainder_(int(prepared.num_experts))
-                topk_weights = torch.full(
-                    (tokens, topk),
-                    1.0 / topk,
-                    dtype=torch.float32,
-                    device=device,
-                )
                 # B12X warmup launches may outlive the Python call that
                 # submits them. Retain every caller-owned input, output, and
                 # scratch tensor until device completion so the allocator


### PR DESCRIPTION
This extracts joninco's B12X MoE warmup buffer-reuse fix from #713, original commit https://github.com/local-inference-lab/vllm/commit/6e2f8037a690234384d6c1c953bb6797dced9ba4. All implementation and regression-test credit belongs to joninco. The commit preserves the original author identity, author date, message and Signed-off-by. It applies without port corrections.

For each planner regime, the int32 and int64 route-id launches share the hidden-state, output, weight and scratch buffers. Route IDs remain separate. Stream ordering and the existing #516 lifetime protection retain every resource until the final synchronization. The diff contains only this independently reviewable fix and its sharing regression test; #713 remains the author's broader TP8 work.

The approximately 0.9 GiB KV-budget recovery is joninco's TP8 measurement reported in the original commit. We did not measure that recovery on our TP4 deployment.

Our validation against current dev/jovian-judgement:

- The sharing assertion fails on unchanged target source and passes with this fix.
- Focused sharing/lifetime regression plus tests/model_executor/test_b12x_warmup.py: 18 passed in CPU-only Docker, runtime runc, no GPU devices, network disabled.
- Ruff 0.14.0 check and format --check pass on both changed files; Python compilation passes.
- A broader run of both complete test files produced 3 failed, 43 passed, 9 skipped. One configuration case rejects CPU, and two unrelated preparation cases query CUDA capture state without a GPU. These are validation limits, not a claim that the full suites passed.
- The warmup method matches the LP31 port by parsed Python AST. The subsequent LP31 integration checks are summarized below.

These checks validate mocked launch scheduling, sharing and resource lifetime. They do not validate GPU kernels, GPU concurrency, memory recovery or serving performance.


## Subsequent integration checks

The composed LP31 image passed 82 synthetic data-accuracy checks with no prefix-reuse failures, plus the planned concurrency, pressure, cancellation and request-ID reuse checks. The final serving validation also passed. Three fenced-JSON responses were recorded as formatting-only deviations.

This tests the complete image with its other fixes. It does not establish an isolated memory or performance gain from this commit; the original author's TP8 measurement remains separately attributed above.
