### PR TITLE
[Perf][Model] Use direct cuBLAS for DeepSeek V4.1 WO-A

### DIFF
--- a/tests/v1/attention/test_b12x_v41_workspace.py
+++ b/tests/v1/attention/test_b12x_v41_workspace.py
@@ -30,6 +30,11 @@ def native_workspace(monkeypatch):
     monkeypatch.setattr(workspace, "_manager", manager)
     monkeypatch.setattr(workspace, "dbo_current_ubatch_id", lambda: 0)
     monkeypatch.setattr(attention, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(
+        torch.backends.cuda.matmul,
+        "allow_bf16_reduced_precision_reduction",
+        torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction,
+    )
     with workspace.use_workspace_lane(0):
         yield attention, manager, workspace
 
@@ -419,20 +424,8 @@ def test_grouped_projection_live_storage_survives_workspace_reuse(native_workspa
 
 
 @pytest.mark.parametrize("width,k", [(128, 512), (1024, 4096)])
-def test_grouped_fp8_weight_only_prefill_preserves_bf16_contract(
-    native_workspace, monkeypatch, width, k
-):
-    from b12x import freeze_kernel_resolution, unfreeze_kernel_resolution
-    from b12x.gemm import bf16_gemv
-
-    attention, manager, workspace = native_workspace
-    monkeypatch.setattr(
-        attention,
-        "get_current_vllm_config",
-        lambda: SimpleNamespace(
-            scheduler_config=SimpleNamespace(max_num_batched_tokens=4096)
-        ),
-    )
+def test_grouped_fp8_projection_preserves_bf16_contract(native_workspace, width, k):
+    attention, _, workspace = native_workspace
     torch.manual_seed(41003)
     groups = 2
     layer = torch.nn.Module()
@@ -454,46 +447,33 @@ def test_grouped_fp8_weight_only_prefill_preserves_bf16_contract(
     ).bfloat16()
     torch.testing.assert_close(layer.weight, dense, rtol=0, atol=0)
     source = torch.randn((1025, groups, k), device="cuda").bfloat16()
-    method.apply(layer, source, is_prefill=True)
-    manager.lock()
-    freeze_kernel_resolution("V4.1 weight-only prefill with BF16 activations")
-    try:
-        for rows in (1, 6, 64, 257, 1025):
-            x = source[:rows]
-            expected = torch.cat(
-                [
-                    x[:, g].float() @ dense[g * width : (g + 1) * width].float().T
-                    for g in range(groups)
-                ],
-                dim=1,
-            )
-            gemv = torch.cat(
-                [
-                    bf16_gemv.mm(x[:, g], dense[g * width : (g + 1) * width])
-                    for g in range(groups)
-                ],
-                dim=1,
-            )
-            actual = method.apply(layer, x, is_prefill=True)
-            actual_rmse = (actual.float() - expected).square().mean().sqrt()
-            gemv_rmse = (gemv.float() - expected).square().mean().sqrt()
-            assert actual_rmse <= gemv_rmse * 1.01 + 1e-7
-            torch.testing.assert_close(actual.float(), expected, rtol=0.01, atol=0.1)
-            torch.testing.assert_close(method.apply(layer, x), gemv, rtol=0, atol=0)
-            graph = torch.cuda.CUDAGraph()
-            with (
-                workspace.collect_cuda_graph_capture_resources() as resources,
-                torch.cuda.graph(graph),
-            ):
-                result = method.apply(layer, x, is_prefill=True)
-            source.normal_()
-            expected = method.apply(layer, x, is_prefill=True)
-            result.fill_(float("nan"))
-            graph.replay()
-            torch.testing.assert_close(result, expected, rtol=0, atol=0)
-            del graph, resources
-    finally:
-        unfreeze_kernel_resolution()
+
+    def reference(x):
+        return torch.cat(
+            [
+                x[:, g].float() @ dense[g * width : (g + 1) * width].float().T
+                for g in range(groups)
+            ],
+            dim=1,
+        )
+
+    for rows in (1, 32, 1025):
+        x = source[:rows]
+        actual = method.apply(layer, x)
+        assert actual.dtype == torch.bfloat16
+        torch.testing.assert_close(actual.float(), reference(x), rtol=0.01, atol=0.1)
+        graph = torch.cuda.CUDAGraph()
+        with (
+            workspace.collect_cuda_graph_capture_resources() as resources,
+            torch.cuda.graph(graph),
+        ):
+            result = method.apply(layer, x)
+        source.normal_()
+        expected = reference(x)
+        result.fill_(float("nan"))
+        graph.replay()
+        torch.testing.assert_close(result.float(), expected, rtol=0.01, atol=0.1)
+        del graph, resources
 
 
 @pytest.mark.parametrize("ratio", [1, 2])

--- a/vllm/models/deepseek_v4_1/attention.py
+++ b/vllm/models/deepseek_v4_1/attention.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""V4.1 Full/Reindex/Reuse topology with native b12x compute only."""
+"""Native V4.1 Full/Reindex/Reuse attention with BF16 grouped projection."""
 
 from typing import cast
 
@@ -12,10 +12,8 @@ from b12x.attention.compressed_sparse_mla.preparation import rotate
 from b12x.attention.compressed_sparse_mla.weight_scale import (
     scale_index_weights,
 )
-from b12x.gemm import bf16_gemv, blockscaled
 from torch import nn
 
-from vllm.config import get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_world_size, get_tp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
@@ -155,7 +153,7 @@ def _unpack_wo_a(Weight, Scale, Out, N: tl.constexpr, K: tl.constexpr, B: tl.con
 
 
 class _GroupedLinearMethod(LinearMethodBase):
-    """WO-A with BF16 activations in both GEMV and weight-only tensor-core paths."""
+    """Exact checkpoint weights, BF16 activations, and direct cuBLAS output."""
 
     def __init__(self, original, groups):
         if type(original) is UnquantizedLinearMethod:
@@ -163,12 +161,13 @@ class _GroupedLinearMethod(LinearMethodBase):
         if not isinstance(original, (B12xFP8LinearMethod, B12xLinearMethod)):
             raise ValueError("V4.1 grouped output requires native b12x weights")
         self.original, self.groups = original, groups
+        # Preserve FP32 reduction of BF16 products, as in the native kernels.
+        torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
 
     def create_weights(self, *args, **kwargs):
         return self.original.create_weights(*args, **kwargs)
 
     def process_weights_after_loading(self, layer):
-        self.prefill_weights = []
         if layer.weight.dtype == torch.float8_e4m3fn:
             scales = layer.weight_scale_inv
             if scales.dtype != torch.float8_e8m0fnu:
@@ -176,24 +175,6 @@ class _GroupedLinearMethod(LinearMethodBase):
             width = layer.weight.shape[0] // self.groups
             if width % 32:
                 raise ValueError("V4.1 WO-A groups must preserve block32 scale rows")
-            for group in range(self.groups):
-                start, end = group * width, (group + 1) * width
-                # Replicating a block-row exponent changes storage, not values.
-                # A16 dequantizes these exact checkpoint weights to BF16 and
-                # never quantizes the inverse-RoPE activation.
-                scale_rows = scales[start // 32 : end // 32].view(torch.uint8)
-                packed = blockscaled.pack_weight(
-                    layer.weight[start:end],
-                    scale_rows.repeat_interleave(32, dim=0),
-                    recipe="mxfp8",
-                )
-                blockscaled.prewarm(packed, (1, 8, 64), mode="a16")
-                self.prefill_weights.append(packed)
-            capacity = get_current_vllm_config().scheduler_config.max_num_batched_tokens
-            self.prefill_workspace_bytes = max(
-                blockscaled.workspace_size(packed, capacity)
-                for packed in self.prefill_weights
-            )
             dense = torch.empty(
                 layer.weight.shape, dtype=torch.bfloat16, device=layer.weight.device
             )
@@ -207,14 +188,15 @@ class _GroupedLinearMethod(LinearMethodBase):
             )
             layer.weight = nn.Parameter(dense, requires_grad=False)
             del layer.weight_scale_inv
+        if layer.weight.dtype != torch.bfloat16:
+            raise TypeError("V4.1 WO-A requires BF16 decoded weights")
         width = layer.weight.shape[0] // self.groups
-        self.weights = []
-        for group in range(self.groups):
-            weight = layer.weight[group * width : (group + 1) * width]
-            bf16_gemv.precompile(weight)
-            self.weights.append(weight)
+        self.weights = [
+            layer.weight[group * width : (group + 1) * width].t()
+            for group in range(self.groups)
+        ]
 
-    def apply(self, layer, x, bias=None, *, is_prefill=False):
+    def apply(self, layer, x, bias=None):
         if bias is not None:
             raise ValueError("V4.1 WO-A must be bias free")
         rows = x.shape[0]
@@ -224,18 +206,7 @@ class _GroupedLinearMethod(LinearMethodBase):
         width = layer.weight.shape[0] // self.groups
         for group in range(self.groups):
             target = result[:, group * width : (group + 1) * width]
-            if is_prefill and self.prefill_weights:
-                (scratch,) = current_workspace_manager().get_simultaneous(
-                    ((self.prefill_workspace_bytes,), torch.uint8)
-                )
-                source = x[:, group].contiguous()
-                projected = blockscaled.mm(
-                    source, self.prefill_weights[group], mode="a16", workspace=scratch
-                )
-                target.copy_(projected)
-                retain_cuda_graph_capture_resource((source, projected))
-            else:
-                bf16_gemv.mm(x[:, group], self.weights[group], out=target)
+            torch.matmul(x[:, group], self.weights[group], out=target)
         retain_cuda_graph_capture_resource((x, result))
         return result
 
@@ -716,14 +687,12 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase):
             dict[str, DeepseekV41B12xMetadata] | None,
             get_forward_context().attn_metadata,
         )
-        is_prefill = True
         if not isinstance(metadata, dict):
             # Memory profiling has no cache pages; serving does not use this branch.
             output.zero_()
         else:
             original_swa = metadata[self.swa_cache_layer.prefix]
             swa = self._query_metadata(original_swa)
-            is_prefill = not swa.is_decode
             self.insert_context_kv(kv, positions, swa.slot_mapping[:rows])
             if swa is original_swa:
                 self._prepare_global_kv(positions, hidden_states)
@@ -741,7 +710,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase):
                 index_query = (iq_data, iq_scale, iw)
                 retain_cuda_graph_capture_resource((weights, index_query))
             self.forward_mqa(q, kv, positions, output, index_query=index_query)
-        return self._o_proj(output, positions, is_prefill=is_prefill)
+        return self._o_proj(output, positions)
 
     def forward_mqa(self, q, kv, positions, output, *, index_query=None):
         metadata = get_forward_context().attn_metadata
@@ -896,13 +865,11 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase):
             cache_format="deepseek_v41",
         )
 
-    def _o_proj(self, o, positions, *, is_prefill=False):
+    def _o_proj(self, o, positions):
         rows = o.shape[0]
         inverse = _rotated(o, positions, self.rotary_emb.cos_sin_cache, inverse=True)
         grouped = inverse.view(rows, self.n_local_groups, -1)
-        local = self.wo_b(
-            self.wo_a.quant_method.apply(self.wo_a, grouped, is_prefill=is_prefill)
-        )
+        local = self.wo_b(self.wo_a.quant_method.apply(self.wo_a, grouped))
         if local.dtype != torch.bfloat16:
             raise TypeError("V4.1 WO-B must round the local projection to BF16")
         if get_tensor_model_parallel_world_size() > 1:


### PR DESCRIPTION
## Purpose

Draft for review against `dev/jovian-judgement` (`d783e291ea96547705e157add7c9d3df409f1d04`). Isolate the measured DS4.1 WO-A optimization from the separate attention/indexer work. No B12X scorer or MLA changes are included.

Replace WO-A's two execution paths with direct-output, per-group cuBLAS matmul:

- Keep the existing FP8 checkpoint + UE8M0 → BF16 weight dequantization. The old implementation already materializes these dense BF16 weights for decode; this is not a new checkpoint conversion.
- Use those BF16 weights and BF16 inverse-RoPE activations for **both prefill and decode**. This intentionally replaces WO-A's blockscaled/MXFP8 A16 prefill path as well as its BF16 GEMV decode path. It is not restricted to checkpoints initially stored as unquantized BF16.
- Write directly into each output group, eliminating the A16 activation-contiguity copy, intermediate projection/copy, duplicate packed weights, workspace, and obsolete `is_prefill` plumbing.
- Preserve BF16 output rounding and graph resource retention. Other FP8 linear layers are untouched.
- Update the existing projection correctness/replay test. Retain the newer upstream attention metadata/global-KV behavior and unrelated tests during the rebase.

### Important review caveat

The implementation sets `torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False` in `_GroupedLinearMethod.__init__` to preserve FP32 reduction of BF16 products. **This setting is process-wide**, not scoped to this projection. Its treatment needs an explicit review decision before merge; the component measurements do not qualify its effect on other BF16 matmuls or other models.

### Dedicated B12X WO projection is not benchmarked here

The tested B12X revision also contains [`b12x.gemm.wo_projection`](https://github.com/local-inference-lab/b12x/tree/864b630235206d1d88338767c59e897f315822ef/b12x/gemm/wo_projection), with grouped WO-A/WO-B `run` and fused inverse-RoPE `run_inv_rope` entry points. **This PR does not compare cuBLAS against that dedicated fused pipeline.** It compares the existing vLLM WO-A BF16-GEMV/A16 dispatch against cuBLAS.

The dedicated API accepts BF16 inputs but quantizes the grouped activation operands to MXFP8 internally. Using it in this adapter would therefore change the current WO-A BF16-activation arithmetic and needs a separate accuracy/performance comparison. The table below is not evidence that cuBLAS beats B12X's dedicated WO projection kernels, and should not be used to dismiss that native alternative.

## Performance evidence

DGX Spark / GB10 / SM121. Real DeepSeek-V4.1-Flash checkpoint weights, layer 3 / TP rank 1; synthetic BF16 activations. Two local groups, each `[M,4096] × [4096,1024]`, with direct output into `[M,2048]`. CUDA-graph component measurements:

| Prefill rows | Existing WO-A A16 | Direct cuBLAS | Component speedup |
|---:|---:|---:|---:|
| 256 | 149.632 µs | 77.824 µs | 1.92× |
| 1,024 | 620.560 µs | 194.864 µs | 3.18× |
| 4,096 | 4,416.528 µs | 730.992 µs | 6.04× |
| 8,192 | 10,602.688 µs | 1,473.504 µs | 7.20× |

These are **projection timings, not full-model throughput gains**. Other GPU architectures have not been qualified by these measurements.

A separate real-model TP4 trace at approximately 532K context confirms that the candidate executes this path: one 8,192-token step contained 80 WO-A `aten::mm` calls linked by profiler external IDs to `nvjet_sm121_tst_mma_256x112x64_2_64x56x64_tmaAB_bz_TNNN`, totaling **60.10 ms GPU time** in a **9.54 s** rank-0 GPU span. The corresponding WO-A total around 90K context was 61.65 ms. This is runtime attribution, not an isolated full-model A/B.

## Test Plan / Result

### Recorded GPU checks on the measured implementation

Inside the frozen candidate image on SM121:

```sh
python3 -m pytest --noconftest -q \
  tests/v1/attention/test_b12x_v41_workspace.py::test_grouped_fp8_projection_preserves_bf16_contract
```

**2 passed, 0 skipped, 12.45 s.** Two geometries `(width,K)=(128,512)` and `(1024,4096)`; rows 1/32/1025; BF16 output against an independent FP32 matmul reference; changed-input CUDA-graph replay. `--noconftest` avoided an unrelated repository `tblib` dependency. The updated test fixture restores the process-wide precision flag after each test.

Measured source provenance: vLLM `a31a2aafc5c46ec6c9375f7dc550a755e9b0ac9d`, B12X `c4901cd1eb043c6721c27dad02c3f4544d4c66fb`; immutable image `sha256:4ddc45d7b792d6bbc338e7a75760d0188620404bc2a043018e0004270bfe0292`. The rebased `_GroupedLinearMethod` is AST-identical to that measured implementation; that comparison is provenance, **not a new GPU test of the rebased branch**.

### Model evaluation and unresolved long-context result

The combined scorer/WO-A image passed eight default quality cases and retrieved all three exact codes from a cold **1,048,448-token** prompt, with zero prefix-cache hits, preemptions, or rank restarts.

However, that combined image's near-1M prefill took **2,907.46 s**, versus **1,494.47 s** in the retained control. Attribution is unresolved. The runs also differed in preceding workload order. This PR does **not** claim to fix that slowdown or establish standalone WO-A full-context performance. A later exact-1M tracing attempt was cancelled before completion; no timing or tail-trace result is claimed from it. The qualified deployment was restored, and the combined image remains unpromoted.

### Fresh checks on this rebase

```sh
uv tool run --from ruff==0.14.0 ruff check \
  vllm/models/deepseek_v4_1/attention.py \
  tests/v1/attention/test_b12x_v41_workspace.py
uv tool run --from ruff==0.14.0 ruff format --check \
  vllm/models/deepseek_v4_1/attention.py \
  tests/v1/attention/test_b12x_v41_workspace.py
```

Both passed; two files already formatted. No new GPU experiments or full-suite run on the rebased branch. Human review, precision-policy review, and fresh integration/long-context qualification remain necessary before merge or promotion.

Full pre-commit is **not green on the untouched base either**. The commit attempt reported six mypy errors in unchanged attention code (tuple typing, nullable indexer members, and `AttentionMetadata.slot_mapping`) plus one existing CUDA-API policy violation in the newer workspace tests. Both failing hooks were then run against a separate, untouched checkout of `d783e291` and reproduced the same failures.

Only `mypy-3.10` and `check-torch-cuda-call` were skipped for the draft commit; remaining applicable hooks passed. No hook configuration or unrelated attention code was changed to hide these baseline failures.

## Duplication / scope

Open WO-A/cuBLAS PR searches found no equivalent DS4.1 projection change. This builds on merged #734 and is separate from #736's bounded MoE/Engram work. The separately measured B12X scorer/MLA port is existing upstream work and is deliberately excluded. No DCP, MHC fusion, MoE overlap, attention-selection, cache-layout, or serving-profile changes are part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved BF16 grouped-projection handling in DeepSeek V4.1 attention.
  - Ensured projection results remain consistent across different input sizes and repeated CUDA Graph execution.
  - Removed reliance on separate prefill and decode behavior for output projections, providing more consistent attention results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->