### PR TITLE
sched: fix zero-progress prefill-turn loop at full KV pool

### DIFF
--- a/tests/v1/core/test_prefill_compute_share_scheduler.py
+++ b/tests/v1/core/test_prefill_compute_share_scheduler.py
@@ -1271,6 +1271,7 @@ def _drain(scheduler, requests, max_steps):
         f"scheduler failed to drain the state within {max_steps} steps"
     )
 
+
 def _drain_async(scheduler, requests, pending_output, max_steps):
     """Run real async schedule/record/update cycles until every request
     finishes, keeping the engine's one-batch overlap: the next batch is

--- a/tests/v1/core/test_prefill_compute_share_scheduler.py
+++ b/tests/v1/core/test_prefill_compute_share_scheduler.py
@@ -1205,6 +1205,7 @@ def test_prefill_fairness_hot_switch_is_atomic(opt_model_path):
     unchanged = scheduler.get_prefill_fairness()
     assert unchanged["prefill_compute_share"] == "auto"
     assert unchanged["prefill_compute_half_life"] == "responsive"
+
 # ---------------------------------------------------------------------------
 # Forward progress at a full KV pool (issue #733).
 #

--- a/tests/v1/core/test_prefill_compute_share_scheduler.py
+++ b/tests/v1/core/test_prefill_compute_share_scheduler.py
@@ -1206,6 +1206,7 @@ def test_prefill_fairness_hot_switch_is_atomic(opt_model_path):
     assert unchanged["prefill_compute_share"] == "auto"
     assert unchanged["prefill_compute_half_life"] == "responsive"
 
+
 # ---------------------------------------------------------------------------
 # Forward progress at a full KV pool (issue #733).
 #

--- a/tests/v1/core/test_prefill_compute_share_scheduler.py
+++ b/tests/v1/core/test_prefill_compute_share_scheduler.py
@@ -1205,3 +1205,322 @@ def test_prefill_fairness_hot_switch_is_atomic(opt_model_path):
     unchanged = scheduler.get_prefill_fairness()
     assert unchanged["prefill_compute_share"] == "auto"
     assert unchanged["prefill_compute_half_life"] == "responsive"
+# ---------------------------------------------------------------------------
+# Forward progress at a full KV pool (issue #733).
+#
+# The block pool always reserves one null block, so num_blocks=N provides
+# N-1 usable blocks in these scenarios.
+
+
+def _fill_pool_with_boundary_decodes(scheduler):
+    """Drive the real scheduler and fairness controller into the issue-#733
+    state: a completely full block pool, two running decodes whose next token
+    each needs a new block, an unschedulable waiting prefill, and the prefill
+    service class selected for the next quantum.
+
+    The controller is driven only through its real select/dispatch/record API:
+    one measured decode quantum, then a cheaper measured prefill quantum, so
+    prefill is selected again at the full pool. This is the alternation that
+    exposed the defect live.
+
+    Returns (first_decode, second_decode, waiting_prefill).
+    """
+    (first_decode,) = create_requests(
+        num_requests=1, num_tokens=15, req_ids=["first-decode"]
+    )
+    scheduler.add_request(first_decode)
+    # The 15-token prompt leaves one in-block slot, so the decode step below
+    # fits without a new block and the request then sits at a block boundary,
+    # needing a new block for its next token.
+    _update(scheduler, scheduler.schedule())
+
+    second_decode, waiting_prefill = create_requests(
+        num_requests=2, num_tokens=16, req_ids=["second-decode", "waiting-prefill"]
+    )
+    scheduler.add_request(second_decode)
+    scheduler.add_request(waiting_prefill)
+    decode_output = scheduler.schedule()
+    assert decode_output.compute_service_class == "decode"
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+
+    prefill_output = scheduler.schedule()
+    assert prefill_output.compute_service_class == "prefill"
+    # The prefill turn admits the second decode's prompt into the last free
+    # block. The leftover decode service cannot schedule the first decode
+    # (it needs a new block) and must not evict the admitted prefill work.
+    assert prefill_output.num_scheduled_tokens == {second_decode.request_id: 16}
+    scheduler.record_compute_time("prefill", 0.005, contended=True)
+    _update(scheduler, prefill_output)
+    return first_decode, second_decode, waiting_prefill
+
+
+def _drain(scheduler, requests, max_steps):
+    """Run real schedule/record/update cycles until every request finishes."""
+    for _ in range(max_steps):
+        if all(request.is_finished() for request in requests):
+            return
+        output = scheduler.schedule()
+        if output.compute_service_class is not None:
+            scheduler.record_compute_time(
+                output.compute_service_class, 0.01, contended=True
+            )
+        _update(scheduler, output)
+    assert all(request.is_finished() for request in requests), (
+        f"scheduler failed to drain the state within {max_steps} steps"
+    )
+
+def _drain_async(scheduler, requests, pending_output, max_steps):
+    """Run real async schedule/record/update cycles until every request
+    finishes, keeping the engine's one-batch overlap: the next batch is
+    scheduled before the previous batch's output is processed."""
+    for _ in range(max_steps):
+        if all(request.is_finished() for request in requests):
+            return
+        output = scheduler.schedule()
+        if pending_output.compute_service_class is not None:
+            scheduler.record_compute_time(
+                pending_output.compute_service_class, 0.01, contended=True
+            )
+        _update(scheduler, pending_output)
+        pending_output = output
+    _update(scheduler, pending_output)
+    assert all(request.is_finished() for request in requests), (
+        f"scheduler failed to drain the state within {max_steps} steps"
+    )
+
+
+def test_prefill_turn_escape_preempts_to_keep_decode_progress(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_seqs=16,
+        max_num_batched_tokens=32,
+        max_model_len=128,
+        num_blocks=3,
+        block_size=16,
+    )
+    first_decode, second_decode, waiting_prefill = _fill_pool_with_boundary_decodes(
+        scheduler
+    )
+
+    output = scheduler.schedule()
+
+    # A prefill quantum that scheduled nothing must not strand runnable
+    # decodes at a full pool: the leftover decode service preempts its way to
+    # forward progress instead of returning an empty batch forever (#733).
+    assert output.num_scheduled_tokens == {first_decode.request_id: 1}
+    # FCFS preemption takes the newest running request as the victim.
+    assert output.preempted_req_ids == {second_decode.request_id}
+    assert second_decode.num_preemptions == 1
+    assert first_decode.num_preemptions == 0
+    # The escape quantum is decode compute and is charged to decode, keeping
+    # fairness accounting tied to work that was actually dispatched.
+    assert output.compute_service_class == "decode"
+    assert output.compute_contention
+    assert waiting_prefill in scheduler.waiting
+
+
+def test_full_pool_fairness_state_drains_within_bounded_steps(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_seqs=16,
+        max_num_batched_tokens=32,
+        max_model_len=128,
+        num_blocks=3,
+        block_size=16,
+    )
+    requests = _fill_pool_with_boundary_decodes(scheduler)
+
+    _drain(scheduler, requests, max_steps=100)
+
+    assert not scheduler.running
+    assert not scheduler.waiting
+
+
+def test_prefill_turn_fallback_never_preempts_admitted_prefill_work(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        max_num_seqs=16,
+        max_num_batched_tokens=32,
+        max_model_len=128,
+        num_blocks=3,
+        block_size=16,
+    )
+    (decode,) = create_requests(num_requests=1, num_tokens=15, req_ids=["decode"])
+    scheduler.add_request(decode)
+    _update(scheduler, scheduler.schedule())
+
+    (prefill,) = create_requests(
+        num_requests=1, num_tokens=16, req_ids=["admitted-prefill"]
+    )
+    scheduler.add_request(prefill)
+    decode_output = scheduler.schedule()
+    assert decode_output.compute_service_class == "decode"
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+    # The decode now sits at a block boundary; the pool has one free block.
+
+    output = scheduler.schedule()
+
+    # The prefill turn admits the waiting prefill into that last block. The
+    # leftover decode service must not evict admitted prefill work to unblock
+    # the decode: this quantum is not empty, so no escape preemption may run.
+    assert output.compute_service_class == "prefill"
+    assert output.num_scheduled_tokens == {prefill.request_id: 16}
+    assert decode.request_id not in output.num_scheduled_tokens
+    assert not output.preempted_req_ids
+    assert decode.num_preemptions == 0
+    assert prefill.num_preemptions == 0
+    assert decode in scheduler.running
+    assert prefill in scheduler.running
+
+
+def _fill_pool_with_priority_decodes(scheduler):
+    """The full-pool state of _fill_pool_with_boundary_decodes under the
+    priority policy, with three running decodes of distinct priorities.
+
+    Admission order (the running list order) is [low(9), urgent(0),
+    victim(10)], and the waiting prefill has the worst priority (11), so it
+    is only tried after every running decode has been admitted.
+    """
+    (low,) = create_requests(num_requests=1, num_tokens=15, req_ids=["low"])
+    low.priority = 9
+    scheduler.add_request(low)
+    _update(scheduler, scheduler.schedule())
+
+    urgent, victim, waiting_prefill = create_requests(
+        num_requests=3,
+        num_tokens=16,
+        req_ids=["urgent", "victim", "waiting-prefill"],
+    )
+    urgent.priority = 0
+    victim.priority = 10
+    waiting_prefill.priority = 11
+    scheduler.add_request(urgent)
+    scheduler.add_request(victim)
+    scheduler.add_request(waiting_prefill)
+    decode_output = scheduler.schedule()
+    assert decode_output.compute_service_class == "decode"
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+
+    prefill_output = scheduler.schedule()
+    assert prefill_output.compute_service_class == "prefill"
+    # Priority-ordered admission fills the pool with two more boundary
+    # decodes; the leftover decode service cannot schedule the blocked decode
+    # and must not preempt the admitted prefill work.
+    assert prefill_output.num_scheduled_tokens == {
+        urgent.request_id: 16,
+        victim.request_id: 16,
+    }
+    scheduler.record_compute_time("prefill", 0.005, contended=True)
+    _update(scheduler, prefill_output)
+    return low, urgent, victim, waiting_prefill
+
+
+def test_priority_escape_preserves_decode_scheduled_within_fallback(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        scheduling_policy="priority",
+        max_num_seqs=16,
+        max_num_batched_tokens=48,
+        max_model_len=128,
+        num_blocks=4,
+        block_size=16,
+    )
+    low, urgent, victim, waiting_prefill = _fill_pool_with_priority_decodes(scheduler)
+
+    output = scheduler.schedule()
+
+    # Empty-quantum escape: the first blocked decode preempts the
+    # lowest-urgency running request (the highest priority value) and is
+    # scheduled, reusing the normal priority-aware preemption unchanged.
+    assert output.num_scheduled_tokens == {low.request_id: 1}
+    assert output.preempted_req_ids == {victim.request_id}
+    assert victim.num_preemptions == 1
+    # Once any work is scheduled, the fallback must stop preempting: the
+    # later blocked decode may neither evict the just-scheduled decode nor
+    # disturb the untouched one.
+    assert low.num_preemptions == 0
+    assert urgent.num_preemptions == 0
+    assert urgent in scheduler.running
+    assert waiting_prefill in scheduler.waiting
+
+    # The escape quantum is decode compute; charge and process it before
+    # further progress, as the engine would.
+    assert output.compute_service_class == "decode"
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, output)
+
+    # The normal priority policy still converges: the urgent decode and the
+    # waiting prefill are served within bounded further progress.
+    _drain(scheduler, [low, urgent, victim, waiting_prefill], max_steps=150)
+
+
+def test_escape_respects_deferred_free_fences(opt_model_path):
+    scheduler = _create_fair_scheduler(
+        opt_model_path,
+        async_scheduling=True,
+        max_num_seqs=16,
+        max_num_batched_tokens=32,
+        max_model_len=128,
+        num_blocks=3,
+        block_size=16,
+    )
+    # Mirror the KV-consumer multi-batch deployment mode (an async
+    # KV-transfer consumer with more than one concurrent batch): a preempted
+    # request whose last scheduled batch is still in flight returns its
+    # blocks only once that batch's output has been processed.
+    scheduler.defer_block_free = True
+
+    (first_decode,) = create_requests(
+        num_requests=1, num_tokens=14, req_ids=["first-decode"]
+    )
+    scheduler.add_request(first_decode)
+    _update(scheduler, scheduler.schedule())
+
+    second_decode, waiting_prefill = create_requests(
+        num_requests=2, num_tokens=16, req_ids=["second-decode", "waiting-prefill"]
+    )
+    scheduler.add_request(second_decode)
+    scheduler.add_request(waiting_prefill)
+    decode_output = scheduler.schedule()
+    assert decode_output.compute_service_class == "decode"
+    scheduler.record_compute_time("decode", 0.01, contended=True)
+    _update(scheduler, decode_output)
+
+    prefill_output = scheduler.schedule()
+    assert prefill_output.compute_service_class == "prefill"
+    scheduler.record_compute_time("prefill", 0.005, contended=True)
+    # The prefill batch stays in flight: the async engine schedules the next
+    # batch before the previous batch's output is processed.
+    assert scheduler.kv_cache_manager.block_pool.get_num_free_blocks() == 0
+
+    output = scheduler.schedule()
+
+    # The escape preempts both blocked decodes, but every freed block is
+    # behind the in-flight fence: the pool must not gain blocks mid-step, so
+    # this step still schedules nothing and no fence is bypassed.
+    assert output.total_num_scheduled_tokens == 0
+    assert output.preempted_req_ids == {
+        first_decode.request_id,
+        second_decode.request_id,
+    }
+    assert scheduler.kv_cache_manager.block_pool.get_num_free_blocks() == 0
+
+    # Once the in-flight batch is processed, the fence drains and the next
+    # quantum resumes the first preempted decode; the rest of the state is
+    # served within bounded further progress.
+    _update(scheduler, prefill_output)
+    assert scheduler.kv_cache_manager.block_pool.get_num_free_blocks() == 2
+
+    resumed_output = scheduler.schedule()
+    assert resumed_output.total_num_scheduled_tokens > 0
+    assert first_decode.request_id in resumed_output.num_scheduled_tokens
+
+    _drain_async(
+        scheduler,
+        [first_decode, second_decode, waiting_prefill],
+        resumed_output,
+        max_steps=100,
+    )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -4,7 +4,7 @@ import itertools
 import math
 import time
 from collections import defaultdict, deque
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import replace
 from typing import Any
 
