### PR TITLE
perf(deepseek-v41): integrate B12X prefill kernels and stabilize adaptive serving

### DIFF
--- a/tests/v1/attention/test_b12x_v41_workspace.py
+++ b/tests/v1/attention/test_b12x_v41_workspace.py
@@ -39,7 +39,9 @@ def _layer(attention, layer_id=0):
     layer.config = SimpleNamespace(
         cache_config=SimpleNamespace(block_size=64),
         scheduler_config=SimpleNamespace(max_num_seqs=4),
-        speculative_config=SimpleNamespace(num_speculative_tokens=5),
+        speculative_config=SimpleNamespace(
+            num_speculative_tokens=5, parallel_drafting=False
+        ),
         compilation_config=SimpleNamespace(max_cudagraph_capture_size=128),
     )
     layer.capacity = 4096
@@ -84,7 +86,8 @@ def test_prepare_memory_is_metadata_not_capacity_activations(native_workspace):
 
 
 @pytest.mark.parametrize(
-    "is_decode,rows,live_rows", [(True, 6, 6), (True, 48, 6), (False, 65, 65)]
+    "is_decode,rows,live_rows",
+    [(True, 6, 6), (True, 36, 36), (True, 48, 6), (False, 65, 65)],
 )
 def test_attention_shared_scratch_graph_replay(
     native_workspace, monkeypatch, is_decode, rows, live_rows
@@ -93,7 +96,12 @@ def test_attention_shared_scratch_graph_replay(
     device = torch.device("cuda", torch.cuda.current_device())
     torch.manual_seed(142)
     layer = _layer(attention)
+    if rows == 36:
+        layer.config.speculative_config.parallel_drafting = True
+        layer.config.compilation_config.max_cudagraph_capture_size = 32
     layer._prepare(device)
+    if rows == 36:
+        assert layer._plans["decode"].caps.max_q_rows == 4 * (1 + 2 * 5)
     length = 1024
     positions = torch.full((rows,), -1, dtype=torch.int64, device=device)
     positions[:live_rows] = torch.arange(

--- a/tests/v1/attention/test_b12x_v41_workspace.py
+++ b/tests/v1/attention/test_b12x_v41_workspace.py
@@ -7,6 +7,8 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from vllm.config import CUDAGraphMode
+
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="Native b12x attention requires CUDA"
 )
@@ -14,19 +16,62 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture
 def native_workspace(monkeypatch):
-    if torch.cuda.get_device_capability()[0] != 12:
+    from vllm.platforms import current_platform
+
+    capability = current_platform.get_device_capability()
+    if capability is None or capability.major != 12:
         pytest.skip("Native b12x attention requires SM12x")
     import vllm.v1.worker.workspace as workspace
     from vllm.models.deepseek_v4_1 import attention
 
     manager = workspace.WorkspaceManager(
-        torch.device("cuda", torch.cuda.current_device())
+        torch.device("cuda", torch.accelerator.current_device_index())
     )
     monkeypatch.setattr(workspace, "_manager", manager)
     monkeypatch.setattr(workspace, "dbo_current_ubatch_id", lambda: 0)
     monkeypatch.setattr(attention, "get_tensor_model_parallel_world_size", lambda: 1)
     with workspace.use_workspace_lane(0):
         yield attention, manager, workspace
+
+
+def test_indexer_loads_complete_projections_on_tp_rank(native_workspace, monkeypatch):
+    from vllm.distributed import parallel_state
+
+    attention, _, _ = native_workspace
+    monkeypatch.setattr(
+        parallel_state,
+        "get_tp_group",
+        lambda: SimpleNamespace(rank_in_group=3, world_size=4),
+    )
+    monkeypatch.setattr(attention, "get_tensor_model_parallel_world_size", lambda: 4)
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(
+                index_n_heads=32,
+                q_lora_rank=128,
+                hidden_size=256,
+            )
+        ),
+        quant_config=None,
+    )
+    indexer = attention.DeepseekV4Indexer(
+        config,
+        "model.layers.2.self_attn.indexer",
+        owns_k=False,
+        k_cache=None,
+        ratio=1,
+    )
+    assert indexer.heads == 32
+    for projection, shape in (
+        (indexer.wq_b, (4096, 128)),
+        (indexer.weights_proj, (32, 256)),
+    ):
+        assert isinstance(projection, attention.ReplicatedLinear)
+        assert projection.weight.shape == shape
+        source = torch.arange(projection.weight.numel(), dtype=torch.float32)
+        source = source.reshape(shape).to(projection.weight)
+        projection.weight.weight_loader(projection.weight, source)
+        torch.testing.assert_close(projection.weight, source, rtol=0, atol=0)
 
 
 def _layer(attention, layer_id=0):
@@ -56,7 +101,7 @@ def _layer(attention, layer_id=0):
     layer.candidate_source_layer = 99
     layer.topk_indices_buffer = None
     layer.indexer = SimpleNamespace(
-        heads=8, k_cache=SimpleNamespace(prefix=layer.prefix + ".indexer.k_cache")
+        heads=32, k_cache=SimpleNamespace(prefix=layer.prefix + ".indexer.k_cache")
     )
     layer.swa_cache_layer = SimpleNamespace(prefix=layer.prefix + ".swa_cache")
     layer.compressor = None
@@ -67,42 +112,106 @@ def _layer(attention, layer_id=0):
 
 def test_prepare_memory_is_metadata_not_capacity_activations(native_workspace):
     attention, manager, _ = native_workspace
-    device = torch.device("cuda", torch.cuda.current_device())
+    device = torch.device("cuda", torch.accelerator.current_device_index())
     first = _layer(attention)
     first._prepare(device)
     manager.lock()
-    before = torch.cuda.memory_allocated()
+    before = torch.accelerator.memory_allocated(device)
     second = _layer(attention, 1)
     second._prepare(device)
-    allocated = torch.cuda.memory_allocated() - before
+    allocated = torch.accelerator.memory_allocated(device) - before
     c = second.INDEX_CHUNK
-    metadata_bytes = 4 * (
-        c * (second.swa_width + second._main_width + second._index_width) + 3 * c + 1
-    )
+    metadata_bytes = 4 * (c * second._index_width + 1)
     persistent_topk_bytes = 4 * second.capacity * 512
     # A second layer must not own Q/O/inverse, indexer activations, or another
     # copy of either mode's planned scratch. Allow CUDA allocator rounding.
     assert allocated <= metadata_bytes + persistent_topk_bytes + 1024**2
 
 
