### PR TITLE
perf(kimi): resume the next turn at a finished request's last computed token

### DIFF
--- a/tests/kernels/mamba/test_request_endpoint_shadow.py
+++ b/tests/kernels/mamba/test_request_endpoint_shadow.py
@@ -1,0 +1,843 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Request-endpoint shadow snapshot and materialization kernels.
+
+``precopy_mamba_align_fused_kernel`` with ``HAS_SHADOW`` copies every
+request's committed state into its shadow pages before the boundary
+migration, including requests that stay in their running block: the conv
+window unshifted and the temporal states of the columns ``src_col + t`` for
+``t`` up to the accepted-token bias. ``materialize_mamba_endpoint_kernel``
+then writes a pool block from either the shadow pages (conv shifted by the
+endpoint bias, temporal slot at that bias) or the request's own state
+blocks, with byte-identical results to the V1 copy specs.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheGroupSpec, MambaSpec
+from vllm.v1.worker.mamba_utils import (
+    _TEMPORAL_TILES,
+    ENDPOINT_COPY_META_FIXED,
+    MambaSpecDecodeGPUContext,
+    materialize_mamba_endpoint_kernel,
+    precopy_mamba_align_fused_kernel,
+)
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="the shadow kernels need CUDA/Triton"
+)
+
+NUM_LAYERS = 3
+CONV_WIDTH = 4  # conv_kernel - 1 + num_spec
+CONV_DIM = 96
+SSM_SHAPE = (4, 16, 16)
+MAX_COLS = 8
+MAX_REQS = 6
+TEMPORAL_SLOTS = 4  # 1 + num_speculative_blocks
+
+
+def _build_state(num_blocks, device, conv_state_dim_first):
+    convs, ssms = [], []
+    for _ in range(NUM_LAYERS):
+        conv_shape = (
+            (num_blocks, CONV_DIM, CONV_WIDTH)
+            if conv_state_dim_first
+            else (num_blocks, CONV_WIDTH, CONV_DIM)
+        )
+        convs.append(torch.randn(*conv_shape, dtype=torch.bfloat16, device=device))
+        ssms.append(
+            torch.randn(num_blocks, *SSM_SHAPE, dtype=torch.float32, device=device)
+        )
+    return convs, ssms
+
+
+def _build_meta(convs, ssms, device, conv_state_dim_first):
+    n = NUM_LAYERS * 2
+    base = torch.zeros(n, dtype=torch.int64, device=device)
+    blk_stride = torch.zeros(n, dtype=torch.int64, device=device)
+    elem = torch.zeros(n, dtype=torch.int32, device=device)
+    inner = torch.zeros(n, dtype=torch.int64, device=device)
+    width = torch.zeros(n, dtype=torch.int32, device=device)
+    group = torch.zeros(n, dtype=torch.int32, device=device)
+    drc = torch.zeros(n, dtype=torch.int32, device=device)
+    drs = torch.zeros(n, dtype=torch.int64, device=device)
+    i = 0
+    for layer in range(NUM_LAYERS):
+        conv, ssm = convs[layer], ssms[layer]
+        base[i] = conv.data_ptr()
+        blk_stride[i] = conv.stride(0) * conv.element_size()
+        elem[i] = conv.element_size()
+        if conv_state_dim_first:
+            width[i] = conv.size(2)
+            inner[i] = 1
+            drc[i] = conv.size(1)
+            drs[i] = conv.stride(1) * conv.element_size()
+        else:
+            width[i] = conv.size(1)
+            inner[i] = conv.stride(1)
+        i += 1
+        base[i] = ssm.data_ptr()
+        blk_stride[i] = ssm.stride(0) * ssm.element_size()
+        elem[i] = ssm.element_size()
+        width[i] = 0
+        inner[i] = ssm[0].numel()
+        i += 1
+    return base, blk_stride, elem, inner, width, group, drc, drs
+
+
+def _build_shadow(convs, ssms, device):
+    """Per-state shadow pages with the state tensor's block stride: one conv
+    page per request slot, ``TEMPORAL_SLOTS`` temporal pages per request slot;
+    viewed with the state's own shape for comparison."""
+    buffers, views, addrs, strides = [], [], [], []
+    for layer in range(NUM_LAYERS):
+        for state, pages in (
+            (convs[layer], MAX_REQS),
+            (ssms[layer], MAX_REQS * TEMPORAL_SLOTS),
+        ):
+            stride = state.stride(0) * state.element_size()
+            buf = torch.zeros(pages * stride, dtype=torch.uint8, device=device)
+            buffers.append(buf)
+            addrs.append(buf.data_ptr())
+            strides.append(stride)
+            views.append(buf.view(state.dtype).view(pages, *state.shape[1:]))
+    return (
+        buffers,
+        views,
+        torch.tensor(addrs, dtype=torch.int64, device=device),
+        torch.tensor(strides, dtype=torch.int64, device=device),
+    )
+
+
+def _normalized(conv, ssm, bt, req, src_col, bias, conv_dim_first):
+    """The committed state of a request per the V1 copy specs: the window of
+    ``src_col`` shifted by ``bias`` and the temporal state of column
+    ``src_col + bias``."""
+    sblk = int(bt[req, src_col])
+    tblk = int(bt[req, src_col + bias])
+    conv_out = torch.zeros_like(conv[sblk])
+    if conv_dim_first:
+        conv_out[:, : CONV_WIDTH - bias] = conv[sblk][:, bias:]
+    else:
+        conv_out[: CONV_WIDTH - bias] = conv[sblk][bias:]
+    return conv_out, ssm[tblk].clone()
+
+
+def _leading(conv, bias, conv_dim_first):
+    """The window entries a reader with the given bias consumes."""
+    if conv_dim_first:
+        return conv[..., : CONV_WIDTH - bias]
+    return conv[: CONV_WIDTH - bias]
+
+
+@pytest.mark.parametrize("conv_state_dim_first", [False, True])
+@pytest.mark.parametrize("temporal_tiles", [1, _TEMPORAL_TILES])
+def test_snapshot_then_materialize_matches_the_copy_specs(
+    conv_state_dim_first, temporal_tiles
+):
+    device = torch.device("cuda")
+    torch.manual_seed(0)
+    num_reqs = 5
+    num_blocks = MAX_REQS * MAX_COLS + 4
+    # Distinct physical blocks per request slot; the kernel reads the block
+    # table in batch order (V2 layout), so it gets the rows gathered by
+    # idx_mapping while the reference indexes the per-slot table.
+    bt = torch.empty(MAX_REQS, MAX_COLS, dtype=torch.int32, device=device)
+    for r in range(MAX_REQS):
+        bt[r] = torch.arange(
+            1 + r * MAX_COLS, 1 + (r + 1) * MAX_COLS, dtype=torch.int32, device=device
+        )
+    # Batch rows map to request slots out of order to exercise idx_mapping.
+    idx_mapping = torch.tensor([3, 0, 4, 1, 2], dtype=torch.int32, device=device)
+    bt_batch = bt[idx_mapping.long()].contiguous()
+    # Per slot: (src_col, dst_col, bias). Slot 0 fresh; slot 1 stays in its
+    # running block (snapshot only); the others cross a boundary.
+    src_col = torch.tensor([-1, 2, 1, 3, 1, 0], dtype=torch.int32, device=device)
+    dst_col = torch.tensor([0, 2, 0, 4, 5, 0], dtype=torch.int32, device=device)
+    bias = torch.tensor([0, 2, 1, 0, 3, 0], dtype=torch.int32, device=device)
+
+    convs, ssms = _build_state(num_blocks, device, conv_state_dim_first)
+    conv_pre = [c.clone() for c in convs]
+    ssm_pre = [s.clone() for s in ssms]
+    base, blk_stride, elem, inner, width, group, drc, drs = _build_meta(
+        convs, ssms, device, conv_state_dim_first
+    )
+    _, shadow_views, shadow_addrs, shadow_strides = _build_shadow(convs, ssms, device)
+    bt_ptrs = torch.tensor([bt_batch.data_ptr()], dtype=torch.int64, device=device)
+
+    grid = (num_reqs, NUM_LAYERS * 2, temporal_tiles)
+    precopy_mamba_align_fused_kernel[grid](
+        dst_col,
+        src_col,
+        bias,
+        bt_ptrs,
+        bt_batch.stride(0),
+        base,
+        blk_stride,
+        elem,
+        inner,
+        width,
+        group,
+        drc,
+        drs,
+        idx_mapping,
+        num_reqs,
+        COPY_BLOCK_SIZE=1024,
+        CONV_STATE_DIM_FIRST=conv_state_dim_first,
+        HAS_IDX_MAPPING=True,
+        TEMPORAL_TILES=temporal_tiles,
+        shadow_base_addrs_ptr=shadow_addrs,
+        shadow_temporal_slots=TEMPORAL_SLOTS,
+        HAS_SHADOW=True,
+        shadow_page_strides_ptr=shadow_strides,
+    )
+    torch.accelerator.synchronize()
+
+    bt_cpu = bt.cpu()
+    scheduled = set(idx_mapping.tolist())
+    for slot in range(MAX_REQS):
+        sc, dc, tb = int(src_col[slot]), int(dst_col[slot]), int(bias[slot])
+        for layer in range(NUM_LAYERS):
+            conv_view = shadow_views[2 * layer]
+            ssm_slots = shadow_views[2 * layer + 1][
+                slot * TEMPORAL_SLOTS : (slot + 1) * TEMPORAL_SLOTS
+            ]
+            if slot not in scheduled or sc < 0:
+                assert not conv_view[slot].any() and not ssm_slots.any()
+                continue
+            # The conv window is kept unshifted; temporal slots 0..bias hold
+            # the states of the columns src_col..src_col + bias.
+            torch.testing.assert_close(
+                conv_view[slot], conv_pre[layer][int(bt_cpu[slot, sc])], rtol=0, atol=0
+            )
+            for t in range(TEMPORAL_SLOTS):
+                if t <= tb:
+                    expected = ssm_pre[layer][int(bt_cpu[slot, sc + t])]
+                    torch.testing.assert_close(ssm_slots[t], expected, rtol=0, atol=0)
+                else:
+                    assert not ssm_slots[t].any()
+            # Boundary migration is unchanged by the snapshot.
+            if sc != dc:
+                conv_ref, ssm_ref = _normalized(
+                    conv_pre[layer],
+                    ssm_pre[layer],
+                    bt_cpu,
+                    slot,
+                    sc,
+                    tb,
+                    conv_state_dim_first,
+                )
+                dblk = int(bt_cpu[slot, dc])
+                torch.testing.assert_close(
+                    _leading(convs[layer][dblk], tb, conv_state_dim_first),
+                    _leading(conv_ref, tb, conv_state_dim_first),
+                    rtol=0,
+                    atol=0,
+                )
+                torch.testing.assert_close(ssms[layer][dblk], ssm_ref, rtol=0, atol=0)
+
+    # Materialize: slot 1 from its shadow at its full bias (2); slot 4 from
+    # its own blocks (bias 3); slot 4 again from its shadow at bias 1 (a stop
+    # inside the accepted tokens keeps two rows less).
+    dst_shadow, dst_slots, dst_trim = num_blocks - 2, num_blocks - 1, num_blocks - 3
+    num_groups = 1
+    width_meta = ENDPOINT_COPY_META_FIXED + 3 * num_groups
+    meta = torch.full((3, width_meta), -1, dtype=torch.int32, device=device)
+    meta[0, :3] = torch.tensor([1, 1, 2], dtype=torch.int32)
+    meta[0, 4] = dst_shadow
+    meta[1, :3] = torch.tensor([0, 0, 3], dtype=torch.int32)
+    meta[1, 4] = dst_slots
+    meta[1, 5] = int(bt_cpu[4, 1])
+    meta[1, 6] = int(bt_cpu[4, 1 + 3])
+    meta[2, :3] = torch.tensor([1, 4, 1], dtype=torch.int32)
+    meta[2, 4] = dst_trim
+    grid = (3, NUM_LAYERS * 2, temporal_tiles)
+    materialize_mamba_endpoint_kernel[grid](
+        meta,
+        meta.stride(0),
+        shadow_addrs,
+        shadow_strides,
+        TEMPORAL_SLOTS,
+        base,
+        blk_stride,
+        elem,
+        inner,
+        width,
+        group,
+        drc,
+        drs,
+        3,
+        NUM_GROUPS=num_groups,
+        COPY_BLOCK_SIZE=1024,
+        CONV_STATE_DIM_FIRST=conv_state_dim_first,
+        TEMPORAL_TILES=temporal_tiles,
+    )
+    torch.accelerator.synchronize()
+    for layer in range(NUM_LAYERS):
+        for dst, req, sc, tb in (
+            (dst_shadow, 1, 2, 2),
+            (dst_slots, 4, 1, 3),
+            (dst_trim, 4, 1, 1),
+        ):
+            conv_ref, ssm_ref = _normalized(
+                conv_pre[layer],
+                ssm_pre[layer],
+                bt_cpu,
+                req,
+                sc,
+                tb,
+                conv_state_dim_first,
+            )
+            torch.testing.assert_close(
+                _leading(convs[layer][dst], tb, conv_state_dim_first),
+                _leading(conv_ref, tb, conv_state_dim_first),
+                rtol=0,
+                atol=0,
+            )
+            torch.testing.assert_close(ssms[layer][dst], ssm_ref, rtol=0, atol=0)
+
+
+def _mock_attention(conv_state, temporal_state):
+    attention = MagicMock()
+    attention.kv_cache = [conv_state, temporal_state]
+    return attention
+
+
+class _Buffer:
+    def __init__(self, size, dtype, device):
+        self.cpu = torch.zeros(size, dtype=dtype, device="cpu")
+        self.gpu = torch.zeros(size, dtype=dtype, device=device)
+        self.np = self.cpu.numpy()
+
+
+def test_context_allocates_shadow_pages_and_materializes_from_them():
+    """End-to-end through ``MambaSpecDecodeGPUContext``: the precopy launch
+    snapshots the committed state and ``run_endpoint_materialize`` writes it
+    into a pool block at the endpoint bias."""
+    from vllm.model_executor.layers.mamba.mamba_utils import (
+        get_conv_copy_spec,
+        get_temporal_copy_spec,
+        is_conv_state_dim_first,
+    )
+
+    device = torch.device("cuda")
+    torch.manual_seed(1)
+    dim_first = is_conv_state_dim_first()
+    # Block ids 1..MAX_REQS * MAX_COLS belong to the block table; the last
+    # blocks are the endpoint destinations.
+    num_blocks = MAX_REQS * MAX_COLS + 4
+    layer_names = ["l0", "l1"]
+    convs, ssms = [], []
+    for _ in layer_names:
+        shape = (
+            (num_blocks, CONV_DIM, CONV_WIDTH)
+            if dim_first
+            else (num_blocks, CONV_WIDTH, CONV_DIM)
+        )
+        convs.append(torch.randn(*shape, dtype=torch.bfloat16, device=device))
+        ssms.append(
+            torch.randn(num_blocks, *SSM_SHAPE, dtype=torch.float32, device=device)
+        )
+    forward_context = {
+        name: _mock_attention(c, s) for name, c, s in zip(layer_names, convs, ssms)
+    }
+    spec = MambaSpec(
+        block_size=16,
+        shapes=((CONV_WIDTH, CONV_DIM), SSM_SHAPE),
+        dtypes=(torch.bfloat16, torch.float32),  # type: ignore[arg-type]
+        mamba_cache_mode="align",
+        num_speculative_blocks=TEMPORAL_SLOTS - 1,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(layer_names, spec)],
+    )
+    ctx = MambaSpecDecodeGPUContext.create(
+        max_num_reqs=MAX_REQS,
+        kv_cache_config=kv_cache_config,
+        num_state_types=2,
+        device=device,
+        make_buffer=lambda n, dtype: _Buffer(n, dtype, device),  # type: ignore[arg-type,return-value]
+    )
+    bt = torch.arange(1, 1 + MAX_REQS * MAX_COLS, dtype=torch.int32, device=device)
+    bt = bt.view(MAX_REQS, MAX_COLS)
+    num_reqs = 2
+    idx_mapping = torch.tensor([2, 5], dtype=torch.int32, device=device)
+    # The registered block table is in batch order (V2 layout).
+    bt_batch = torch.zeros(MAX_REQS, MAX_COLS, dtype=torch.int32, device=device)
+    bt_batch[:num_reqs] = bt[idx_mapping.long()]
+    ctx.initialize_from_forward_context(
+        kv_cache_config,
+        forward_context,
+        (get_conv_copy_spec, get_temporal_copy_spec),
+        [bt_batch],
+    )
+    assert not ctx.has_endpoint_shadow
+    ctx.ensure_endpoint_shadow(MAX_REQS)
+    assert ctx.has_endpoint_shadow and ctx.shadow_num_slots == MAX_REQS
+    assert ctx.shadow_temporal_slots == TEMPORAL_SLOTS
+    ctx.ensure_endpoint_shadow(MAX_REQS)  # idempotent
+
+    conv_pre = [c.clone() for c in convs]
+    ssm_pre = [s.clone() for s in ssms]
+    state_idx = torch.zeros(MAX_REQS, dtype=torch.int32, device=device)
+    src_col = torch.full((MAX_REQS,), -1, dtype=torch.int32, device=device)
+    token_bias = torch.zeros(MAX_REQS, dtype=torch.int32, device=device)
+    # Slot 2 stays in column 1 with 2 accepted drafts; slot 5 crosses 0 -> 1.
+    state_idx[2], src_col[2], token_bias[2] = 1, 1, 2
+    state_idx[5], src_col[5], token_bias[5] = 1, 0, 1
+    ctx.run_fused_precopy(
+        num_reqs, state_idx, src_col, token_bias, idx_mapping, snapshot_to_shadow=True
+    )
+
+    # Slot 2 materialized at its full bias and one row earlier (a stop inside
+    # the accepted tokens); slot 5 at its full bias.
+    dst_a, dst_a_trim, dst_b = num_blocks - 1, num_blocks - 2, num_blocks - 3
+    meta = torch.full(
+        (3, ENDPOINT_COPY_META_FIXED + 3 * ctx.num_groups),
+        -1,
+        dtype=torch.int32,
+        device=device,
+    )
+    meta[0, :3] = torch.tensor([1, 2, 2], dtype=torch.int32)
+    meta[0, 4] = dst_a
+    meta[1, :3] = torch.tensor([1, 2, 1], dtype=torch.int32)
+    meta[1, 4] = dst_a_trim
+    meta[2, :3] = torch.tensor([1, 5, 1], dtype=torch.int32)
+    meta[2, 4] = dst_b
+    ctx.run_endpoint_materialize(meta)
+    torch.accelerator.synchronize()
+
+    bt_cpu = bt.cpu()
+    for layer in range(len(layer_names)):
+        for dst, req, sc, tb in (
+            (dst_a, 2, 1, 2),
+            (dst_a_trim, 2, 1, 1),
+            (dst_b, 5, 0, 1),
+        ):
+            conv_ref, ssm_ref = _normalized(
+                conv_pre[layer], ssm_pre[layer], bt_cpu, req, sc, tb, dim_first
+            )
+            torch.testing.assert_close(
+                _leading(convs[layer][dst], tb, dim_first),
+                _leading(conv_ref, tb, dim_first),
+                rtol=0,
+                atol=0,
+            )
+            torch.testing.assert_close(ssms[layer][dst], ssm_ref, rtol=0, atol=0)
+
+
+def _two_group_context(device, num_blocks, layer_names, convs, ssms, bts):
+    from vllm.model_executor.layers.mamba.mamba_utils import (
+        get_conv_copy_spec,
+        get_temporal_copy_spec,
+    )
+
+    spec = MambaSpec(
+        block_size=16,
+        shapes=((CONV_WIDTH, CONV_DIM), SSM_SHAPE),
+        dtypes=(torch.bfloat16, torch.float32),  # type: ignore[arg-type]
+        mamba_cache_mode="align",
+        num_speculative_blocks=TEMPORAL_SLOTS - 1,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(layer_names[:2], spec),
+            KVCacheGroupSpec(layer_names[2:], spec),
+        ],
+    )
+    forward_context = {
+        name: _mock_attention(c, s) for name, c, s in zip(layer_names, convs, ssms)
+    }
+    ctx = MambaSpecDecodeGPUContext.create(
+        max_num_reqs=MAX_REQS,
+        kv_cache_config=kv_cache_config,
+        num_state_types=2,
+        device=device,
+        make_buffer=lambda n, dtype: _Buffer(n, dtype, device),  # type: ignore[arg-type,return-value]
+    )
+    ctx.initialize_from_forward_context(
+        kv_cache_config,
+        forward_context,
+        (get_conv_copy_spec, get_temporal_copy_spec),
+        bts,
+    )
+    ctx.ensure_endpoint_shadow(MAX_REQS)
+    return ctx, kv_cache_config, forward_context
+
+
+def _meta_from_records(records, num_groups, device):
+    """Kernel records: [from_shadow, req_idx, token_bias, reserved, dst[G],
+    conv_src[G], temporal_src[G]]."""
+    width = ENDPOINT_COPY_META_FIXED + 3 * num_groups
+    meta = torch.full((len(records), width), -1, dtype=torch.int32)
+    for row, rec in enumerate(records):
+        meta[row, :3] = torch.tensor(
+            [int(rec.from_shadow), rec.req_idx, rec.token_bias]
+        )
+        meta[row, 4 : 4 + num_groups] = torch.tensor(rec.dst_block_ids)
+        if not rec.from_shadow:
+            meta[row, 4 + num_groups : 4 + 2 * num_groups] = torch.tensor(
+                rec.conv_src_block_ids
+            )
+            meta[row, 4 + 2 * num_groups : width] = torch.tensor(
+                rec.temporal_src_block_ids
+            )
+    return meta.to(device)
+
+
+def test_torch_reference_matches_kernel_and_verifies():
+    """``materialize_endpoints_torch`` writes the same bytes as the kernel for
+    shadow and block sources with one destination block per group, and
+    ``verify_endpoints`` reports no mismatch for either result but flags a
+    corrupted destination."""
+    from vllm.model_executor.layers.mamba.mamba_utils import is_conv_state_dim_first
+    from vllm.v1.worker.mamba_utils import (
+        EndpointCopyRecord,
+        endpoint_layer_states,
+        materialize_endpoints_torch,
+        verify_endpoints,
+    )
+
+    device = torch.device("cuda")
+    torch.manual_seed(2)
+    dim_first = is_conv_state_dim_first()
+    # Block-table ids, four records x two groups of destinations, and the
+    # torch-path destinations 16 above them.
+    num_blocks = MAX_REQS * MAX_COLS + 32
+    layer_names = ["l0", "l1", "l2"]
+    convs, ssms = [], []
+    for _ in layer_names:
+        shape = (
+            (num_blocks, CONV_DIM, CONV_WIDTH)
+            if dim_first
+            else (num_blocks, CONV_WIDTH, CONV_DIM)
+        )
+        convs.append(torch.randn(*shape, dtype=torch.bfloat16, device=device))
+        ssms.append(
+            torch.randn(num_blocks, *SSM_SHAPE, dtype=torch.float32, device=device)
+        )
+    num_reqs = 2
+    idx_mapping = torch.tensor([2, 5], dtype=torch.int32, device=device)
+    bts = []
+    for group in range(2):
+        bt = torch.zeros(MAX_REQS, MAX_COLS, dtype=torch.int32, device=device)
+        bt[0] = torch.arange(1, 1 + MAX_COLS) + group * 20
+        bt[1] = torch.arange(9, 9 + MAX_COLS) + group * 20
+        bts.append(bt)
+    ctx, kv_cache_config, forward_context = _two_group_context(
+        device, num_blocks, layer_names, convs, ssms, bts
+    )
+    layer_states = endpoint_layer_states(
+        kv_cache_config, forward_context, ctx.mamba_group_ids
+    )
+    assert [s[0].data_ptr() for s in layer_states] == [c.data_ptr() for c in convs]
+
+    state_idx = torch.zeros(MAX_REQS, dtype=torch.int32, device=device)
+    src_col = torch.full((MAX_REQS,), -1, dtype=torch.int32, device=device)
+    token_bias = torch.zeros(MAX_REQS, dtype=torch.int32, device=device)
+    state_idx[2], src_col[2], token_bias[2] = 1, 1, 3
+    state_idx[5], src_col[5], token_bias[5] = 0, 0, 1
+    ctx.run_fused_precopy(
+        num_reqs, state_idx, src_col, token_bias, idx_mapping, snapshot_to_shadow=True
+    )
+    bt_cpu = [bt.cpu() for bt in bts]
+    first = MAX_REQS * MAX_COLS + 1
+    dst = [(first + r, first + 8 + r) for r in range(4)]
+    records = [
+        EndpointCopyRecord(True, 2, 3, dst[0], (), ()),
+        EndpointCopyRecord(True, 2, 1, dst[1], (), ()),
+        EndpointCopyRecord(True, 5, 1, dst[2], (), ()),
+        EndpointCopyRecord(
+            False,
+            0,
+            1,
+            dst[3],
+            tuple(int(bt_cpu[g][1, 0]) for g in range(2)),
+            tuple(int(bt_cpu[g][1, 1]) for g in range(2)),
+        ),
+    ]
+    ctx.run_endpoint_materialize(_meta_from_records(records, ctx.num_groups, device))
+    torch.accelerator.synchronize()
+    assert verify_endpoints(ctx, layer_states, records, dim_first) == []
+
+    torch_records = [
+        rec._replace(dst_block_ids=tuple(d + 16 for d in rec.dst_block_ids))
+        for rec in records
+    ]
+    materialize_endpoints_torch(ctx, layer_states, torch_records, dim_first)
+    torch.accelerator.synchronize()
+    assert verify_endpoints(ctx, layer_states, torch_records, dim_first) == []
+    for layer in range(len(layer_names)):
+        group = ctx.state_group_indices_cpu[2 * layer]
+        for rec, trec in zip(records, torch_records):
+            d, td = rec.dst_block_ids[group], trec.dst_block_ids[group]
+            torch.testing.assert_close(
+                _leading(convs[layer][d], rec.token_bias, dim_first),
+                _leading(convs[layer][td], rec.token_bias, dim_first),
+                rtol=0,
+                atol=0,
+            )
+            torch.testing.assert_close(ssms[layer][d], ssms[layer][td], rtol=0, atol=0)
+
+    # A corrupted destination is reported with its layer and state kind.
+    ssms[1][records[0].dst_block_ids[0]].add_(1.0)
+    mismatches = verify_endpoints(ctx, layer_states, records, dim_first)
+    assert [(m["record"], m["layer"], m["kind"]) for m in mismatches] == [
+        (0, 1, "temporal")
+    ]
+
+
+def test_groups_sharing_raw_tensors_need_distinct_destinations():
+    """Served layout: one raw tensor per layer index is shared by every
+    cache group, so a block id names the same page in each group. Distinct
+    per-group destinations materialize every layer; a shared destination
+    (the layout of the failed candidate) makes the groups overwrite each
+    other."""
+    from vllm.model_executor.layers.mamba.mamba_utils import is_conv_state_dim_first
+    from vllm.v1.worker.mamba_utils import (
+        EndpointCopyRecord,
+        endpoint_layer_states,
+        materialize_endpoints_torch,
+        verify_endpoints,
+    )
+
+    device = torch.device("cuda")
+    torch.manual_seed(4)
+    dim_first = is_conv_state_dim_first()
+    num_blocks = MAX_REQS * MAX_COLS + 24
+    shape = (
+        (num_blocks, CONV_DIM, CONV_WIDTH)
+        if dim_first
+        else (num_blocks, CONV_WIDTH, CONV_DIM)
+    )
+    # Layer i of group 0 and layer i of group 1 view the same storage.
+    shared_convs = [
+        torch.randn(*shape, dtype=torch.bfloat16, device=device) for _ in range(2)
+    ]
+    shared_ssms = [
+        torch.randn(num_blocks, *SSM_SHAPE, dtype=torch.float32, device=device)
+        for _ in range(2)
+    ]
+    layer_names = ["g0l0", "g0l1", "g1l0", "g1l1"]
+    convs = [shared_convs[0], shared_convs[1], shared_convs[0], shared_convs[1]]
+    ssms = [shared_ssms[0], shared_ssms[1], shared_ssms[0], shared_ssms[1]]
+    num_reqs = 1
+    idx_mapping = torch.tensor([1], dtype=torch.int32, device=device)
+    # Block ids are unique across groups, as with a shared block pool.
+    bts = []
+    for group in range(2):
+        bt = torch.zeros(MAX_REQS, MAX_COLS, dtype=torch.int32, device=device)
+        bt[0] = torch.arange(1, 1 + MAX_COLS) + group * MAX_COLS
+        bts.append(bt)
+    ctx, kv_cache_config, forward_context = _two_group_context(
+        device, num_blocks, layer_names, convs, ssms, bts
+    )
+    layer_states = endpoint_layer_states(
+        kv_cache_config, forward_context, ctx.mamba_group_ids
+    )
+    state_idx = torch.zeros(MAX_REQS, dtype=torch.int32, device=device)
+    src_col = torch.full((MAX_REQS,), -1, dtype=torch.int32, device=device)
+    token_bias = torch.zeros(MAX_REQS, dtype=torch.int32, device=device)
+    state_idx[1], src_col[1], token_bias[1] = 0, 0, 2
+    ctx.run_fused_precopy(
+        num_reqs, state_idx, src_col, token_bias, idx_mapping, snapshot_to_shadow=True
+    )
+    bt_cpu = [bt.cpu() for bt in bts]
+    first = 2 * MAX_COLS + 1
+    good = [
+        EndpointCopyRecord(True, 1, 2, (first, first + 1), (), ()),
+        EndpointCopyRecord(
+            False,
+            0,
+            2,
+            (first + 2, first + 3),
+            tuple(int(bt_cpu[g][0, 0]) for g in range(2)),
+            tuple(int(bt_cpu[g][0, 2]) for g in range(2)),
+        ),
+    ]
+    ctx.run_endpoint_materialize(_meta_from_records(good, ctx.num_groups, device))
+    torch.accelerator.synchronize()
+    assert verify_endpoints(ctx, layer_states, good, dim_first) == []
+    torch_good = [
+        rec._replace(dst_block_ids=tuple(d + 4 for d in rec.dst_block_ids))
+        for rec in good
+    ]
+    materialize_endpoints_torch(ctx, layer_states, torch_good, dim_first)
+    torch.accelerator.synchronize()
+    assert verify_endpoints(ctx, layer_states, torch_good, dim_first) == []
+
+    shared = [
+        rec._replace(dst_block_ids=(first + 8 + i,) * 2) for i, rec in enumerate(good)
+    ]
+    materialize_endpoints_torch(ctx, layer_states, shared, dim_first)
+    torch.accelerator.synchronize()
+    mismatches = verify_endpoints(ctx, layer_states, shared, dim_first)
+    # Group 1 writes last on the sequential torch path: group 0's states
+    # (two layers, two state types each) are overwritten for both records.
+    assert len(mismatches) == 2 * 4
+    assert {m["layer"] for m in mismatches} == {0, 1}
+
+
+def test_served_page_geometry_kernel_torch_and_trace():
+    """The served Kimi-K3 layout: conv ``(6, 4608)`` bf16 and temporal
+    ``(12, 128, 128)`` fp32 views of every layer share 1,007,616-byte pages
+    (temporal at byte offset 55,296), four recurrent groups whose layers
+    share one raw tensor, four temporal slots. The kernel's shadow and
+    block-source materializations, the torch reference path and the
+    resolved-address trace must all agree."""
+    from vllm.model_executor.layers.mamba.mamba_utils import (
+        get_conv_copy_spec,
+        get_temporal_copy_spec,
+        is_conv_state_dim_first,
+    )
+    from vllm.v1.worker.mamba_utils import (
+        EndpointCopyRecord,
+        endpoint_layer_states,
+        materialize_endpoints_torch,
+        verify_endpoints,
+    )
+
+    if is_conv_state_dim_first():
+        pytest.skip("the served layout keeps the conv slide axis first")
+    device = torch.device("cuda")
+    torch.manual_seed(3)
+    page, temporal_off = 1007616, 55296
+    conv_shape, temporal_shape = (6, 4608), (12, 128, 128)
+    num_groups, num_blocks, max_reqs, max_cols, slots = 4, 96, 4, 8, 4
+    # One raw tensor shared by the single layer of every group (served
+    # sharing rule: raw tensor i holds layer i of each group).
+    raw = torch.randint(0, 256, (num_blocks * page,), dtype=torch.uint8, device=device)
+    conv = raw.view(torch.bfloat16).as_strided(
+        (num_blocks,) + conv_shape, (page // 2, 4608, 1)
+    )
+    temp = (
+        raw[temporal_off:]
+        .view(torch.float32)
+        .as_strided((num_blocks,) + temporal_shape, (page // 4, 16384, 128, 1))
+    )
+    conv.copy_(torch.randn(conv.shape, dtype=torch.bfloat16, device=device))
+    temp.copy_(torch.randn(temp.shape, dtype=torch.float32, device=device))
+    assert temp.data_ptr() - conv.data_ptr() == temporal_off
+    groups = [[f"g{g}"] for g in range(num_groups)]
+    forward_context = {names[0]: _mock_attention(conv, temp) for names in groups}
+    spec = MambaSpec(
+        block_size=4608,
+        shapes=(conv_shape, temporal_shape),
+        dtypes=(torch.bfloat16, torch.float32),  # type: ignore[arg-type]
+        mamba_cache_mode="align",
+        num_speculative_blocks=slots - 1,
+        page_size_padded=page,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(names, spec) for names in groups],
+    )
+    ctx = MambaSpecDecodeGPUContext.create(
+        max_num_reqs=max_reqs,
+        kv_cache_config=kv_cache_config,
+        num_state_types=2,
+        device=device,
+        make_buffer=lambda n, dtype: _Buffer(n, dtype, device),  # type: ignore[arg-type,return-value]
+    )
+    # Block ids are unique across groups (nine per group).
+    bts = []
+    for g in range(num_groups):
+        base = 1 + 9 * g
+        bt = torch.zeros(max_reqs, max_cols, dtype=torch.int32, device=device)
+        bt[0] = torch.tensor([base, base + 1, base + 2, base + 3, base + 4, 0, 0, 0])
+        bt[1] = torch.tensor([base + 5, base + 6, base + 7, base + 8, 0, 0, 0, 0])
+        bts.append(bt)
+    first_free = 1 + 9 * num_groups
+    ctx.initialize_from_forward_context(
+        kv_cache_config,
+        forward_context,
+        (get_conv_copy_spec, get_temporal_copy_spec),
+        bts,
+    )
+    ctx.ensure_endpoint_shadow(max_reqs)
+    assert ctx.state_block_strides_cpu[:2] == [page, page]
+    layer_states = endpoint_layer_states(
+        kv_cache_config, forward_context, ctx.mamba_group_ids
+    )
+
+    num_reqs = 2
+    idx_mapping = torch.tensor([1, 3], dtype=torch.int32, device=device)
+    state_idx = torch.zeros(max_reqs, dtype=torch.int32, device=device)
+    src_col = torch.full((max_reqs,), -1, dtype=torch.int32, device=device)
+    token_bias = torch.zeros(max_reqs, dtype=torch.int32, device=device)
+    state_idx[1], src_col[1], token_bias[1] = 1, 1, 3
+    state_idx[3], src_col[3], token_bias[3] = 0, 0, 1
+    conv_pre = conv.clone()
+    temp_pre = temp.clone()
+    ctx.run_fused_precopy(
+        num_reqs, state_idx, src_col, token_bias, idx_mapping, snapshot_to_shadow=True
+    )
+    bt_cpu = [bt.cpu() for bt in bts]
+    # Record r of group g writes block first_free + 4 * g + r.
+    dst = [tuple(first_free + 4 * g + r for g in range(num_groups)) for r in range(4)]
+    records = [
+        EndpointCopyRecord(True, 1, 3, dst[0], (), ()),
+        EndpointCopyRecord(True, 1, 2, dst[1], (), ()),
+        EndpointCopyRecord(True, 3, 1, dst[2], (), ()),
+        EndpointCopyRecord(
+            False,
+            0,
+            1,
+            dst[3],
+            tuple(int(bt_cpu[g][1, 0]) for g in range(num_groups)),
+            tuple(int(bt_cpu[g][1, 1]) for g in range(num_groups)),
+        ),
+    ]
+    total_states = ctx.num_layers * ctx.num_state_types
+    trace = torch.zeros(
+        (len(records), total_states, 4), dtype=torch.int64, device=device
+    )
+    ctx.run_endpoint_materialize(_meta_from_records(records, num_groups, device), trace)
+    torch.accelerator.synchronize()
+    assert trace.cpu().tolist() == [
+        [list(t) for t in per_state]
+        for per_state in ctx.expected_endpoint_addresses(records)
+    ]
+    assert verify_endpoints(ctx, layer_states, records, False) == []
+
+    # Reference semantics straight from the pre-copy clones: the window of
+    # the source column shifted by the bias and the temporal slot at the bias.
+    for layer in range(num_groups):
+        g = ctx.state_group_indices_cpu[2 * layer]
+        for rec, row in zip(records, (0, 0, 1, 1)):
+            col = 1 if row == 0 else 0
+            sblk = int(bt_cpu[g][row, col])
+            tblk = int(bt_cpu[g][row, col + rec.token_bias])
+            n = 6 - rec.token_bias
+            d = rec.dst_block_ids[g]
+            assert torch.equal(conv[d][:n], conv_pre[sblk][rec.token_bias :])
+            assert torch.equal(temp[d], temp_pre[tblk])
+    for b in range(first_free):
+        assert torch.equal(conv[b], conv_pre[b])
+        assert torch.equal(temp[b], temp_pre[b])
+
+    torch_records = [
+        rec._replace(dst_block_ids=tuple(d + 4 * num_groups for d in rec.dst_block_ids))
+        for rec in records
+    ]
+    materialize_endpoints_torch(ctx, layer_states, torch_records, False)
+    torch.accelerator.synchronize()
+    assert verify_endpoints(ctx, layer_states, torch_records, False) == []
+    for layer in range(num_groups):
+        g = ctx.state_group_indices_cpu[2 * layer]
+        for rec, trec in zip(records, torch_records):
+            n = 6 - rec.token_bias
+            d, td = rec.dst_block_ids[g], trec.dst_block_ids[g]
+            assert torch.equal(conv[d][:n], conv[td][:n])
+            assert torch.equal(temp[d], temp[td])

--- a/tests/v1/core/prefix_cache/test_request_endpoint_cache.py
+++ b/tests/v1/core/prefix_cache/test_request_endpoint_cache.py
@@ -1,0 +1,506 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Request-endpoint prefix-cache entries on a DCP9 hybrid layout.
+
+A finished request publishes the pages holding its last computed token, the
+draft window before it and one pool block for its recurrent state. A later
+prompt that extends the same token sequence resumes at that token (not at
+the last hash boundary) through the ordinary partial-hit copy-on-write path.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tests.v1.core.test_prefix_caching import make_kv_cache_manager, make_request
+from vllm import envs
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import init_none_hash
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+    SlidingWindowSpec,
+)
+
+UNIT = 2
+MAMBA_BLOCK = 6
+NUM_SPEC = 3
+WINDOW = 6
+ATTN_GROUP, MAMBA_GROUP, DRAFT_GROUP = 0, 1, 2
+
+
+@pytest.fixture(autouse=True)
+def _none_hash():
+    init_none_hash(sha256)
+
+
+@pytest.fixture(autouse=True)
+def _endpoint_cache_env(monkeypatch):
+    monkeypatch.setattr(envs, "VLLM_K3_REQUEST_ENDPOINT_CACHE", True)
+    monkeypatch.setattr(envs, "VLLM_K3_REQUEST_ENDPOINT_CACHE_MAX_ENTRIES", 8)
+    monkeypatch.setattr(envs, "VLLM_K3_REQUEST_ENDPOINT_CACHE_DISABLE_FILE", "")
+
+
+def _dcp9_config() -> KVCacheConfig:
+    return KVCacheConfig(
+        num_blocks=64,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["target_attention"],
+                FullAttentionSpec(
+                    block_size=UNIT,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["target_recurrent"],
+                MambaSpec(
+                    block_size=MAMBA_BLOCK,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                    num_speculative_blocks=NUM_SPEC,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["draft_attention"],
+                SlidingWindowSpec(
+                    block_size=UNIT,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=WINDOW,
+                    dcp_replicated=True,
+                ),
+            ),
+        ],
+    )
+
+
+def _two_recurrent_groups_config() -> KVCacheConfig:
+    """The DCP9 layout with a second recurrent group (group 3)."""
+    config = _dcp9_config()
+    recurrent = config.kv_cache_groups[MAMBA_GROUP]
+    return KVCacheConfig(
+        num_blocks=config.num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            *config.kv_cache_groups,
+            KVCacheGroupSpec(["target_recurrent_2"], recurrent.kv_cache_spec),
+        ],
+    )
+
+
+def _manager(kv_cache_config: KVCacheConfig | None = None):
+    return make_kv_cache_manager(
+        kv_cache_config=kv_cache_config or _dcp9_config(),
+        max_model_len=128,
+        enable_caching=True,
+        scheduler_block_size=18,
+        hash_block_size=UNIT,
+        dcp_world_size=9,
+        use_eagle=False,
+    )
+
+
+def _prefill(manager, request):
+    scheduler = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=UNIT),
+        mamba_block_size=MAMBA_BLOCK,
+        max_num_scheduled_tokens=MAMBA_BLOCK,
+        scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+        use_eagle=False,
+        use_eagle_for_target_cache=False,
+        mamba_eagle_block_sizes=(),
+        hash_block_size=UNIT,
+        mamba_partial_cache_hit=True,
+    )
+    while request.num_computed_tokens < request.num_tokens:
+        remaining = request.num_tokens - request.num_computed_tokens
+        chunk = Scheduler._mamba_block_aligned_split(
+            scheduler, request, min(MAMBA_BLOCK, remaining)
+        )
+        assert chunk > 0
+        assert manager.allocate_slots(request, chunk) is not None
+        request.num_computed_tokens += chunk
+        _end_step(manager)
+
+
+def _decode_step(manager, request, num_drafts, num_accepted, next_token):
+    """One speculative decode step: schedule ``num_drafts + 1`` rows from the
+    committed position, then commit ``num_accepted + 1`` tokens."""
+    request.spec_token_ids = [900 + i for i in range(num_drafts)]
+    assert manager.allocate_slots(request, num_drafts + 1) is not None
+    request.spec_token_ids = []
+    request.num_computed_tokens += num_accepted + 1
+    request.append_output_token_ids([next_token + i for i in range(num_accepted + 1)])
+    _end_step(manager)
+
+
+def _end_step(manager):
+    """What the scheduler does per step: drain the copy-on-write copies and,
+    once the step has run, release the blocks retained for them."""
+    _, retained = manager.take_kv_cache_block_copies()
+    manager.block_pool.free_blocks(retained)
+    manager.new_step_starts()
+
+
+def _run_producer(manager, prompt_len=23, steps=((3, 1), (3, 1), (3, 1))):
+    producer = make_request("producer", list(range(prompt_len)), UNIT, sha256)
+    _prefill(manager, producer)
+    # The first sampled token of the prompt's last chunk.
+    producer.append_output_token_ids(500)
+    token = 600
+    for num_drafts, num_accepted in steps:
+        _decode_step(manager, producer, num_drafts, num_accepted, token)
+        token += 10
+    assert producer.num_computed_tokens == producer.num_tokens - 1
+    return producer, steps[-1]
+
+
+def _mamba_blocks(manager, request):
+    return list(
+        manager.coordinator.single_type_managers[MAMBA_GROUP].req_to_blocks[
+            request.request_id
+        ]
+    )
+
+
+@pytest.mark.parametrize("in_flight", [False, True])
+def test_next_turn_resumes_at_the_last_computed_token(in_flight):
+    manager = _manager()
+    producer, final_step = _run_producer(manager)
+    num_tokens = producer.num_tokens - 1
+    assert num_tokens == 29 and num_tokens % UNIT == 1
+    producer_mamba = _mamba_blocks(manager, producer)
+    producer_page = manager.coordinator.single_type_managers[ATTN_GROUP].req_to_blocks[
+        producer.request_id
+    ][(num_tokens - 1) // 18]
+
+    assert manager.cache_endpoint(producer, final_step, in_flight=in_flight)
+    assert manager.block_pool.num_endpoint_entries == 1
+    manager.free(producer)
+    manager.new_step_starts()
+
+    copies, retained = manager.take_mamba_endpoint_copies()
+    assert len(copies) == 1
+    copy = copies[0]
+    assert copy.req_id == "producer"
+    assert copy.from_shadow == in_flight
+    dst = next(block for block in retained if block.block_id == copy.dst_block_ids[0])
+    assert dst.ref_cnt == 1 and dst.block_hash is not None
+    num_drafts, num_accepted = final_step
+    # The bias selects the conv shift and, for a shadow source, the temporal
+    # shadow slot: the accepted count of the final step in both cases.
+    assert copy.token_bias == num_accepted
+    if in_flight:
+        assert copy.conv_src_block_ids == () and copy.temporal_src_block_ids == ()
+    else:
+        # Final step: 4 rows from position 27 (column 5 after the crossing at
+        # 30), 1 draft accepted -> temporal slot 1 of column 5, window bias 1.
+        num_before = num_tokens - num_accepted - 1
+        base = (num_before + num_drafts) // MAMBA_BLOCK
+        assert copy.conv_src_block_ids == (producer_mamba[base].block_id,)
+        assert copy.temporal_src_block_ids == (
+            producer_mamba[base + num_accepted].block_id,
+        )
+        assert {block.block_id for block in retained} >= set(
+            copy.conv_src_block_ids + copy.temporal_src_block_ids
+        )
+    # The step that runs the copy has completed: release the retentions.
+    manager.block_pool.free_blocks(retained)
+    assert dst.ref_cnt == 0 and dst.block_hash is not None
+
+    consumer_tokens = list(producer.all_token_ids) + [700, 701, 702, 703, 704]
+    consumer = make_request("consumer", consumer_tokens, UNIT, sha256)
+    blocks, hit, boundary = manager.get_computed_blocks(consumer)
+    assert hit == num_tokens and boundary == 0
+    attn, mamba, draft = blocks.blocks
+    assert len(attn) == (num_tokens - 1) // 18 + 1 and attn[-1] is producer_page
+    assert [block.is_null for block in mamba] == [True] * ((num_tokens - 1) // 6) + [
+        False
+    ]
+    assert mamba[-1] is dst
+    first_window_block = max(0, num_tokens - WINDOW + 1) // UNIT
+    assert len(draft) == (num_tokens - 1) // UNIT + 1
+    assert all(block.is_null for block in draft[:first_window_block])
+    assert not any(block.is_null for block in draft[first_window_block:])
+
+    assert (
+        manager.allocate_slots(consumer, consumer.num_tokens - hit, hit, blocks)
+        is not None
+    )
+    cow_copies, _ = manager.take_kv_cache_block_copies()
+    # Every group ends mid-block at 29 tokens: page, state and draft block
+    # are all redirected to private copies before the consumer writes, and
+    # the entry's recurrent state is one of the copied sources.
+    assert len(cow_copies) >= 3
+    sources = {copy.src_block_id for copy in cow_copies}
+    assert dst.block_id in sources
+    destinations = {copy.dst_block_id for copy in cow_copies}
+    assert dst.block_id not in destinations
+    # The entry itself is untouched by the consumer: the durable blocks keep
+    # their endpoint keys.
+    assert manager.block_pool.num_endpoint_entries == 1
+
+
+@pytest.mark.parametrize("in_flight", [False, True])
+def test_a_stop_inside_the_accepted_tokens_moves_the_endpoint_back(in_flight):
+    """The final step accepts 2 drafts but the stop token is the first new
+    token: the request keeps 1 new token, and the endpoint is the state
+    after row 0 of that step (bias 0), one row before the committed one."""
+    manager = _manager()
+    producer = make_request("producer", list(range(23)), UNIT, sha256)
+    _prefill(manager, producer)
+    producer.append_output_token_ids(500)
+    _decode_step(manager, producer, 3, 1, 600)  # 23 -> 25 computed
+    # Final step: 4 rows from 25, 2 drafts accepted (committed 28), but the
+    # output is trimmed to the first new token (num_tokens 27).
+    producer.spec_token_ids = [900, 901, 902]
+    assert manager.allocate_slots(producer, 4) is not None
+    producer.spec_token_ids = []
+    producer.num_computed_tokens += 3
+    producer.append_output_token_ids(700)
+    _end_step(manager)
+    assert producer.num_computed_tokens == 28 and producer.num_tokens == 27
+    producer_mamba = _mamba_blocks(manager, producer)
+
+    assert manager.cache_endpoint(producer, (3, 2), in_flight=in_flight)
+    manager.free(producer)
+    manager.new_step_starts()
+    copies, retained = manager.take_mamba_endpoint_copies()
+    copy = copies[0]
+    assert copy.token_bias == 0
+    if not in_flight:
+        base = (25 + 3) // MAMBA_BLOCK
+        assert copy.conv_src_block_ids == (producer_mamba[base].block_id,)
+        assert copy.temporal_src_block_ids == (producer_mamba[base].block_id,)
+    manager.block_pool.free_blocks(retained)
+
+    consumer = make_request(
+        "consumer", list(producer.all_token_ids) + [800, 801], UNIT, sha256
+    )
+    _, hit, _ = manager.get_computed_blocks(consumer)
+    assert hit == 26
+
+
+def test_a_stop_after_a_boundary_normalization_publishes_nothing():
+    """The final step's accepted rows end exactly on a recurrent block
+    boundary in the running column, so the post-step kernel shifted the
+    window in place; a stop before that boundary has no restorable state."""
+    manager = _manager()
+    producer = make_request("producer", list(range(23)), UNIT, sha256)
+    _prefill(manager, producer)
+    producer.append_output_token_ids(500)
+    _decode_step(manager, producer, 3, 1, 600)  # committed 25
+    # Final step: rows 25..28, all 3 drafts accepted -> committed 29; the
+    # rows end in column 4 which also holds the boundary at 30? No: use a
+    # step whose last accepted row completes the block: from 26.
+    _decode_step(manager, producer, 0, 0, 700)  # committed 26
+    producer.spec_token_ids = [900, 901, 902]
+    assert manager.allocate_slots(producer, 4) is not None
+    producer.spec_token_ids = []
+    producer.num_computed_tokens += 4  # rows 26..29 all accepted -> 30
+    producer.append_output_token_ids(800)  # trimmed to one new token (27)
+    _end_step(manager)
+    assert producer.num_computed_tokens == 30 and producer.num_tokens == 28
+    assert not manager.cache_endpoint(producer, (3, 3), in_flight=False)
+    assert not manager.cache_endpoint(producer, (3, 3), in_flight=True)
+    # Without the trim the normalized state itself is publishable.
+    producer.append_output_token_ids([801, 802, 803])
+    assert producer.num_tokens == 31
+    assert manager.cache_endpoint(producer, (3, 3), in_flight=True)
+    copy = manager.take_mamba_endpoint_copies()[0][0]
+    assert copy.token_bias == 0
+
+
+def test_a_different_tail_does_not_hit_the_endpoint():
+    manager = _manager()
+    producer, final_step = _run_producer(manager)
+    num_tokens = producer.num_tokens - 1
+    assert manager.cache_endpoint(producer, final_step, in_flight=True)
+    manager.free(producer)
+    manager.new_step_starts()
+    _, retained = manager.take_mamba_endpoint_copies()
+    manager.block_pool.free_blocks(retained)
+
+    tokens = list(producer.all_token_ids)
+    tokens[num_tokens - 1] = 12345
+    consumer = make_request("consumer", tokens + [700, 701], UNIT, sha256)
+    _, hit, _ = manager.get_computed_blocks(consumer)
+    # Falls back to the ordinary aligned hit below the endpoint.
+    assert hit < num_tokens and hit % UNIT == 0
+
+
+def test_replaying_exactly_the_producer_sequence_hits_the_endpoint():
+    manager = _manager()
+    producer, final_step = _run_producer(manager)
+    num_tokens = producer.num_tokens - 1
+    assert manager.cache_endpoint(producer, final_step, in_flight=True)
+    manager.free(producer)
+    manager.new_step_starts()
+    _, retained = manager.take_mamba_endpoint_copies()
+    manager.block_pool.free_blocks(retained)
+
+    consumer = make_request("consumer", list(producer.all_token_ids), UNIT, sha256)
+    _, hit, _ = manager.get_computed_blocks(consumer)
+    # Only the last token (the one that must be recomputed for logits) is left.
+    assert hit == num_tokens == consumer.num_tokens - 1
+
+
+def test_reusing_an_endpoint_block_drops_the_entry():
+    manager = _manager()
+    producer, final_step = _run_producer(manager)
+    assert manager.cache_endpoint(producer, final_step, in_flight=True)
+    manager.free(producer)
+    manager.new_step_starts()
+    _, retained = manager.take_mamba_endpoint_copies()
+    manager.block_pool.free_blocks(retained)
+    assert manager.block_pool.num_endpoint_entries == 1
+
+    # Take every free block: the LRU hands out the endpoint blocks as well.
+    pool = manager.block_pool
+    taken = pool.get_new_blocks(pool.get_num_free_blocks())
+    assert pool.num_endpoint_entries == 0
+    assert all(block.block_hash is None for block in taken)
+    pool.free_blocks(taken)
+
+    consumer = make_request(
+        "consumer", list(producer.all_token_ids) + [700, 701], UNIT, sha256
+    )
+    _, hit, _ = manager.get_computed_blocks(consumer)
+    assert hit == 0
+
+
+def test_entry_cap_drops_the_oldest_entry(monkeypatch):
+    monkeypatch.setattr(envs, "VLLM_K3_REQUEST_ENDPOINT_CACHE_MAX_ENTRIES", 1)
+    manager = _manager()
+    first, final_step = _run_producer(manager)
+    assert manager.cache_endpoint(first, final_step, in_flight=True)
+    manager.free(first)
+    manager.new_step_starts()
+    _, retained = manager.take_mamba_endpoint_copies()
+    manager.block_pool.free_blocks(retained)
+
+    second = make_request("second", list(range(100, 123)), UNIT, sha256)
+    _prefill(manager, second)
+    second.append_output_token_ids(500)
+    _decode_step(manager, second, 3, 1, 600)
+    assert manager.cache_endpoint(second, (3, 1), in_flight=True)
+    assert manager.block_pool.num_endpoint_entries == 1
+    manager.free(second)
+    manager.new_step_starts()
+    _, retained = manager.take_mamba_endpoint_copies()
+    manager.block_pool.free_blocks(retained)
+
+    stale = make_request("stale", list(first.all_token_ids) + [700], UNIT, sha256)
+    _, hit, _ = manager.get_computed_blocks(stale)
+    assert hit < first.num_tokens - 1
+    fresh = make_request("fresh", list(second.all_token_ids) + [700], UNIT, sha256)
+    _, hit, _ = manager.get_computed_blocks(fresh)
+    assert hit == second.num_tokens - 1
+
+
+def test_reset_prefix_cache_forgets_endpoints():
+    manager = _manager()
+    producer, final_step = _run_producer(manager)
+    assert manager.cache_endpoint(producer, final_step, in_flight=True)
+    manager.free(producer)
+    manager.new_step_starts()
+    _, retained = manager.take_mamba_endpoint_copies()
+    manager.block_pool.free_blocks(retained)
+    assert manager.reset_prefix_cache()
+    assert manager.block_pool.num_endpoint_entries == 0
+    consumer = make_request(
+        "consumer", list(producer.all_token_ids) + [700], UNIT, sha256
+    )
+    _, hit, _ = manager.get_computed_blocks(consumer)
+    assert hit == 0
+
+
+def test_disabled_feature_registers_nothing(monkeypatch, tmp_path):
+    manager = _manager()
+    producer, final_step = _run_producer(manager)
+    disable_file = tmp_path / "endpoint-cache-disable"
+    disable_file.write_text("")
+    monkeypatch.setattr(
+        envs, "VLLM_K3_REQUEST_ENDPOINT_CACHE_DISABLE_FILE", str(disable_file)
+    )
+    assert not manager.cache_endpoint(producer, final_step, in_flight=True)
+    disable_file.unlink()
+    monkeypatch.setattr(envs, "VLLM_K3_REQUEST_ENDPOINT_CACHE", False)
+    assert not manager.cache_endpoint(producer, final_step, in_flight=True)
+    assert manager.block_pool.num_endpoint_entries == 0
+    assert manager.take_mamba_endpoint_copies() == ([], [])
+
+
+def test_an_incomplete_request_publishes_nothing():
+    manager = _manager()
+    producer = make_request("producer", list(range(23)), UNIT, sha256)
+    _prefill(manager, producer)
+    # Aborted before its first token: nothing beyond the prompt is committed.
+    assert not manager.cache_endpoint(producer, (0, 0), in_flight=False)
+    assert manager.block_pool.num_endpoint_entries == 0
+
+
+@pytest.mark.parametrize("in_flight", [False, True])
+def test_every_recurrent_group_gets_its_own_durable_block(in_flight):
+    """Block ids name the same physical page in every group, so an entry
+    holds one distinct block per recurrent group and the copy record lists
+    them in group order."""
+    manager = _manager(_two_recurrent_groups_config())
+    producer, final_step = _run_producer(manager)
+    num_tokens = producer.num_tokens - 1
+    free_before = manager.block_pool.get_num_free_blocks()
+    assert manager.cache_endpoint(producer, final_step, in_flight=in_flight)
+    assert manager.block_pool.get_num_free_blocks() == free_before - 2
+    manager.free(producer)
+    manager.new_step_starts()
+    copies, retained = manager.take_mamba_endpoint_copies()
+    (copy,) = copies
+    assert len(copy.dst_block_ids) == 2
+    assert len(set(copy.dst_block_ids)) == 2
+    retained_ids = {block.block_id for block in retained}
+    assert set(copy.dst_block_ids) <= retained_ids
+    if not in_flight:
+        assert len(copy.conv_src_block_ids) == 2
+        assert len(copy.temporal_src_block_ids) == 2
+    entry = manager.block_pool.find_endpoints(
+        producer.block_hashes[num_tokens // UNIT - 1]
+    )[0]
+    recurrent_groups = [MAMBA_GROUP, 3]
+    assert [entry.group_blocks[gid][1][0].block_id for gid in recurrent_groups] == list(
+        copy.dst_block_ids
+    )
+    manager.block_pool.free_blocks(retained)
+
+    consumer_tokens = list(producer.all_token_ids) + [700, 701, 702]
+    consumer = make_request("consumer", consumer_tokens, UNIT, sha256)
+    blocks, hit, _ = manager.get_computed_blocks(consumer)
+    assert hit == num_tokens
+    for gid, dst_id in zip(recurrent_groups, copy.dst_block_ids):
+        assert blocks.blocks[gid][-1].block_id == dst_id
+
+
+def test_endpoint_needs_a_spare_block_beyond_one_per_group():
+    manager = _manager(_two_recurrent_groups_config())
+    producer, final_step = _run_producer(manager)
+    pool = manager.block_pool
+    spare = pool.get_new_blocks(pool.get_num_free_blocks() - 2)
+    assert pool.get_num_free_blocks() == 2
+    assert not manager.cache_endpoint(producer, final_step, in_flight=True)
+    assert pool.num_endpoint_entries == 0
+    pool.free_blocks(spare)
+    assert manager.cache_endpoint(producer, final_step, in_flight=True)
+    assert pool.num_endpoint_entries == 1
+    manager.free(producer)
+    manager.new_step_starts()
+    _, retained = manager.take_mamba_endpoint_copies()
+    pool.free_blocks(retained)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -239,6 +239,12 @@ if TYPE_CHECKING:
     VLLM_USE_DIRECT_DCP_A2A: bool | None = None
     VLLM_USE_DIRECT_DCP_Q_GATHER: bool | None = None
     VLLM_USE_DIRECT_DCP_KV_GATHER: bool | None = None
+    VLLM_K3_REQUEST_ENDPOINT_CACHE: bool = False
+    VLLM_K3_REQUEST_ENDPOINT_CACHE_MAX_ENTRIES: int = 4
+    VLLM_K3_REQUEST_ENDPOINT_CACHE_DISABLE_FILE: str = ""
+    VLLM_K3_REQUEST_ENDPOINT_CACHE_DEBUG: bool = False
+    VLLM_K3_REQUEST_ENDPOINT_CACHE_TORCH_COPY: bool = False
+    VLLM_K3_REQUEST_ENDPOINT_CACHE_TORCH_COPY_FILE: str = ""
     VLLM_DEEP_GEMM_WARMUP: Literal[
         "skip",
         "full",
@@ -2423,6 +2429,40 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_USE_DIRECT_DCP_KV_GATHER": lambda: maybe_convert_bool(
         os.getenv("VLLM_USE_DIRECT_DCP_KV_GATHER")
+    ),
+    # Publish every finished request's end state (attention pages, draft
+    # pages and a normalized recurrent state) under a request-endpoint
+    # prefix-cache entry, so the next turn that extends the same sequence
+    # resumes at the last computed token instead of the last hash boundary.
+    # Needs a hybrid (recurrent + attention) cache in align mode and at
+    # most two concurrent batches; the scheduler disables it otherwise.
+    "VLLM_K3_REQUEST_ENDPOINT_CACHE": lambda: bool(
+        int(os.getenv("VLLM_K3_REQUEST_ENDPOINT_CACHE", "0"))
+    ),
+    # Upper bound on live request-endpoint entries. Each entry pins one
+    # pool block per recurrent cache group for its state, so the bound caps
+    # the KV capacity the endpoint cache can hold back from attention pages.
+    "VLLM_K3_REQUEST_ENDPOINT_CACHE_MAX_ENTRIES": lambda: int(
+        os.getenv("VLLM_K3_REQUEST_ENDPOINT_CACHE_MAX_ENTRIES", "4")
+    ),
+    # File whose presence switches request-endpoint registration and lookup
+    # off without an engine restart.
+    "VLLM_K3_REQUEST_ENDPOINT_CACHE_DISABLE_FILE": lambda: os.getenv(
+        "VLLM_K3_REQUEST_ENDPOINT_CACHE_DISABLE_FILE", ""
+    ),
+    # Log endpoint registration/hit geometry and, on the worker, checksums of
+    # the recurrent-state pages read and written by the endpoint copies.
+    "VLLM_K3_REQUEST_ENDPOINT_CACHE_DEBUG": lambda: bool(
+        int(os.getenv("VLLM_K3_REQUEST_ENDPOINT_CACHE_DEBUG", "0"))
+    ),
+    # Materialize request-endpoint recurrent states with per-state torch
+    # copies instead of the fused Triton kernel (same results; a fallback
+    # and reference path). The file, when named, enables it while present.
+    "VLLM_K3_REQUEST_ENDPOINT_CACHE_TORCH_COPY": lambda: bool(
+        int(os.getenv("VLLM_K3_REQUEST_ENDPOINT_CACHE_TORCH_COPY", "0"))
+    ),
+    "VLLM_K3_REQUEST_ENDPOINT_CACHE_TORCH_COPY_FILE": lambda: os.getenv(
+        "VLLM_K3_REQUEST_ENDPOINT_CACHE_TORCH_COPY_FILE", ""
     ),
     # Whether to enable dual cuda streams for LoRA computation
     # (used by both BaseLinearLayerWithLoRA and FusedMoEWithLoRA to

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections.abc import Iterable, Sequence
+from collections import deque
+from collections.abc import Iterable, Iterator, Sequence
 from typing import Any
 
 from vllm.distributed.kv_events import (
@@ -13,6 +14,7 @@ from vllm.distributed.kv_events import (
 from vllm.logger import init_logger
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
+    ENDPOINT_GROUP_ID_OFFSET,
     BlockHash,
     BlockHashWithGroupId,
     ExternalBlockHash,
@@ -140,6 +142,61 @@ class BlockHashToBlockMap:
         raise AssertionError(f"Invalid KV cache block type {type(blocks)}")
 
 
+def _iter_group_blocks(
+    group_blocks: dict[int, tuple[int, list[KVCacheBlock]]],
+) -> Iterator[tuple[int, KVCacheBlock]]:
+    for group_id, (_, blocks) in group_blocks.items():
+        for block in blocks:
+            yield group_id, block
+
+
+class EndpointEntry:
+    """A finished request's end position, reachable by a later prefix.
+
+    ``num_tokens`` tokens of the producing request are restorable. For each
+    KV cache group ``group_blocks[group_id] = (first_block_index, blocks)``
+    lists the blocks that must be handed to a consumer starting at block
+    index ``first_block_index``: the page holding position ``num_tokens - 1``
+    for attention groups, that page plus the window before it for
+    sliding-window groups, and for every recurrent group the one pool block
+    holding the state after ``num_tokens`` tokens. The entry hangs off
+    ``parent_hash``, the chain hash of the last full hash unit below
+    ``num_tokens``; ``tail_tokens`` and ``extra_keys`` describe the tokens
+    between that unit and ``num_tokens`` and must match the consumer's.
+    """
+
+    __slots__ = (
+        "parent_hash",
+        "num_tokens",
+        "tail_tokens",
+        "extra_keys",
+        "group_blocks",
+    )
+
+    def __init__(
+        self,
+        parent_hash: BlockHash,
+        num_tokens: int,
+        tail_tokens: tuple[int, ...],
+        extra_keys: tuple[Any, ...] | None,
+        group_blocks: dict[int, tuple[int, list[KVCacheBlock]]],
+    ) -> None:
+        self.parent_hash = parent_hash
+        self.num_tokens = num_tokens
+        self.tail_tokens = tail_tokens
+        self.extra_keys = extra_keys
+        self.group_blocks = group_blocks
+
+    def blocks(self) -> Iterator[tuple[int, KVCacheBlock]]:
+        for group_id, (_, blocks) in self.group_blocks.items():
+            for block in blocks:
+                yield group_id, block
+
+
+# Endpoint entries kept per parent hash; older entries are dropped first.
+_MAX_ENDPOINTS_PER_PARENT = 2
+
+
 class BlockPool:
     """BlockPool that manages KVCacheBlocks.
     It provides methods to allocate, free and cache the kv cache blocks. The
@@ -183,6 +240,13 @@ class BlockPool:
         # Cache for block lookup
         self.cached_block_hash_to_block: BlockHashToBlockMap = BlockHashToBlockMap()
         self.cached_block_hashes_by_block: dict[int, set[BlockHashWithGroupId]] = {}
+
+        # Request-endpoint entries by parent hash, the entries each block takes
+        # part in (an entry is dropped when any of its blocks is reused), and
+        # their registration order for the global cap.
+        self.endpoint_entries: dict[BlockHash, list[EndpointEntry]] = {}
+        self._endpoints_by_block: dict[int, list[EndpointEntry]] = {}
+        self._endpoint_order: deque[EndpointEntry] = deque()
 
         # To represent a placeholder block with block_id=0.
         # The ref_cnt of null_block is not maintained, needs special care to
@@ -558,6 +622,122 @@ class BlockPool:
         # entry for any group block size is the hash at that prefix boundary.
         return request.block_hashes[num_hash_blocks - 1]
 
+    def cache_endpoint(
+        self,
+        parent_hash: BlockHash,
+        num_tokens: int,
+        tail_tokens: tuple[int, ...],
+        extra_keys: tuple[Any, ...] | None,
+        group_blocks: dict[int, tuple[int, list[KVCacheBlock]]],
+        max_entries: int,
+    ) -> EndpointEntry | None:
+        """Register a request-endpoint entry over the given per-group blocks.
+
+        Every block gains an endpoint key (the parent hash in the endpoint
+        group-id namespace) so it is retained like a cached block and so
+        eviction, reset and promotion drop the entry together with the block.
+        Older entries beyond ``max_entries`` (globally) or beyond the
+        per-parent cap are dropped. Returns ``None`` when caching is disabled,
+        ``max_entries`` is not positive, or a block is the null block.
+        """
+        if not self.enable_caching or not group_blocks or max_entries <= 0:
+            return None
+        if any(block.is_null for _, block in _iter_group_blocks(group_blocks)):
+            return None
+        entry = EndpointEntry(
+            parent_hash, num_tokens, tail_tokens, extra_keys, group_blocks
+        )
+        for group_id, block in entry.blocks():
+            key = make_block_hash_with_group_id(
+                parent_hash, ENDPOINT_GROUP_ID_OFFSET + group_id
+            )
+            self._insert_block_hash(key, block, num_tokens=num_tokens)
+            refs = self._endpoints_by_block.setdefault(block.block_id, [])
+            if entry not in refs:
+                refs.append(entry)
+        entries = self.endpoint_entries.setdefault(parent_hash, [])
+        entries.append(entry)
+        self._endpoint_order.append(entry)
+        while len(entries) > _MAX_ENDPOINTS_PER_PARENT:
+            self._drop_endpoint_entry(entries[0])
+        while len(self._endpoint_order) > max_entries:
+            self._drop_endpoint_entry(self._endpoint_order[0])
+        return entry
+
+    def find_endpoints(self, parent_hash: BlockHash) -> list[EndpointEntry]:
+        """Return the endpoint entries registered under ``parent_hash``,
+        longest first."""
+        entries = self.endpoint_entries.get(parent_hash)
+        if not entries:
+            return []
+        return sorted(entries, key=lambda entry: entry.num_tokens, reverse=True)
+
+    @property
+    def num_endpoint_entries(self) -> int:
+        return len(self._endpoint_order)
+
+    def _drop_endpoint_entry(self, entry: EndpointEntry) -> None:
+        """Forget ``entry`` and remove its endpoint keys from its blocks (a key
+        shared with a surviving entry of the same parent stays)."""
+        parent_hash = entry.parent_hash
+        entries = self.endpoint_entries.get(parent_hash)
+        if entries is not None:
+            if entry in entries:
+                entries.remove(entry)
+            if not entries:
+                del self.endpoint_entries[parent_hash]
+        if entry in self._endpoint_order:
+            self._endpoint_order.remove(entry)
+        for group_id, block in entry.blocks():
+            refs = self._endpoints_by_block.get(block.block_id)
+            if refs is None:
+                continue
+            refs[:] = [ref for ref in refs if ref is not entry]
+            if not refs:
+                del self._endpoints_by_block[block.block_id]
+            if any(
+                ref.parent_hash == parent_hash
+                and any(
+                    peer is block for peer in ref.group_blocks.get(group_id, (0, ()))[1]
+                )
+                for ref in refs
+            ):
+                continue
+            self._remove_endpoint_key(
+                block,
+                make_block_hash_with_group_id(
+                    parent_hash, ENDPOINT_GROUP_ID_OFFSET + group_id
+                ),
+            )
+
+    def _remove_endpoint_key(
+        self, block: KVCacheBlock, key: BlockHashWithGroupId
+    ) -> None:
+        if block.block_hash == key:
+            # The endpoint key was the block's primary hash: promote one of
+            # its secondary keys (if any) so the block stays a cached block.
+            secondary = self.cached_block_hashes_by_block.pop(block.block_id, set())
+            self.cached_block_hash_to_block.pop(key, block.block_id)
+            block.reset_hash()
+            for other in secondary:
+                self.cached_block_hash_to_block.pop(other, block.block_id)
+                self._insert_block_hash(other, block, num_tokens=None)
+            return
+        remaining = self.cached_block_hashes_by_block.get(block.block_id)
+        if remaining is not None:
+            remaining.discard(key)
+            if not remaining:
+                del self.cached_block_hashes_by_block[block.block_id]
+        self.cached_block_hash_to_block.pop(key, block.block_id)
+
+    def _drop_endpoints_of_block(self, block: KVCacheBlock) -> None:
+        """Forget every endpoint entry that used ``block`` (block reuse)."""
+        refs = self._endpoints_by_block.get(block.block_id)
+        if not refs:
+            return
+        for entry in list(refs):
+            self._drop_endpoint_entry(entry)
+
     def _get_partial_block_parent_hash_and_start(
         self,
         request: Request,
@@ -586,9 +766,12 @@ class BlockPool:
             if (
                 self.cached_block_hash_to_block.pop(block_hash, block.block_id)
                 is not None
-            ):
+            ) and get_group_id(block_hash) < ENDPOINT_GROUP_ID_OFFSET:
+                # Endpoint keys never emit events; their entries are dropped
+                # with the block below.
                 removed_hashes.append(block_hash)
         block.reset_hash()
+        self._drop_endpoints_of_block(block)
         return removed_hashes
 
     def _emit_block_removed_events(
@@ -783,6 +966,9 @@ class BlockPool:
         # Remove all hashes so that no new blocks will hit.
         self.cached_block_hash_to_block = BlockHashToBlockMap()
         self.cached_block_hashes_by_block.clear()
+        self.endpoint_entries.clear()
+        self._endpoints_by_block.clear()
+        self._endpoint_order.clear()
 
         # Remove all hashes from all blocks.
         for block in self.blocks:

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -14,7 +14,21 @@ from vllm.v1.core.kv_cache_coordinator import (
     get_kv_cache_coordinator,
 )
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
-from vllm.v1.core.kv_cache_utils import KVCacheBlock, KVCacheBlockCopy
+from vllm.v1.core.kv_cache_utils import (
+    KVCacheBlock,
+    KVCacheBlockCopy,
+    MambaEndpointStateCopy,
+    generate_block_hash_extra_keys,
+    request_endpoint_cache_debug,
+    request_endpoint_cache_enabled,
+    request_endpoint_cache_max_entries,
+)
+from vllm.v1.core.single_type_kv_cache_manager import (
+    FullAttentionManager,
+    MambaManager,
+    RSWAManager,
+    SlidingWindowManager,
+)
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     CrossAttentionSpec,
@@ -191,6 +205,11 @@ class KVCacheManager:
         # offload; pinned until the request's blocks are freed.
         self._partial_tail_pins: dict[str, list[KVCacheBlock]] = {}
 
+        # Request-endpoint cache: state copies for the worker and the blocks
+        # they read or write, retained until the step that runs them.
+        self._pending_endpoint_copies: list[MambaEndpointStateCopy] = []
+        self._endpoint_retained_blocks: list[KVCacheBlock] = []
+
     @property
     def usage(self) -> float:
         """Get the KV cache usage.
@@ -263,12 +282,19 @@ class KVCacheManager:
                 request.block_hashes, max_cache_hit_length
             )
         )
+        endpoint_hit = self._find_endpoint_hit(
+            request, max_cache_hit_length, num_new_computed_tokens
+        )
+        if endpoint_hit is not None:
+            computed_blocks, num_new_computed_tokens = endpoint_hit
+            num_uncached = 0
 
         # When kv_cache_report_mode is "full", emit BlockStored events
         # for the reused prefix cache blocks so that external consumers
         # (e.g. gateway) can learn about them.
         if (
             num_new_computed_tokens > 0
+            and endpoint_hit is None
             and self.enable_kv_cache_events
             and getattr(request, "kv_cache_report_mode", "incremental") == "full"
         ):
@@ -338,6 +364,12 @@ class KVCacheManager:
             return *self.get_computed_blocks(request), False
 
         num_local = per_group_hits[fa_group_id]
+        endpoint_hit = self._find_endpoint_hit(
+            request, request.num_tokens - 1, num_local
+        )
+        if endpoint_hit is not None:
+            endpoint_blocks, num_endpoint = endpoint_hit
+            return self.create_kv_cache_blocks(endpoint_blocks), num_endpoint, 0, False
         blocks = self.create_kv_cache_blocks(computed)
         # Per-group lookups do not detect an uncached shared prefix (boundary 0).
         return blocks, num_local, 0, min(per_group_hits) < num_local
@@ -834,6 +866,303 @@ class KVCacheManager:
                 start_idx = start_token // mgr.block_size
                 blocks = mgr.req_to_blocks[request_id]
                 mgr.new_block_ids.extend(blk.block_id for blk in blocks[start_idx:])
+
+    # ------------------------------------------------------------------
+    # Request-endpoint cache
+    #
+    # A finished request publishes its end position: the attention pages and
+    # draft-window blocks holding its last computed token, plus one pool block
+    # that receives every recurrent group's state after that token. A later
+    # prompt that extends the same token sequence resumes at that position
+    # instead of at the last hash boundary.
+    # ------------------------------------------------------------------
+
+    def cache_endpoint(
+        self,
+        request: Request,
+        final_step: tuple[int, int],
+        in_flight: bool,
+    ) -> bool:
+        """Publish a finished request's end position as a prefix-cache entry.
+
+        Args:
+            request: The finished request; its blocks must still be held.
+            final_step: (scheduled draft tokens, accepted draft tokens) of the
+                step that produced the request's last computed token; locates
+                the recurrent-state slot of the endpoint within the request's
+                blocks.
+            in_flight: Whether a later step of the request is still executing.
+                That step overwrites the request's state slots, so the
+                recurrent state is then taken from the worker's shadow pages
+                (written before the step ran) instead of the blocks.
+
+        Returns:
+            True if an entry was registered. The recurrent state is written by
+            the worker from the copy record drained by
+            ``take_mamba_endpoint_copies``; the destination block and the
+            source blocks stay retained until that step completes.
+        """
+        if not self.enable_caching or not request_endpoint_cache_enabled():
+            return False
+        max_entries = request_endpoint_cache_max_entries()
+        if max_entries <= 0:
+            return False
+        unit = self.block_pool.hash_block_size
+        # The endpoint is the last token with KV. A stop inside the accepted
+        # tokens of the final step trims the sequence below the committed
+        # position; the recurrent state of every accepted row is kept, so the
+        # endpoint may sit up to ``num_accepted`` rows before it.
+        num_tokens = request.num_tokens - 1
+        committed = request.num_computed_tokens - request.num_in_flight_tokens
+        num_draft_tokens, num_accepted = final_step
+        num_before = committed - num_accepted - 1
+        accepted_at_endpoint = num_tokens - num_before - 1
+        if (
+            num_tokens < unit
+            or num_tokens > committed
+            or not 0 <= accepted_at_endpoint <= num_accepted
+        ):
+            return False
+        num_units = num_tokens // unit
+        if num_units > len(request.block_hashes):
+            return False
+        parent_hash = request.block_hashes[num_units - 1]
+        tail_start = num_units * unit
+        tail_tokens = tuple(request.all_token_ids[tail_start:num_tokens])
+        extra_keys, _ = generate_block_hash_extra_keys(
+            request, tail_start, num_tokens, 0
+        )
+
+        req_id = request.request_id
+        group_blocks: dict[int, tuple[int, list[KVCacheBlock]]] = {}
+        mamba_managers: list[MambaManager] = []
+        mamba_group_ids: list[int] = []
+        for group_id, (manager, group) in enumerate(
+            zip(
+                self.coordinator.single_type_managers,
+                self.kv_cache_config.kv_cache_groups,
+                strict=True,
+            )
+        ):
+            req_blocks = manager.req_to_blocks.get(req_id)
+            if not req_blocks:
+                return False
+            if isinstance(manager, MambaManager):
+                if manager.mamba_cache_mode != "align":
+                    return False
+                mamba_managers.append(manager)
+                mamba_group_ids.append(group_id)
+                continue
+            block_size = manager.block_size
+            last_idx = (num_tokens - 1) // block_size
+            if isinstance(manager, SlidingWindowManager):
+                window = get_kv_cache_spec_sliding_window(group.kv_cache_spec)
+                if window is None:
+                    return False
+                first_idx = max(0, num_tokens - window + 1) // block_size
+            elif isinstance(manager, FullAttentionManager) and not isinstance(
+                manager, RSWAManager
+            ):
+                first_idx = last_idx
+            else:
+                return False
+            if last_idx >= len(req_blocks):
+                return False
+            blocks = list(req_blocks[first_idx : last_idx + 1])
+            if any(block.is_null for block in blocks):
+                return False
+            group_blocks[group_id] = (first_idx, blocks)
+        if not mamba_managers:
+            return False
+
+        mamba_block_size = mamba_managers[0].block_size
+        retained: list[KVCacheBlock] = []
+        conv_src_ids: list[int] = []
+        temporal_src_ids: list[int] = []
+        # The final step scheduled ``num_draft_tokens + 1`` rows from the
+        # committed position ``num_before`` and wrote row ``j`` of its state
+        # into column ``base + j``; the conv window lives in ``base`` and is
+        # read with the accepted count as its shift. When acceptance landed
+        # exactly on a block boundary inside the running column the post-step
+        # kernel normalized the committed state into slot 0 and shifted the
+        # window in place, which leaves no state for an earlier endpoint.
+        base = (num_before + num_draft_tokens) // mamba_block_size
+        aligned = committed // mamba_block_size * mamba_block_size
+        normalized = (
+            aligned >= num_before + 1 and aligned // mamba_block_size - 1 == base
+        )
+        if normalized and accepted_at_endpoint != num_accepted:
+            return False
+        token_bias = 0 if normalized else accepted_at_endpoint
+        if not in_flight:
+            temporal_idx = base + token_bias
+            for manager in mamba_managers:
+                req_blocks = manager.req_to_blocks[req_id]
+                if temporal_idx >= len(req_blocks) or base >= len(req_blocks):
+                    return False
+                conv_src = req_blocks[base]
+                temporal_src = req_blocks[temporal_idx]
+                if conv_src.is_null or temporal_src.is_null:
+                    return False
+                conv_src_ids.append(conv_src.block_id)
+                temporal_src_ids.append(temporal_src.block_id)
+                retained.append(conv_src)
+                retained.append(temporal_src)
+
+        # One durable block per recurrent group: a block id names the same
+        # physical page in every group (each raw KV tensor is shared by one
+        # layer of every group), so groups must not share a block. Keep one
+        # block spare so publishing never takes the pool's last block.
+        num_dst = len(mamba_managers)
+        if self.block_pool.get_num_free_blocks() < num_dst + 1:
+            return False
+        dsts = self.block_pool.get_new_blocks(num_dst)
+        state_idx = (num_tokens - 1) // mamba_block_size
+        for group_id, dst in zip(mamba_group_ids, dsts):
+            group_blocks[group_id] = (state_idx, [dst])
+        entry = self.block_pool.cache_endpoint(
+            parent_hash, num_tokens, tail_tokens, extra_keys, group_blocks, max_entries
+        )
+        if entry is None:
+            self.block_pool.free_blocks(dsts)
+            return False
+        self.block_pool.touch(retained)
+        self._pending_endpoint_copies.append(
+            MambaEndpointStateCopy(
+                req_id=req_id,
+                dst_block_ids=tuple(dst.block_id for dst in dsts),
+                from_shadow=in_flight,
+                conv_src_block_ids=tuple(conv_src_ids),
+                temporal_src_block_ids=tuple(temporal_src_ids),
+                token_bias=token_bias,
+            )
+        )
+        self._endpoint_retained_blocks.extend(dsts)
+        self._endpoint_retained_blocks.extend(retained)
+        if request_endpoint_cache_debug():
+            logger.info(
+                "[endpoint] register req=%s L=%d committed=%d drafts=%d accepted=%d "
+                "accepted_at_endpoint=%d base=%d normalized=%s in_flight=%s "
+                "bias=%d dst=%s conv_src=%s temporal_src=%s groups=%s",
+                req_id,
+                num_tokens,
+                committed,
+                num_draft_tokens,
+                num_accepted,
+                accepted_at_endpoint,
+                base,
+                normalized,
+                in_flight,
+                token_bias,
+                [dst.block_id for dst in dsts],
+                conv_src_ids,
+                temporal_src_ids,
+                {
+                    gid: (first, [b.block_id for b in blocks])
+                    for gid, (first, blocks) in group_blocks.items()
+                },
+            )
+        return True
+
+    def take_mamba_endpoint_copies(
+        self,
+    ) -> tuple[list[MambaEndpointStateCopy], list[KVCacheBlock]]:
+        """Drain endpoint state copies and the blocks retained for them."""
+        copies = self._pending_endpoint_copies
+        retained = self._endpoint_retained_blocks
+        self._pending_endpoint_copies = []
+        self._endpoint_retained_blocks = []
+        return copies, retained
+
+    def _find_endpoint_hit(
+        self,
+        request: Request,
+        max_cache_hit_length: int,
+        min_hit_length: int,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int] | None:
+        """Find the longest request-endpoint entry the request can resume from.
+
+        Entries hang off the chain hash of their last full hash unit, so the
+        candidate parents are the request's hashes from the longest one whose
+        endpoint could fit under ``max_cache_hit_length`` down to the one whose
+        endpoint could still exceed ``min_hit_length``. An entry matches when
+        its tail tokens and extra keys equal the request's, and every
+        attention page before its endpoint page is still cached.
+
+        Returns:
+            Per-group block lists and the endpoint length, or ``None``.
+        """
+        if not request_endpoint_cache_enabled():
+            return None
+        if self.block_pool.num_endpoint_entries == 0:
+            return None
+        unit = self.block_pool.hash_block_size
+        block_hashes = request.block_hashes
+        token_ids = request.all_token_ids
+        highest = min(len(block_hashes), max_cache_hit_length // unit) - 1
+        lowest = max(0, min_hit_length // unit - 1)
+        for parent_idx in range(highest, lowest - 1, -1):
+            entries = self.block_pool.find_endpoints(block_hashes[parent_idx])
+            if not entries:
+                continue
+            tail_start = (parent_idx + 1) * unit
+            for entry in entries:
+                num_tokens = entry.num_tokens
+                if num_tokens > max_cache_hit_length or num_tokens <= min_hit_length:
+                    continue
+                if tuple(token_ids[tail_start:num_tokens]) != entry.tail_tokens:
+                    continue
+                extra_keys, _ = generate_block_hash_extra_keys(
+                    request, tail_start, num_tokens, 0
+                )
+                if extra_keys != entry.extra_keys:
+                    continue
+                blocks = self._endpoint_hit_blocks(entry, block_hashes)
+                if blocks is not None:
+                    if request_endpoint_cache_debug():
+                        logger.info(
+                            "[endpoint] hit req=%s L=%d parent_idx=%d prompt=%d "
+                            "aligned_hit=%d blocks=%s",
+                            request.request_id,
+                            num_tokens,
+                            parent_idx,
+                            request.num_tokens,
+                            min_hit_length,
+                            [[b.block_id for b in group] for group in blocks],
+                        )
+                    return blocks, num_tokens
+        return None
+
+    def _endpoint_hit_blocks(
+        self, entry, block_hashes
+    ) -> tuple[list[KVCacheBlock], ...] | None:
+        unit = self.block_pool.hash_block_size
+        null_block = self.block_pool.null_block
+        result: list[list[KVCacheBlock]] = []
+        for group_id, manager in enumerate(self.coordinator.single_type_managers):
+            group_entry = entry.group_blocks.get(group_id)
+            if group_entry is None:
+                return None
+            first_idx, blocks = group_entry
+            if isinstance(manager, (MambaManager, SlidingWindowManager)):
+                result.append([null_block] * first_idx + list(blocks))
+                continue
+            # Full attention: every page before the endpoint page must still
+            # be cached under the request's chain.
+            scale = manager.block_size // unit
+            chain: list[KVCacheBlock] = []
+            for page_idx in range(first_idx):
+                hash_idx = (page_idx + 1) * scale - 1
+                if hash_idx >= len(block_hashes):
+                    return None
+                cached = self.block_pool.get_cached_block(
+                    block_hashes[hash_idx], [group_id]
+                )
+                if not cached:
+                    return None
+                chain.append(cached[0])
+            result.append(chain + list(blocks))
+        return tuple(result)
 
     def take_kv_cache_block_copies(
         self,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -183,6 +183,73 @@ class KVCacheBlockCopy(NamedTuple):
     dst_block_id: int
 
 
+class MambaEndpointStateCopy(NamedTuple):
+    """Materialize a finished request's recurrent state into durable blocks.
+
+    ``dst_block_ids`` holds one pool block per recurrent cache group, in
+    ascending group-id order. A block id names the same physical page in
+    every group (each raw KV tensor is shared by one layer of every group),
+    so groups must not share a destination. Every block receives the state
+    after the request's endpoint token. When ``from_shadow`` is set the
+    state is read from the worker's per-request shadow pages (written before
+    the request's final in-flight step could overwrite its state slots): the
+    unshifted conv window shifted by ``token_bias`` and temporal shadow slot
+    ``token_bias``. Otherwise it is read from the request's own blocks: the
+    temporal state of ``temporal_src_block_ids`` and the convolution window
+    of ``conv_src_block_ids`` shifted by ``token_bias``, one entry per
+    recurrent cache group in ascending group-id order.
+    """
+
+    req_id: str
+    dst_block_ids: tuple[int, ...]
+    from_shadow: bool
+    conv_src_block_ids: tuple[int, ...]
+    temporal_src_block_ids: tuple[int, ...]
+    token_bias: int
+
+
+# Prefix-cache keys of request-endpoint entries reuse the block hash map with
+# the group id lifted into this namespace, so a page can be reachable both at
+# its hash boundaries and at a request's end position.
+ENDPOINT_GROUP_ID_OFFSET = 1 << 24
+
+
+def request_endpoint_cache_enabled() -> bool:
+    """Whether finished requests publish request-endpoint cache entries.
+
+    Gated by ``VLLM_K3_REQUEST_ENDPOINT_CACHE`` and switched off, without a
+    restart, by the file named in
+    ``VLLM_K3_REQUEST_ENDPOINT_CACHE_DISABLE_FILE``.
+
+    An entry restores the end position of every cache group, a speculative
+    draft's sliding window included, so a deployment that hides restored KV
+    from its draft group must keep the flag off.
+    """
+    if not envs.VLLM_K3_REQUEST_ENDPOINT_CACHE:
+        return False
+    disable_file = envs.VLLM_K3_REQUEST_ENDPOINT_CACHE_DISABLE_FILE
+    return not (disable_file and os.path.exists(disable_file))
+
+
+def request_endpoint_cache_debug() -> bool:
+    """Whether endpoint registration, hits and worker copies are logged."""
+    return bool(envs.VLLM_K3_REQUEST_ENDPOINT_CACHE_DEBUG)
+
+
+def request_endpoint_cache_torch_copy() -> bool:
+    """Whether endpoint states are materialized by torch copies (env flag or
+    the presence of the named file) instead of the fused kernel."""
+    if envs.VLLM_K3_REQUEST_ENDPOINT_CACHE_TORCH_COPY:
+        return True
+    path = envs.VLLM_K3_REQUEST_ENDPOINT_CACHE_TORCH_COPY_FILE
+    return bool(path) and os.path.exists(path)
+
+
+def request_endpoint_cache_max_entries() -> int:
+    """Upper bound on live request-endpoint entries (each pins one block)."""
+    return max(int(envs.VLLM_K3_REQUEST_ENDPOINT_CACHE_MAX_ENTRIES), 0)
+
+
 class FreeKVCacheBlockQueue:
     """This class organizes a list of KVCacheBlock objects to a doubly linked
     list of free blocks. We implement this class instead of using Python

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -18,12 +18,13 @@ if TYPE_CHECKING:
     from vllm.multimodal.inputs import MultiModalFeatureSpec
     from vllm.pooling_params import PoolingParams
     from vllm.sampling_params import SamplingParams
-    from vllm.v1.core.kv_cache_utils import KVCacheBlockCopy
+    from vllm.v1.core.kv_cache_utils import KVCacheBlockCopy, MambaEndpointStateCopy
     from vllm.v1.request import Request
 else:
     ECConnectorMetadata = object
     KVConnectorMetadata = object
     KVCacheBlockCopy = object
+    MambaEndpointStateCopy = object
     LoRARequest = object
     MultiModalFeatureSpec = object
     PoolingParams = object
@@ -257,6 +258,12 @@ class SchedulerOutput:
 
     # CoW copies to apply after zeroing new blocks and before forward.
     kv_cache_block_copies: list[KVCacheBlockCopy] | None = None
+
+    # Finished requests' recurrent states to write into their durable
+    # request-endpoint blocks. The worker applies them while the finished
+    # requests are still mapped, before this step's CoW copies (a consumer
+    # may already copy from a destination block).
+    mamba_endpoint_copies: list[MambaEndpointStateCopy] | None = None
 
     # Producer partial-tail offload hand-off for external KV connectors:
     # {request_id: [(group_id, block_id, boundary_tokens), ...]} pointing at

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable
 from dataclasses import replace
 from typing import Any
 
+from vllm import envs
 from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.config import KVEventsConfig, VllmConfig
 from vllm.distributed.ec_transfer.ec_connector.base import (
@@ -274,6 +275,22 @@ class Scheduler(SchedulerInterface):
         if hash_block_size is None:
             hash_block_size = block_size
         self.hash_block_size = hash_block_size
+        # Request-endpoint cache: a finished request's recurrent state is read
+        # either from its blocks or from the worker's shadow slot written
+        # before the one step that may still be in flight. More concurrent
+        # batches would leave states neither source covers.
+        self.request_endpoint_cache = (
+            self.kv_cache_config.has_mamba_layers
+            and bool(envs.VLLM_K3_REQUEST_ENDPOINT_CACHE)
+            and self.vllm_config.max_concurrent_batches <= 2
+        )
+        if envs.VLLM_K3_REQUEST_ENDPOINT_CACHE and not self.request_endpoint_cache:
+            logger.warning(
+                "VLLM_K3_REQUEST_ENDPOINT_CACHE is set but unsupported here "
+                "(mamba layers: %s, concurrent batches: %d); disabled.",
+                self.kv_cache_config.has_mamba_layers,
+                self.vllm_config.max_concurrent_batches,
+            )
         self.kv_cache_manager = KVCacheManager(
             kv_cache_config=kv_cache_config,
             max_model_len=self.max_model_len,
@@ -1241,6 +1258,18 @@ class Scheduler(SchedulerInterface):
             self._free_cow_retained_blocks(cow_retained_blocks, self.sched_step_seq + 1)
         pending_kv_cache_block_copies = kv_cache_block_copies or None
 
+        # Request-endpoint state copies run before this step's CoW copies (a
+        # consumer may already copy from a destination block); the blocks they
+        # read and write stay retained until the step completes.
+        mamba_endpoint_copies, endpoint_retained_blocks = (
+            self.kv_cache_manager.take_mamba_endpoint_copies()
+        )
+        if mamba_endpoint_copies:
+            self._free_cow_retained_blocks(
+                endpoint_retained_blocks, self.sched_step_seq + 1
+            )
+        pending_mamba_endpoint_copies = mamba_endpoint_copies or None
+
         # Dynamic speculative decoding: compute optimal K
         num_spec_tokens_to_schedule = (
             self.acceptance_length_controller.num_spec_tokens
@@ -1280,6 +1309,7 @@ class Scheduler(SchedulerInterface):
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=self._get_new_block_ids_to_zero(),
             kv_cache_block_copies=pending_kv_cache_block_copies,
+            mamba_endpoint_copies=pending_mamba_endpoint_copies,
             partial_tail_offloads=pending_partial_tail_offloads,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
             ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
@@ -1976,6 +2006,10 @@ class Scheduler(SchedulerInterface):
                         self.kv_cache_manager.estimate_cached_tokens(request)
                     )
 
+            # The request-endpoint cache locates the committed recurrent state
+            # from the last step's draft geometry.
+            request.endpoint_final_step = (num_draft_tokens, num_accepted)
+
             finish_reason = None
             if stopped:
                 # Capture finish_reason BEFORE _handle_stopped_request, which may
@@ -2426,6 +2460,7 @@ class Scheduler(SchedulerInterface):
         assert request.is_finished()
 
         self._inflight_prefills.discard(request)
+        self._cache_request_endpoint(request)
         connector_delay_free_blocks, kv_xfer_params = self._connector_finished(request)
 
         # EC Connector: mirror the KV hook. The contract requires firing
@@ -2448,6 +2483,21 @@ class Scheduler(SchedulerInterface):
             self._free_blocks(request)
 
         return kv_xfer_params, ec_xfer_params
+
+    def _cache_request_endpoint(self, request: Request) -> None:
+        """Publish the finished request's end position to the prefix cache.
+
+        Runs at finish time, while the request still holds its blocks: a
+        connector may delay the free, and the worker slot the recurrent state
+        is copied from is recycled once the request is reported finished.
+        """
+        if not self.request_endpoint_cache:
+            return
+        self.kv_cache_manager.cache_endpoint(
+            request,
+            request.endpoint_final_step,
+            in_flight=request.num_in_flight_tokens > 0,
+        )
 
     def _free_blocks(self, request: Request):
         assert request.is_finished()

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -172,6 +172,10 @@ class Request:
 
         self.spec_token_ids: list[int] = []
         self.num_computed_tokens = 0
+        # (scheduled draft tokens, accepted draft tokens) of the step that
+        # finished the request; the request-endpoint cache uses them to locate
+        # the committed recurrent state slot.
+        self.endpoint_final_step: tuple[int, int] = (0, 0)
         self.cache_salt: str | None = cache_salt
 
         # Multi-modal related

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1250,6 +1250,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         return True
 
     def finish_requests(self, scheduler_output: SchedulerOutput) -> None:
+        # Finished requests' end states are read from their (still mapped)
+        # request slots, so materialize them before the slots are recycled.
+        if scheduler_output.mamba_endpoint_copies:
+            self.model_state.materialize_request_endpoints(
+                scheduler_output.mamba_endpoint_copies,
+                self.req_states.req_id_to_index,
+            )
         finished_req_ids = scheduler_output.finished_req_ids
         if self.pooling_runner is not None:
             # Preempted docs keep their query-use reservation until rescheduled.

--- a/vllm/v1/worker/gpu/model_states/interface.py
+++ b/vllm/v1/worker/gpu/model_states/interface.py
@@ -8,6 +8,7 @@ import torch.nn as nn
 
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
+from vllm.logger import init_logger
 from vllm.tasks import GenerationTask
 from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.core.sched.output import NewRequestData
@@ -17,6 +18,8 @@ from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.mm.encoder_runner import EncoderRunner
 from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.utils import AttentionGroup
+
+logger = init_logger(__name__)
 
 
 class ModelSpecificAttnMetadata:
@@ -123,6 +126,23 @@ class ModelState(ABC):
         num_sampled: torch.Tensor,
         num_computed_tokens: torch.Tensor | None = None,
     ) -> None:
+        return None
+
+    def materialize_request_endpoints(
+        self,
+        copies: list[Any],
+        req_id_to_index: dict[str, int],
+    ) -> None:
+        """Write finished requests' committed recurrent states into the pool
+        blocks named by ``copies`` (``MambaEndpointStateCopy`` records). Runs
+        before the finished requests are removed from the worker. Only hybrid
+        recurrent model states implement it; the scheduler emits copies only
+        when such a model publishes request-endpoint cache entries."""
+        if copies:
+            logger.warning_once(
+                "Request-endpoint copies received by a model state without "
+                "recurrent state; the entries stay unmaterialized."
+            )
         return None
 
     @abstractmethod

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -7,11 +7,19 @@ import numpy as np
 import torch
 import torch.nn as nn
 
+from vllm import envs
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
+from vllm.distributed.parallel_state import get_tensor_model_parallel_rank
+from vllm.logger import init_logger
+from vllm.model_executor.layers.mamba.mamba_utils import is_conv_state_dim_first
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadataBuilder
+from vllm.v1.core.kv_cache_utils import (
+    request_endpoint_cache_debug,
+    request_endpoint_cache_torch_copy,
+)
 from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.utils import CpuGpuBuffer
@@ -21,10 +29,40 @@ from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.model_states.default import DefaultModelState
 from vllm.v1.worker.gpu.model_states.interface import ModelSpecificAttnMetadata
 from vllm.v1.worker.mamba_utils import (
+    ENDPOINT_COPY_META_FIXED,
+    EndpointCopyRecord,
     MambaSpecDecodeGPUContext,
+    endpoint_layer_states,
+    materialize_endpoints_torch,
     preprocess_mamba_align_fused_kernel,
+    verify_endpoints,
 )
 from vllm.v1.worker.utils import AttentionGroup
+
+logger = init_logger(__name__)
+
+
+def _page_sig(tensor: torch.Tensor, block: int) -> str:
+    """A cheap fingerprint of one block page for endpoint debugging."""
+    page = tensor[block].float()
+    flat = page.flatten()
+    return (
+        f"sum={page.sum().item():.6e} abs={page.abs().sum().item():.6e} "
+        f"head={[round(v, 5) for v in flat[:3].tolist()]} "
+        f"tail={[round(v, 5) for v in flat[-3:].tolist()]}"
+    )
+
+
+def _bytes_sig(raw: torch.Tensor, dtype: torch.dtype) -> str:
+    """Fingerprint of a raw (uint8) shadow page viewed as ``dtype``."""
+    elem = torch.empty((), dtype=dtype).element_size()
+    usable = raw.numel() // elem * elem
+    page = raw[:usable].view(dtype).float()
+    return (
+        f"sum={page.sum().item():.6e} abs={page.abs().sum().item():.6e} "
+        f"head={[round(v, 5) for v in page[:3].tolist()]} "
+        f"tail={[round(v, 5) for v in page[-3:].tolist()]}"
+    )
 
 
 @dataclass
@@ -83,8 +121,15 @@ class MambaHybridModelState(DefaultModelState):
                 self.max_num_reqs, dtype=torch.int32, device=self.device
             )
             self._mamba_ctx: MambaSpecDecodeGPUContext | None = None
+            # Every recurrent layer's state views in the context's state
+            # order (torch reference path of the endpoint materialization).
+            self._mamba_layer_states: list[tuple[torch.Tensor, ...]] = []
             self._mamba_group_ids: list[int] = []
             self._mamba_spec: MambaSpec | None = None
+            # Request-endpoint cache: keep every request's committed state in
+            # a shadow slot so a finished request's state survives the step
+            # that was already in flight when it finished.
+            self._endpoint_shadow = bool(envs.VLLM_K3_REQUEST_ENDPOINT_CACHE)
 
     def add_request(self, req_index: int, new_req_data: NewRequestData) -> None:
         super().add_request(req_index, new_req_data)
@@ -111,7 +156,19 @@ class MambaHybridModelState(DefaultModelState):
             assert all(specs[0] == s for s in specs)
             self._mamba_group_ids = group_ids
             self._mamba_spec = specs[0]
+            self._first_mamba_layer_name = kv_cache_config.kv_cache_groups[
+                group_ids[0]
+            ].layer_names[0]
         return self._mamba_group_ids, self._mamba_spec
+
+    def _debug_mamba_states(self) -> list[torch.Tensor] | None:
+        """The first recurrent layer's ``[conv_state, temporal_state]``."""
+        name = getattr(self, "_first_mamba_layer_name", None)
+        if name is None:
+            return None
+        forward_context = self.vllm_config.compilation_config.static_forward_context
+        attention = forward_context.get(name)
+        return getattr(attention, "kv_cache", None)
 
     def _ensure_align_ctx(
         self,
@@ -147,6 +204,11 @@ class MambaHybridModelState(DefaultModelState):
                 self.model.get_mamba_state_copy_func(),
                 [block_tables[gid] for gid in mamba_group_ids],
             )
+            self._mamba_layer_states = endpoint_layer_states(
+                kv_cache_config, forward_context, mamba_group_ids
+            )
+        if self._endpoint_shadow and not ctx.has_endpoint_shadow:
+            ctx.ensure_endpoint_shadow(self.max_num_reqs)
         return ctx
 
     def preprocess_state(
@@ -196,7 +258,250 @@ class MambaHybridModelState(DefaultModelState):
             self._mamba_src_col_gpu,
             self._mamba_src_off_gpu,
             input_batch.idx_mapping,
+            snapshot_to_shadow=self._endpoint_shadow,
         )
+
+    def materialize_request_endpoints(
+        self,
+        copies: list[Any],
+        req_id_to_index: dict[str, int],
+    ) -> None:
+        """Write finished requests' committed states into pool blocks.
+
+        Each ``MambaEndpointStateCopy`` names the destination block and either
+        the request's shadow pages (``from_shadow``; ``token_bias`` selects the
+        conv shift and the temporal slot) or its own state blocks per
+        recurrent group. Runs on the current stream before the finished
+        requests' slots are recycled, so it is ordered after the in-flight
+        step that may have overwritten their state slots and before any
+        consumer's copy-on-write of the destination block.
+
+        The fused kernel performs the copies; with the torch-copy switch the
+        per-state torch reference performs them instead. In debug mode the
+        kernel result is verified against the reference for every state and
+        the mismatches are logged on the first tensor-parallel rank.
+        """
+        if not copies or not self._align_mode:
+            return
+        ctx = self._mamba_ctx
+        if ctx is None or not ctx.is_initialized:
+            logger.warning_once(
+                "Request-endpoint copies arrived before the recurrent-state "
+                "context was initialized; %d entr(ies) stay unmaterialized.",
+                len(copies),
+            )
+            return
+        num_groups = ctx.num_groups
+        width = ENDPOINT_COPY_META_FIXED + 3 * num_groups
+        meta = np.full((len(copies), width), -1, dtype=np.int32)
+        records: list[EndpointCopyRecord] = []
+        rows = 0
+        for copy in copies:
+            req_idx = req_id_to_index.get(copy.req_id)
+            if copy.from_shadow:
+                if req_idx is None or not ctx.has_endpoint_shadow:
+                    logger.warning(
+                        "Request-endpoint copy for %s skipped: shadow source "
+                        "unavailable (slot=%s, shadow=%s)",
+                        copy.req_id,
+                        req_idx,
+                        ctx.has_endpoint_shadow,
+                    )
+                    continue
+                meta[rows, 0] = 1
+                meta[rows, 1] = req_idx
+                meta[rows, 2] = copy.token_bias
+            else:
+                if (
+                    len(copy.conv_src_block_ids) != num_groups
+                    or len(copy.temporal_src_block_ids) != num_groups
+                ):
+                    logger.warning(
+                        "Request-endpoint copy for %s skipped: %d/%d source "
+                        "blocks for %d recurrent groups",
+                        copy.req_id,
+                        len(copy.conv_src_block_ids),
+                        len(copy.temporal_src_block_ids),
+                        num_groups,
+                    )
+                    continue
+                meta[rows, 0] = 0
+                meta[rows, 1] = 0
+                meta[rows, 2] = copy.token_bias
+                meta[rows, 4 + num_groups : 4 + 2 * num_groups] = (
+                    copy.conv_src_block_ids
+                )
+                meta[rows, 4 + 2 * num_groups : width] = copy.temporal_src_block_ids
+            if len(copy.dst_block_ids) != num_groups:
+                logger.warning(
+                    "Request-endpoint copy for %s skipped: %d destination "
+                    "blocks for %d recurrent groups",
+                    copy.req_id,
+                    len(copy.dst_block_ids),
+                    num_groups,
+                )
+                meta[rows] = -1
+                continue
+            meta[rows, 4 : 4 + num_groups] = copy.dst_block_ids
+            records.append(
+                EndpointCopyRecord(
+                    from_shadow=bool(copy.from_shadow),
+                    req_idx=req_idx if copy.from_shadow and req_idx is not None else 0,
+                    token_bias=int(copy.token_bias),
+                    dst_block_ids=tuple(int(b) for b in copy.dst_block_ids),
+                    conv_src_block_ids=tuple(copy.conv_src_block_ids),
+                    temporal_src_block_ids=tuple(copy.temporal_src_block_ids),
+                )
+            )
+            rows += 1
+        if rows == 0:
+            return
+        torch_copy = request_endpoint_cache_torch_copy()
+        debug = request_endpoint_cache_debug() and get_tensor_model_parallel_rank() == 0
+        conv_dim_first = is_conv_state_dim_first()
+        layer_states = self._mamba_layer_states
+        if debug:
+            self._debug_log_endpoint_sources(copies, req_id_to_index, ctx)
+        if not torch_copy or debug:
+            copy_meta = torch.from_numpy(meta[:rows]).to(self.device)
+            trace = None
+            if debug:
+                trace = torch.zeros(
+                    (rows, ctx.num_layers * ctx.num_state_types, 4),
+                    dtype=torch.int64,
+                    device=self.device,
+                )
+            ctx.run_endpoint_materialize(copy_meta, trace)
+            if debug:
+                torch.accelerator.synchronize()
+                self._debug_log_trace(records, trace)
+                self._debug_log_verification(
+                    "kernel", records, layer_states, conv_dim_first
+                )
+        if torch_copy:
+            materialize_endpoints_torch(ctx, layer_states, records, conv_dim_first)
+            if debug:
+                torch.accelerator.synchronize()
+                self._debug_log_verification(
+                    "torch", records, layer_states, conv_dim_first
+                )
+
+    def _debug_log_trace(
+        self, records: list[EndpointCopyRecord], trace: torch.Tensor | None
+    ) -> None:
+        """Compare the addresses the kernel resolved with the host
+        expectation for every record and state."""
+        ctx = self._mamba_ctx
+        if ctx is None or trace is None:
+            return
+        expected = ctx.expected_endpoint_addresses(records)
+        actual = trace.cpu().tolist()
+        mismatches: list[dict[str, Any]] = []
+        for record_idx, per_state in enumerate(expected):
+            for state_idx, want in enumerate(per_state):
+                got = tuple(actual[record_idx][state_idx])
+                if got != want:
+                    mismatches.append(
+                        {
+                            "record": record_idx,
+                            "state_idx": state_idx,
+                            "kernel": [hex(v) for v in got],
+                            "expected": [hex(v) for v in want],
+                        }
+                    )
+        logger.info(
+            "[endpoint] trace records=%d states=%d address_mismatches=%d first=%s",
+            len(records),
+            len(expected[0]) if expected else 0,
+            len(mismatches),
+            mismatches[0] if mismatches else None,
+        )
+
+    def _debug_log_verification(
+        self,
+        path: str,
+        records: list[EndpointCopyRecord],
+        layer_states: list[tuple[torch.Tensor, ...]],
+        conv_dim_first: bool,
+    ) -> None:
+        ctx = self._mamba_ctx
+        assert ctx is not None
+        mismatches = verify_endpoints(ctx, layer_states, records, conv_dim_first)
+        total = len(records) * len(layer_states) * ctx.num_state_types
+        by_record: dict[int, int] = {}
+        for entry in mismatches:
+            by_record[entry["record"]] = by_record.get(entry["record"], 0) + 1
+        logger.info(
+            "[endpoint] verify path=%s records=%d states=%d mismatched=%d "
+            "per_record=%s first=%s",
+            path,
+            len(records),
+            total,
+            len(mismatches),
+            {records[i].dst_block_ids[0]: n for i, n in sorted(by_record.items())},
+            mismatches[0] if mismatches else None,
+        )
+
+    def _debug_log_endpoint_sources(self, copies, req_id_to_index, ctx) -> None:
+        states = self._debug_mamba_states()
+        if states is None or len(states) < 2 or not ctx.is_initialized:
+            return
+        torch.accelerator.synchronize()
+        strides = ctx.shadow_page_strides_cpu[:2]
+        base0 = int(ctx.state_base_addrs[0].item())
+        base1 = int(ctx.state_base_addrs[1].item())
+        logger.info(
+            "[endpoint] views conv_ptr=%#x ctx_base0=%#x temporal_ptr=%#x "
+            "ctx_base1=%#x "
+            "shadow0_ptr=%#x ctx_shadow0=%#x shadow1_ptr=%#x ctx_shadow1=%#x layers=%d",
+            states[0].data_ptr(),
+            base0,
+            states[1].data_ptr(),
+            base1,
+            ctx.shadow_buffers[0].data_ptr() if ctx.has_endpoint_shadow else 0,
+            int(ctx.shadow_base_addrs[0].item()),
+            ctx.shadow_buffers[1].data_ptr() if ctx.has_endpoint_shadow else 0,
+            int(ctx.shadow_base_addrs[1].item()),
+            len(self._mamba_layer_states),
+        )
+        for copy in copies:
+            if copy.from_shadow:
+                req_idx = req_id_to_index.get(copy.req_id)
+                if req_idx is None or not ctx.has_endpoint_shadow:
+                    continue
+                bufs = ctx.shadow_buffers
+                conv_page = bufs[0][req_idx * strides[0] : (req_idx + 1) * strides[0]]
+                slot = req_idx * ctx.shadow_temporal_slots + copy.token_bias
+                temporal_page = bufs[1][slot * strides[1] : (slot + 1) * strides[1]]
+                conv_sig = _bytes_sig(conv_page, states[0].dtype)
+                temporal_sig = _bytes_sig(temporal_page, states[1].dtype)
+                src_desc = f"shadow slot={req_idx} temporal_slot={slot}"
+            else:
+                conv_sig = _page_sig(states[0], copy.conv_src_block_ids[0])
+                temporal_sig = _page_sig(states[1], copy.temporal_src_block_ids[0])
+                src_desc = (
+                    f"blocks conv={copy.conv_src_block_ids[0]} "
+                    f"temporal={copy.temporal_src_block_ids[0]}"
+                )
+            logger.info(
+                "[endpoint] source req=%s %s bias=%d dst0=%d conv=%s temporal=%s "
+                "state0=(base=%#x stride=%d) state1=(base=%#x stride=%d) "
+                "shape0=%s stride0=%s shape1=%s stride1=%s",
+                copy.req_id,
+                src_desc,
+                copy.token_bias,
+                copy.dst_block_ids[0],
+                conv_sig,
+                temporal_sig,
+                base0,
+                int(strides[0]),
+                base1,
+                int(strides[1]),
+                tuple(states[0].shape),
+                tuple(states[0].stride()),
+                tuple(states[1].shape),
+                tuple(states[1].stride()),
+            )
 
     def prepare_attn(
         self,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1275,6 +1275,13 @@ class GPUModelRunner(
         # stale NaN/data from corrupting attention or SSM computation.
         if scheduler_output.new_block_ids_to_zero:
             self._zero_block_ids(scheduler_output.new_block_ids_to_zero)
+        if scheduler_output.mamba_endpoint_copies:
+            # The request-endpoint cache needs the v2 runner's recurrent-state
+            # shadow; this runner leaves the entries unmaterialized.
+            logger.warning_once(
+                "Request-endpoint state copies are not applied by this runner; "
+                "run with the v2 model runner to use the request-endpoint cache."
+            )
         if scheduler_output.kv_cache_block_copies:
             copy_kv_cache_blocks_inplace(
                 self.kv_caches,

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -114,6 +114,105 @@ def _memcpy_u64_tiled(
 
 
 @triton.jit
+def _copy_mamba_state_addrs(
+    state_idx,
+    conv_src_addr,
+    temporal_src_addr,
+    dst_addr,
+    token_bias,
+    state_elem_sizes_ptr,
+    state_inner_sizes_ptr,
+    state_conv_widths_ptr,
+    # DS conv row metadata. Zero keeps the single-region copy path.
+    state_dim_row_count_ptr,
+    state_dim_row_stride_ptr,
+    tile_idx,
+    COPY_BLOCK_SIZE: tl.constexpr,
+    CONV_STATE_DIM_FIRST: tl.constexpr,
+    TEMPORAL_TILES: tl.constexpr,
+):
+    """Copy one (layer, state-type) mamba state between resolved block
+    addresses (V1 ``get_conv_copy_spec`` / ``get_temporal_copy_spec``
+    semantics):
+    - conv state (conv_width > 0): shift the window by ``token_bias`` tokens,
+      ``conv_src[token_bias:] -> dst[:conv_width - token_bias]``
+    - temporal state: ``temporal_src -> dst`` (the caller resolves the
+      accepted speculative column into ``temporal_src_addr``)
+
+    ``tile_idx`` in ``[0, TEMPORAL_TILES)`` partitions the temporal state's
+    u64 range into ``TEMPORAL_TILES`` contiguous, COPY_BLOCK_SIZE-aligned
+    slices, giving more CTAs to fill the SMs at small batch (multi-MiB
+    temporal copies otherwise leave the GPU under-filled). Conv states are
+    small; only ``tile_idx == 0`` copies them. ``TEMPORAL_TILES == 1`` and
+    ``tile_idx == 0`` reproduces the untiled behavior.
+    """
+    state_elem_size = tl.load(state_elem_sizes_ptr + state_idx)
+    state_inner_size = tl.load(state_inner_sizes_ptr + state_idx)
+    conv_width = tl.load(state_conv_widths_ptr + state_idx)
+
+    is_conv_state = conv_width > 0
+
+    if CONV_STATE_DIM_FIRST and is_conv_state:
+        # Conv states are small; only tile 0 does the copy. Higher tiles
+        # early-return so they contribute nothing beyond a bounds check.
+        if tile_idx > 0:
+            return
+        # DS conv layout: state_len is the slide axis; copy per dim row.
+        dim_rows = tl.load(state_dim_row_count_ptr + state_idx)
+        row_stride = tl.load(state_dim_row_stride_ptr + state_idx)
+        per_row_bytes = (conv_width - token_bias).to(tl.int64) * state_elem_size
+        bias_bytes = token_bias.to(tl.int64) * state_elem_size
+        offsets = tl.arange(0, COPY_BLOCK_SIZE)
+        for d in range(0, dim_rows):
+            row_src = conv_src_addr + d * row_stride + bias_bytes
+            row_dst = dst_addr + d * row_stride
+            for i in range(0, per_row_bytes, COPY_BLOCK_SIZE):
+                mask = (i + offsets) < per_row_bytes
+                curr_src = (row_src + i + offsets).to(tl.pointer_type(tl.uint8))
+                curr_dst = (row_dst + i + offsets).to(tl.pointer_type(tl.uint8))
+                data = tl.load(curr_src, mask=mask)
+                tl.store(curr_dst, data, mask=mask)
+        return
+
+    if is_conv_state:
+        if tile_idx > 0:
+            return
+        # SD conv: copy conv_src[token_bias:] -> dst[:conv_width - token_bias].
+        # Small per-block bytes (~60-80 KiB) make tiling degenerate, so
+        # conv runs as a single-CTA memcpy (NUM_TILES=1).
+        src_offset = token_bias.to(tl.int64) * state_inner_size * state_elem_size
+        src_addr = conv_src_addr + src_offset
+        copy_size = (
+            (conv_width - token_bias).to(tl.int64) * state_inner_size * state_elem_size
+        )
+        _memcpy_u64_tiled(
+            src_addr,
+            dst_addr,
+            copy_size,
+            tile_idx,
+            COPY_BLOCK_SIZE=COPY_BLOCK_SIZE,
+            NUM_TILES=1,
+        )
+        return
+
+    # Temporal state: copy temporal_src -> dst. Body u64 range is partitioned
+    # across TEMPORAL_TILES CTAs to keep the SMs filled at small batch.
+    src_addr = temporal_src_addr
+    # Use natural block data size (inner_size * elem_size), NOT
+    # state_block_stride which is the page stride and can exceed the
+    # actual data when the state tensor uses as_strided page padding.
+    copy_size = state_inner_size * state_elem_size
+    _memcpy_u64_tiled(
+        src_addr,
+        dst_addr,
+        copy_size,
+        tile_idx,
+        COPY_BLOCK_SIZE=COPY_BLOCK_SIZE,
+        NUM_TILES=TEMPORAL_TILES,
+    )
+
+
+@triton.jit
 def _copy_mamba_state_block(
     state_idx,
     bt_row_idx,
@@ -148,20 +247,11 @@ def _copy_mamba_state_block(
       ``state[bt[src_col + token_bias]] -> state[bt[dst_col]]``
 
     The caller owns the decision logic (which columns, whether to copy); this
-    device function only performs the byte copy for the given metadata slot.
-
-    ``tile_idx`` in ``[0, TEMPORAL_TILES)`` partitions the temporal state's
-    u64 range into ``TEMPORAL_TILES`` contiguous, COPY_BLOCK_SIZE-aligned
-    slices, giving more CTAs to fill the SMs at small batch (multi-MiB
-    temporal copies otherwise leave the GPU under-filled). Conv states are
-    small; only ``tile_idx == 0`` copies them. ``TEMPORAL_TILES == 1`` and
-    ``tile_idx == 0`` reproduces the untiled behavior.
+    device function resolves the block-table columns to addresses and
+    delegates the byte copy to ``_copy_mamba_state_addrs``.
     """
     state_base_addr = tl.load(state_base_addrs_ptr + state_idx)
     state_block_stride = tl.load(state_block_strides_ptr + state_idx)
-    state_elem_size = tl.load(state_elem_sizes_ptr + state_idx)
-    state_inner_size = tl.load(state_inner_sizes_ptr + state_idx)
-    conv_width = tl.load(state_conv_widths_ptr + state_idx)
 
     # Load the group index for this state, then index into the correct
     # group's block table. Each mamba group has independently allocated
@@ -176,73 +266,336 @@ def _copy_mamba_state_block(
     # and Triton would otherwise do the multiply in int32 and wrap.
     dest_block_id = tl.load(block_table_base + dst_col).to(tl.int64)
     dst_addr = state_base_addr + dest_block_id * state_block_stride
+    # The conv window lives in the source column; the accepted temporal state
+    # in the column ``token_bias`` slots after it (same row, in range for
+    # every state of the request).
+    conv_src_block_id = tl.load(block_table_base + src_col).to(tl.int64)
+    temporal_src_block_id = tl.load(block_table_base + src_col + token_bias).to(
+        tl.int64
+    )
+    conv_src_addr = state_base_addr + conv_src_block_id * state_block_stride
+    temporal_src_addr = state_base_addr + temporal_src_block_id * state_block_stride
 
-    is_conv_state = conv_width > 0
+    _copy_mamba_state_addrs(
+        state_idx,
+        conv_src_addr,
+        temporal_src_addr,
+        dst_addr,
+        token_bias,
+        state_elem_sizes_ptr,
+        state_inner_sizes_ptr,
+        state_conv_widths_ptr,
+        state_dim_row_count_ptr,
+        state_dim_row_stride_ptr,
+        tile_idx,
+        COPY_BLOCK_SIZE,
+        CONV_STATE_DIM_FIRST,
+        TEMPORAL_TILES,
+    )
 
-    if CONV_STATE_DIM_FIRST and is_conv_state:
-        # Conv states are small; only tile 0 does the copy. Higher tiles
-        # early-return so they contribute nothing beyond a bounds check.
-        if tile_idx > 0:
-            return
-        # DS conv layout: state_len is the slide axis; copy per dim row.
-        src_block_id = tl.load(block_table_base + src_col).to(tl.int64)
-        dim_rows = tl.load(state_dim_row_count_ptr + state_idx)
-        row_stride = tl.load(state_dim_row_stride_ptr + state_idx)
-        per_row_bytes = (conv_width - token_bias).to(tl.int64) * state_elem_size
-        bias_bytes = token_bias.to(tl.int64) * state_elem_size
-        src_block_addr = state_base_addr + src_block_id * state_block_stride
-        offsets = tl.arange(0, COPY_BLOCK_SIZE)
-        for d in range(0, dim_rows):
-            row_src = src_block_addr + d * row_stride + bias_bytes
-            row_dst = dst_addr + d * row_stride
-            for i in range(0, per_row_bytes, COPY_BLOCK_SIZE):
-                mask = (i + offsets) < per_row_bytes
-                curr_src = (row_src + i + offsets).to(tl.pointer_type(tl.uint8))
-                curr_dst = (row_dst + i + offsets).to(tl.pointer_type(tl.uint8))
-                data = tl.load(curr_src, mask=mask)
-                tl.store(curr_dst, data, mask=mask)
+
+@triton.jit
+def _snapshot_mamba_state_to_shadow(
+    state_idx,
+    bt_row_idx,
+    src_col,
+    token_bias,
+    shadow_slot,
+    shadow_temporal_slots,
+    block_table_ptrs_ptr,
+    block_table_stride_req,
+    state_base_addrs_ptr,
+    state_block_strides_ptr,
+    shadow_base_addrs_ptr,
+    shadow_page_strides_ptr,
+    state_elem_sizes_ptr,
+    state_inner_sizes_ptr,
+    state_conv_widths_ptr,
+    state_group_indices_ptr,
+    state_dim_row_count_ptr,
+    state_dim_row_stride_ptr,
+    tile_idx,
+    COPY_BLOCK_SIZE: tl.constexpr,
+    CONV_STATE_DIM_FIRST: tl.constexpr,
+    TEMPORAL_TILES: tl.constexpr,
+):
+    """Copy a request's committed state into its shadow pages, compact pages
+    (one state's data bytes each) outside the block tables that only this
+    snapshot writes.
+
+    The conv window of ``src_col`` is copied unshifted (the materialization
+    applies the shift), and the temporal states of the columns ``src_col +
+    t`` for ``t`` in ``[0, token_bias]`` land in the request's temporal
+    shadow slots ``t``, so any acceptance count up to the committed one can
+    be materialized later (a stop inside the accepted tokens keeps fewer).
+    """
+    state_base_addr = tl.load(state_base_addrs_ptr + state_idx)
+    state_block_stride = tl.load(state_block_strides_ptr + state_idx)
+    conv_width = tl.load(state_conv_widths_ptr + state_idx)
+    group_idx = tl.load(state_group_indices_ptr + state_idx).to(tl.int64)
+    group_base_addr = tl.load(block_table_ptrs_ptr + group_idx)
+    block_table_typed = group_base_addr.to(tl.pointer_type(tl.int32))
+    block_table_base = block_table_typed + bt_row_idx * block_table_stride_req
+    shadow_base_addr = tl.load(shadow_base_addrs_ptr + state_idx)
+    shadow_page_stride = tl.load(shadow_page_strides_ptr + state_idx)
+
+    if conv_width > 0:
+        conv_src_block_id = tl.load(block_table_base + src_col).to(tl.int64)
+        conv_src_addr = state_base_addr + conv_src_block_id * state_block_stride
+        dst_addr = shadow_base_addr + shadow_slot.to(tl.int64) * shadow_page_stride
+        _copy_mamba_state_addrs(
+            state_idx,
+            conv_src_addr,
+            conv_src_addr,
+            dst_addr,
+            token_bias - token_bias,
+            state_elem_sizes_ptr,
+            state_inner_sizes_ptr,
+            state_conv_widths_ptr,
+            state_dim_row_count_ptr,
+            state_dim_row_stride_ptr,
+            tile_idx,
+            COPY_BLOCK_SIZE,
+            CONV_STATE_DIM_FIRST,
+            TEMPORAL_TILES,
+        )
         return
 
-    if is_conv_state:
-        if tile_idx > 0:
-            return
-        # SD conv: copy
-        #   state[bt[src_col], token_bias:] ->
-        #   state[bt[dst_col], :conv_width - token_bias]
-        # Small per-block bytes (~60-80 KiB) make tiling degenerate, so
-        # conv runs as a single-CTA memcpy (NUM_TILES=1).
-        src_block_id = tl.load(block_table_base + src_col).to(tl.int64)
-        src_offset = token_bias.to(tl.int64) * state_inner_size * state_elem_size
-        src_addr = state_base_addr + src_block_id * state_block_stride + src_offset
-        copy_size = (
-            (conv_width - token_bias).to(tl.int64) * state_inner_size * state_elem_size
-        )
+    state_elem_size = tl.load(state_elem_sizes_ptr + state_idx)
+    state_inner_size = tl.load(state_inner_sizes_ptr + state_idx)
+    copy_size = state_inner_size * state_elem_size
+    slot_base = shadow_slot.to(tl.int64) * shadow_temporal_slots.to(tl.int64)
+    for t in range(0, token_bias + 1):
+        src_block_id = tl.load(block_table_base + src_col + t).to(tl.int64)
+        src_addr = state_base_addr + src_block_id * state_block_stride
+        dst_addr = shadow_base_addr + (slot_base + t) * shadow_page_stride
         _memcpy_u64_tiled(
             src_addr,
             dst_addr,
             copy_size,
             tile_idx,
             COPY_BLOCK_SIZE=COPY_BLOCK_SIZE,
-            NUM_TILES=1,
+            NUM_TILES=TEMPORAL_TILES,
         )
+
+
+class EndpointCopyRecord(NamedTuple):
+    """One request-endpoint materialization (host form of a kernel record)."""
+
+    from_shadow: bool
+    req_idx: int
+    token_bias: int
+    dst_block_ids: tuple[int, ...]
+    conv_src_block_ids: tuple[int, ...]
+    temporal_src_block_ids: tuple[int, ...]
+
+
+def endpoint_layer_states(
+    kv_cache_config: KVCacheConfig,
+    forward_context: dict[str, Any],
+    mamba_group_ids: list[int],
+) -> list[tuple[torch.Tensor, ...]]:
+    """Every recurrent layer's state views in the context's state order
+    (groups in ``mamba_group_ids`` order, layers in group order)."""
+    return [
+        tuple(forward_context[layer_name].kv_cache)
+        for group_id in mamba_group_ids
+        for layer_name in kv_cache_config.kv_cache_groups[group_id].layer_names
+    ]
+
+
+def _conv_window_copy(
+    dst: torch.Tensor, src: torch.Tensor, token_bias: int, conv_dim_first: bool
+) -> None:
+    """``src[token_bias:] -> dst[:width - token_bias]`` along the conv slide
+    axis (V1 ``get_conv_copy_spec`` semantics for both conv layouts)."""
+    if conv_dim_first:
+        width = src.shape[1]
+        dst[:, : width - token_bias].copy_(src[:, token_bias:])
+    else:
+        width = src.shape[0]
+        dst[: width - token_bias].copy_(src[token_bias:])
+
+
+def materialize_endpoints_torch(
+    ctx: "MambaSpecDecodeGPUContext",
+    layer_states: list[tuple[torch.Tensor, ...]],
+    records: list[EndpointCopyRecord],
+    conv_dim_first: bool,
+) -> None:
+    """Torch reference of ``materialize_mamba_endpoint_kernel``: one tensor
+    copy per (record, layer, state type) with identical results."""
+    for record in records:
+        sources = ctx.endpoint_source_pages(record, layer_states)
+        for layer, states in enumerate(layer_states):
+            for type_idx, state in enumerate(states):
+                state_idx = layer * ctx.num_state_types + type_idx
+                src = sources[layer][type_idx]
+                group = ctx.state_group_indices_cpu[state_idx]
+                dst = state[record.dst_block_ids[group]]
+                if ctx.state_conv_widths_cpu[state_idx] > 0:
+                    _conv_window_copy(dst, src, record.token_bias, conv_dim_first)
+                else:
+                    dst.copy_(src)
+
+
+def verify_endpoints(
+    ctx: "MambaSpecDecodeGPUContext",
+    layer_states: list[tuple[torch.Tensor, ...]],
+    records: list[EndpointCopyRecord],
+    conv_dim_first: bool,
+) -> list[dict[str, Any]]:
+    """Compare every record's destination block with the copy-spec reference
+    (the conv window a reader consumes and the whole temporal page). Returns
+    one entry per mismatching (record, layer, state type)."""
+    mismatches: list[dict[str, Any]] = []
+    for record_idx, record in enumerate(records):
+        sources = ctx.endpoint_source_pages(record, layer_states)
+        for layer, states in enumerate(layer_states):
+            for type_idx, state in enumerate(states):
+                state_idx = layer * ctx.num_state_types + type_idx
+                src = sources[layer][type_idx]
+                group = ctx.state_group_indices_cpu[state_idx]
+                dst = state[record.dst_block_ids[group]]
+                if ctx.state_conv_widths_cpu[state_idx] > 0:
+                    bias = record.token_bias
+                    if conv_dim_first:
+                        expected = src[:, bias:]
+                        actual = dst[:, : src.shape[1] - bias]
+                    else:
+                        expected = src[bias:]
+                        actual = dst[: src.shape[0] - bias]
+                else:
+                    expected, actual = src, dst
+                if torch.equal(expected, actual):
+                    continue
+                mismatches.append(
+                    {
+                        "record": record_idx,
+                        "layer": layer,
+                        "state_idx": state_idx,
+                        "kind": "conv"
+                        if ctx.state_conv_widths_cpu[state_idx] > 0
+                        else "temporal",
+                        "expected_head": expected.flatten()[:3].float().tolist(),
+                        "actual_head": actual.flatten()[:3].float().tolist(),
+                        "expected_sum": float(expected.float().sum().item()),
+                        "actual_sum": float(actual.float().sum().item()),
+                    }
+                )
+    return mismatches
+
+
+# Per-copy int32 record of ``materialize_mamba_endpoint_kernel``:
+# [from_shadow, req_idx, token_bias, reserved, dst[num_groups],
+#  conv_src[num_groups], temporal_src[num_groups]]. Every recurrent group has
+# its own destination block because block ids alias the same physical pages
+# across groups. ``token_bias`` selects the conv shift and, for a shadow
+# source, the temporal shadow slot; the block-source columns are resolved by
+# the scheduler and carry the temporal slot already.
+ENDPOINT_COPY_META_FIXED = 4
+
+
+@triton.jit(do_not_specialize=["num_copies"])
+def materialize_mamba_endpoint_kernel(
+    copy_meta_ptr,  # int32 [num_copies, copy_meta_stride]
+    copy_meta_stride: tl.int64,
+    shadow_base_addrs_ptr,  # int64 [total_states]; 0 when no shadow exists
+    shadow_page_strides_ptr,  # int64 [total_states]; bytes per shadow page
+    shadow_temporal_slots,  # temporal shadow slots per request
+    state_base_addrs_ptr,
+    state_block_strides_ptr,
+    state_elem_sizes_ptr,
+    state_inner_sizes_ptr,
+    state_conv_widths_ptr,
+    state_group_indices_ptr,
+    state_dim_row_count_ptr,
+    state_dim_row_stride_ptr,
+    num_copies,
+    NUM_GROUPS: tl.constexpr,
+    COPY_BLOCK_SIZE: tl.constexpr,
+    CONV_STATE_DIM_FIRST: tl.constexpr,
+    TEMPORAL_TILES: tl.constexpr = 1,
+    # Optional address trace: int64 [num_copies, total_states, 4] receiving
+    # (conv source, temporal source, destination, from_shadow) per state.
+    trace_ptr=None,
+    trace_copy_stride=0,
+    HAS_TRACE: tl.constexpr = False,
+):
+    """Write finished requests' committed recurrent states into pool blocks.
+
+    Grid: (num_copies, num_layers * num_state_types [, TEMPORAL_TILES]). A
+    record reads either the request's shadow pages (``from_shadow``: the
+    unshifted conv window shifted here by ``token_bias`` and temporal shadow
+    slot ``token_bias``) or its own blocks per recurrent group (the conv
+    window of ``conv_src`` shifted by ``token_bias`` and the temporal slot
+    ``temporal_src``), and writes the destination block's page of every
+    recurrent cache group.
+    """
+    copy_idx = tl.program_id(0)
+    state_idx = tl.program_id(1)
+    tile_idx = tl.program_id(2)
+    if copy_idx >= num_copies:
         return
 
-    # Temporal state: copy state[bt[src_col + token_bias]] -> state[bt[dst_col]]
-    # Body u64 range is partitioned across TEMPORAL_TILES CTAs to keep the
-    # SMs filled at small batch.
-    actual_src_block_id = tl.load(block_table_base + src_col + token_bias).to(tl.int64)
-    src_addr = state_base_addr + actual_src_block_id * state_block_stride
-    # Use natural block data size (inner_size * elem_size), NOT
-    # state_block_stride which is the page stride and can exceed the
-    # actual data when the state tensor uses as_strided page padding.
-    copy_size = state_inner_size * state_elem_size
-    _memcpy_u64_tiled(
-        src_addr,
+    meta = copy_meta_ptr + copy_idx * copy_meta_stride
+    from_shadow = tl.load(meta + 0)
+    req_idx = tl.load(meta + 1).to(tl.int64)
+    token_bias = tl.load(meta + 2)
+    # Block ids alias the same physical pages across cache groups (one raw
+    # tensor per layer index is shared by every group), so each recurrent
+    # group has its own destination block.
+    group_idx = tl.load(state_group_indices_ptr + state_idx).to(tl.int64)
+    dst_block_id = tl.load(meta + 4 + group_idx).to(tl.int64)
+    if dst_block_id < 0:
+        return
+
+    state_base_addr = tl.load(state_base_addrs_ptr + state_idx)
+    state_block_stride = tl.load(state_block_strides_ptr + state_idx)
+    dst_addr = state_base_addr + dst_block_id * state_block_stride
+
+    conv_src_block_id = tl.load(meta + 4 + NUM_GROUPS + group_idx).to(tl.int64)
+    temporal_src_block_id = tl.load(meta + 4 + 2 * NUM_GROUPS + group_idx).to(tl.int64)
+    slot_conv_addr = state_base_addr + conv_src_block_id * state_block_stride
+    slot_temporal_addr = state_base_addr + temporal_src_block_id * state_block_stride
+
+    # Shadow layout: one unshifted conv page per request; temporal pages
+    # ``req_idx * shadow_temporal_slots + t`` for accepted-slot ``t``.
+    shadow_base_addr = tl.load(shadow_base_addrs_ptr + state_idx)
+    shadow_page_stride = tl.load(shadow_page_strides_ptr + state_idx)
+    shadow_conv_addr = shadow_base_addr + req_idx * shadow_page_stride
+    shadow_temporal_addr = (
+        shadow_base_addr
+        + (req_idx * shadow_temporal_slots.to(tl.int64) + token_bias.to(tl.int64))
+        * shadow_page_stride
+    )
+
+    use_shadow = from_shadow != 0
+    conv_src_addr = tl.where(use_shadow, shadow_conv_addr, slot_conv_addr)
+    temporal_src_addr = tl.where(use_shadow, shadow_temporal_addr, slot_temporal_addr)
+    if HAS_TRACE:  # noqa: SIM102 (constexpr guard kept separate for Triton)
+        if tile_idx == 0:
+            trace = trace_ptr + copy_idx * trace_copy_stride + state_idx * 4
+            tl.store(trace + 0, conv_src_addr.to(tl.int64))
+            tl.store(trace + 1, temporal_src_addr.to(tl.int64))
+            tl.store(trace + 2, dst_addr.to(tl.int64))
+            tl.store(trace + 3, from_shadow.to(tl.int64))
+
+    _copy_mamba_state_addrs(
+        state_idx,
+        conv_src_addr,
+        temporal_src_addr,
         dst_addr,
-        copy_size,
+        token_bias,
+        state_elem_sizes_ptr,
+        state_inner_sizes_ptr,
+        state_conv_widths_ptr,
+        state_dim_row_count_ptr,
+        state_dim_row_stride_ptr,
         tile_idx,
-        COPY_BLOCK_SIZE=COPY_BLOCK_SIZE,
-        NUM_TILES=TEMPORAL_TILES,
+        COPY_BLOCK_SIZE,
+        CONV_STATE_DIM_FIRST,
+        TEMPORAL_TILES,
     )
 
 
@@ -455,6 +808,14 @@ def precopy_mamba_align_fused_kernel(
     # TEMPORAL_TILES: see postprocess_mamba_fused_kernel. Default 1 preserves
     # the 2D-grid contract; > 1 requires a 3D grid.
     TEMPORAL_TILES: tl.constexpr = 1,
+    # Request-endpoint shadow: before the boundary decision, copy every
+    # request's committed state into its shadow slot (indexed by req_idx) so
+    # a request that finishes this step keeps a readable state even though
+    # this step overwrites its state slots.
+    shadow_base_addrs_ptr=None,
+    shadow_temporal_slots=1,
+    HAS_SHADOW: tl.constexpr = False,
+    shadow_page_strides_ptr=None,
 ):
     """Pre-copy mamba "align" state across block boundaries.
 
@@ -484,13 +845,43 @@ def precopy_mamba_align_fused_kernel(
 
     src_col = tl.load(src_col_ptr + req_idx)
     dst_col = tl.load(mamba_state_idx_ptr + req_idx)
-    # Fresh state, or still writing the same block: kernels locate the initial
-    # state in-block via num_accepted (preserved when no boundary is crossed),
-    # so there is nothing to copy.
-    if src_col < 0 or src_col == dst_col:
+    # Fresh state: nothing committed yet.
+    if src_col < 0:
         return
 
     token_bias = tl.load(token_bias_ptr + req_idx)
+    if HAS_SHADOW:
+        _snapshot_mamba_state_to_shadow(
+            state_idx,
+            batch_idx,
+            src_col,
+            token_bias,
+            req_idx,
+            shadow_temporal_slots,
+            block_table_ptrs_ptr,
+            block_table_stride_req,
+            state_base_addrs_ptr,
+            state_block_strides_ptr,
+            shadow_base_addrs_ptr,
+            shadow_page_strides_ptr,
+            state_elem_sizes_ptr,
+            state_inner_sizes_ptr,
+            state_conv_widths_ptr,
+            state_group_indices_ptr,
+            state_dim_row_count_ptr,
+            state_dim_row_stride_ptr,
+            tile_idx,
+            COPY_BLOCK_SIZE,
+            CONV_STATE_DIM_FIRST,
+            TEMPORAL_TILES,
+        )
+
+    # Still writing the same block: kernels locate the initial state in-block
+    # via num_accepted (preserved when no boundary is crossed), so there is
+    # nothing to migrate.
+    if src_col == dst_col:
+        return
+
     _copy_mamba_state_block(
         state_idx,
         batch_idx,
@@ -632,6 +1023,9 @@ class MambaSpecDecodeGPUContext:
     # table tensors (whose data_ptr is stable across steps).
     block_table_ptrs: torch.Tensor
     block_table_stride_req: int = 0
+    # Recurrent state slots a request can hold at once: the committed state
+    # plus one per speculative token.
+    num_state_slots: int = 1
 
     # Per-request staging buffers (CPU+GPU mirrors). The runner stages
     # values into the CPU view in ``_prepare_inputs`` and the fused kernel
@@ -643,6 +1037,30 @@ class MambaSpecDecodeGPUContext:
     num_draft_tokens_buf: CpuGpuBuffer | None = None
     precopy_src_col_buf: CpuGpuBuffer | None = None
     precopy_token_bias_buf: CpuGpuBuffer | None = None
+
+    # Request-endpoint shadow: one block-strided slot per request state index
+    # for every (layer, state type), written by the fused pre-copy launch and
+    # read by ``materialize_mamba_endpoint_kernel``. ``shadow_base_addrs`` is
+    # all zeros until ``ensure_endpoint_shadow`` allocates the slots.
+    shadow_base_addrs: torch.Tensor | None = None
+    # Bytes per shadow page per state: the state's data bytes per block
+    # rounded up to 64, smaller than the pool page stride (which pads every
+    # state to the page shared by all groups' layers).
+    shadow_page_strides: torch.Tensor | None = None
+    shadow_buffers: list[torch.Tensor] | None = None
+    shadow_num_slots: int = 0
+    # Temporal shadow pages per request: one per speculative state slot, so a
+    # stop inside the accepted tokens can still be materialized.
+    shadow_temporal_slots: int = 1
+    # Host copies of the per-state metadata (filled by
+    # ``initialize_from_forward_context``) for the torch reference path of
+    # the request-endpoint materialization and its verification.
+    state_block_strides_cpu: list[int] = dataclasses.field(default_factory=list)
+    state_conv_widths_cpu: list[int] = dataclasses.field(default_factory=list)
+    state_group_indices_cpu: list[int] = dataclasses.field(default_factory=list)
+    state_base_addrs_cpu: list[int] = dataclasses.field(default_factory=list)
+    shadow_base_addrs_cpu: list[int] = dataclasses.field(default_factory=list)
+    shadow_page_strides_cpu: list[int] = dataclasses.field(default_factory=list)
 
     # Flag to track if metadata has been populated
     is_initialized: bool = False
@@ -696,6 +1114,7 @@ class MambaSpecDecodeGPUContext:
             num_state_types=num_state_types,
             mamba_group_ids=mamba_group_ids,
             num_groups=len(mamba_group_ids),
+            num_state_slots=1 + mamba_spec.num_speculative_blocks,
             num_accepted_tokens_out=torch.zeros(
                 max_num_reqs, dtype=torch.int32, device=device
             ),
@@ -708,8 +1127,124 @@ class MambaSpecDecodeGPUContext:
             num_draft_tokens_buf=make_buffer(max_num_reqs, dtype=torch.int32),
             precopy_src_col_buf=make_buffer(max_num_reqs, dtype=torch.int32),
             precopy_token_bias_buf=make_buffer(max_num_reqs, dtype=torch.int32),
+            shadow_base_addrs=torch.zeros(
+                total_states, dtype=torch.int64, device=device
+            ),
+            shadow_page_strides=torch.zeros(
+                total_states, dtype=torch.int64, device=device
+            ),
             is_initialized=False,
         )
+
+    def state_page_bytes(self, state_idx: int) -> int:
+        """Data bytes of one block of state ``state_idx`` (conv window or
+        temporal state), without the pool page padding."""
+        elem = int(self.state_elem_sizes[state_idx].item())
+        inner = int(self.state_inner_sizes[state_idx].item())
+        conv_width = int(self.state_conv_widths[state_idx].item())
+        if conv_width > 0 and is_conv_state_dim_first():
+            rows = int(self.state_dim_row_count[state_idx].item())
+            return rows * conv_width * elem
+        if conv_width > 0:
+            return conv_width * inner * elem
+        return inner * elem
+
+    def ensure_endpoint_shadow(self, num_slots: int) -> None:
+        """Allocate the request-endpoint shadow slots (idempotent).
+
+        Each (layer, state type) gets ``num_slots`` compact pages (temporal
+        states: ``num_slots`` × temporal slots) of the state's data bytes
+        rounded up to 64, so the copy kernels address a shadow page like a
+        pool block with the state's own page stride. Must run after
+        ``initialize_from_forward_context``.
+        """
+        if self.shadow_buffers is not None:
+            return
+        assert self.is_initialized, "state metadata must be populated first"
+        assert self.shadow_base_addrs is not None
+        assert self.shadow_page_strides is not None
+        device = self.shadow_base_addrs.device
+        conv_widths = self.state_conv_widths.tolist()
+        temporal_slots = self.num_state_slots
+        buffers: list[torch.Tensor] = []
+        addrs: list[int] = []
+        strides: list[int] = []
+        total_bytes = 0
+        for state_idx, conv_width in enumerate(conv_widths):
+            pages = num_slots * (1 if conv_width > 0 else temporal_slots)
+            stride = (self.state_page_bytes(state_idx) + 63) // 64 * 64
+            nbytes = stride * pages
+            # Slots are zero-initialized so a never-written slot reads as an
+            # all-zero state rather than as stale device memory.
+            buf = torch.zeros(max(nbytes, 1), dtype=torch.uint8, device=device)
+            buffers.append(buf)
+            addrs.append(buf.data_ptr())
+            strides.append(stride)
+            total_bytes += nbytes
+        self.shadow_base_addrs.copy_(
+            torch.tensor(addrs, dtype=torch.int64, device=device)
+        )
+        self.shadow_page_strides.copy_(
+            torch.tensor(strides, dtype=torch.int64, device=device)
+        )
+        self.shadow_base_addrs_cpu = list(addrs)
+        self.shadow_page_strides_cpu = list(strides)
+        self.shadow_buffers = buffers
+        self.shadow_num_slots = num_slots
+        self.shadow_temporal_slots = temporal_slots
+        logger.info(
+            "Request-endpoint recurrent-state shadow: %d slot(s) x %d state(s), "
+            "%d temporal page(s) per slot, %.1f MiB",
+            num_slots,
+            len(strides),
+            temporal_slots,
+            total_bytes / (1 << 20),
+        )
+
+    @property
+    def has_endpoint_shadow(self) -> bool:
+        return self.shadow_buffers is not None
+
+    def shadow_page(
+        self, state_idx: int, page: int, like: torch.Tensor
+    ) -> torch.Tensor:
+        """Shadow page ``page`` of state ``state_idx`` viewed as one block of
+        ``like`` (the state tensor whose blocks the shadow mirrors)."""
+        assert self.shadow_buffers is not None
+        stride = self.shadow_page_strides_cpu[state_idx]
+        nbytes = like[0].numel() * like.element_size()
+        raw = self.shadow_buffers[state_idx][page * stride : page * stride + nbytes]
+        return raw.view(like.dtype).view(like.shape[1:])
+
+    def endpoint_source_pages(
+        self,
+        record: "EndpointCopyRecord",
+        layer_states: list[tuple[torch.Tensor, ...]],
+    ) -> list[list[torch.Tensor]]:
+        """Per layer and state type, the page a request-endpoint copy reads:
+        the request's shadow pages (conv unshifted, temporal slot
+        ``token_bias``) or its own state blocks per recurrent group."""
+        pages: list[list[torch.Tensor]] = []
+        for layer, states in enumerate(layer_states):
+            per_layer: list[torch.Tensor] = []
+            for type_idx, state in enumerate(states):
+                state_idx = layer * self.num_state_types + type_idx
+                is_conv = self.state_conv_widths_cpu[state_idx] > 0
+                if record.from_shadow:
+                    page = record.req_idx
+                    if not is_conv:
+                        page = page * self.shadow_temporal_slots + record.token_bias
+                    per_layer.append(self.shadow_page(state_idx, page, state))
+                else:
+                    group = self.state_group_indices_cpu[state_idx]
+                    block = (
+                        record.conv_src_block_ids[group]
+                        if is_conv
+                        else record.temporal_src_block_ids[group]
+                    )
+                    per_layer.append(state[block])
+            pages.append(per_layer)
+        return pages
 
     def initialize_from_forward_context(
         self,
@@ -854,6 +1389,14 @@ class MambaSpecDecodeGPUContext:
         for i, bt in enumerate(block_tables):
             self.block_table_ptrs[i] = bt.data_ptr()
 
+        self.state_block_strides_cpu = [
+            int(v) for v in self.state_block_strides.tolist()
+        ]
+        self.state_conv_widths_cpu = [int(v) for v in self.state_conv_widths.tolist()]
+        self.state_group_indices_cpu = [
+            int(v) for v in self.state_group_indices.tolist()
+        ]
+        self.state_base_addrs_cpu = [int(v) for v in self.state_base_addrs.tolist()]
         self.is_initialized = True
 
     def run_fused_postprocess(
@@ -922,6 +1465,7 @@ class MambaSpecDecodeGPUContext:
         src_col_gpu: torch.Tensor,
         token_bias_gpu: torch.Tensor,
         idx_mapping: torch.Tensor | None,
+        snapshot_to_shadow: bool = False,
     ) -> None:
         """Pre-copy each request's previous running block into its new window
         block before the forward pass (align boundary migration).
@@ -933,9 +1477,15 @@ class MambaSpecDecodeGPUContext:
             token_bias_gpu: [max_reqs] accepted-token bias (num_accepted - 1).
             idx_mapping: optional [num_reqs] batch_idx -> req_state_idx.
                 None means V1 batch order already equals request state order.
+            snapshot_to_shadow: also copy every request's committed state into
+                its request-endpoint shadow slot (requires
+                ``ensure_endpoint_shadow`` and an ``idx_mapping``).
         """
         if num_reqs == 0 or not self.is_initialized:
             return
+        has_shadow = snapshot_to_shadow and self.shadow_buffers is not None
+        if has_shadow:
+            assert idx_mapping is not None, "shadow slots are indexed by req idx"
         total_states = self.num_layers * self.num_state_types
         grid = (num_reqs, total_states, _TEMPORAL_TILES)
         precopy_mamba_align_fused_kernel[grid](
@@ -958,7 +1508,91 @@ class MambaSpecDecodeGPUContext:
             CONV_STATE_DIM_FIRST=is_conv_state_dim_first(),
             HAS_IDX_MAPPING=idx_mapping is not None,
             TEMPORAL_TILES=_TEMPORAL_TILES,
+            shadow_base_addrs_ptr=self.shadow_base_addrs,
+            shadow_temporal_slots=self.shadow_temporal_slots,
+            HAS_SHADOW=has_shadow,
+            shadow_page_strides_ptr=self.shadow_page_strides,
         )
+
+    def run_endpoint_materialize(
+        self, copy_meta: torch.Tensor, trace: torch.Tensor | None = None
+    ) -> None:
+        """Run ``materialize_mamba_endpoint_kernel`` over ``copy_meta``, an
+        int32 ``[num_copies, ENDPOINT_COPY_META_FIXED + 2 * num_groups]``
+        device tensor of per-copy records. ``trace``, when given, is an
+        int64 ``[num_copies, total_states, 4]`` device tensor that receives
+        the addresses the kernel resolved (conv source, temporal source,
+        destination) and the source kind per state."""
+        num_copies = int(copy_meta.shape[0])
+        if num_copies == 0 or not self.is_initialized:
+            return
+        assert copy_meta.dtype == torch.int32 and copy_meta.dim() == 2
+        assert copy_meta.shape[1] == ENDPOINT_COPY_META_FIXED + 3 * self.num_groups
+        assert copy_meta.is_contiguous()
+        assert self.shadow_base_addrs is not None
+        assert self.shadow_page_strides is not None
+        total_states = self.num_layers * self.num_state_types
+        if trace is not None:
+            assert trace.dtype == torch.int64 and trace.is_contiguous()
+            assert tuple(trace.shape) == (num_copies, total_states, 4)
+        grid = (num_copies, total_states, _TEMPORAL_TILES)
+        materialize_mamba_endpoint_kernel[grid](
+            copy_meta,
+            copy_meta.stride(0),
+            self.shadow_base_addrs,
+            self.shadow_page_strides,
+            self.shadow_temporal_slots,
+            self.state_base_addrs,
+            self.state_block_strides,
+            self.state_elem_sizes,
+            self.state_inner_sizes,
+            self.state_conv_widths,
+            self.state_group_indices,
+            self.state_dim_row_count,
+            self.state_dim_row_stride,
+            num_copies,
+            NUM_GROUPS=self.num_groups,
+            COPY_BLOCK_SIZE=1024,
+            CONV_STATE_DIM_FIRST=is_conv_state_dim_first(),
+            TEMPORAL_TILES=_TEMPORAL_TILES,
+            trace_ptr=trace,
+            trace_copy_stride=0 if trace is None else trace.stride(0),
+            HAS_TRACE=trace is not None,
+        )
+
+    def expected_endpoint_addresses(
+        self, records: list["EndpointCopyRecord"]
+    ) -> list[list[tuple[int, int, int, int]]]:
+        """Per record and state, the (conv source, temporal source,
+        destination, from_shadow) addresses ``materialize_mamba_endpoint_kernel``
+        must resolve, computed on the host from the captured metadata."""
+        total_states = self.num_layers * self.num_state_types
+        out: list[list[tuple[int, int, int, int]]] = []
+        for record in records:
+            per_state: list[tuple[int, int, int, int]] = []
+            for state_idx in range(total_states):
+                base = self.state_base_addrs_cpu[state_idx]
+                stride = self.state_block_strides_cpu[state_idx]
+                group = self.state_group_indices_cpu[state_idx]
+                dst = base + record.dst_block_ids[group] * stride
+                if record.from_shadow:
+                    shadow = self.shadow_base_addrs_cpu[state_idx]
+                    sstride = self.shadow_page_strides_cpu[state_idx]
+                    conv_src = shadow + record.req_idx * sstride
+                    temporal_src = (
+                        shadow
+                        + (
+                            record.req_idx * self.shadow_temporal_slots
+                            + record.token_bias
+                        )
+                        * sstride
+                    )
+                else:
+                    conv_src = base + record.conv_src_block_ids[group] * stride
+                    temporal_src = base + record.temporal_src_block_ids[group] * stride
+                per_state.append((conv_src, temporal_src, dst, int(record.from_shadow)))
+            out.append(per_state)
+        return out
 
     def run_fused_postprocess_align(
         self,


### PR DESCRIPTION
## What this changes

A hybrid engine that keeps its recurrent state on a checkpoint grid can only resume a follow-up prompt at the last hash boundary below the reused prefix, so every agentic turn recomputes the remainder of that unit plus the tokens the previous turn generated. Under `VLLM_K3_REQUEST_ENDPOINT_CACHE` a finished request publishes its **end position** as a prefix-cache entry — the attention page holding its last computed token, the pages of a speculative draft's sliding window, and one durable pool block per recurrent cache group carrying the state after that token. A later prompt whose tokens extend the producing sequence resumes there through the ordinary partial-hit copy-on-write path and computes only its new tokens.

Entry keys are the hash of the last whole unit below the end position; the lookup additionally verifies the remaining tail tokens and the request's extra keys, so a non-aligned end position is admitted only for a sequence that matches it exactly. Entries live in the block pool under an endpoint key in a separate group-id namespace, so eviction, reset and block reuse drop them together with the block they name, and `VLLM_K3_REQUEST_ENDPOINT_CACHE_MAX_ENTRIES` (default 4) bounds the pool capacity they hold back.

Two properties are worth calling out:

- **One destination block per recurrent group.** One raw KV tensor is shared by one layer of every cache group, so a block id names the same physical page in each group. A single shared destination makes the groups' layers overwrite one another; the test suite pins this with groups whose layers share raw tensors.
- **A shadow for asynchronous scheduling.** The step after a request finishes is already in flight and overwrites its state slots, so the fused align pre-copy launch first snapshots every request's committed state into compact per-request shadow pages (conv window unshifted, temporal state per accepted speculative column). The materialization kernel then writes the durable blocks from those pages, or from the request's own blocks when no step is in flight, with the V1 copy-spec semantics.

`materialize_endpoints_torch` performs the same copies through per-state torch operations (`VLLM_K3_REQUEST_ENDPOINT_CACHE_TORCH_COPY`, or the file it names) and `verify_endpoints` compares a destination against that reference. With `VLLM_K3_REQUEST_ENDPOINT_CACHE_DEBUG` the first tensor-parallel rank verifies every materialization and logs the addresses the kernel resolved against the host expectation.

## Blast radius

Off by default. The scheduler disables it unless the model has recurrent layers in align mode with at most two concurrent batches, and the file named by `VLLM_K3_REQUEST_ENDPOINT_CACHE_DISABLE_FILE` switches registration and lookup off without a restart. An entry restores the end position of every cache group, a speculative draft's window included, so a deployment that hides restored KV from its draft group must keep the flag off. Model state v1 logs once and ignores the copies.

## Validation

| Check | Result |
| --- | --- |
| `tests/v1/core/prefix_cache/` (15 new endpoint cases) | 49 passed |
| `tests/v1/core/test_kv_cache_utils.py`, `test_prefix_caching.py` | 20 failed, identical to the branch point (HF-config dependent) |
| Snapshot + materialization kernels through the Triton interpreter, 14 recurrent groups sharing one raw tensor | byte-identical for the kernel and the torch path; the resolved-address trace matches the host expectation; a shared destination corrupts 104 of 112 states |
| `tests/kernels/mamba/test_request_endpoint_shadow.py` | copy-spec equivalence, torch path, address trace, shared-raw-tensor groups, and a page geometry with conv and temporal views sharing 1,007,616-byte pages |

On a Kimi-K3 TP9/DCP9 deployment (93 layers, 69 recurrent, 4,608-token recurrent grid, 1,536-token hash unit, draft depth 3, two concurrent batches):

| Warm turn | Recomputed tokens | Time to first token |
| --- | --- | --- |
| Resumed at the end position | 18 | 0.37–0.62 s |
| Resumed at the last hash boundary | 118–606 | 0.35–0.58 s |
| Cold | full prompt | 1.9–4.9 s |

A document-recall oracle over 10 arms (stop-string and max_tokens producers, kernel and torch paths, aligned-path controls) reproduces the cold replay's greedy tokens with a largest per-token logprob difference of 1.1e-2, and every materialization on the serving engine verified byte-identical to its source. The end-position state is the one decode produced, so a cold prefill of the same tokens differs at that ~1e-2 level; resuming from a decode-reached boundary on the existing aligned path shows the same difference.

Costs on that deployment: the shadow reserves 842.6 MiB per GPU while the flag is on, and each entry pins one pool block per recurrent group (14 of 860 blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHgPwYj1bBoXUtb7HedKti


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional request-endpoint caching for Mamba speculative decoding.
  * Completed requests can preserve recurrent state, allowing later matching requests to resume from the cached endpoint.
  * Added configuration options for enabling the cache, limiting entries, debugging, and selecting state-copy methods.
  * Added support for endpoint caching across hybrid attention, recurrent, and sliding-window cache layouts.

* **Tests**
  * Added comprehensive coverage for endpoint caching, state materialization, cache reuse, limits, resets, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->