@@ -892,7 +892,7 @@ class Scheduler(SchedulerInterface):
         def schedule_running_requests(
             service_class: ComputeServiceClass | None = None,
             *,
-            allow_preemption: bool = True,
+            allow_preemption: bool | Callable[[], bool] = True,
             enforce_lora_limit: bool = False,
         ) -> None:
             nonlocal draft_input_budget
@@ -1062,9 +1062,14 @@ class Scheduler(SchedulerInterface):
                             # The request can be scheduled.
                             break
 
-                        if not allow_preemption:
-                            # Leftover service must not evict work selected and
-                            # admitted earlier in this model step.
+                        preemption_allowed = (
+                            allow_preemption()
+                            if callable(allow_preemption)
+                            else allow_preemption
+                        )
+                        if not preemption_allowed:
+                            # Leftover service must not evict work selected
+                            # and admitted earlier in this model step.
                             break
 
                         # The request cannot be scheduled.
@@ -1809,7 +1814,14 @@ class Scheduler(SchedulerInterface):
         if adaptive_prefill_turn and token_budget > 0:
             schedule_running_requests(
                 "decode",
-                allow_preemption=False,
+                # Empty-quantum escape (#733): a prefill turn that scheduled
+                # nothing must not strand runnable decodes at a full pool, or
+                # the uncharged quantum reselects prefill forever. Allow the
+                # normal preemption path, but only while this step is still
+                # empty, so the escape can never evict work that the current
+                # batch already admitted or scheduled. Deferred block frees
+                # and stale output are handled by _preempt_request as usual.
+                allow_preemption=lambda: not num_scheduled_tokens,
                 enforce_lora_limit=True,
             )
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -4,7 +4,7 @@ import itertools
 import math
 import time
 from collections import defaultdict, deque
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from dataclasses import replace
 from typing import Any
 
