### PR TITLE
perf(moe): declare B12X loader-owned inference scales immutable

### DIFF
--- a/vllm/model_executor/layers/fused_moe/b12x.py
+++ b/vllm/model_executor/layers/fused_moe/b12x.py
@@ -333,6 +333,9 @@ class B12xExperts(mk.FusedMoEExpertsModular):
             w2_global_scale=w2_global_scale,
             a2_gscale=a2_gscale,
             params_dtype=params_dtype,
+            # Loaded inference scales remain constant for this prepared owner
+            # and its CUDA graphs; reloading constructs another owner.
+            immutable_input_scales=True,
         )
 
     def _refresh_quant_config(self, layer: torch.nn.Module) -> None:


### PR DESCRIPTION
## Behavior

Declare loaded B12X MoE input scales immutable for the prepared inference owner
and its CUDA graphs. This enables B12X to prove exact expert-scale equality once
and reuse input quantization without replacing the canonical scale vectors.
Weight reload constructs another prepared owner.

This three-line adapter change requires the paired B12X
`immutable_input_scales` preparation API. It must not merge without that dependency.
It does not select kernels, change checkpoint scale values, alter target/draft
precision, or introduce a vLLM-owned backend heuristic.

## Review units and evidence

No existing PR exposes this loader-owned immutability contract.
[B12X #354](https://github.com/local-inference-lab/b12x/pull/354) supplies the proof
and mutation accounting; L14nY1Wang's
[B12X #353](https://github.com/local-inference-lab/b12x/pull/353) supplies the
split-prefill kernels. This PR is based directly on `dev/jovian-judgement` and
does not duplicate those kernels or the community image's other patches.

[Committed serving evidence and reproduction clients](https://github.com/voipmonitor/b12x/blob/perf/nvfp4-immutable-input-scales/docs/nvfp4-immutable-input-serving.md)
identify exact revisions, devices, clock offsets, raw samples and correctness
limits. The combined source-locked image also passes 39 installed B12X CPU/GPU
contracts; this is not an E2E qualification of an otherwise unmodified JJ head.

Changed-file Ruff lint/format and `git diff --check` pass. The B12X companion's
15 focused CPU tests pass. The identical adapter was exercised with complete
models in the source-locked R32 dependency environment on RTX PRO 6000 WS,
VRAM +6000: cold 32K GLM TP4/no-spec **15,842 → 17,152 tok/s (+8.27%)**;
Qwen TP1/MTP3 **15,707 → 17,211 tok/s (+9.57%)**. Same devices per A/B.
No decode speedup is claimed. GLM budget 4,096; Qwen budget 6,019 tokens.

Independent numerical oracles, CUDA-graph replay and literal lookup/cache
checks pass. Split and monolithic kernels are not bit-identical: a diagnostic
0.9999 cross-kernel cosine threshold fails at approximately 0.99989, while
the split result has lower error against the independent oracle. Broad model
quality/distribution equivalence is not established. GLM speculative release
guards are reported separately with the image evidence.

AI-assisted implementation and validation, submitted for human maintainer review.
