### PR TITLE
perf(dspark): fuse full-vocabulary greedy Markov reduction

### DIFF
--- a/tests/v1/worker/test_dspark_greedy_markov.py
+++ b/tests/v1/worker/test_dspark_greedy_markov.py
@@ -11,6 +11,36 @@ from vllm.v1.worker.gpu.spec_decode.dspark.greedy import (
 )
 
 
+@pytest.mark.parametrize("base_vocab,bias_vocab", [(2049, 2048), (2048, 2049)])
+def test_greedy_markov_rejects_mismatched_vocabulary_before_dispatch(
+    base_vocab, bias_vocab
+):
+    """An invalid model head must fail before any GPU buffer is accessed."""
+    base = torch.empty((2, base_vocab))
+    bias = torch.empty((2, bias_vocab))
+    output = torch.empty(2, dtype=torch.int64)
+    shape = scratch_shape(2, max(base_vocab, bias_vocab))
+    with pytest.raises(ValueError, match="identical shapes"):
+        sample_greedy_markov(
+            base,
+            bias,
+            output,
+            torch.empty(shape),
+            torch.empty(shape, dtype=torch.int32),
+        )
+
+
+@pytest.mark.parametrize("short_values", [False, True])
+def test_greedy_markov_rejects_insufficient_scratch_before_dispatch(short_values):
+    base = torch.empty((2, 2049))
+    bias = torch.empty_like(base)
+    output = torch.empty(2, dtype=torch.int64)
+    values = torch.empty(3 if short_values else 4)
+    indices = torch.empty(4 if short_values else 3, dtype=torch.int32)
+    with pytest.raises(ValueError, match="scratch is smaller"):
+        sample_greedy_markov(base, bias, output, values, indices)
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
 @pytest.mark.parametrize("vocab", [1, 2047, 2048, 2049, 129280])

--- a/tests/v1/worker/test_dspark_greedy_markov.py
+++ b/tests/v1/worker/test_dspark_greedy_markov.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Exact full-vocabulary DSpark greedy tokens, including graph replay."""
+
+import pytest
+import torch
+
+from vllm.v1.worker.gpu.spec_decode.dspark.greedy import (
+    sample_greedy_markov,
+    scratch_shape,
+)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+@pytest.mark.parametrize("vocab", [1, 2047, 2048, 2049, 129280])
+@pytest.mark.parametrize("rows", [1, 4])
+def test_greedy_markov_exact_replay(dtype, vocab, rows):
+    torch.manual_seed(41612)
+    storage = torch.randn((rows, 7, vocab), device="cuda", dtype=dtype)
+    base = storage[:, 3]
+    bias = torch.randn_like(base)
+    result = torch.full((rows, 7), -77, device="cuda", dtype=torch.int64)
+    output = result[:, 3]
+    shape = scratch_shape(rows, vocab)
+    values = torch.full(shape, float("nan"), device="cuda")
+    indices = torch.full(shape, -1, device="cuda", dtype=torch.int32)
+    run = lambda: sample_greedy_markov(base, bias, output, values, indices)
+    run()
+    torch.testing.assert_close(output, (base + bias).argmax(-1), rtol=0, atol=0)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run()
+    for case in ("mutated", "ties", "negative-infinity", "nan"):
+        if case == "mutated":
+            base.normal_()
+            bias.normal_()
+        elif case == "ties":
+            base.fill_(-1)
+            bias.zero_()
+            base[:, 0] = 2
+            base[:, -1] = 2
+        elif case == "negative-infinity":
+            base.fill_(-float("inf"))
+            bias.zero_()
+        else:
+            base.zero_()
+            base[:, -1] = float("nan")
+            base[:, vocab // 2] = float("nan")
+        values.fill_(float("nan"))
+        indices.fill_(-1)
+        allocated = torch.accelerator.memory_allocated()
+        graph.replay()
+        torch.accelerator.synchronize()
+        assert torch.accelerator.memory_allocated() == allocated
+        torch.testing.assert_close(output, (base + bias).argmax(-1), rtol=0, atol=0)
+        assert torch.all(result[:, :3] == -77)
+        assert torch.all(result[:, 4:] == -77)

--- a/vllm/v1/worker/gpu/spec_decode/dspark/greedy.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/greedy.py
@@ -82,9 +82,26 @@ def sample_greedy_markov(
     scratch of ``scratch_shape(capacity, vocabulary_size)`` and int32/int64
     output, which may be a strided speculative-token column. Ties, NaNs, and
     addition rounding follow PyTorch argmax. No proposal truncation is used.
+
+    Args:
+        base_logits: Per-request full-vocabulary base logits.
+        markov_bias: Transition bias with the same shape and dtype as base_logits.
+        output: Caller-owned column receiving one token ID per request.
+        partial_values: Contiguous FP32 scratch for the partial maxima.
+        partial_indices: Contiguous int32 scratch for the partial token indices.
+
+    Raises:
+        ValueError: Input shapes differ or scratch cannot hold every partial.
     """