+def test_mhc_fixed_capacity_buckets_preserve_decode_policy(
+    native_workspace, monkeypatch
+):
+    from vllm.models.deepseek_v4_1 import b12x_layers
+
+    _, _, workspace = native_workspace
+    observed = []
+    original = b12x_layers._mhc_plan
+
+    def record(device, capacity, hidden):
+        plan = original(device, capacity, hidden)
+        observed.append((capacity, plan.config.backend))
+        return plan
+
+    monkeypatch.setattr(b12x_layers, "_mhc_plan", record)
+    device = torch.device("cuda", torch.accelerator.current_device_index())
+    hidden = 5120
+    fn = torch.randn((24, hidden * 4), device=device) / 64
+    scale = torch.ones(3, device=device)
+    bias = torch.zeros(24, device=device)
+    norm = torch.ones(hidden, device=device, dtype=torch.bfloat16)
+    for rows, capacity, backend in (
+        (6, 64, "native"),
+        (64, 64, "native"),
+        (65, 4096, "tf32_tma"),
+    ):
+        residual = torch.randn((rows, 4, hidden), device=device, dtype=torch.bfloat16)
+        pre = torch.full((rows, 4), 0.25, device=device)
+        out = torch.empty_like(residual)
+        y = torch.empty((rows, hidden), device=device, dtype=torch.bfloat16)
+        post = torch.empty_like(pre)
+        comb = torch.empty((rows, 4, 4), device=device)
+        predicted = torch.empty_like(pre)
+        with workspace.use_workspace_lane(0):
+            b12x_layers._mhc_pre(
+                residual,
+                fn,
+                scale,
+                bias,
+                norm,
+                pre,
+                out,
+                y,
+                post,
+                comb,
+                predicted,
+                1e-20,
+                1e-6,
+                20,
+                4096,
+            )
+        assert observed[-1] == (capacity, backend)
+        assert torch.equal(out, residual)
+        assert bool(torch.isfinite(y).all())
+
+
 @pytest.mark.parametrize(
     "is_decode,rows,live_rows",
-    [(True, 6, 6), (True, 36, 36), (True, 48, 6), (False, 65, 65)],
+    [
+        (True, 6, 6),
+        (True, 36, 36),
+        (True, 48, 6),
+        (False, 65, 65),
+        (False, 257, 257),
+        (False, 1025, 1025),
+    ],
 )
 def test_attention_shared_scratch_graph_replay(
     native_workspace, monkeypatch, is_decode, rows, live_rows
 ):
     attention, manager, workspace = native_workspace
-    device = torch.device("cuda", torch.cuda.current_device())
+    # A TP4 rank must score all replicated heads without obtaining a TP group.
+    monkeypatch.setattr(attention, "get_tensor_model_parallel_world_size", lambda: 4)
+    device = torch.device("cuda", torch.accelerator.current_device_index())
     torch.manual_seed(142)
     layer = _layer(attention)
+    layer.max_model_len = 4096
     if rows == 36:
         layer.config.speculative_config.parallel_drafting = True
         layer.config.compilation_config.max_cudagraph_capture_size = 32
     layer._prepare(device)
     if rows == 36:
         assert layer._plans["decode"].caps.max_q_rows == 4 * (1 + 2 * 5)
-    length = 1024
+    length = 2048
     positions = torch.full((rows,), -1, dtype=torch.int64, device=device)
     positions[:live_rows] = torch.arange(
         length - live_rows, length, dtype=torch.int64, device=device
@@ -132,11 +241,12 @@ def test_attention_shared_scratch_graph_replay(
         )
 
     context = SimpleNamespace(
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
         attn_metadata={
             layer.swa_cache_layer.prefix: metadata(32),
             layer.prefix: metadata(64),
             layer.indexer.k_cache.prefix: metadata(64),
-        }
+        },
     )
     monkeypatch.setattr(attention, "get_forward_context", lambda: context)
     kv = torch.randn((length, 512), device=device, dtype=torch.bfloat16)