@@ -892,7 +892,8 @@ class Scheduler(SchedulerInterface):
         def schedule_running_requests(
             service_class: ComputeServiceClass | None = None,
             *,
-            allow_preemption: bool | Callable[[], bool] = True,
+            allow_preemption: bool = True,
+            preempt_only_if_empty: bool = False,
             enforce_lora_limit: bool = False,
         ) -> None:
             nonlocal draft_input_budget
@@ -1062,12 +1063,9 @@ class Scheduler(SchedulerInterface):
                             # The request can be scheduled.
                             break
 
-                        preemption_allowed = (
-                            allow_preemption()
-                            if callable(allow_preemption)
-                            else allow_preemption
-                        )
-                        if not preemption_allowed:
+                        if not allow_preemption or (
+                            preempt_only_if_empty and num_scheduled_tokens
+                        ):
                             # Leftover service must not evict work selected
                             # and admitted earlier in this model step.
                             break
@@ -1814,14 +1812,11 @@ class Scheduler(SchedulerInterface):
         if adaptive_prefill_turn and token_budget > 0:
             schedule_running_requests(
                 "decode",
-                # Empty-quantum escape (#733): a prefill turn that scheduled
-                # nothing must not strand runnable decodes at a full pool, or
-                # the uncharged quantum reselects prefill forever. Allow the
-                # normal preemption path, but only while this step is still
-                # empty, so the escape can never evict work that the current
-                # batch already admitted or scheduled. Deferred block frees
-                # and stale output are handled by _preempt_request as usual.
-                allow_preemption=lambda: not num_scheduled_tokens,
+                # An empty prefill turn must allow decode preemption to avoid
+                # reselecting prefill forever without a compute-time charge.
+                # Recheck emptiness at each allocation failure so later decode
+                # attempts cannot evict work scheduled by this fallback.
+                preempt_only_if_empty=True,
                 enforce_lora_limit=True,
             )
 