+    if base_logits.shape != markov_bias.shape:
+        raise ValueError(
+            "DSpark greedy base logits and Markov bias must have identical shapes: "
+            f"{tuple(base_logits.shape)} != {tuple(markov_bias.shape)}"
+        )
     rows, vocab = base_logits.shape
     parts = triton.cdiv(vocab, _BLOCK)
+    if min(partial_values.numel(), partial_indices.numel()) < rows * parts:
+        raise ValueError("DSpark greedy scratch is smaller than the logits require")
     _partial_argmax[(rows, parts)](
         base_logits,
         markov_bias,

--- a/vllm/v1/worker/gpu/spec_decode/dspark/greedy.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/greedy.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Allocation-free greedy reduction of base logits and sequential Markov bias."""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+_BLOCK = 2048
+
+
+@triton.jit
+def _first_argmax(av, ai, bv, bi):
+    a_nan = av != av
+    b_nan = bv != bv
+    take_a = (a_nan & (~b_nan | (ai < bi))) | (
+        ~a_nan & ~b_nan & ((av > bv) | ((av == bv) & (ai < bi)))
+    )
+    return tl.where(take_a, av, bv), tl.where(take_a, ai, bi)
+
+
+@triton.jit
+def _partial_argmax(
+    base,
+    bias,
+    values,
+    indices,
+    base_stride,
+    bias_stride,
+    VOCAB: tl.constexpr,
+    PARTS: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    part = tl.program_id(1)
+    col = part * BLOCK + tl.arange(0, BLOCK)
+    a = tl.load(base + row * base_stride + col, col < VOCAB, other=0)
+    b = tl.load(bias + row * bias_stride + col, col < VOCAB, other=0)
+    # Preserve the materialized torch.add rounding before comparing logits.
+    summed = (
+        (a.to(tl.float32) + b.to(tl.float32)).to(base.dtype.element_ty).to(tl.float32)
+    )
+    summed = tl.where(col < VOCAB, summed, -float("inf"))
+    idx = tl.where(col < VOCAB, col, 2147483647)
+    value, index = tl.reduce((summed, idx), 0, _first_argmax)
+    tl.store(values + row * PARTS + part, value)
+    tl.store(indices + row * PARTS + part, index)
+
+
+@triton.jit
+def _finish_argmax(
+    values,
+    indices,
+    output,
+    output_stride,
+    PARTS: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    part = tl.arange(0, BLOCK)
+    value = tl.load(values + row * PARTS + part, part < PARTS, other=-float("inf"))
+    index = tl.load(indices + row * PARTS + part, part < PARTS, other=2147483647)
+    _, result = tl.reduce((value, index), 0, _first_argmax)
+    tl.store(output + row * output_stride, result)
+
+
+def scratch_shape(max_requests: int, vocabulary_size: int) -> tuple[int, int]:
+    return max_requests, triton.cdiv(vocabulary_size, _BLOCK)
+
+
+def sample_greedy_markov(
+    base_logits: torch.Tensor,
+    markov_bias: torch.Tensor,
+    output: torch.Tensor,
+    partial_values: torch.Tensor,
+    partial_indices: torch.Tensor,
+) -> None:
+    """Write exactly ``(base_logits + markov_bias).argmax(-1)`` into output.
+
+    Both inputs share FP32, FP16, or BF16 dtype and have contiguous vocabulary
+    columns. Request strides may differ. The caller owns disjoint FP32/int32
+    scratch of ``scratch_shape(capacity, vocabulary_size)`` and int32/int64
+    output, which may be a strided speculative-token column. Ties, NaNs, and
+    addition rounding follow PyTorch argmax. No proposal truncation is used.
+    """
+    rows, vocab = base_logits.shape
+    parts = triton.cdiv(vocab, _BLOCK)
+    _partial_argmax[(rows, parts)](
+        base_logits,
+        markov_bias,
+        partial_values,
+        partial_indices,
+        base_logits.stride(0),
+        markov_bias.stride(0),
+        vocab,
+        parts,
+        _BLOCK,
+    )
+    _finish_argmax[(rows,)](
+        partial_values,
+        partial_indices,
+        output,
+        output.stride(0),
+        parts,
+        triton.next_power_of_2(parts),
+    )

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -89,9 +89,9 @@ class DSparkSpeculator(DFlashSpeculator):
         self.enable_adaptive_verification = (
             self.speculative_config.enable_adaptive_verification
         )
-        draft_vocab = (
-            getattr(self.draft_model_config.hf_config, "draft_vocab_size", None)
-            or self.draft_model_config.hf_config.vocab_size
+        draft_vocab = max(
+            self.draft_model_config.hf_config.vocab_size,
+            getattr(self.draft_model_config.hf_config, "draft_vocab_size", None) or 0,
         )
         shape = scratch_shape(self.max_num_reqs, draft_vocab)
         self._greedy_partial_values = torch.empty(

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -32,6 +32,10 @@ from vllm.config.compilation import CUDAGraphMode
 from vllm.logger import init_logger
 from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
 from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
+from vllm.v1.worker.gpu.spec_decode.dspark.greedy import (
+    sample_greedy_markov,
+    scratch_shape,
+)
 from vllm.v1.worker.gpu.spec_decode.dspark.utils import load_dspark_model
 
 logger = init_logger(__name__)
@@ -84,6 +88,17 @@ class DSparkSpeculator(DFlashSpeculator):
         )
         self.enable_adaptive_verification = (
             self.speculative_config.enable_adaptive_verification
+        )
+        draft_vocab = (
+            getattr(self.draft_model_config.hf_config, "draft_vocab_size", None)
+            or self.draft_model_config.hf_config.vocab_size
+        )
+        shape = scratch_shape(self.max_num_reqs, draft_vocab)
+        self._greedy_partial_values = torch.empty(
+            shape, dtype=torch.float32, device=device
+        )
+        self._greedy_partial_indices = torch.empty(
+            shape, dtype=torch.int32, device=device
         )
 
     @property
@@ -198,11 +213,25 @@ class DSparkSpeculator(DFlashSpeculator):
             if self.enable_adaptive_verification:
                 confidence_markov_embeds.append(markov_embed)
             bias = self.model.markov_bias(markov_embed)
-            logits_i = base_logits[:, i] + bias
-            draft_sampled_i = self._sample_logits(
-                logits_i, idx_map[:, i], sample_pos[:, i], i
-            )
-            self.draft_tokens[:num_reqs, i] = draft_sampled_i
+            if (
+                self.draft_logits is None
+                and self.model.draft_id_to_target_id is None
+                and base_logits.dtype == bias.dtype
+            ):
+                draft_sampled_i = self.draft_tokens[:num_reqs, i]
+                sample_greedy_markov(
+                    base_logits[:, i],
+                    bias,
+                    draft_sampled_i,
+                    self._greedy_partial_values,
+                    self._greedy_partial_indices,
+                )
+            else:
+                logits_i = base_logits[:, i] + bias
+                draft_sampled_i = self._sample_logits(
+                    logits_i, idx_map[:, i], sample_pos[:, i], i
+                )
+                self.draft_tokens[:num_reqs, i] = draft_sampled_i
             prev = draft_sampled_i
 
         if self.enable_adaptive_verification:


### PR DESCRIPTION
## Purpose and behavior

DSpark greedy drafting repeatedly computes `(base_logits + markov_bias).argmax(-1)` over the full vocabulary. Fuse the addition and a two-stage argmax, and write directly into the caller-owned draft-token column. This removes the materialized sum and separate token copy without changing the Markov projection or truncating the vocabulary.

- Preserve source-dtype addition rounding, first-index ties, and first-NaN selection.
- Allocate FP32/int32 partial-reduction scratch once per proposer; reuse it during CUDA graph replay.
- Select the implementation only for full-vocabulary greedy proposals with matching input dtypes. Probabilistic, reduced-vocabulary, and gathered-top-k proposal paths retain their existing sampling implementations.
- Leave target weights/logits, rejection sampling, adaptive verification, and B12X unchanged. No additional configuration switch is required.

Status: **implemented**, with **qualified GPU operation parity** under the conditions below. A stable whole-model throughput gain remains **research-only**.

## Correctness validation

```bash
/opt/venv/bin/python -m pytest -q --confcutdir=tests/v1/worker \
  tests/v1/worker/test_dspark_greedy_markov.py
```

**30 passed in 7.37 s** in the serving image. Coverage: BF16/FP16/FP32; 1/4 rows; vocabulary sizes 1, 2047, 2048, 2049, and 129280; strided request/output tensors; vocabulary tails; ties, infinities and NaNs; input mutation; poisoned scratch; CUDA graph replay with unchanged allocation count; untouched neighboring output columns. These tests are self-contained; `--confcutdir` excludes parent fixtures requiring `tblib`, which is absent from the serving dependency set.

A diagnostic TP4 worker also compared every fused invocation against the materialized PyTorch operation on the **same live logits**, including graph replay. Three 1024-output-token requests and the prefill sequence completed without an assertion. That diagnostic extension is not part of the patch or serving image. Ruff, applicable commit hooks, and `git diff --check` passed for the source change.

Whole-completion bit equality is not established: repeated temperature-zero completions differ even within the unmodified control. No generated-code quality evaluation was performed; Sieve below is a coding-prompt speed probe.

## GPU microbenchmark

RTX PRO 6000 Blackwell Workstation, memory offset **+6000**. CUDA graphs execute seven full-vocabulary reductions at vocabulary size 129280. Both arms include addition, argmax, and output-column writes. After warmup, 41 samples alternate measurement order; output tokens match exactly.

| Dtype / requests | Materialized operation | Fused operation |
|---|---:|---:|
| BF16 / 1 | 135.82 µs | 13.85 µs |
| BF16 / 4 | 144.17 µs | 15.86 µs |
| FP32 / 1 | 134.79 µs | 14.84 µs |
| FP32 / 4 | 142.80 µs | 17.40 µs |

This saves about **0.12 ms per seven-position reduction sequence**, not 10× model throughput. The benchmark excludes the Markov projection itself.

## Serving observations and limits

Both arms used the same physical quartet: TP4/DCP1, native DeepSeek V4.1 Flash DSpark K7, greedy proposals, standard rejection, adaptive verification, V2, breakable `FULL_AND_PIECEWISE` graphs, B12X backends, mapped pinned-RAM Engram, batch budget 4096, max sequences 4, OMP8, NCCL16/2 MiB, no expert parallelism. Target sampling: temperature 1 / top-p 0.95. Memory offset **+6000**, graphics offset zero, automatic graphics clocks, 600 W limit; these are **not stock-clock results**.

C1/context-zero: five cells per arm, each requesting 15 s warmup and 30 s measurement. Sieve: one excluded warmup and five measured requests. Seeds were not paired across these stochastic probes.

| Five-run median | Control | Fused | Observed change |
|---|---:|---:|---:|
| C1 output tokens/s | 241.10 | 250.12 | +3.74% |
| C1 verifier steps/s | 90.67 | 91.53 | +0.94% |
| C1 emitted tokens/step | 2.653 | 2.735 | +3.10% |
| Sieve output tokens/s | 358.02 | 366.14 | +2.27% |
| Sieve min–max | 320.29–381.70 | 355.48–385.38 | Overlap |

Acceptance and adaptive verifier width change the work per step, so output differences do **not** establish an equivalent compute speedup. A fused-image restart measured 266.67 output tokens/s but 90.29 steps/s and 2.953 emitted tokens/step, reinforcing that limitation.

Cold unique 32768-token prefills used one output token and 30-second cells after warmup. Counters confirmed all 32768 tokens computed, with zero local/external cache hits:

| Process / measurement | Input tokens/s |
|---|---:|
| Control | 14793.57 |
| Control restart | 14757.88 |
| Fused, first process | 12832.12 |
| Fused, same first process repeated | 12997.00 |
| Fused, live-parity diagnostic process, profiler inactive | 14858.35 |
| Fused, uninstrumented restart before decode | 15004.55 |
| Fused, same restart after C1 and Sieve | 14810.74 |

**The first-process prefill slowdown remains unexplained.** Ordinary fused-image launches used identical source, flags, clocks, and cache directory. Restart results match the control, but do not qualify first-boot reliability or prove the cause. This PR does not claim a prefill fix or a regression-free release.

## Scope, provenance, and related work

The PR changes only the DSpark sampler and its test. Both serving arms include the separate B12X TP-padding correction [b12x#361](https://github.com/local-inference-lab/b12x/pull/361); it is not part of this optimization.

Open fork/upstream PRs were checked before submission. [vLLM #736](https://github.com/local-inference-lab/vllm/pull/736) concerns MoE/Engram execution, not sampling. [Upstream #50737](https://github.com/vllm-project/vllm/pull/50737) fuses bias addition into the Markov GEMM and changes logit layout; this PR instead preserves the projection and fuses the full-vocabulary reduction. They are related alternatives for removing the addition pass, not independently additive speedup claims. [Upstream #54433](https://github.com/vllm-project/vllm/pull/54433) restricts proposal candidates; this PR does not. [Upstream #50843](https://github.com/vllm-project/vllm/pull/50843) concerns other sampler tail bounds; this reduction masks tail indices and tests partial tiles and all-negative-infinity rows.

<details>
<summary>Immutable source and image identities</summary>

- Base JJ commit: `377c93be7e74619c629a3177292f49deac5639fd`.
- PR commit: `9d0c33e4227db6fe09b8b838a84a47b40e970d57`.
- Tested/PR source tree: `d59cf27e8f50b911a708d9fadc9c98e9045305ac`.
- Tested image records commit `956cd4b67edaee8b408bd5c18079a58e95ef9832`; its tree is identical to the PR tree. Only commit metadata differs, including the AI co-author trailer.
- Control local image ID: `sha256:da403ee8ceff7b510aeae1a04ca751478b2413099cfde4b45b99b96397ea0bd4`.
- Fused local image ID: `sha256:4dc417893f9f32b6fdeceba3ccfb23e6d18c74ff3446074c0f5285f93db6c264`.
- Both arms use B12X `fcecbfe605bd3e1155efd2df2d983d012e68f987`; native libraries are unchanged. The images are local test artifacts, not published registry releases.

</details>

AI assistance was used for implementation, profiling, validation, and this description. Human maintainer review is requested; this description does not assert that such review has already occurred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added greedy Markov sampling for speculative decoding.
  - Supports exact vocabulary-wide selection across multiple data types and request sizes.
  - Preserves expected handling of ties, special values, and strided outputs.
  - Supports CUDA graph replay without intermediate allocations for improved efficiency.
  - Reports invalid vocabulary dimensions and insufficient workspace before GPU execution.

- **Tests**
  - Added CUDA coverage for eager execution and graph replay, including input mutation, output correctness, sentinel preservation, and stable memory usage.
  - Added validation coverage for invalid input dimensions and workspace sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->