@@ -184,11 +294,11 @@ def test_attention_shared_scratch_graph_replay(
     q = torch.randn(
         (rows, layer.n_local_heads, 512), dtype=torch.bfloat16, device=device
     )
-    iq = torch.zeros((rows, 8, 128), dtype=torch.bfloat16, device=device)
+    iq = torch.zeros((rows, 32, 128), dtype=torch.bfloat16, device=device)
     iq[..., 0], iq[..., 1] = 1, -0.25
-    weights = (torch.rand((rows, 8), dtype=torch.bfloat16, device=device) + 1) / 64
-    packed = torch.empty((rows, 8, 64), dtype=torch.uint8, device=device)
-    scales = torch.empty((rows, 8, 4), dtype=torch.uint8, device=device)
+    weights = (torch.rand((rows, 32), dtype=torch.bfloat16, device=device) + 1) / 64
+    packed = torch.empty((rows, 32, 64), dtype=torch.uint8, device=device)
+    scales = torch.empty((rows, 32, 4), dtype=torch.uint8, device=device)
     out = torch.empty_like(q)
 
     def run():
@@ -198,6 +308,13 @@ def test_attention_shared_scratch_graph_replay(
         )
 
     run()
+    batched_output = out.clone()
+    # Token-independent attention must not change when its batching is
+    # decoupled from index selection. Reuse the same plan and live operands.
+    layer.MLA_CHUNK = layer.DECODE_CHUNK
+    run()
+    torch.testing.assert_close(out, batched_output, rtol=0, atol=0)
+    del layer.MLA_CHUNK
     manager.lock()
     stream = torch.cuda.Stream()
     stream.wait_stream(torch.cuda.current_stream())
@@ -205,9 +322,11 @@ def test_attention_shared_scratch_graph_replay(
         run()
     torch.cuda.current_stream().wait_stream(stream)
     graph = torch.cuda.CUDAGraph()
-    with workspace.collect_cuda_graph_capture_resources() as resources:
-        with torch.cuda.graph(graph, stream=stream):
-            run()
+    with (
+        workspace.collect_cuda_graph_capture_resources() as resources,
+        torch.cuda.graph(graph, stream=stream),
+    ):
+        run()
     # Changed queries exercise both selection and attention on replay, after
     # all plan storage has been reused by another operation.
     for step, seed in enumerate((143, 144)):
@@ -240,7 +359,7 @@ def test_attention_shared_scratch_graph_replay(
 
 def test_grouped_projection_live_storage_survives_workspace_reuse(native_workspace):
     attention, manager, workspace = native_workspace
-    device = torch.device("cuda", torch.cuda.current_device())
+    device = torch.device("cuda", torch.accelerator.current_device_index())
     torch.manual_seed(145)
     rows, groups, width, rank = 3, 2, 512, 64
     layer = SimpleNamespace(
@@ -275,9 +394,11 @@ def test_grouped_projection_live_storage_survives_workspace_reuse(native_workspa
         run()
     torch.cuda.current_stream().wait_stream(stream)
     graph = torch.cuda.CUDAGraph()
-    with workspace.collect_cuda_graph_capture_resources() as resources:
-        with torch.cuda.graph(graph, stream=stream):
-            run()
+    with (
+        workspace.collect_cuda_graph_capture_resources() as resources,
+        torch.cuda.graph(graph, stream=stream),
+    ):
+        run()
     for seed in (146, 147):
         torch.manual_seed(seed)
         source.normal_()
@@ -296,11 +417,89 @@ def test_grouped_projection_live_storage_survives_workspace_reuse(native_workspa
     del graph, resources
 
 
+@pytest.mark.parametrize("width,k", [(128, 512), (1024, 4096)])
+def test_grouped_fp8_weight_only_prefill_preserves_bf16_contract(
+    native_workspace, monkeypatch, width, k
+):
+    from b12x import freeze_kernel_resolution, unfreeze_kernel_resolution
+    from b12x.gemm import bf16_gemv
+
+    attention, manager, workspace = native_workspace
+    monkeypatch.setattr(
+        attention,
+        "get_current_vllm_config",
+        lambda: SimpleNamespace(
+            scheduler_config=SimpleNamespace(max_num_batched_tokens=4096)
+        ),
+    )
+    torch.manual_seed(41003)
+    groups = 2
+    layer = torch.nn.Module()
+    value = torch.randn((groups * width, k), device="cuda").to(torch.float8_e4m3fn)
+    exponent = torch.randint(121, 128, (groups * width // 32, k // 32), device="cuda")
+    scale = exponent.byte().view(torch.float8_e8m0fnu)
+    layer.weight = torch.nn.Parameter(value, requires_grad=False)
+    layer.weight_scale_inv = torch.nn.Parameter(scale, requires_grad=False)
+    method = attention._GroupedLinearMethod(
+        attention.B12xFP8LinearMethod(SimpleNamespace(weight_block_size=[32, 32])),
+        groups,
+    )
+    method.process_weights_after_loading(layer)
+    dense = (
+        value.float()
+        * torch.exp2(exponent.float() - 127)
+        .repeat_interleave(32, 0)
+        .repeat_interleave(32, 1)
+    ).bfloat16()
+    torch.testing.assert_close(layer.weight, dense, rtol=0, atol=0)
+    source = torch.randn((1025, groups, k), device="cuda").bfloat16()
+    method.apply(layer, source, is_prefill=True)
+    manager.lock()
+    freeze_kernel_resolution("V4.1 weight-only prefill with BF16 activations")
+    try:
+        for rows in (1, 6, 64, 257, 1025):
+            x = source[:rows]
+            expected = torch.cat(
+                [
+                    x[:, g].float() @ dense[g * width : (g + 1) * width].float().T
+                    for g in range(groups)
+                ],
+                dim=1,
+            )
+            gemv = torch.cat(
+                [
+                    bf16_gemv.mm(x[:, g], dense[g * width : (g + 1) * width])
+                    for g in range(groups)
+                ],
+                dim=1,
+            )
+            actual = method.apply(layer, x, is_prefill=True)
+            actual_rmse = (actual.float() - expected).square().mean().sqrt()
+            gemv_rmse = (gemv.float() - expected).square().mean().sqrt()
+            assert actual_rmse <= gemv_rmse * 1.01 + 1e-7
+            torch.testing.assert_close(actual.float(), expected, rtol=0.01, atol=0.1)
+            torch.testing.assert_close(method.apply(layer, x), gemv, rtol=0, atol=0)
+            graph = torch.cuda.CUDAGraph()
+            with (
+                workspace.collect_cuda_graph_capture_resources() as resources,
+                torch.cuda.graph(graph),
+            ):
+                result = method.apply(layer, x, is_prefill=True)
+            source.normal_()
+            expected = method.apply(layer, x, is_prefill=True)
+            result.fill_(float("nan"))
+            graph.replay()
+            torch.testing.assert_close(result, expected, rtol=0, atol=0)
+            del graph, resources
+    finally:
+        unfreeze_kernel_resolution()
+
+
 @pytest.mark.parametrize("ratio", [1, 2])
 def test_index_visibility_crosses_old_capacity_cutoff(native_workspace, ratio):
     """Source and reindex must retain winners beyond the former 64-state cap."""
     attention, _, _ = native_workspace
-    device = torch.device("cuda", torch.cuda.current_device())
+    device = torch.device("cuda", torch.accelerator.current_device_index())
     layers = [_layer(attention, index) for index in (2, 20, 24)]
     for layer in layers:
         layer.config.cache_config.block_size = 256
@@ -334,13 +533,14 @@ def test_index_visibility_crosses_old_capacity_cutoff(native_workspace, ratio):
     attention.dsa_indexer.quantize_write_index_k_mxfp4(
         keys, index_k_cache=pool, slot_mapping=slots, page_size=page
     )
-    q = torch.zeros((1, 8, 128), dtype=torch.bfloat16, device=device)
+    heads = layers[0].indexer.heads
+    q = torch.zeros((1, heads, 128), dtype=torch.bfloat16, device=device)
     q[..., 0] = 1
-    packed = torch.empty((1, 8, 64), dtype=torch.uint8, device=device)
-    scales = torch.empty((1, 8, 4), dtype=torch.uint8, device=device)
+    packed = torch.empty((1, heads, 64), dtype=torch.uint8, device=device)
+    scales = torch.empty((1, heads, 4), dtype=torch.uint8, device=device)
     attention.dsa_indexer.quantize_q_mxfp4(q, q_mxfp4=packed, q_scales=scales)
     lengths = torch.tensor([old_cutoff + 256], dtype=torch.int32, device=device)
-    weights = torch.ones((1, 8), dtype=torch.bfloat16, device=device) / 32
+    weights = torch.ones((1, heads), dtype=torch.bfloat16, device=device) / 32
     for mode in ("decode", "prefill"):
         for layer in layers:
             candidate_args = {}
@@ -581,11 +781,12 @@ def test_ced_compact_attention_bounded_oracle_and_frozen_replay(
         page_size=64,
     )
     q = torch.randn((rows, 16, 512), device=device, dtype=torch.bfloat16)
-    iq = torch.zeros((rows, 8, 128), device=device, dtype=torch.bfloat16)
+    heads = layer.indexer.heads
+    iq = torch.zeros((rows, heads, 128), device=device, dtype=torch.bfloat16)
     iq[..., 0] = 1
-    packed = torch.empty((rows, 8, 64), device=device, dtype=torch.uint8)
-    scales = torch.empty((rows, 8, 4), device=device, dtype=torch.uint8)
-    weights = torch.full((rows, 8), 1 / 64, device=device, dtype=torch.bfloat16)
+    packed = torch.empty((rows, heads, 64), device=device, dtype=torch.uint8)
+    scales = torch.empty((rows, heads, 4), device=device, dtype=torch.uint8)
+    weights = torch.full((rows, heads), 1 / 64, device=device, dtype=torch.bfloat16)
     layer.attn_sink = torch.zeros(16, device=device)
     out = torch.empty_like(q)
 
@@ -622,9 +823,11 @@ def test_ced_compact_attention_bounded_oracle_and_frozen_replay(
     graph = torch.cuda.CUDAGraph()
     freeze_kernel_resolution("CED attention must replay using capacity-planned kernels")
     try:
-        with workspace.collect_cuda_graph_capture_resources() as resources:
-            with torch.cuda.graph(graph, stream=stream):
-                run()
+        with (
+            workspace.collect_cuda_graph_capture_resources() as resources,
+            torch.cuda.graph(graph, stream=stream),
+        ):
+            run()
         for live in (128, 65, 17):
             positions.fill_(-1)
             positions[:live] = torch.arange(boundary, boundary + live, device=device)

--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -9,8 +9,10 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.sample.ops.topk_topp_sampler import (
+    apply_top_k_top_p,
     apply_top_k_top_p_pytorch,
     random_sample,
+    warmup_top_k_top_p,
 )
 from vllm.v1.sample.sampler import Sampler
 
@@ -18,6 +20,35 @@ DEVICE_TYPE = current_platform.device_type
 
 BATCH_SIZE = 1024
 VOCAB_SIZE = 128 * 1024
+
+
+@pytest.mark.skipif(
+    not HAS_TRITON or not current_platform.is_cuda(),
+    reason="requires GPU Triton compilation",
+)
+@pytest.mark.parametrize("vocab_size", [257, 129280])
+def test_filter_warmup_covers_speculative_rows_and_constraint_subsets(
+    monkeypatch: pytest.MonkeyPatch, vocab_size: int
+):
+    """Four K5 requests must not compile top-p-only filtering after warmup."""
+    from triton import knobs
+
+    device = torch.device(DEVICE_TYPE)
+    warmup_top_k_top_p(vocab_size, 24, device)
+    torch.accelerator.synchronize()
+
+    def unexpected_compile(**kwargs):
+        pytest.fail("Filtering compiled a kernel after bounded sampler warmup")
+
+    monkeypatch.setattr(knobs.runtime, "jit_post_compile_hook", unexpected_compile)
+    for num_rows in (8, 9, 15, 16, 17, 24):
+        logits = torch.zeros(num_rows, vocab_size, device=device)
+        top_k = torch.full((num_rows,), 20, dtype=torch.int32, device=device)
+        top_p = torch.full((num_rows,), 0.95, device=device)
+        for k, p in ((top_k, None), (None, top_p), (top_k, top_p)):
+            filtered = apply_top_k_top_p(logits.clone(), k, p)
+            assert torch.isfinite(filtered).any(dim=-1).all()
+    torch.accelerator.synchronize()
 
 
 def _flashinfer_topk_topp_supported() -> bool:

--- a/tests/v1/spec_decode/test_adaptive_verification.py
+++ b/tests/v1/spec_decode/test_adaptive_verification.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import numpy as np
 import pytest
+import torch
 
 from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.worker.gpu.async_utils import StepTimingSample
@@ -34,6 +36,61 @@ def make_manager(
     manager._max_total_logits = 1 << 30
     manager.num_bonus_tokens = 1
     return manager
+
+
+@pytest.mark.parametrize("world_size,expected_budget", [(1, 0), (2, 1)])
+def test_confidence_snapshot_agrees_before_cpu_and_gpu_budgeting(
+    monkeypatch, world_size, expected_budget
+):
+    # One FP32 ULP across a utility threshold changes the graph's token count.
+    local = torch.tensor([[np.nextafter(np.float32(0.5), np.float32(0.0))]])
+    leader = torch.tensor([[np.nextafter(np.float32(0.5), np.float32(1.0))]])
+    manager = make_manager(local.numpy().copy(), np.array([1.0, 1.0, 1.5]))
+    manager.req_states.device = torch.device("cpu")
+    manager._confidence_probs = torch.empty_like(local)
+    manager._pending_resets = []
+
+    class CopyBuffer:
+        def __init__(self):
+            self.np = np.ones((1, 1), dtype=np.float32)
+            self.gpu = torch.empty_like(local)
+
+        def copy_to_cpu(self):
+            self.np[:] = self.gpu.numpy()
+
+    manager._stale_confidences = [CopyBuffer(), CopyBuffer()]
+    manager._copy_events = [
+        SimpleNamespace(synchronize=lambda: None, record=lambda: None) for _ in range(2)
+    ]
+    manager._copy_stream = SimpleNamespace(wait_stream=lambda _stream: None)
+    calls = []
+
+    def broadcast(tensor, src):
+        assert src == 0
+        calls.append(tensor)
+        tensor.copy_(leader)
+
+    monkeypatch.setattr(
+        adaptive_module,
+        "get_tp_group",
+        lambda: SimpleNamespace(world_size=world_size, broadcast=broadcast),
+    )
+    monkeypatch.setattr(adaptive_module, "gpu_sync_allowed", nullcontext)
+    monkeypatch.setattr(adaptive_module.torch.cuda, "current_stream", lambda _: None)
+    monkeypatch.setattr(adaptive_module, "stream", lambda *_: nullcontext())
+    batch = SimpleNamespace(num_reqs=1, idx_mapping=torch.tensor([0]))
+
+    # Two records expose the completed previous-step snapshot to CPU selection.
+    for _ in range(2):
+        manager.record_confidences(local, batch)
+    expected = leader if world_size > 1 else local
+    torch.testing.assert_close(manager._confidence_probs, expected, rtol=0, atol=0)
+    np.testing.assert_array_equal(
+        manager._stale_confidences[manager._stale_idx].np, expected.numpy()
+    )
+    assert manager.get_num_tokens({"low": 2}, {"low": [7]}) == 1 + expected_budget
+    assert len(calls) == (2 if world_size > 1 else 0)
+    assert local.item() < 0.5  # The caller's proposal confidence is not mutated.
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/worker/test_gpu_warmup_blocks.py
+++ b/tests/v1/worker/test_gpu_warmup_blocks.py
@@ -80,6 +80,7 @@ def _make_runner(
         is_pooling_model=False,
         is_encoder_decoder=False,
         is_last_pp_rank=True,
+        device=torch.device(current_platform.device_type),
         max_num_reqs=4,
         max_model_len=MAX_MODEL_LEN,
         model_config=SimpleNamespace(get_vocab_size=lambda: 64),
@@ -180,7 +181,7 @@ def test_warmup_covers_both_sampling_paths_without_repeating_model_warmup(
     runner.max_num_reqs = num_reqs
     runner.is_last_pp_rank = is_last_pp_rank
     recorder = _StepRecorder()
-    live_params = {}
+    live_params: dict[str, SamplingParams | None] = {}
     sampled_paths = set()
     pending = None
     prefill_tokens = 0

--- a/vllm/models/deepseek_v4_1/attention.py
+++ b/vllm/models/deepseek_v4_1/attention.py
@@ -2,8 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """V4.1 Full/Reindex/Reuse topology with native b12x compute only."""
 
-import re
+from typing import cast
 
+import regex as re
 import torch
 from b12x.attention import compressed_sparse_mla as mla
 from b12x.attention import dsa_indexer
@@ -11,9 +12,10 @@ from b12x.attention.compressed_sparse_mla.preparation import rotate
 from b12x.attention.compressed_sparse_mla.weight_scale import (
     scale_index_weights,
 )
-from b12x.gemm import bf16_gemv
+from b12x.gemm import bf16_gemv, blockscaled
 from torch import nn
 
+from vllm.config import get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_world_size, get_tp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
@@ -33,7 +35,11 @@ from vllm.models.deepseek_v4_1.b12x_layers import (
 from vllm.models.deepseek_v4_1.ced import ced_decoder_start
 from vllm.models.deepseek_v4_1.common.rope import build_deepseek_v4_rope
 from vllm.models.deepseek_v4_1.compressor import DeepseekCompressor
-from vllm.models.deepseek_v4_1.sparse_mla import DeepseekV41B12xBackend, _chunk
+from vllm.models.deepseek_v4_1.sparse_mla import (
+    DeepseekV41B12xBackend,
+    DeepseekV41B12xMetadata,
+    _chunk,
+)
 from vllm.triton_utils import tl, triton
 from vllm.v1.kv_cache_interface import MLAAttentionSpec, SlidingWindowMLASpec
 from vllm.v1.worker.workspace import (
@@ -149,7 +155,7 @@ def _unpack_wo_a(Weight, Scale, Out, N: tl.constexpr, K: tl.constexpr, B: tl.con
 
 
 class _GroupedLinearMethod(LinearMethodBase):
-    """Reference WO-A: unpack weights once; never quantize inverse-RoPE output."""
+    """WO-A with BF16 activations in both GEMV and weight-only tensor-core paths."""
 
     def __init__(self, original, groups):
         if type(original) is UnquantizedLinearMethod:
@@ -162,10 +168,32 @@ class _GroupedLinearMethod(LinearMethodBase):
         return self.original.create_weights(*args, **kwargs)
 
     def process_weights_after_loading(self, layer):
+        self.prefill_weights = []
         if layer.weight.dtype == torch.float8_e4m3fn:
             scales = layer.weight_scale_inv
             if scales.dtype != torch.float8_e8m0fnu:
                 raise ValueError("V4.1 WO-A requires UE8M0 checkpoint scales")
+            width = layer.weight.shape[0] // self.groups
+            if width % 32:
+                raise ValueError("V4.1 WO-A groups must preserve block32 scale rows")
+            for group in range(self.groups):
+                start, end = group * width, (group + 1) * width
+                # Replicating a block-row exponent changes storage, not values.
+                # A16 dequantizes these exact checkpoint weights to BF16 and
+                # never quantizes the inverse-RoPE activation.
+                scale_rows = scales[start // 32 : end // 32].view(torch.uint8)
+                packed = blockscaled.pack_weight(
+                    layer.weight[start:end],
+                    scale_rows.repeat_interleave(32, dim=0),
+                    recipe="mxfp8",
+                )
+                blockscaled.prewarm(packed, (1, 8, 64), mode="a16")
+                self.prefill_weights.append(packed)
+            capacity = get_current_vllm_config().scheduler_config.max_num_batched_tokens
+            self.prefill_workspace_bytes = max(
+                blockscaled.workspace_size(packed, capacity)
+                for packed in self.prefill_weights
+            )
             dense = torch.empty(
                 layer.weight.shape, dtype=torch.bfloat16, device=layer.weight.device
             )
@@ -186,7 +214,7 @@ class _GroupedLinearMethod(LinearMethodBase):
             bf16_gemv.precompile(weight)
             self.weights.append(weight)
 
-    def apply(self, layer, x, bias=None):
+    def apply(self, layer, x, bias=None, *, is_prefill=False):
         if bias is not None:
             raise ValueError("V4.1 WO-A must be bias free")
         rows = x.shape[0]
@@ -195,11 +223,19 @@ class _GroupedLinearMethod(LinearMethodBase):
         )
         width = layer.weight.shape[0] // self.groups
         for group in range(self.groups):
-            bf16_gemv.mm(
-                x[:, group],
-                self.weights[group],
-                out=result[:, group * width : (group + 1) * width],
-            )
+            target = result[:, group * width : (group + 1) * width]
+            if is_prefill and self.prefill_weights:
+                (scratch,) = current_workspace_manager().get_simultaneous(
+                    ((self.prefill_workspace_bytes,), torch.uint8)
+                )
+                source = x[:, group].contiguous()
+                projected = blockscaled.mm(
+                    source, self.prefill_weights[group], mode="a16", workspace=scratch
+                )
+                target.copy_(projected)
+                retain_cuda_graph_capture_resource((source, projected))
+            else:
+                bf16_gemv.mm(x[:, group], self.weights[group], out=target)
         retain_cuda_graph_capture_resource((x, result))
         return result
 
@@ -209,8 +245,10 @@ class DeepseekV4Indexer(nn.Module):
         super().__init__()
         hf = config.model_config.hf_config
         self.prefix, self.owns_k, self.k_cache = prefix, owns_k, k_cache
-        self.heads = hf.index_n_heads // get_tensor_model_parallel_world_size()
-        self.wq_b = ColumnParallelLinear(
+        # Replicating the small indexer avoids reducing a rows-by-context score
+        # matrix across TP ranks. Every rank selects from all index heads.
+        self.heads = hf.index_n_heads
+        self.wq_b = ReplicatedLinear(
             hf.q_lora_rank,
             hf.index_n_heads * 128,
             bias=False,
@@ -219,7 +257,7 @@ class DeepseekV4Indexer(nn.Module):
             prefix=f"{prefix}.wq_b",
         )
         _native_linear(self.wq_b)
-        self.weights_proj = ColumnParallelLinear(
+        self.weights_proj = ReplicatedLinear(
             hf.hidden_size,
             hf.index_n_heads,
             bias=False,
@@ -280,7 +318,9 @@ def _prepare_global_kv_fake(hidden, positions, prefix):
 
 class DeepseekV4Attention(nn.Module, AttentionLayerBase):
     backend_cls = DeepseekV41B12xBackend
-    INDEX_CHUNK = 64
+    # Index scores need bounded row scratch; attention handles the whole batch.
+    INDEX_CHUNK = 256
+    DECODE_CHUNK = 64
 
     @classmethod
     def get_padded_num_q_heads(cls, num_heads):
@@ -298,7 +338,10 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase):
         self.config = vllm_config
         hf = vllm_config.model_config.hf_config
         self.prefix = prefix
-        self.layer_id = int(re.search(r"layers\.(\d+)", prefix).group(1))
+        layer_match = re.search(r"layers\.(\d+)", prefix)
+        if layer_match is None:
+            raise ValueError("V4.1 attention prefix must contain a layer index")
+        self.layer_id = int(layer_match.group(1))
         self.hidden_size, self.head_dim = hf.hidden_size, hf.head_dim
         self.rope_head_dim = hf.qk_rope_head_dim
         tp = get_tensor_model_parallel_world_size()
@@ -555,11 +598,12 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase):
             h = self.indexer.heads
             self._index_plans = {}
             for mode in ("decode", "prefill"):
+                plan_rows = self.DECODE_CHUNK if mode == "decode" else c
                 plan = dsa_indexer.plan(
                     dsa_indexer.Caps(
                         device=device,
                         num_q_heads=h,
-                        max_q_rows=c,
+                        max_q_rows=plan_rows,
                         max_page_table_width=self._index_width,
                         topk=512,
                         mode=mode,
@@ -668,13 +712,18 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase):
         q = _rotated(q, positions, self.rotary_emb.cos_sin_cache)
         output = torch.empty_like(q)
         retain_cuda_graph_capture_resource(output)
-        metadata = get_forward_context().attn_metadata
+        metadata = cast(
+            dict[str, DeepseekV41B12xMetadata] | None,
+            get_forward_context().attn_metadata,
+        )
+        is_prefill = True
         if not isinstance(metadata, dict):
-            # vLLM memory profiling has no cache pages; no serving call uses this branch.
+            # Memory profiling has no cache pages; serving does not use this branch.
             output.zero_()
         else:
             original_swa = metadata[self.swa_cache_layer.prefix]
             swa = self._query_metadata(original_swa)
+            is_prefill = not swa.is_decode
             self.insert_context_kv(kv, positions, swa.slot_mapping[:rows])
             if swa is original_swa:
                 self._prepare_global_kv(positions, hidden_states)
@@ -692,7 +741,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase):
                 index_query = (iq_data, iq_scale, iw)
                 retain_cuda_graph_capture_resource((weights, index_query))
             self.forward_mqa(q, kv, positions, output, index_query=index_query)
-        return self._o_proj(output, positions)
+        return self._o_proj(output, positions, is_prefill=is_prefill)
 
     def forward_mqa(self, q, kv, positions, output, *, index_query=None):
         metadata = get_forward_context().attn_metadata
@@ -707,12 +756,13 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase):
         plan = self._plans[mode]
         if rows > plan.caps.max_q_rows:
             raise ValueError(
-                f"V4.1 {mode} rows {rows} exceed planned capacity {plan.caps.max_q_rows}"
+                f"V4.1 {mode} rows {rows} exceed planned capacity "
+                f"{plan.caps.max_q_rows}"
             )
         owner = (
             self._context[_source(self.prefix, self.index_source_layer_id)]
             if self.compress_ratio
-            else None
+            else self
         )
 
         # Only the score matrix needs row chunking. All selected positions
@@ -732,8 +782,9 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase):
                     self._index_width * self._index_page,
                     max(1, triton.cdiv(im.max_seq_len, self.compress_ratio)),
                 )
-            for offset in range(0, rows, self.INDEX_CHUNK):
-                end = min(offset + self.INDEX_CHUNK, rows)
+            chunk_rows = self.DECODE_CHUNK if mode == "decode" else self.INDEX_CHUNK
+            for offset in range(0, rows, chunk_rows):
+                end = min(offset + chunk_rows, rows)
                 count = end - offset
                 _pages[(count, triton.cdiv(self._index_width, 128))](
                     im.req_id_per_token,
@@ -759,7 +810,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase):
                         candidate_indices=source._candidates[offset:end],
                         candidate_lengths=source._candidate_lens[offset:end],
                     )
-                # One borrow spans score -> TP reduction -> select.
+                # All replicated heads are ranked locally in one scratch borrow.
                 binding = dsa_indexer.bind(
                     index_plan,
                     scratch=_scratch(index_plan),
@@ -775,12 +826,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase):
                     **candidate_args,
                 )
                 retain_cuda_graph_capture_resource(binding)
-                scores = dsa_indexer.score(binding)
-                if get_tensor_model_parallel_world_size() > 1:
-                    reduced = get_tp_group().all_reduce(scores)
-                    retain_cuda_graph_capture_resource(reduced)
-                    if reduced.data_ptr() != scores.data_ptr():
-                        scores.copy_(reduced)
+                dsa_indexer.score(binding)
                 dsa_indexer.select(binding)
 
         # Reuse the shared arena only after indexing completes. Keep full-batch
@@ -850,11 +896,13 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase):
             cache_format="deepseek_v41",
         )
 
-    def _o_proj(self, o, positions):
+    def _o_proj(self, o, positions, *, is_prefill=False):
         rows = o.shape[0]
         inverse = _rotated(o, positions, self.rotary_emb.cos_sin_cache, inverse=True)
         grouped = inverse.view(rows, self.n_local_groups, -1)
-        local = self.wo_b(self.wo_a.quant_method.apply(self.wo_a, grouped))
+        local = self.wo_b(
+            self.wo_a.quant_method.apply(self.wo_a, grouped, is_prefill=is_prefill)
+        )
         if local.dtype != torch.bfloat16:
             raise TypeError("V4.1 WO-B must round the local projection to BF16")
         if get_tensor_model_parallel_world_size() > 1:

--- a/vllm/models/deepseek_v4_1/attention.py
+++ b/vllm/models/deepseek_v4_1/attention.py
@@ -497,9 +497,13 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase):
         self._index_page = self._main_page
         self._index_width = self._main_width
         spec = self.config.speculative_config
-        decode_rows = self.config.scheduler_config.max_num_seqs * (
-            1 + (spec.num_speculative_tokens if spec is not None else 0)
+        # Parallel drafting can admit two draft spans during verifier profiling.
+        query_width = (
+            1 + (2 if spec.parallel_drafting else 1) * spec.num_speculative_tokens
+            if spec is not None
+            else 1
         )
+        decode_rows = self.config.scheduler_config.max_num_seqs * query_width
         # Graph buffers include padding beyond the live decode-token bound.
         decode_rows = max(
             decode_rows,

--- a/vllm/models/deepseek_v4_1/b12x_layers.py
+++ b/vllm/models/deepseek_v4_1/b12x_layers.py
@@ -71,7 +71,7 @@ def _execution_capacities() -> tuple[int, ...]:
     )
 
 
-_LINEARS = WeakValueDictionary()
+_LINEARS: WeakValueDictionary[int, nn.Module] = WeakValueDictionary()
 
 
 @cache
@@ -321,6 +321,11 @@ def _mhc_pre(
     previous_post: torch.Tensor | None = None,
     previous_comb: torch.Tensor | None = None,
 ) -> None:
+    # Use fixed capacity buckets so B12X can plan decode and prefill separately.
+    # Live row counts never become compilation or plan-cache keys.
+    decode_capacity = min(capacity, 64)
+    if residual.shape[0] <= decode_capacity:
+        capacity = decode_capacity
     plan = _mhc_plan(residual.device, capacity, y.shape[-1])
     (scratch,) = current_workspace_manager().get_simultaneous(*plan.shapes_and_dtypes())
     binding = mhc.bind(

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -364,6 +364,30 @@ def apply_top_k_top_p(
     return apply_top_k_top_p_pytorch(logits, k, p)
 
 
+def warmup_top_k_top_p(
+    vocab_size: int, max_num_rows: int, device: torch.device
+) -> None:
+    """Compile GPU filter variants without executing the model or consuming RNG."""
+    if not HAS_TRITON or device.type == "cpu" or max_num_rows < 8:
+        return
+
+    # Top-k-only, top-p-only and combined filtering have distinct compile keys.
+    # Triton also specializes the row count on divisibility by 16; two small
+    # representative batches cover that distinction without allocating the
+    # maximum speculative verification batch's logits.
+    for num_rows in (8, 16):
+        if num_rows > max_num_rows:
+            continue
+        logits = torch.empty(num_rows, vocab_size, dtype=torch.float32, device=device)
+        top_k = torch.full(
+            (num_rows,), min(20, vocab_size), dtype=torch.int32, device=device
+        )
+        top_p = torch.full((num_rows,), 0.95, dtype=torch.float32, device=device)
+        for k, p in ((top_k, None), (None, top_p), (top_k, top_p)):
+            logits.zero_()
+            apply_top_k_top_p(logits, k, p)
+
+
 def apply_top_k_top_p_pytorch(
     logits: torch.Tensor,
     k: torch.Tensor | None,

--- a/vllm/v1/worker/gpu/spec_decode/adaptive_verification.py
+++ b/vllm/v1/worker/gpu/spec_decode/adaptive_verification.py
@@ -257,6 +257,12 @@ class AdaptiveVerificationManager:
         self._stale_idx, write_idx = ready_idx, self._stale_idx
 
         self._confidence_probs[input_batch.idx_mapping] = confidence_probs[:num_reqs]
+        # Replicated projections may differ through unordered floating-point
+        # reductions. Both CPU graph selection and GPU request compaction must
+        # consume one TP-wide confidence snapshot to issue matching collectives.
+        tp_group = get_tp_group()
+        if tp_group.world_size > 1:
+            tp_group.broadcast(self._confidence_probs, src=0)
         write_slot = self._stale_confidences[write_idx]
         write_slot.gpu.copy_(self._confidence_probs)
 

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -20,6 +20,7 @@ from vllm.v1.core.sched.output import (
 )
 from vllm.v1.kv_cache_interface import CrossAttentionSpec, KVCacheSpec, MambaSpec
 from vllm.v1.request import Request
+from vllm.v1.sample.ops.topk_topp_sampler import warmup_top_k_top_p
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
 
 logger = init_logger(__name__)
@@ -440,4 +441,13 @@ def warmup_kernels(
     cleanup_output.finished_req_ids = set(req_ids)
     worker_execute_model(cleanup_output)
     model_runner.kv_connector.set_disabled(False)
+    if model_runner.is_last_pp_rank and not model_runner.is_pooling_model:
+        warmup_top_k_top_p(
+            model_runner.model_config.get_vocab_size(),
+            min(
+                model_runner.scheduler_config.max_num_batched_tokens,
+                model_runner.max_num_reqs * decode_query_len,
+            ),
+            model_runner.device,
+        )
     torch.accelerator.synchronize()


### PR DESCRIPTION
## Purpose

Integrate the paired **[B12X native DeepSeek V4.1 prefill optimizations (#358)](https://github.com/local-inference-lab/b12x/pull/358)** into `dev/jovian-judgement`, preserving the compressed encoder-decoder (CED) behavior already present in the branch. Merge B12X #358 first; this PR uses its packed-indexer and projection capabilities.

Status: implemented and qualified for TP4/DCP1 native DSpark K5 under the conditions below. The combined repositories deliver **+16.5% 32K prefill** in a same-quartet A/B/A comparison. **No stable decode-verifier speedup is claimed.**

## Changes

| Area | Behavior and reason |
|---|---|
| Sparse indexer | Replicate all 32 index-query heads/projection weights on each TP rank and rank locally, removing the index-score all-reduce. Use compact caller-owned scoring workspace, 256-row prefill chunks and 64-row decode chunks. |
| Attention output projection | Route WO-A prefill through B12X's matrix path with the checkpoint's FP8 weights and BF16 activations. BF16 activations were also used by the scalar reference; this is not an activation-precision downgrade. |
| Multipath hyperconnection (MHC) | Bind a fixed decode-sized plan separately from prefill capacity. Live row counts do not become compile/cache keys. |
| Adaptive verification correctness | Broadcast the rank-zero confidence snapshot before CPU draft-budget selection and GPU request compaction. Replicated floating-point projections could otherwise select different TP collective geometries and hang. |
| Parallel draft capacity | Reserve both speculative spans during adaptive profiling: `max_num_seqs * (1 + 2*K)` when parallel drafting is active. |
| Sampler startup | Warm top-k-only, top-p-only and combined filters at representative row classes before strict runtime JIT monitoring. No sampling math change. |

The confidence, capacity and sampler fixes are separate prerequisite commits, **included in both A and B**. Their effect is not counted in the prefill gain. The vLLM performance delta over the common reference is limited to the native model's attention/projection bindings and their tests. No GLM, Qwen, LMCache, fairness or external backend replacement is imported.

## Serving evidence

Four stock RTX PRO 6000 Workstation GPUs on the same physical quartet; TP4/DCP1 with expert parallelism, native DSpark K5/adaptive verification, **4096-token scheduler budget**, max sequences 4, temperature 1/top-p 0.95, greedy draft and standard rejection. Full-and-piecewise graphs, strict JIT error mode; OMP8, NCCL16 channels/2 MiB, disk Engram.

| Metric | Reference A | Optimized B | Reference return A |
|---|---:|---:|---:|
| 32K prefill, input tok/s | 10,539 median | 12,288 median | 10,548 |
| C1 output, 60-second control, tok/s | 130.118 | 147.400 | 133.196 |
| C1 verifier, 60-second control, steps/s | 52.417 | 51.767 | 51.978 |
| C1 output tokens/verifier step | 2.482 | 2.847 | 2.563 |

Prefill improves **16.60%** versus the initial median and **16.50%** versus the return control. Input tok/s is measured from client TTFT, not pure CUDA prefill time. C1 output differs with acceptance and adaptive per-step work; the 60-second controls do not establish a faster verifier. All measured requests had zero errors.

[B12X #358](https://github.com/local-inference-lab/b12x/pull/358) contains the complete raw cell values, source/image identities and numerical-oracle qualification. Its `852303bca2e4f8b6f4bc520a63e3da9a5eda0727` source is paired with this exact vLLM head `70e0633d7e79d5c072bc7d9e3c345d12bedae5a0`. The common vLLM reference is `697c882788f482788eb1653cc7a8a07aec8d86f8`, directly above JJ `3674c9d2e853e4884454b982e0041ed10f796551`. Packaged sources match Git exports; native extensions and serving settings match across images.

## Validation

- **49 common prerequisite tests passed:** 13 adaptive-verification tests, 2 GPU filter-warmup tests and 34 worker-warmup tests.
- **18 optimized workspace/binding tests passed**, including parallel draft capacity and grouped FP8-weight/BF16-activation prefill.
- **202 paired B12X kernel/plan tests passed** with a true FP32 Torch reference.
- The TP-confidence regression fails against its parent; a TP4 reproducer selected budgets `1/1/3/3` at the same token position. Synchronizing the confidence snapshot resolves the inconsistent collective geometry while retaining adaptive verification, small GEMM plans and CUDA graphs.
- Strict-JIT serving and deterministic arithmetic smoke passed. The GPU warmup test covers 8/9/15/16/17/24 rows and all three filter combinations.

Focused tests used the image's isolated `/opt/venv/bin/python`. The following commands rerun the recorded suites; `--confcutdir` excludes unavailable unrelated root fixtures:

```bash
/opt/venv/bin/python -m pytest -q --confcutdir tests/v1 \
  tests/v1/spec_decode/test_adaptive_verification.py \
  tests/v1/worker/test_gpu_warmup_blocks.py \
  tests/v1/sample/test_topk_topp_sampler.py \
  -k 'adaptive or warmup'

NVIDIA_TF32_OVERRIDE=0 TORCH_ALLOW_TF32_CUBLAS_OVERRIDE=0 \
/opt/venv/bin/python -m pytest -q --confcutdir tests/v1/attention \
  tests/v1/attention/test_b12x_v41_workspace.py
```

`git diff --check` passes. The target JJ commit already has inferred-tuple and optional-metadata type errors in the native DS41 files. Those remain reported; this is **not** a claim of a green repository-wide mypy/CI run. The measured implementation is published without an unrelated typing rewrite.

<details>
<summary>Serving and benchmark reproduction parameters</summary>

Use the same installed CUDA 13.3/PyTorch 2.13/CUTLASS DSL 4.6.2 runtime for both source pairs and a local read-only model mount at `/model`: `deepseek-ai/DeepSeek-V4.1-Flash`, revision `fb2764a5cf321eaa5070ca8f9e892818f477c16d`.

Serving environment includes:

```bash
export CUTE_DSL_ARCH=sm_120a OMP_NUM_THREADS=8
export VLLM_USE_V2_MODEL_RUNNER=1 VLLM_USE_BREAKABLE_CUDAGRAPH=1
export VLLM_ENABLE_PCIE_ALLREDUCE=1 VLLM_PCIE_ALLREDUCE_BACKEND=b12x
export NCCL_MIN_NCHANNELS=16 NCCL_MAX_NCHANNELS=16 NCCL_BUFFSIZE=2097152
export NCCL_IB_DISABLE=1 NCCL_P2P_LEVEL=SYS
```

The tested serving arguments are:

```bash
/opt/venv/bin/python -m vllm.entrypoints.cli.main serve /model \
  --served-model-name DeepSeek-V4.1-Flash --host 0.0.0.0 --port 5053 \
  --dtype bfloat16 --tensor-parallel-size 4 --pipeline-parallel-size 1 \
  --decode-context-parallel-size 1 --enable-expert-parallel \
  --load-format safetensors --safetensors-load-strategy lazy \
  --block-size 256 --kv-cache-dtype fp8 --enable-prefix-caching \
  --enable-chunked-prefill --gpu-memory-utilization 0.95 \
  --max-model-len 131072 --max-num-seqs 4 --max-num-batched-tokens 4096 \
  --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
  --cudagraph-capture-sizes 1 2 4 8 16 24 32 \
  --generation-config vllm \
  --override-generation-config '{"temperature":1.0,"top_p":0.95}' \
  --limit-mm-per-prompt '{"image":2}' \
  --engram-config '{"cpu_offload":false,"table_memory":"disk"}' \
  --linear-backend b12x --moe-backend b12x \
  --attention-backend B12X_MLA_SPARSE_DSV41 \
  --jit-monitor-mode error --reasoning-parser deepseek_v41 \
  --tool-call-parser deepseek_v41 --enable-auto-tool-choice \
  --speculative-config '{"method":"dspark","num_speculative_tokens":5,"draft_tensor_parallel_size":4,"attention_backend":"B12X_MLA_SPARSE_DSV41","draft_sample_method":"greedy","rejection_sample_method":"standard","enable_adaptive_verification":true}'
```

The measured container also configured an inactive rank-zero Torch profiler. Native KV is mixed MXFP8 sliding-window and NVFP4 indexed storage, not all-FP8 despite the CLI dtype spelling.

Benchmark source: `llm_decode_bench.py` at `80d1f1b0ab9830c3fd8a22c42f461c40cbc7cf96`, file SHA-256 `516dc590b80dda6d9880f9f5034026fdf1b2074e9747bf8a920758680f019817`. Only the interactive self-update check was disabled.

Common options: `--host 127.0.0.1 --port 5053 --model DeepSeek-V4.1-Flash --display-mode plain --no-hw-monitor --no-resume --token-targeting exact`.

- Prefill: `--standalone-prefill --prefill-only --prefill-contexts 32k --prefill-duration 30 --max-tokens 1`; one warmup cell, then three measured cells, then a separately warmed return control.
- C1: `--skip-prefill --concurrency 1 --contexts 0 --duration 30 --max-tokens 8192 --temperature 1 --decode-warmup-seconds 15`; three cells per arm, followed by 60-second A/B/A controls.

</details>

## Scope, existing work and attribution

The native B12X binding change is not the official vLLM DeepGEMM/DSA or attention-megakernel path; no duplicate native integration PR was found in this fork. Related upstream [vllm-project/vllm#45601](https://github.com/vllm-project/vllm/pull/45601) addresses **V1** sampler warmup and changes Triton specialization. This PR's measured **V2** startup coverage retains kernel specialization and warms bounded representative batches; it does not duplicate or replace that upstream submission.

Model-quality equivalence is **research-only**: both A and B inherit CED's bounded 128-row decoder replay after full encoder processing. The performance result does not establish parity with full-decoder prefill. Arithmetic output `703` is a smoke check, not an agentic/coding evaluation. TP8, vision, 1M context and cache restore are not qualified here.

Luke Alonso's JJ commits and Martin Vit's measured implementation commits remain intact, including sign-off and Codex co-authorship. AI assistance was used for implementation, analysis, tests and this PR description. Publication was requested by Martin Vit for Luke's review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved DeepSeek V4.1 attention performance and scaling for tensor-parallel inference, speculative decoding, and larger workloads.
  * Added optimized FP8 prefill processing for supported projections.
  * Added warmup for top-k/top-p sampling kernels to reduce runtime compilation delays.
  * Improved adaptive speculative decoding consistency across parallel devices.

* **Bug Fixes**
  * Fixed decode planning and capacity handling to provide more stable execution across varying request sizes.
  * Improved CUDA graph capture and resource reuse behavior.
  * Corrected projection visibility and confidence synchronization in distributed inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->