### PR DESCRIPTION
Fixes #733

## Summary

A `compute_share` prefill turn that cannot admit any work falls back to running decodes with `allow_preemption=False`. When the block pool is completely full and every runnable decode needs a new KV block, that fallback cannot schedule anything: the model step is empty, no fairness quantum is charged (an empty step exports `compute_service_class=None`), the controller's virtual runtimes do not move, and the same prefill turn is selected again — a zero-progress loop matching the live multi-minute stall in the issue.

This restores forward progress with a narrow **empty-quantum escape**:

- `schedule_running_requests` retains its boolean `allow_preemption` option and adds `preempt_only_if_empty`, checked against the live scheduled-token map at each allocation failure.
- The prefill-turn decode fallback enables `preempt_only_if_empty=True`: while the step has scheduled nothing, the normal preemption path may run (same victim selection, same `_preempt_request`, with its deferred-block-free fences and stale-output handling); as soon as any work is scheduled or admitted in the current batch, later fallback iterations cannot evict it. This uses no per-batch callback allocation or callable/type dispatch.

The proposed one-line direction in the issue (`allow_preemption=not num_scheduled_tokens` evaluated at the call site) is implemented as a per-decision emptiness check for a specific reason: a bool evaluated once would remain `True` for the whole fallback pass, letting a later blocked decode evict work the escape itself had just scheduled (visible under the priority policy, where the victim is the highest-priority-value running request).

