### PR TITLE
Allow deployment MoE defaults while preserving explicit backend overrides

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -655,6 +655,37 @@ def test_numa_bind_args():
     assert engine_args.numa_bind_cpus == ["0-3", "4-7", "8-11", "12-15"]
 
 
+@pytest.mark.parametrize(
+    "options,expected",
+    [
+        ([], "b12x"),
+        (["--moe-backend", "auto"], "auto"),
+        (["--moe-backend", "flashinfer-cutlass"], "flashinfer_cutlass"),
+        (["--kernel-config.moe_backend", "auto"], "auto"),
+        (["--kernel-config", '{"moe_backend":"triton"}'], "triton"),
+        (["--kernel-config.moe_backend", "triton", "--moe-backend", "auto"], "auto"),
+    ],
+)
+def test_moe_backend_cli_precedence(monkeypatch, tmp_path, options, expected):
+    """An omitted flat option preserves the nested deployment configuration."""
+    from transformers import LlamaConfig
+
+    monkeypatch.setenv("VLLM_DEFAULT_MOE_BACKEND", "b12x")
+    LlamaConfig(
+        architectures=["LlamaForCausalLM"],
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        vocab_size=128,
+    ).save_pretrained(tmp_path)
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(["--model", str(tmp_path), *options])
+    engine_args = EngineArgs.from_cli_args(args)
+    assert engine_args.create_engine_config().kernel_config.moe_backend == expected
+
+
 def test_ir_op_priority():
     from vllm.config.kernel import IrOpPriorityConfig, KernelConfig
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,6 +41,29 @@ from vllm.v1.attention.backend import AttentionCGSupport
 DEVICE_TYPE = current_platform.device_type
 
 
+@pytest.mark.parametrize(
+    "configured,expected",
+    [(None, "auto"), ("b12x", "b12x"), ("FLASHINFER-CUTLASS", "flashinfer_cutlass")],
+)
+def test_moe_backend_deployment_default(monkeypatch, configured, expected):
+    monkeypatch.delenv("VLLM_DEFAULT_MOE_BACKEND", raising=False)
+    if configured is not None:
+        monkeypatch.setenv("VLLM_DEFAULT_MOE_BACKEND", configured)
+    assert KernelConfig().moe_backend == expected
+
+
+@pytest.mark.parametrize("backend", ["auto", "b12x", "flashinfer_cutlass"])
+def test_explicit_moe_backend_overrides_deployment_default(monkeypatch, backend):
+    monkeypatch.setenv("VLLM_DEFAULT_MOE_BACKEND", "b12x")
+    assert KernelConfig(moe_backend=backend).moe_backend == backend
+
+
+def test_invalid_moe_backend_deployment_default_fails_validation(monkeypatch):
+    monkeypatch.setenv("VLLM_DEFAULT_MOE_BACKEND", "not_a_backend")
+    with pytest.raises(ValidationError, match="moe_backend"):
+        KernelConfig()
+
+
 def test_kda_recoverssm_derivation_is_revalidated():
     config = SimpleNamespace(
         cache_config=SimpleNamespace(

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import Field, field_validator
 
+import vllm.envs as envs
 from vllm.config.utils import config, get_hash_factors, hash_factors
 from vllm.logger import init_logger
 
@@ -232,8 +233,14 @@ class KernelConfig:
     enable_bf16x3_router_gemm: bool = False
     """If True, use the experimental SM100 BF16x3 CuteDSL router GEMM."""
 
-    moe_backend: MoEBackend = "auto"
-    """Backend for MoE expert computation kernels. Available options:
+    moe_backend: MoEBackend = Field(
+        default_factory=lambda: envs.VLLM_DEFAULT_MOE_BACKEND,
+        validate_default=True,
+    )
+    """Backend for MoE expert computation kernels. Defaults to
+    `VLLM_DEFAULT_MOE_BACKEND`, or "auto" when the variable is unset.
+    Explicit configuration takes precedence over the deployment default.
+    Available options:
 
     - "auto": Automatically select the best backend based on model and hardware
     - "triton": Use Triton-based fused MoE kernels

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -501,7 +501,7 @@ class EngineArgs:
         ParallelConfig.enable_batch_sharded_sampling
     )
     enable_ep_weight_filter: bool = ParallelConfig.enable_ep_weight_filter
-    moe_backend: MoEBackend = KernelConfig.moe_backend
+    moe_backend: MoEBackend | None = None
     linear_backend: LinearBackend = KernelConfig.linear_backend
     all2all_backend: All2AllBackend = ParallelConfig.all2all_backend
     enable_elastic_ep: bool = ParallelConfig.enable_elastic_ep
@@ -1669,6 +1669,9 @@ class EngineArgs:
             **kernel_kwargs["enable_bf16x3_router_gemm"],
         )
         moe_backend_kwargs = kernel_kwargs["moe_backend"]
