### PR TITLE
fix(quantization): defer optional DeepSeek V4.1 kernel imports

### DIFF
--- a/tests/quantization/test_register_quantization_config.py
+++ b/tests/quantization/test_register_quantization_config.py
@@ -105,7 +105,7 @@ class CustomQuantConfig(QuantizationConfig):
 
 
 def test_quantization_discovery_does_not_require_optional_model_kernels():
-    """Registry lookup must work without DeepSeek V4.1's optional CUDA package."""
+    """Config discovery must not import model-specific native implementations."""
     script = textwrap.dedent(
         """
         import importlib.abc
@@ -114,9 +114,7 @@ def test_quantization_discovery_does_not_require_optional_model_kernels():
 
         class RejectOptionalKernels(importlib.abc.MetaPathFinder):
             def find_spec(self, fullname, path=None, target=None):
-                if fullname == "flashinfer.b12x" or fullname.startswith(
-                    "flashinfer.b12x."
-                ):
+                if fullname == "vllm.models.deepseek_v4_1.b12x_layers":
                     raise ModuleNotFoundError("optional model kernels unavailable")
                 return None
 

--- a/tests/quantization/test_register_quantization_config.py
+++ b/tests/quantization/test_register_quantization_config.py
@@ -8,6 +8,9 @@ Run `pytest tests/quantization/test_register_quantization_config.py`.
 """
 
 import logging
+import subprocess
+import sys
+import textwrap
 from typing import Any
 
 import pytest
@@ -99,6 +102,54 @@ class CustomQuantConfig(QuantizationConfig):
         if isinstance(layer, LinearBase):
             return FakeQuantLinearMethod(num_bits=self.num_bits)
         return None
+
+
+def test_quantization_discovery_does_not_require_optional_model_kernels():
+    """Registry lookup must work without DeepSeek V4.1's optional CUDA package."""
+    script = textwrap.dedent(
+        """
+        import importlib.abc
+        import sys
+        from unittest.mock import Mock
+
+        class RejectOptionalKernels(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "flashinfer.b12x" or fullname.startswith(
+                    "flashinfer.b12x."
+                ):
+                    raise ModuleNotFoundError("optional model kernels unavailable")
+                return None
+
+        sys.meta_path.insert(0, RejectOptionalKernels())
+        from vllm.model_executor.layers.linear import LinearBase
+        from vllm.model_executor.layers.quantization import get_quantization_config
+        import torch
+
+        for method, expected_class in {
+            "fp8": "Fp8Config",
+            "modelopt_fp4": "ModelOptNvFp4Config",
+            "modelopt_mixed": "ModelOptMixedPrecisionConfig",
+            "modelopt_mxfp8": "ModelOptMxFp8Config",
+            "deepseek_v4_fp8": "DeepseekV4FP8Config",
+            "deepseek_v41_fp8": "DeepseekV41FP8Config",
+        }.items():
+            config = get_quantization_config(method)
+            assert config.__name__ == expected_class
+
+        config = get_quantization_config("deepseek_v41_fp8")()
+        assert config.get_quant_method(torch.nn.Identity(), "experts") is None
+        try:
+            config.get_quant_method(Mock(spec=LinearBase), "projection")
+        except ModuleNotFoundError as error:
+            assert "optional model kernels unavailable" in str(error)
+        else:
+            raise AssertionError("Native dispatch must not hide a missing backend")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_register_quantization_config(caplog_vllm):

--- a/vllm/models/deepseek_v4_1/quant_config.py
+++ b/vllm/models/deepseek_v4_1/quant_config.py
@@ -7,8 +7,6 @@ from vllm.model_executor.layers.quantization.fp8 import Fp8Config
 from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 
-from .b12x_layers import B12xEmbeddingMethod, B12xFP8LinearMethod, B12xLinearMethod
-
 
 class DeepseekV41FP8Config(Fp8Config):
     is_scale_e8m0 = True
@@ -28,6 +26,8 @@ class DeepseekV41FP8Config(Fp8Config):
 
     def get_quant_method(self, layer, prefix):
         if isinstance(layer, LinearBase):
+            from .b12x_layers import B12xFP8LinearMethod, B12xLinearMethod
+
             if is_layer_skipped(
                 prefix=prefix,
                 ignored_layers=self.ignored_layers,
@@ -37,6 +37,8 @@ class DeepseekV41FP8Config(Fp8Config):
                 return B12xLinearMethod()
             return B12xFP8LinearMethod(self)
         if isinstance(layer, VocabParallelEmbedding):
+            from .b12x_layers import B12xEmbeddingMethod
+
             return B12xEmbeddingMethod()
         # Routed experts own their checkpoint loader and native recipe rather
         # than delegating to a generic MoE provider.


### PR DESCRIPTION
## Behavior

Quantization configuration discovery does not load DeepSeek V4.1's model-specific native layer implementations. Those implementations are imported only when selecting a DeepSeek V4.1 linear or embedding method. Selecting that backend without its dependency still raises an import error; no numerical fallback is added.

## Reason and compatibility

The quantization registry imports every registered configuration. An unconditional native-kernel import in `DeepseekV41FP8Config` therefore couples unrelated GLM `modelopt_mixed` configuration discovery to DeepSeek-specific runtime dependencies. This patch changes dependency loading, not weights, kernels or sampling.

JJ commit `a6571d0a602` selects standalone B12X instead of `flashinfer.b12x`, fixing the missing packaged namespace. This PR preserves that selection and separately removes model-specific native imports from global configuration discovery. Duplicate searches found no matching open dependency-isolation fix in this fork or upstream.

## Validation

Status: **implemented; isolated import contract qualified**.

- Run `pytest --noconftest tests/quantization/test_register_quantization_config.py::test_quantization_discovery_does_not_require_optional_model_kernels` in the isolated serving-image environment: one passed.
- The fresh-process test rejects the DeepSeek V4.1 native layer module explicitly. Six quantization configuration lookups succeed; selecting a DeepSeek V4.1 native linear method still fails with the dependency error.
- The import-isolation reproducer fails without the lazy import. A GLM image based on JJ `60b7b7191be` also reproduced a missing packaged B12X namespace during model configuration, before loading weights; `a6571d0a602` addresses that specific namespace failure.
- Ruff and commit hooks, including mypy, pass. Composed GPU serving qualification is pending; this is not a model-quality or throughput claim.

Implementation and validation used OpenAI Codex assistance. Human review remains required before merge.