### How already-admitted work stays protected

- Only the leftover decode service of a prefill turn changes. The main pass, waiting admission, the decode-turn prefill fallback, and the prefill-interleave redistribution pass (`allow_preemption=False`) are untouched.
- The escape is armed only while `num_scheduled_tokens` is empty and is re-checked at every preemption decision:
  - If the prefill turn admitted a prefill (or any other work), the fallback still cannot preempt at all — same behavior as before.
  - If the escape schedules a decode after a preemption, any later blocked decode in the same pass stops instead of evicting it.
- Fairness accounting stays tied to dispatched work: the escape quantum is decode compute and is exported/charged as `"decode"`; empty steps still dispatch and charge nothing.

## Tests

Regression coverage in `tests/v1/core/test_prefill_compute_share_scheduler.py` drives the real scheduler, the real block pool (2–3 usable blocks), and the real controller `select`/`dispatch`/`record` flow into the issue state (full pool, running decodes at block boundaries, unschedulable waiting prefill, prefill turn selected):

- `test_prefill_turn_escape_preempts_to_keep_decode_progress` — FCFS: the empty prefill turn now schedules the oldest decode and preempts the newest (normal FCFS victim choice); the quantum is charged as decode. Fails on the parent commit (empty output, zero preemptions).
- `test_full_pool_fairness_state_drains_within_bounded_steps` — the whole state drains to completion within bounded steps instead of looping empty forever. Fails on the parent commit.
- `test_prefill_turn_fallback_never_preempts_admitted_prefill_work` — pins the protection invariant: when the prefill turn admits a prefill into the last free block, the fallback does not preempt it. Passes before and after; guards against an over-broad escape.
- `test_priority_escape_preserves_decode_scheduled_within_fallback` — priority policy: the escape preempts the lowest-urgency running request (highest priority value) and, once a decode is scheduled, a later blocked decode can neither evict it nor disturb an untouched one; the full state still drains within bounded progress. Fails on the parent commit, and also fails if the dynamic stop is weakened to a call-time bool.
- `test_escape_respects_deferred_free_fences` — async scheduler with deferred block frees: the escape preempts through the unchanged `_preempt_request`, the in-flight fence is not bypassed (the pool gains no blocks mid-step; the step stays empty), and the preempted decodes resume once the in-flight batch is processed and the fence drains. Fails on the parent commit.