+        # Omission preserves nested configuration and its deployment default;
+        # an explicit "auto" must still override a pinned deployment backend.
+        moe_backend_kwargs["default"] = None
         moe_backend_kwargs["type"] = lambda s: s.lower().replace("-", "_")
         kernel_group.add_argument("--moe-backend", **moe_backend_kwargs)
         linear_backend_kwargs = kernel_kwargs["linear_backend"]
@@ -2518,7 +2521,7 @@ class EngineArgs:
             kernel_config.enable_flashinfer_autotune = self.enable_flashinfer_autotune
         if self.enable_bf16x3_router_gemm is not None:
             kernel_config.enable_bf16x3_router_gemm = self.enable_bf16x3_router_gemm
-        if self.moe_backend != "auto":
+        if self.moe_backend is not None:
             kernel_config.moe_backend = self.moe_backend
         if self.linear_backend != "auto":
             kernel_config.linear_backend = self.linear_backend

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -190,6 +190,7 @@ if TYPE_CHECKING:
     VLLM_HUMMING_USE_F16_ACCUM: bool = False
     VLLM_HUMMING_MOE_GEMM_TYPE: Literal["indexed", "grouped", "auto"] | None = None
     VLLM_B12X_MOE_FP4_FORCE_A16: bool = False
+    VLLM_DEFAULT_MOE_BACKEND: str = "auto"
     VLLM_B12X_DENSE_ACTIVATION_MODE: Literal["auto", "a16", "quantized"] = "auto"
     VLLM_B12X_NVFP4_ACTIVATION_MODE: Literal["auto", "a16", "quantized"] | None = None
     VLLM_B12X_MXFP8_ACTIVATION_MODE: Literal["auto", "a16", "quantized"] | None = None
@@ -1639,6 +1640,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER": lambda: bool(
         int(os.getenv("VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER", "1"))
     ),
+    # Deployment default; explicit kernel configuration or CLI selection wins.
+    "VLLM_DEFAULT_MOE_BACKEND": lambda: os.getenv("VLLM_DEFAULT_MOE_BACKEND", "auto"),
     # Force b12x FP4 MoE to use BF16 activations.
     "VLLM_B12X_MOE_FP4_FORCE_A16": lambda: bool(
         int(os.getenv("VLLM_B12X_MOE_FP4_FORCE_A16", "0"))


### PR DESCRIPTION
## Behavior

Allow an image or deployment to select its default MoE backend through
`VLLM_DEFAULT_MOE_BACKEND`. Unset environments keep `auto`; the Jovian community
image sets `b12x`. An explicit flat CLI/API selection, including `auto`, overrides
that default. An omitted flat option preserves explicit nested kernel settings.
Invalid environment defaults fail the normal backend validation.

Native `vllm serve` previously selected FlashInfer CUTLASS for NVFP4 when the
target backend option was omitted, whereas the published GLM and Qwen launchers
explicitly selected B12X. The deployment setting makes those entrypoints
consistent without hardcoding B12X into portable vLLM's automatic oracle.

No kernel, attention selection, quantization, sampling, or explicit speculative
backend is changed. Unsupported B12X configurations still fail rather than
silently choosing another implementation. `EngineArgs.moe_backend` uses `None`
for omission; its effective default remains available in `KernelConfig`.

## Validation

- 13 focused cases pass for environment validation, explicit overrides, nested
  configuration, and complete CLI-to-engine configuration resolution. Tests use
  a locally constructed tiny model config, without downloading model weights.
- Ruff 0.14.0, repository pre-commit hooks including mypy, and diff checks pass.
- Qwen3.8-Flash-Next NVFP4, TP1/MTP3, one RTX PRO 6000 Workstation with VRAM
  +6000: three warmed C1 runs and five uncached 32K requests. Explicit B12X versus
  omitted target option (FlashInfer CUTLASS) gives median 204.039 versus 182.970
  output tok/s (+11.52%), 96.915 versus 86.784 verifier steps/s (+11.67%), and
  17,268.178 versus 16,958.185 prefill tok/s (+1.83%). Draft MoE stays B12X in both
  arms; temperature 1, top-p 0.95, top-k 20. All cells complete without errors.
- These measurements compare backend selection, not a kernel change or a speedup
  over correctly configured B12X deployments. They do not establish bit-exact
  equivalence between B12X and FlashInfer CUTLASS.

Duplicate checks found no open PR for this deployment-default setting in either
this fork or upstream vLLM. This focused PR targets `dev/jovian-judgement`; it
does not include the community image's complete integration stack.

AI assistance was used for implementation and validation. Human maintainer
review is required before merge. Packaged-image evidence is reported separately
when the immutable artifact has passed its serving check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for setting the default Mixture-of-Experts (MoE) backend through the `VLLM_DEFAULT_MOE_BACKEND` environment variable.
  - Nested kernel configuration and deployment defaults are now preserved when the `--moe-backend` option is omitted.
  - Explicit command-line values, including `auto`, continue to override configured defaults.

- **Bug Fixes**
  - Improved validation for invalid MoE backend defaults and configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->