## Testing

Focused CPU-only runs in an isolated worktree (base `cf4b944e3`, branch `fix/fairness-kv-forward-progress`), interpreter `/tmp/vllm-fairness-venv/bin/python` (Python 3.12.14), env `VLLM_TARGET_DEVICE=cpu PYTORCH_CUDA_ALLOC_CONF= VLLM_USE_V1=1`:

- Parent code (production change reverted, tests kept):
  `.../python -m pytest tests/v1/core/test_prefill_compute_share_scheduler.py -q`
  → **4 failed / 71 passed** — exactly the four new forward-progress tests fail with empty-schedule signatures (`assert {} == {...}`, no drain, empty preempted set).
- With this change: same command → **75 passed**.
- `.../python -m pytest tests/v1/core/test_priority_preemption_bug.py -q` → **1 passed**.
- `.../python -m pytest tests/v1/core/test_scheduler.py -q -k "preempt or priority or async"` → **28 passed, 8 failed**; the 8 failures are pre-existing offline-environment `ModelConfig` validation errors (multimodal architecture inspection) and are identical with and without this change.

## Limitations

- CPU scheduler-unit coverage only: no GPU, model workload, or live serving was run, and no production qualification is claimed. Sustained near-capacity mixed traffic with MTP/DCP (from the issue's verification list) remains open.
- The deployed compatibility port in the issue pins an older upstream commit; this PR fixes the current `dev/jovian-judgement` line, where the unconditional no-preemption fallback is still present.

Implementation and CPU test construction used an autonomous local coding agent. Independent review, the allocation-free boolean-mode refinement, and final verification used OpenAI Codex assistance. No serving process was modified.

## Independent parent review and verification

The supervising agent independently inspected the diff and replaced the callback-based guard with an allocation-free `preempt_only_if_empty` boolean mode. Emptiness is still evaluated at each allocation failure, not captured once per fallback pass. The normal `allow_preemption` contract remains boolean.

- Final formatted source: **76 passed** across `test_prefill_compute_share_scheduler.py` and `test_priority_preemption_bug.py` (26.61s pytest time).
- Separate pristine-upstream worktree at `cf4b944e3`, with the new regressions copied in: **4 failed, 1 passed, 70 deselected** for `-k 'escape or full_pool or fallback_never_preempts_admitted'`. The admitted-prefill protection test passes; all four forward-progress regressions fail.
- Independent mutation check: replacing the live emptiness guard with a call-time boolean makes `test_priority_escape_preserves_decode_scheduled_within_fallback` fail: the fallback evicts the just-scheduled `low` request and returns `urgent` instead.
- Repository-pinned Ruff **0.14.0** formatting and lint pass for both changed files.
- An initial parent run with `HF_HUB_OFFLINE=1` passed 68 tests but failed eight existing CLI cases because the default Qwen model repository metadata was not cached. With the original environment (no forced offline flag), all 76 pass. These metadata-only CLI checks do not execute a model.
- The broader multimodal `ModelConfig` limitations reported above remain outside this focused green result. No GPU, live-model validation or deployment was performed.

A concurrent GitHub whitespace correction was preserved during publication; the final integrated scheduler/test files are byte-identical to the independently tested files.
