### PR TITLE
perf(glm): reuse serving scratch and bound vision memory

### DIFF
--- a/tests/distributed/test_dcp_direct_a2a_lse_reduce.py
+++ b/tests/distributed/test_dcp_direct_a2a_lse_reduce.py
@@ -583,6 +583,33 @@ def test_mla_dcp_manager_selects_pcp_combine(monkeypatch):
     assert manager.query_gather is None
 
 
+@pytest.mark.parametrize(
+    "backend,use_pcp", [("ag_rs", False), ("ag_rs", True), ("a2a", False)]
+)
+def test_mla_output_workspace_hook_only_applies_to_head_reduce_scatter(
+    monkeypatch, backend, use_pcp
+):
+    monkeypatch.setattr(dcp, "get_dcp_group", lambda: MagicMock(world_size=2))
+    monkeypatch.setattr(dcp, "get_direct_dcp_q_gather_workspace", lambda *args: None)
+    monkeypatch.setattr(dcp, "get_direct_dcp_a2a_workspace", lambda *args: None)
+    callback = MagicMock()
+    manager = dcp.MLADCPManager(
+        vllm_config=_manager_config(dcp_comm_backend=backend),
+        device=torch.device("cpu"),
+        num_heads=2,
+        query_head_dim=8,
+        output_head_dim=4,
+        query_dtype=torch.bfloat16,
+        output_dtype=torch.bfloat16,
+        padded_num_heads=None,
+        is_lse_base_on_e=True,
+        use_pcp=use_pcp,
+        output_reduce_scatter=callback,
+    )
+    expected = callback if backend == "ag_rs" and not use_pcp else None
+    assert manager.combine.keywords.get("output_reduce_scatter") is expected
+
+
 def test_dcp_chunk_workspace_alignment_covers_interleave():
     from vllm.model_executor.layers.attention.mla_attention import (
         align_mla_chunked_context_workspace_size,

--- a/tests/distributed/test_dcp_direct_a2a_lse_reduce.py
+++ b/tests/distributed/test_dcp_direct_a2a_lse_reduce.py
@@ -143,9 +143,7 @@ class _FakeProcessGroup:
 class TestDirectDCPGating:
     def test_a2a_factory_falls_back_without_p2p(self, monkeypatch):
         monkeypatch.delenv("VLLM_USE_DIRECT_DCP_A2A", raising=False)
-        monkeypatch.setattr(
-            dcp, "direct_cp_peer_access_enabled", lambda *args: False
-        )
+        monkeypatch.setattr(dcp, "direct_cp_peer_access_enabled", lambda *args: False)
         dcp.get_direct_dcp_a2a_workspace.cache_clear()
 
         assert (
@@ -191,9 +189,7 @@ class TestDirectDCPGating:
             assert value == 2
             output[:] = [2, 3]
 
-        monkeypatch.setattr(
-            torch.distributed, "all_gather_object", gather_local_ranks
-        )
+        monkeypatch.setattr(torch.distributed, "all_gather_object", gather_local_ranks)
         peer_checks = MagicMock(
             side_effect=lambda src, dst: p2p_available or (src, dst) != (3, 2)
         )
@@ -526,6 +522,43 @@ def test_dcp_workspace_covers_parallel_drafting():
     config.speculative_config = MagicMock(parallel_drafting=True)
 
     assert dcp.get_dcp_workspace_max_num_tokens(config) == 28
+
+
+@pytest.mark.parametrize("direct_capacity", [None, 4])
+@pytest.mark.parametrize("rows", [2, 8])
+def test_mla_query_scratch_fallback_preserves_direct_transport_priority(
+    monkeypatch, direct_capacity, rows
+):
+    group = MagicMock(world_size=2)
+    direct = (
+        None if direct_capacity is None else MagicMock(max_num_tokens=direct_capacity)
+    )
+    fallback = MagicMock(return_value=torch.empty((rows, 4, 8)))
+    monkeypatch.setattr(dcp, "get_dcp_group", lambda: group)
+    monkeypatch.setattr(dcp, "get_direct_dcp_q_gather_workspace", lambda *args: direct)
+    manager = dcp.MLADCPManager(
+        vllm_config=_manager_config(dcp_comm_backend="ag_rs"),
+        device=torch.device("cpu"),
+        num_heads=2,
+        query_head_dim=8,
+        output_head_dim=4,
+        query_dtype=torch.bfloat16,
+        output_dtype=torch.bfloat16,
+        padded_num_heads=None,
+        is_lse_base_on_e=True,
+        use_pcp=False,
+        query_gather_fallback=fallback,
+    )
+    query = torch.empty((rows, 2, 8), dtype=torch.bfloat16)
+    actual = manager.query_gather(query)
+    if direct is not None and rows <= direct_capacity:
+        direct.gather.assert_called_once_with(query)
+        fallback.assert_not_called()
+        assert actual is direct.gather.return_value
+    else:
+        fallback.assert_called_once_with(query)
+        assert actual is fallback.return_value
+    group.all_gather.assert_not_called()
 
 
 def test_mla_dcp_manager_selects_pcp_combine(monkeypatch):

--- a/tests/distributed/test_pynccl.py
+++ b/tests/distributed/test_pynccl.py
@@ -255,6 +255,75 @@ def test_ckv_inplace_all_gather_preserves_padded_rank_records(world_size):
 
 
 @worker_fn_wrapper
+def glm_dcp_query_scratch_worker_fn():
+    from vllm.v1.attention.backends.mla import b12x_mla_sparse
+    from vllm.v1.worker.workspace import WorkspaceManager
+
+    world = get_world_group()
+    comm = PyNcclCommunicator(world.cpu_group, device=world.device)
+    rank, size = comm.rank, comm.world_size
+    group = SimpleNamespace(
+        world_size=size,
+        rank_in_group=rank,
+        device_communicator=SimpleNamespace(pynccl_comm=comm),
+        device_group=world.device_group,
+    )
+    manager = WorkspaceManager(world.device)
+    impl = object.__new__(b12x_mla_sparse.B12xMLASparseImpl)
+    impl._is_glm_next = True
+    impl._decode_max_rows = 16
+    impl._max_tokens = 512
+    impl._input_num_heads = size * 4
+    impl._q_head_dim = 512
+    impl._scratch_nbytes = 512 * impl._input_num_heads * 512 * 2
+    impl._decode_plan = object()
+    impl._ckv_local_capacity = 0
+    impl._cache_record_bytes = 528
+    impl.dcp_world_size = size
+    b12x_mla_sparse.current_workspace_manager = lambda: manager
+    b12x_mla_sparse.get_dcp_group = lambda: group
+    q_buffer, scratch = impl._borrow_workspaces()
+    manager.lock()
+    for transport in ("pynccl", "torch"):
+        group.device_communicator.pynccl_comm = comm if transport == "pynccl" else None
+        for rows in (32, 512, 64):
+            base = torch.arange(rows * 4 * 512, device=world.device).remainder(127)
+            parts = [
+                (base + source).to(torch.bfloat16).view(4, rows, 512).transpose(0, 1)
+                for source in range(size)
+            ]
+            actual = impl.gather_dcp_query(parts[rank])
+            assert actual.data_ptr() == q_buffer.data_ptr()
+            expected = torch.cat(parts, dim=1)
+            assert torch.equal(actual, expected)
+            scratch.fill_(255)
+            assert torch.equal(actual, expected)
+
+    group.device_communicator.pynccl_comm = comm
+    local = torch.empty((4, 64, 512), dtype=torch.bfloat16, device=world.device)
+    local.fill_(rank)
+    query = local.transpose(0, 1)
+    impl.gather_dcp_query(query)
+    torch.accelerator.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = impl.gather_dcp_query(query)
+    for iteration in range(3):
+        local.fill_(rank + iteration * 8)
+        graph.replay()
+        expected = torch.cat(
+            [torch.full_like(query, source + iteration * 8) for source in range(size)],
+            dim=1,
+        )
+        assert torch.equal(actual, expected)
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() < 2, reason="Need two GPUs")
+def test_glm_dcp_query_scratch_preserves_values_and_graph_inputs():
+    distributed_run(glm_dcp_query_scratch_worker_fn, 2)
+
+
+@worker_fn_wrapper
 def cuda_communicator_all_gather_dim_worker_fn():
     with ensure_current_vllm_config():
         ensure_model_parallel_initialized(2, 1)

--- a/tests/distributed/test_pynccl.py
+++ b/tests/distributed/test_pynccl.py
@@ -317,9 +317,70 @@ def glm_dcp_query_scratch_worker_fn():
         )
         assert torch.equal(actual, expected)
 
+    from vllm.v1.attention.ops.dcp import cp_lse_ag_out_rs
+
+    def gather_lse(value, dim):
+        assert dim == 0
+        result = value.new_empty((size * value.shape[0], *value.shape[1:]))
+        comm.all_gather(result, value.contiguous())
+        return result
+
+    def reduce_output(value, dim):
+        packed = value.movedim(0, dim).contiguous()
+        result = packed.new_empty((packed.shape[0] // size, *packed.shape[1:]))
+        comm.reduce_scatter(result, packed)
+        return result.movedim(0, dim).contiguous()
+
+    group.all_gather = gather_lse
+    group.reduce_scatter = reduce_output
+    for rows in (32, 512, 64):
+        shape = (rows, impl._input_num_heads, 512)
+        partial = (
+            scratch[: rows * impl._input_num_heads * 512 * 2]
+            .view(torch.bfloat16)
+            .view(shape)
+        )
+        source = torch.arange(partial.numel(), device=world.device).remainder(127)
+        source = (source + rank).to(torch.bfloat16).view(shape)
+        lse = torch.arange(rows * impl._input_num_heads, device=world.device)
+        lse = lse.float().remainder(17).view(shape[:2]) + rank
+        lse[::7].fill_(float("-inf"))
+        for base_e in (True, False):
+            expected, expected_lse = cp_lse_ag_out_rs(
+                source.clone(),
+                lse.clone(),
+                group,
+                return_lse=True,
+                is_lse_base_on_e=base_e,
+            )
+            partial.copy_(source)
+            actual, actual_lse = cp_lse_ag_out_rs(
+                partial,
+                lse.clone(),
+                group,
+                return_lse=True,
+                is_lse_base_on_e=base_e,
+                output_reduce_scatter=impl.reduce_scatter_dcp_output,
+            )
+            assert torch.equal(actual, expected)
+            assert torch.equal(actual_lse, expected_lse)
+            assert actual.transpose(0, 1).is_contiguous()
+
+    partial.fill_(rank)
+    impl.reduce_scatter_dcp_output(partial)
+    torch.accelerator.synchronize()
+    output_graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(output_graph):
+        actual = impl.reduce_scatter_dcp_output(partial)
+    for iteration in range(3):
+        partial.fill_(rank + iteration * 8)
+        output_graph.replay()
+        expected_sum = sum(range(size)) + size * iteration * 8
+        assert torch.equal(actual, torch.full_like(actual, expected_sum))
+
 
 @pytest.mark.skipif(torch.accelerator.device_count() < 2, reason="Need two GPUs")
-def test_glm_dcp_query_scratch_preserves_values_and_graph_inputs():
+def test_glm_dcp_query_scratch_preserves_query_output_and_graph_inputs():
     distributed_run(glm_dcp_query_scratch_worker_fn, 2)
 
 

--- a/tests/distributed/test_pynccl.py
+++ b/tests/distributed/test_pynccl.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+from types import SimpleNamespace
 
 import multiprocess as mp
 import numpy as np
@@ -198,6 +199,59 @@ def all_gather_worker_fn():
 )
 def test_pynccl_all_gather():
     distributed_run(all_gather_worker_fn, 2)
+
+
+@worker_fn_wrapper
+def ckv_inplace_all_gather_worker_fn():
+    from vllm.v1.attention.backends.mla.b12x_mla_sparse import (
+        _dcp_all_gather_current_stream,
+    )
+
+    world = get_world_group()
+    comm = PyNcclCommunicator(world.cpu_group, device=world.device)
+    rank, size = comm.rank, comm.world_size
+    with ensure_current_vllm_config():
+        ensure_model_parallel_initialized(size, 1)
+    tp = get_tp_group()
+    storage = torch.empty((size * 8192, 528), dtype=torch.uint8, device=world.device)
+    for transport in ("pynccl", "torch", "coordinator"):
+        group = SimpleNamespace(
+            world_size=size,
+            rank_in_group=rank,
+            device_communicator=SimpleNamespace(
+                pynccl_comm=comm if transport == "pynccl" else None
+            ),
+            device_group=world.device_group if transport == "torch" else None,
+            all_gather=tp.all_gather,
+        )
+        for padded in (1024, 2048, 8192, 1024):
+            storage.fill_(255)
+            expected_parts = []
+            for source_rank in range(size):
+                part = (
+                    (
+                        torch.arange(padded * 528, device=world.device).remainder(251)
+                        + source_rank
+                    )
+                    .to(torch.uint8)
+                    .view(padded, 528)
+                )
+                part[padded - source_rank * 4 - 1 :].zero_()
+                expected_parts.append(part)
+            send = storage[rank * padded : (rank + 1) * padded]
+            send.copy_(expected_parts[rank])
+            receive = storage[: size * padded]
+            _dcp_all_gather_current_stream(group, send.view(-1), receive.view(-1))
+            torch.accelerator.synchronize()
+            assert torch.equal(receive, torch.cat(expected_parts))
+            assert torch.all(storage[size * padded :] == 255)
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_ckv_inplace_all_gather_preserves_padded_rank_records(world_size):
+    if torch.accelerator.device_count() < world_size:
+        pytest.skip(f"Need {world_size} GPUs")
+    distributed_run(ckv_inplace_all_gather_worker_fn, world_size)
 
 
 @worker_fn_wrapper

--- a/tests/distributed/test_pynccl.py
+++ b/tests/distributed/test_pynccl.py
@@ -272,10 +272,11 @@ def glm_dcp_query_scratch_worker_fn():
     impl = object.__new__(b12x_mla_sparse.B12xMLASparseImpl)
     impl._is_glm_next = True
     impl._decode_max_rows = 16
-    impl._max_tokens = 512
-    impl._input_num_heads = size * 4
+    impl._max_tokens = 2048
+    local_heads = 32
+    impl._input_num_heads = size * local_heads
     impl._q_head_dim = 512
-    impl._scratch_nbytes = 512 * impl._input_num_heads * 512 * 2
+    impl._scratch_nbytes = impl._max_tokens * impl._input_num_heads * 512 * 2
     impl._decode_plan = object()
     impl._ckv_local_capacity = 0
     impl._cache_record_bytes = 528
@@ -286,10 +287,15 @@ def glm_dcp_query_scratch_worker_fn():
     manager.lock()
     for transport in ("pynccl", "torch"):
         group.device_communicator.pynccl_comm = comm if transport == "pynccl" else None
-        for rows in (32, 512, 64):
-            base = torch.arange(rows * 4 * 512, device=world.device).remainder(127)
+        for rows in (32, 2048, 64):
+            base = torch.arange(
+                rows * local_heads * 512, device=world.device
+            ).remainder(127)
             parts = [
-                (base + source).to(torch.bfloat16).view(4, rows, 512).transpose(0, 1)
+                (base + source)
+                .to(torch.bfloat16)
+                .view(local_heads, rows, 512)
+                .transpose(0, 1)
                 for source in range(size)
             ]
             actual = impl.gather_dcp_query(parts[rank])
@@ -300,7 +306,9 @@ def glm_dcp_query_scratch_worker_fn():
             assert torch.equal(actual, expected)
 
     group.device_communicator.pynccl_comm = comm
-    local = torch.empty((4, 64, 512), dtype=torch.bfloat16, device=world.device)
+    local = torch.empty(
+        (local_heads, 64, 512), dtype=torch.bfloat16, device=world.device
+    )
     local.fill_(rank)
     query = local.transpose(0, 1)
     impl.gather_dcp_query(query)
@@ -333,7 +341,7 @@ def glm_dcp_query_scratch_worker_fn():
 
     group.all_gather = gather_lse
     group.reduce_scatter = reduce_output
-    for rows in (32, 512, 64):
+    for rows in (32, 2048, 64):
         shape = (rows, impl._input_num_heads, 512)
         partial = (
             scratch[: rows * impl._input_num_heads * 512 * 2]

--- a/tests/kernels/mamba/test_kda_conv_workspace.py
+++ b/tests/kernels/mamba/test_kda_conv_workspace.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Convolution outputs occupy workspace disjoint from the KDA consumer."""
+
+import weakref
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.mamba.gdn import kimi_gdn_linear_attn as kda
+from vllm.model_executor.layers.mamba.ops.causal_conv1d import causal_conv1d_fn
+from vllm.v1.worker.workspace import WorkspaceManager
+
+
+def _layer():
+    layer: Any = object.__new__(kda.KimiGatedDeltaNetAttention)
+    torch.nn.Module.__init__(layer)
+    layer.kda_prefill_backend = "b12x"
+    layer.get_state_dtype = lambda: (torch.bfloat16, torch.float32)
+    layer._b12x_prefill_plan = SimpleNamespace(
+        scratch_specs=lambda: [SimpleNamespace(shape=(1024,), dtype=torch.uint8)]
+    )
+    layer._b12x_prefill_max_tokens = 32
+    layer.local_num_heads = 2
+    layer.head_dim = 128
+    layer.local_projection_size = 256
+    layer.model_config = SimpleNamespace(dtype=torch.bfloat16)
+    return layer
+
+
+@pytest.mark.parametrize("capacity", [1024, 100000])
+def test_convolution_suffix_preserves_kda_workspace(monkeypatch, capacity):
+    manager = WorkspaceManager(torch.device("cpu"))
+    manager.reserve_all(((capacity,), torch.uint8))
+    manager.lock()
+    monkeypatch.setattr(kda, "current_workspace_manager", lambda: manager)
+    layer = _layer()
+    outputs = layer._borrow_b12x_prefill_transients(32, torch.bfloat16)
+    if capacity == 1024:
+        assert outputs is None
+        return
+    for index, output in enumerate(outputs):
+        output.fill_(index + 1)
+    scratch, target = layer._get_b12x_prefill_workspace()
+    scratch.fill_(255)
+    target.fill_(17)
+    for index, output in enumerate(outputs):
+        assert output.shape == (32, 256) and output.is_contiguous()
+        assert torch.all(output == index + 1)
+
+
+@pytest.mark.parametrize(
+    "backend,dtype", [("flashkda", torch.bfloat16), ("b12x", torch.float32)]
+)
+def test_convolution_suffix_keeps_unsupported_paths(backend, dtype):
+    layer = _layer()
+    layer.kda_prefill_backend = backend
+    assert layer._borrow_b12x_prefill_transients(32, dtype) is None
+
+
+def test_mixed_selection_survives_convolution_and_kda_writes(monkeypatch):
+    manager = WorkspaceManager(torch.device("cpu"))
+    manager.reserve_all(((200000,), torch.uint8))
+    manager.lock()
+    monkeypatch.setattr(kda, "current_workspace_manager", lambda: manager)
+    layer = _layer()
+    source = torch.randn(32, 768, dtype=torch.bfloat16)
+    indices = torch.tensor([21, 2, 4, 0, 31, 17, 8, 7], dtype=torch.int64)
+    specs = (((8, 768), source.dtype),)
+    outputs = layer._borrow_b12x_prefill_transients(8, source.dtype, specs)
+    selected = outputs[3]
+    torch.index_select(source, 0, indices, out=selected)
+    conv = layer._borrow_b12x_prefill_transients(8, source.dtype)
+    for buffer in conv:
+        buffer.fill_(5)
+    scratch, target = layer._get_b12x_prefill_workspace()
+    scratch.fill_(255)
+    target.fill_(9)
+    torch.testing.assert_close(selected, source[indices], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("full_rank_gate", [False, True])
+def test_consumed_kda_projections_release_before_output_gemm(full_rank_gate):
+    layer = _layer()
+    layer.local_num_heads = 2
+    layer.head_dim = 4
+    layer.local_projection_size = 8
+    layer.use_full_rank_gate = full_rank_gate
+    layer.in_proj_padding = 2 if full_rank_gate else 0
+    owners = []
+
+    def project(x, columns):
+        result = torch.ones(x.shape[0], columns)
+        owners.append(weakref.ref(result))
+        return result, None
+
+    layer.in_proj_qkvgfab = lambda x: project(x, 40 if full_rank_gate else 30)
+    layer.g_a_proj = lambda x: project(x, 4)
+    layer.g_b_proj = lambda x: project(x, 8)
+    layer.f_b_proj = lambda x: project(x, 8)
+
+    def recurrence(*, mixed_qkv, g1, g2, beta, core_attn_out):
+        core_attn_out.copy_(
+            mixed_qkv[:, :8].view(1, -1, 2, 4)
+            + g1
+            + g2.unsqueeze(0)
+            + beta.unsqueeze(-1)
+        )
+
+    layer._forward = recurrence
+
+    def output_projection(x):
+        assert all(owner() is None for owner in owners)
+        return x * 2, None
+
+    layer.o_proj = output_projection
+    output = torch.empty(17, 8)
+    layer.forward(torch.ones(17, 8), torch.arange(17), output)
+    torch.testing.assert_close(output, torch.full_like(output, 8), rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("rows", [33, 2048, 3072])
+@pytest.mark.parametrize("speculative_slots", [0, 3])
+def test_caller_owned_convolution_preserves_output_and_history(rows, speculative_slots):
+    channels, width = 4096, 4
+    storage = torch.empty(rows * 4 * channels, device="cuda", dtype=torch.bfloat16)
+    source = storage[rows * channels :].view(rows, 3 * channels)
+    source.normal_()
+    original = source.clone()
+    weight = torch.randn(channels, width, device="cuda", dtype=source.dtype)
+    starts = torch.tensor([0, rows // 2, rows], dtype=torch.int32, device="cuda")
+    slots = torch.tensor([1, 2], dtype=torch.int32, device="cuda")
+    initial = torch.tensor([False, True], device="cuda")
+    history = torch.randn(
+        4, channels, width - 1 + speculative_slots, device="cuda", dtype=source.dtype
+    )
+    expected_history = history.clone()
+    supplied = storage[: rows * channels].view(rows, channels)
+    value = source[:, channels : 2 * channels].transpose(0, 1)
+    kwargs = dict(
+        query_start_loc=starts,
+        cache_indices=slots,
+        has_initial_state=initial,
+        activation="silu",
+    )
+    expected = causal_conv1d_fn(value, weight, None, expected_history, **kwargs)
+    actual = causal_conv1d_fn(
+        value, weight, None, history, out=supplied.transpose(0, 1), **kwargs
+    )
+    assert actual.data_ptr() == supplied.data_ptr()
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    torch.testing.assert_close(history, expected_history, rtol=0, atol=0)
+    torch.testing.assert_close(source, original, rtol=0, atol=0)
+    with pytest.raises(ValueError, match="disjoint"):
+        causal_conv1d_fn(value, weight, None, history, out=value, **kwargs)

--- a/tests/model_executor/kernels/test_b12x_linear.py
+++ b/tests/model_executor/kernels/test_b12x_linear.py
@@ -409,11 +409,27 @@ def test_b12x_mxfp8_support_respects_runtime_probe(monkeypatch) -> None:
     assert reason == "b12x.gemm.blockscaled is not supported"
 
 
+@dataclass(frozen=True)
+class _MXFP8Rows:
+    values: torch.Tensor
+    scale_mma: torch.Tensor
+    scale_rows: torch.Tensor | None
+
+
+@dataclass(frozen=True)
+class _MXFP8LinearWeight:
+    weight: _MXFP8Rows
+    out_features: int
+
+
 def test_b12x_mxfp8_process_weights_packs_modelopt_layout(monkeypatch) -> None:
     import vllm.model_executor.kernels.linear.mxfp8.b12x as b12x_mod
 
     calls = []
-    packed = types.SimpleNamespace(out_features=48)
+    packed = _MXFP8LinearWeight(
+        _MXFP8Rows(torch.empty(48, 128), torch.empty(48, 4), torch.empty(48, 4)),
+        out_features=48,
+    )
 
     def pack(weight: torch.Tensor, weight_scale: torch.Tensor):
         calls.append((weight, weight_scale))
@@ -443,7 +459,10 @@ def test_b12x_mxfp8_process_weights_packs_modelopt_layout(monkeypatch) -> None:
 
     kernel.process_weights_after_loading(layer)
 
-    assert layer.b12x_mxfp8_packed_weight is packed
+    retained = layer.b12x_mxfp8_packed_weight
+    assert retained.weight.values is packed.weight.values
+    assert retained.weight.scale_mma is packed.weight.scale_mma
+    assert retained.weight.scale_rows is None
     assert layer.b12x_warmup_provider is kernel
     assert len(calls) == 1
     weight, weight_scale = calls[0]
@@ -460,16 +479,13 @@ def test_b12x_mxfp8_process_weights_packs_modelopt_layout(monkeypatch) -> None:
 def test_b12x_mxfp8_reload_reuses_packed_tensor_addresses(monkeypatch) -> None:
     import vllm.model_executor.kernels.linear.mxfp8.b12x as b12x_mod
 
-    @dataclass(frozen=True)
-    class PackedWeight:
-        values: torch.Tensor
-        scales: torch.Tensor
-        out_features: int
-
-    def pack(weight: torch.Tensor, weight_scale: torch.Tensor) -> PackedWeight:
-        return PackedWeight(
-            values=weight.clone(),
-            scales=weight_scale.clone(),
+    def pack(weight: torch.Tensor, weight_scale: torch.Tensor) -> _MXFP8LinearWeight:
+        return _MXFP8LinearWeight(
+            weight=_MXFP8Rows(
+                values=weight.clone(),
+                scale_mma=weight_scale.clone(),
+                scale_rows=weight_scale.clone(),
+            ),
             out_features=int(weight.shape[0]),
         )
 
@@ -492,8 +508,8 @@ def test_b12x_mxfp8_reload_reuses_packed_tensor_addresses(monkeypatch) -> None:
 
     kernel.process_weights_after_loading(layer)
     packed = layer.b12x_mxfp8_packed_weight
-    values_ptr = packed.values.data_ptr()
-    scales_ptr = packed.scales.data_ptr()
+    values_ptr = packed.weight.values.data_ptr()
+    scales_ptr = packed.weight.scale_mma.data_ptr()
 
     layer.weight = torch.nn.Parameter(
         torch.ones((48, 128), dtype=torch.float8_e4m3fn),
@@ -506,14 +522,15 @@ def test_b12x_mxfp8_reload_reuses_packed_tensor_addresses(monkeypatch) -> None:
     kernel.process_weights_after_loading(layer)
 
     assert layer.b12x_mxfp8_packed_weight is packed
-    assert packed.values.data_ptr() == values_ptr
-    assert packed.scales.data_ptr() == scales_ptr
+    assert packed.weight.values.data_ptr() == values_ptr
+    assert packed.weight.scale_mma.data_ptr() == scales_ptr
+    assert packed.weight.scale_rows is None
     torch.testing.assert_close(
-        packed.values,
+        packed.weight.values,
         torch.ones((48, 128), dtype=torch.float8_e4m3fn),
     )
     torch.testing.assert_close(
-        packed.scales,
+        packed.weight.scale_mma,
         torch.full((48, 4), 3, dtype=torch.uint8),
     )
     assert layer.weight.numel() == 0
@@ -983,6 +1000,7 @@ def test_b12x_dense_precision_gpu_graph_replay(monkeypatch, recipe, mode):
     torch.manual_seed(1234)
     n, k = 4096, 5376
     layer = torch.nn.Module()
+    counts: tuple[int, ...]
     if recipe == "nvfp4":
         codes = torch.randint(0, 16, (n, k), device="cuda", dtype=torch.uint8)
         values = codes[:, ::2] | (codes[:, 1::2] << 4)
@@ -1007,11 +1025,14 @@ def test_b12x_dense_precision_gpu_graph_replay(monkeypatch, recipe, mode):
             exponents.float() - 127
         ).repeat_interleave(32, 1)
         kernel = object.__new__(B12xMxfp8LinearKernel)
-        counts = (1, 14, 32)
+        counts = (1, 14, 32, 3072)
     layer.weight = torch.nn.Parameter(values, requires_grad=False)
     layer.weight_scale = torch.nn.Parameter(scales, requires_grad=False)
     kernel.process_weights_after_loading(layer)
     packed = getattr(layer, f"b12x_{recipe}_packed_weight")
+    if recipe == "mxfp8":
+        assert packed.weight.scale_rows is None
+        row_scale_reference = blockscaled.pack_weight(values, scales)
     if recipe == "nvfp4":
         assert packed.values.data_ptr() == layer.weight.data_ptr()
         assert packed.scale_mma.data_ptr() == layer.weight_scale.data_ptr()
@@ -1050,6 +1071,11 @@ def test_b12x_dense_precision_gpu_graph_replay(monkeypatch, recipe, mode):
         expected = reference(source, a16)
         for _ in range(3):
             actual = kernel.apply_weights(layer, source, bias)
+        if recipe == "mxfp8":
+            unchanged = blockscaled.mm(
+                source, row_scale_reference, bias=bias, expected_m=m, mode=mode
+            )
+            torch.testing.assert_close(actual, unchanged, atol=0, rtol=0)
         torch.testing.assert_close(actual, expected, atol=0.5, rtol=0.02)
         freeze_kernel_resolution("vLLM dense precision replay")
         try:
@@ -1156,12 +1182,14 @@ def test_v41_block32_adapter_preserves_native_output_view_and_replay(
                 atol=0.01,
             )
         graph = torch.cuda.CUDAGraph()
-        with workspace.collect_cuda_graph_capture_resources() as retained:
-            with torch.cuda.graph(graph):
-                captured = method.apply(layer, source)
+        with (
+            workspace.collect_cuda_graph_capture_resources() as retained,
+            torch.cuda.graph(graph),
+        ):
+            captured = method.apply(layer, source)
         source.mul_(0.5)
         graph.replay()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         torch.testing.assert_close(captured, oracle(), rtol=0.01, atol=0.01)
         del retained
     finally:
@@ -1225,16 +1253,18 @@ def _check_v41_vocab_embedding_and_tied_head(device):
     freeze_kernel_resolution("V4.1 sharded vocabulary embedding replay")
     try:
         graph = torch.cuda.CUDAGraph()
-        with workspace.collect_cuda_graph_capture_resources() as retained:
-            with graph_capture(device=device) as capture_context:
-                with torch.cuda.graph(graph, stream=capture_context.stream):
-                    captured = target(ids)
+        with (
+            workspace.collect_cuda_graph_capture_resources() as retained,
+            graph_capture(device=device) as capture_context,
+            torch.cuda.graph(graph, stream=capture_context.stream),
+        ):
+            captured = target(ids)
         for offset in (3, 17):
             ids.add_(offset).remainder_(vocab)
             checkpoint.neg_()
             target.weight_loader(target.weight, checkpoint)
             graph.replay()
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
             torch.testing.assert_close(captured, checkpoint[ids], rtol=0, atol=0)
             # Reload the target after tying: the head must see current weights,
             # not a copied or prepacked snapshot from embedding finalization.
@@ -1261,7 +1291,7 @@ def _run_v41_sharded_embedding(rank, port):
     )
 
     device = torch.device("cuda", rank)
-    torch.cuda.set_device(device)
+    torch.accelerator.set_device_index(device)
     with set_current_vllm_config(VllmConfig()), torch.no_grad():
         try:
             init_test_distributed_environment(2, 1, rank, str(port), local_rank=rank)
@@ -1275,7 +1305,7 @@ def _run_v41_sharded_embedding(rank, port):
 def test_v41_vocab_embedding_sharded_global_ids_and_target_weight_tie(monkeypatch):
     # This test already spawns fresh workers. Forking an outer test process
     # after a preceding CUDA test would inherit an unusable CUDA context.
-    if not torch.cuda.is_available() or torch.cuda.device_count() < 2:
+    if not torch.cuda.is_available() or torch.accelerator.device_count() < 2:
         pytest.skip("native b12x embedding requires two GPUs")
     if any(torch.cuda.get_device_capability(i)[0] != 12 for i in range(2)):
         pytest.skip("native b12x embedding requires two SM12x GPUs")
@@ -1304,7 +1334,7 @@ def test_v41_mhc_shares_scratch_and_preserves_live_outputs(
 
     if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 12:
         pytest.skip("native b12x mHC requires SM12x")
-    device = torch.device("cuda", torch.cuda.current_device())
+    device = torch.device("cuda", torch.accelerator.current_device_index())
     capacity, hidden = 4096, 5120
     monkeypatch.setattr(b12x_layers, "_capacity", lambda: capacity)
     monkeypatch.setattr(
@@ -1320,11 +1350,11 @@ def test_v41_mhc_shares_scratch_and_preserves_live_outputs(
         hc_eps=1e-6,
         hc_sinkhorn_iters=20,
     )
-    allocated = torch.cuda.memory_allocated(device)
+    allocated = torch.accelerator.memory_allocated(device)
     with torch.device(device):
         first, second = b12x_layers.B12xMHC(config), b12x_layers.B12xMHC(config)
     # Model construction must not reserve capacity-sized activations per layer.
-    assert torch.cuda.memory_allocated(device) - allocated < 1024**2
+    assert torch.accelerator.memory_allocated(device) - allocated < 1024**2
     torch.manual_seed(4124096)
     shape = (tokens, hidden) if broadcast else (tokens, 4, hidden)
     residual = torch.randn(shape, device=device, dtype=torch.bfloat16)
@@ -1344,7 +1374,7 @@ def test_v41_mhc_shares_scratch_and_preserves_live_outputs(
     def expected():
         incoming = identity
         state = residual
-        outputs = []
+        outputs: list[torch.Tensor] = []
         for index in range(2):
             predicted = torch.empty_like(incoming)
             result = mhc.run_pre(
@@ -1382,13 +1412,15 @@ def test_v41_mhc_shares_scratch_and_preserves_live_outputs(
     freeze_kernel_resolution("V4.1 shared mHC workspace")
     try:
         graph = torch.cuda.CUDAGraph()
-        with workspace.collect_cuda_graph_capture_resources() as resources:
-            with torch.cuda.graph(graph):
-                captured = run()
+        with (
+            workspace.collect_cuda_graph_capture_resources() as resources,
+            torch.cuda.graph(graph),
+        ):
+            captured = run()
         for factor in (0.5, -1.0):
             residual.mul_(factor)
             graph.replay()
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
             for got, want in zip(captured, expected(), strict=True):
                 torch.testing.assert_close(got, want, rtol=2e-5, atol=0.008)
         del resources

--- a/tests/models/test_glm5next_indexer_storage.py
+++ b/tests/models/test_glm5next_indexer_storage.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Ownership checks for serial GLM target/MTP indexer storage."""
+
+import weakref
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.models.glm5next.nvidia.mtp import Glm5NextMTP
+from vllm.models.glm5next.nvidia.pooled_indexer import (
+    Glm5NextIndexerScratch,
+    Glm5NextPooledIndexer,
+)
+
+
+def make_indexer(device="cpu", shared=None):
+    indexer = Glm5NextPooledIndexer.__new__(Glm5NextPooledIndexer)
+    nn.Module.__init__(indexer)
+    for name, value in dict(
+        max_tokens=16,
+        max_seqs=4,
+        max_model_len=1048576,
+        block_size=2048,
+        dcp_world_size=2,
+        dcp_rank=0,
+        pool_interleave=1,
+    ).items():
+        setattr(indexer, name, value)
+    indexer.scratch = (
+        shared.scratch
+        if shared
+        else Glm5NextIndexerScratch(16, 4, torch.device(device))
+    )
+    for name, width in (
+        ("topk_indices_buffer", 2051),
+        ("pool_topk_indices_buffer", 512),
+    ):
+        value = (
+            getattr(shared, name)
+            if shared
+            else torch.empty((16, width), dtype=torch.int32, device=device)
+        )
+        setattr(indexer, name, value)
+    indexer.indexer_op = nn.Module()
+    indexer.indexer_op.topk_indices_buffer = indexer.pool_topk_indices_buffer
+    indexer._index_cache = torch.ones(32, dtype=torch.uint8, device=device)
+    indexer.register_buffer("_tail", torch.ones(32, device=device), persistent=False)
+    indexer.register_parameter("weight", nn.Parameter(torch.ones(4, device=device)))
+    return indexer
+
+
+def make_pair(device="cpu"):
+    target = nn.Module()
+    first = make_indexer(device)
+    target.layers = nn.ModuleList([first, make_indexer(device, shared=first)])
+    draft = Glm5NextMTP.__new__(Glm5NextMTP)
+    nn.Module.__init__(draft)
+    draft.model = nn.Module()
+    draft.model.num_mtp_layers = 1
+    draft.model.indexer = make_indexer(device)
+    draft.model.attention = nn.Module()
+    draft.model.attention.topk_indices_buffer = draft.model.indexer.topk_indices_buffer
+    draft.model.attention.impl = SimpleNamespace(
+        topk_indices_buffer=draft.model.indexer.topk_indices_buffer
+    )
+    return target, draft
+
+
+def test_share_indexer_storage_preserves_roles_and_persistent_state():
+    target, draft = make_pair()
+    source, indexer = target.layers[0], draft.model.indexer
+    scratch_ref = weakref.ref(indexer.scratch)
+    token_ref = weakref.ref(indexer.topk_indices_buffer)
+    pool_ref = weakref.ref(indexer.pool_topk_indices_buffer)
+    cache, tail, weight = indexer._index_cache, indexer._tail, indexer.weight
+    assert draft.share_target_indexer_storage(target)
+    assert scratch_ref() is token_ref() is pool_ref() is None
+    assert indexer.scratch is source.scratch
+    assert indexer.topk_indices_buffer is source.topk_indices_buffer
+    assert indexer.pool_topk_indices_buffer is source.pool_topk_indices_buffer
+    assert indexer.indexer_op.topk_indices_buffer is source.pool_topk_indices_buffer
+    assert draft.model.attention.topk_indices_buffer is source.topk_indices_buffer
+    assert draft.model.attention.impl.topk_indices_buffer is source.topk_indices_buffer
+    assert indexer._index_cache is cache
+    assert indexer._tail is tail
+    assert indexer.weight is weight
+    source.scratch.bind_tables(2048, torch.device("cpu"))
+    pointer = source.scratch.decode_block_table.data_ptr()
+    indexer.scratch.bind_tables(2048, torch.device("cpu"))
+    assert indexer.scratch.decode_block_table.data_ptr() == pointer
+    assert draft.share_target_indexer_storage(target)  # Idempotent ownership.
+
+
+@pytest.mark.parametrize(
+    "difference",
+    [
+        "layers",
+        "geometry",
+        "capacity",
+        "dtype",
+        "scratch",
+        "target_storage",
+    ],
+)
+def test_incompatible_indexer_storage_remains_independent(difference):
+    target, draft = make_pair()
+    indexer = draft.model.indexer
+    if difference == "layers":
+        draft.model.num_mtp_layers = 2
+    elif difference == "geometry":
+        indexer.dcp_world_size = 1
+    elif difference == "capacity":
+        indexer.topk_indices_buffer = indexer.topk_indices_buffer[:8]
+    elif difference == "dtype":
+        indexer.pool_topk_indices_buffer = indexer.pool_topk_indices_buffer.long()
+    elif difference == "scratch":
+        indexer.scratch.bind_tables(2, torch.device("cpu"))
+    else:
+        target.layers[1].scratch = Glm5NextIndexerScratch(16, 4, torch.device("cpu"))
+    scratch, tokens, pools = (
+        indexer.scratch,
+        indexer.topk_indices_buffer,
+        indexer.pool_topk_indices_buffer,
+    )
+    assert not draft.share_target_indexer_storage(target)
+    assert indexer.scratch is scratch
+    assert indexer.topk_indices_buffer is tokens
+    assert indexer.pool_topk_indices_buffer is pools
+
+
+@pytest.mark.parametrize(
+    "pp,dbo,expected", [(1, False, True), (2, False, False), (1, True, False)]
+)
+def test_loader_shares_only_serial_indexers(monkeypatch, pp, dbo, expected):
+    from vllm.v1.worker.gpu.spec_decode.eagle import utils
+
+    inner, draft = make_pair()
+    target = nn.Module()
+    target.model = inner
+    config = SimpleNamespace(
+        speculative_config=SimpleNamespace(draft_model_config=None),
+        parallel_config=SimpleNamespace(enable_dbo=dbo),
+    )
+    monkeypatch.setattr(utils, "_make_eagle_draft_vllm_config", lambda value: value)
+    monkeypatch.setattr(utils, "get_model", lambda **_: draft)
+    monkeypatch.setattr(utils, "get_pp_group", lambda: SimpleNamespace(world_size=pp))
+    assert utils.load_eagle_model(target, config) is draft
+    assert (draft.model.indexer.scratch is inner.layers[0].scratch) is expected
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA graph ownership")
+def test_shared_indexer_storage_serial_graph_replay():
+    target, draft = make_pair("cuda")
+    assert draft.share_target_indexer_storage(target)
+    source, indexer = target.layers[0], draft.model.indexer
+    value = torch.ones((), device="cuda")
+
+    def run(owner, factor):
+        owner.scratch.pool_scores.copy_(value * factor)
+        owner.topk_indices_buffer.fill_(factor)
+        owner.pool_topk_indices_buffer.fill_(factor + 1)
+        return (
+            owner.scratch.pool_scores.clone(),
+            owner.topk_indices_buffer.clone(),
+            owner.pool_topk_indices_buffer.clone(),
+        )
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        run(source, 2)
+        run(indexer, 3)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        target_result = run(source, 2)
+        draft_result = run(indexer, 3)
+    for scalar in (1, 5, 9):
+        value.fill_(scalar)
+        graph.replay()
+        for result, factor in ((target_result, 2), (draft_result, 3)):
+            assert torch.equal(result[0], torch.full_like(result[0], scalar * factor))
+            assert torch.equal(result[1], torch.full_like(result[1], factor))
+            assert torch.equal(result[2], torch.full_like(result[2], factor + 1))

--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -3,6 +3,7 @@
 
 import json
 import math
+import weakref
 from dataclasses import dataclass
 from types import SimpleNamespace
 
@@ -193,6 +194,41 @@ def test_glm5next_mtp_selects_only_draft_checkpoint_weights() -> None:
         "model.layers.45.",
         "layers.45.",
     )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@torch.inference_mode()
+def test_glm5next_draft_head_preserves_target_and_quantized_weight() -> None:
+    if torch.cuda.get_device_capability() != (12, 0):
+        pytest.skip("NVFP4 draft vocabulary head requires SM120")
+    import flashinfer
+
+    from vllm.models.glm5next.nvidia.mtp_draft_head import QuantizedDraftHead
+
+    weight = torch.randn(1024, 256, device="cuda", dtype=torch.bfloat16)
+    original = weight.clone()
+    scale = (448.0 * 6.0) / weight.float().abs().nan_to_num().max()
+    values, scales = flashinfer.nvfp4_quantize(
+        weight,
+        scale,
+        sfLayout=flashinfer.SfLayout.layout_128x4,
+        do_shuffle=False,
+        backend="cuda",
+    )
+    expected = flashinfer.prepare_bf16_fp4_weights(
+        values.view(torch.uint8),
+        scales,
+        scale.reciprocal().reshape(1),
+        backend="cute-dsl",
+    )
+    head = QuantizedDraftHead(
+        SimpleNamespace(weight=weight, tp_size=1, shard_indices=object()), "nvfp4"
+    )
+    torch.testing.assert_close(weight, original, rtol=0, atol=0)
+    for actual, reference in zip(
+        (head.weight, head.weight_scale, head.weight_global_scale), expected
+    ):
+        torch.testing.assert_close(actual, reference, rtol=0, atol=0)
 
 
 def test_glm5next_mtp_reuses_runtime_quantized_draft_head(monkeypatch) -> None:
@@ -1704,11 +1740,12 @@ def test_glm_adaptive_kda_graph_matches_independent_request_states(monkeypatch, 
         context.attn_metadata[layer.prefix] = metadata
         layer.kv_cache[0].copy_(initial_conv)
         layer.kv_cache[1].copy_(initial_state)
-        allocations = torch.cuda.memory_stats(device)["allocation.all.allocated"]
+        allocations = torch.accelerator.memory_stats(device)["allocation.all.allocated"]
         graph.replay()
-        torch.cuda.synchronize(device)
+        torch.accelerator.synchronize(device)
         assert (
-            torch.cuda.memory_stats(device)["allocation.all.allocated"] == allocations
+            torch.accelerator.memory_stats(device)["allocation.all.allocated"]
+            == allocations
         )
         graph_output = output.clone()
         graph_states = tuple(state.clone() for state in layer.kv_cache)
@@ -2018,6 +2055,154 @@ def test_glm5next_processing_info_pins_processor_revision(monkeypatch) -> None:
             {"revision": "checkpoint-commit"},
         )
     ]
+
+
+def test_glm5next_vision_attention_releases_projection_and_norm_inputs(monkeypatch):
+    from vllm.models.glm5next.nvidia import multimodal
+
+    owners = {}
+
+    def project(value):
+        packed = value.repeat(1, 1, 3)
+        owners["packed"] = weakref.ref(packed)
+        return packed, None
+
+    def normalize(q, k, *args):
+        owners["q_norm_input"] = weakref.ref(q)
+        owners["k_norm_input"] = weakref.ref(k)
+        return q.clone(), k.clone()
+
+    def attention(query, key, value, **kwargs):
+        assert all(owner() is None for owner in owners.values())
+        owners.update(q=weakref.ref(query), k=weakref.ref(key), v=weakref.ref(value))
+        return value.clone()
+
+    def output_project(value):
+        assert all(owner() is None for owner in owners.values())
+        return value, None
+
+    layer = SimpleNamespace(
+        head_dim=2,
+        num_attention_heads_per_partition=2,
+        hidden_size_per_attention_head=2,
+        qkv=project,
+        q_norm=SimpleNamespace(weight=torch.ones(2), variance_epsilon=1e-5),
+        k_norm=SimpleNamespace(weight=torch.ones(2)),
+        apply_rotary_emb=lambda value, cos, sin: value.clone(),
+        attn=attention,
+        proj=output_project,
+    )
+    layer.split_qkv = lambda value: multimodal.Glm5NextVisionAttention.split_qkv(
+        layer, value
+    )
+    layer._project_qkv = lambda *args: multimodal.Glm5NextVisionAttention._project_qkv(
+        layer, *args
+    )
+    monkeypatch.setattr(multimodal, "fused_q_kv_rmsnorm", normalize)
+    x = torch.arange(28, dtype=torch.float32).view(7, 1, 4)
+    original = x.clone()
+    output = multimodal.Glm5NextVisionAttention.forward(
+        layer, x, torch.tensor([0, 7]), torch.ones(7, 1), torch.zeros(7, 1), 7
+    )
+    torch.testing.assert_close(output, original, rtol=0, atol=0)
+    torch.testing.assert_close(x, original, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("reserved_bytes", [0, 256, 4096])
+def test_glm5next_chunked_projection_keeps_whole_image_attention(
+    monkeypatch, reserved_bytes
+):
+    from vllm.models.glm5next.nvidia import multimodal
+    from vllm.v1.worker import workspace
+
+    manager = workspace.WorkspaceManager(torch.device("cpu"))
+    manager.reserve_all(((reserved_bytes,), torch.uint8))
+    manager.lock()
+    monkeypatch.setattr(workspace, "_manager", manager)
+    monkeypatch.setattr(multimodal, "_VISION_PROJECTION_CHUNK_ROWS", 4)
+    x = torch.randn(11, 1, 8, generator=torch.Generator().manual_seed(72))
+    cu_seqlens = torch.tensor([0, 3, 11])
+    cos, sin = torch.ones(11, 2), torch.zeros(11, 2)
+    projected_rows = []
+    attention_calls = []
+
+    def project(value, cos, sin):
+        projected_rows.append(len(value))
+        assert cos.shape[0] == sin.shape[0] == len(value)
+        value = value.reshape(1, len(value), 2, 4)
+        return value, value * 0.5, value * 2
+
+    def attention(query, key, value, **metadata):
+        assert metadata["cu_seqlens"] is cu_seqlens
+        attention_calls.append(query.shape[1])
+        outputs = []
+        for start, stop in zip(cu_seqlens[:-1], cu_seqlens[1:]):
+            q, k, v = (t[:, start:stop].transpose(1, 2) for t in (query, key, value))
+            outputs.append(
+                torch.nn.functional.scaled_dot_product_attention(q, k, v).transpose(
+                    1, 2
+                )
+            )
+        return torch.cat(outputs, dim=1)
+
+    layer = SimpleNamespace(
+        num_attention_heads_per_partition=2,
+        hidden_size_per_attention_head=4,
+        _project_qkv=project,
+        _borrow_qkv_workspace=True,
+        attn=attention,
+    )
+    norm = torch.nn.RMSNorm(8)
+    q, k, v = project(norm(x), cos, sin)
+    expected = attention(q, k, v, cu_seqlens=cu_seqlens).reshape_as(x)
+    projected_rows.clear()
+    attention_calls.clear()
+    actual = multimodal.Glm5NextVisionAttention.context_with_chunked_projection(
+        layer, x, norm, cu_seqlens, cos, sin, 8
+    )
+    torch.testing.assert_close(actual, expected)
+    assert projected_rows == [4, 4, 3]
+    assert attention_calls == [11]
+
+
+@pytest.mark.parametrize("token_budget,expand", [(8000, 1), (8192, 1), (8000, 2)])
+def test_glm5next_image_budget_covers_rectangular_canvases(token_budget, expand):
+    from vllm.models.glm5next.nvidia.multimodal import Glm5NextProcessingInfo
+
+    processor = SimpleNamespace(
+        patch_size=14, merge_size=2, temporal_patch_size=2, patch_expand_factor=expand
+    )
+    info = Glm5NextProcessingInfo.__new__(Glm5NextProcessingInfo)
+    info.get_hf_processor = lambda **kwargs: SimpleNamespace(image_processor=processor)
+    info.get_hf_config = lambda: SimpleNamespace(
+        vision_config=SimpleNamespace(
+            patch_size=14, spatial_merge_size=2, temporal_patch_size=2
+        )
+    )
+    info._get_image_max_pixels = lambda: token_budget * 2 * 28**2
+    canvas = info.get_image_size_with_most_features()
+    assert canvas.width % (28 * expand) == 0
+    assert canvas.height % (28 * expand) == 0
+    assert canvas.width * canvas.height // 28**2 == token_budget
+    assert info.get_max_image_tokens() == token_budget
+    assert (
+        info.get_num_image_tokens(image_width=3082, image_height=2048) <= token_budget
+    )
+    if token_budget == 8000 and expand == 1:
+        assert (canvas.width, canvas.height) == (2800, 2240)
+        assert canvas.width * canvas.height // 28**2 > 7957
+
+
+def test_glm5next_image_pixel_budget_respects_token_override():
+    from vllm.models.glm5next.nvidia.multimodal import Glm5NextProcessingInfo
+
+    processor = SimpleNamespace(patch_size=14, merge_size=2, temporal_patch_size=2)
+    info = Glm5NextProcessingInfo.__new__(Glm5NextProcessingInfo)
+    info.get_hf_processor = lambda **kwargs: SimpleNamespace(image_processor=processor)
+    info.ctx = SimpleNamespace(
+        get_merged_mm_kwargs=lambda kwargs: {"max_image_tokens": 2048}
+    )
+    assert info._get_image_max_pixels() == 2048 * 2 * 28**2
 
 
 def test_glm5next_processor_counts_video_only_tokens() -> None:

--- a/tests/models/test_glm5next_pooled_indexer.py
+++ b/tests/models/test_glm5next_pooled_indexer.py
@@ -10,6 +10,7 @@ import torch
 from torch import nn
 
 from vllm.models.deepseek_v4.nvidia.b12x_indexer import _flatten_index_cache
+from vllm.models.glm5next.nvidia import pooled_indexer as indexer_module
 from vllm.models.glm5next.nvidia.ops import glm_kpool
 from vllm.models.glm5next.nvidia.ops.glm_kpool import (
     expand_c4_block_table,
@@ -19,7 +20,10 @@ from vllm.models.glm5next.nvidia.ops.glm_kpool import (
     prepare_c4_decode_metadata,
     update_decode_pools,
 )
-from vllm.models.glm5next.nvidia.pooled_indexer import Glm5NextPooledIndexer
+from vllm.models.glm5next.nvidia.pooled_indexer import (
+    Glm5NextIndexerScratch,
+    Glm5NextPooledIndexer,
+)
 from vllm.platforms import current_platform
 from vllm.triton_utils import triton
 from vllm.v1.attention.backends.mla.b12x_mla_sparse import (
@@ -655,7 +659,7 @@ def test_glm53_physical_selection_provider_is_explicit() -> None:
     indexer.dcp_world_size = 1
     indexer._emit_physical_selection = True
     indexer.topk_indices_buffer = torch.empty((8, 2051), dtype=torch.int32)
-    indexer._physical_active_counts = torch.empty(8, dtype=torch.int32)
+    indexer.scratch = Glm5NextIndexerScratch(8, 1, torch.device("cpu"))
 
     selected = indexer.get_b12x_physical_selection(
         num_tokens=3,
@@ -738,11 +742,14 @@ def test_glm53_decode_table_capacity_uses_batched_token_limit() -> None:
     indexer.max_model_len = 4096
     indexer.dcp_world_size = 1
     indexer.indexer_op = SimpleNamespace(max_model_len=4096 // 4)
+    indexer.scratch = Glm5NextIndexerScratch(
+        indexer.max_tokens, indexer.max_seqs, device
+    )
 
     indexer.bind_main_kv_cache(main)
 
-    assert indexer._decode_block_table.shape[0] == indexer.max_tokens
-    assert indexer._decode_block_table.shape[0] > indexer.max_seqs * (5 + 1)
+    assert indexer.scratch.decode_block_table.shape[0] == indexer.max_tokens
+    assert indexer.scratch.decode_block_table.shape[0] > indexer.max_seqs * (5 + 1)
     assert indexer.indexer_op.max_model_len == 4096 // 4
 
 
@@ -757,6 +764,133 @@ def test_glm53_selector_capacity_tracks_auto_fit_max_model_len() -> None:
     indexer.update_max_model_len(1_985)
     assert indexer._aligned_max_seq_len == 1_988
     assert indexer.indexer_op.max_model_len == 497
+
+
+def test_glm53_indexer_scratch_rebind_preserves_same_geometry_storage() -> None:
+    scratch = Glm5NextIndexerScratch(128, 4, torch.device("cpu"))
+    scratch.bind_tables(32, torch.device("cpu"))
+    pointers = {name: buffer.data_ptr() for name, buffer in scratch.named_buffers()}
+    scratch.decode_block_table.fill_(53)
+    scratch.bind_tables(32, torch.device("cpu"))
+    assert {
+        name: buffer.data_ptr() for name, buffer in scratch.named_buffers()
+    } == pointers
+    assert torch.all(scratch.decode_block_table == 53)
+    scratch.bind_tables(16, torch.device("cpu"))
+    assert scratch.decode_block_table.shape == (128, 16)
+    assert scratch.pool_block_table.shape == (4, 16)
+    assert scratch.q_fp8.data_ptr() == pointers["q_fp8"]
+    assert not scratch.state_dict()
+
+
+def test_glm53_shared_scratch_keeps_layer_checkpoints_and_draft_selection_private(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        indexer_module, "ReplicatedLinear", lambda *a, **k: nn.Identity()
+    )
+    monkeypatch.setattr(
+        indexer_module, "B12xC4SparseIndexer", lambda *a, **k: SimpleNamespace()
+    )
+    monkeypatch.setattr(
+        indexer_module,
+        "get_b12x_sparse_mla",
+        lambda: SimpleNamespace(expand_pooled_topk_to_physical_slots=lambda *a: None),
+    )
+    config = SimpleNamespace(
+        index_topk=2048,
+        index_n_heads=32,
+        index_head_dim=128,
+        index_kpool=4,
+        qk_rope_head_dim=0,
+    )
+    vllm_config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=128, max_num_seqs=4),
+        model_config=SimpleNamespace(max_model_len=4096),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1, cp_kv_cache_interleave_size=4
+        ),
+        speculative_config=SimpleNamespace(num_speculative_tokens=3),
+    )
+    scratch = Glm5NextIndexerScratch(128, 4, torch.device("cpu"))
+    target_ids = torch.zeros((128, 2051), dtype=torch.int32)
+    target_pools = torch.zeros((128, 512), dtype=torch.int32)
+
+    def make(name, shared):
+        return Glm5NextPooledIndexer(
+            vllm_config,
+            config,
+            8,
+            8,
+            None,
+            SimpleNamespace(block_size=2048),
+            target_ids if shared else torch.full_like(target_ids, 42),
+            target_pools if shared else torch.full_like(target_pools, 42),
+            main_layer_name=name,
+            prefix=name,
+            scratch=scratch if shared else None,
+        )
+
+    first, second, draft = (
+        make("target.0", True),
+        make("target.1", True),
+        make("mtp", False),
+    )
+    assert first.scratch is second.scratch
+    assert draft.scratch is not scratch
+    for indexer, value in ((first, 1), (second, 2), (draft, 3)):
+        indexer._tail.fill_(value)
+        indexer.snapshot_speculative_interval_starts()
+    scratch.q_fp8.view(torch.uint8).fill_(255)
+    target_ids.fill_(-1)
+    first._tail.zero_()
+    first.restore_speculative_interval_starts()
+    for indexer, value in ((first, 1), (second, 2), (draft, 3)):
+        assert torch.all(indexer._tail == value)
+        assert torch.all(indexer._tail_snapshot == value)
+    assert torch.all(draft.topk_indices_buffer == 42)
+    assert torch.all(draft.pool_topk_indices_buffer == 42)
+
+
+def test_glm53_shared_indexer_scratch_graph_consumes_each_live_query() -> None:
+    device = _require_glm_gpu()
+    scratch = Glm5NextIndexerScratch(8, 1, device)
+    inputs = [
+        torch.randn((8, 32, 128), device=device, dtype=torch.bfloat16) for _ in range(2)
+    ]
+    outputs = [torch.empty_like(scratch.q_fp8) for _ in range(2)]
+    scales = [torch.empty_like(scratch.q_scale) for _ in range(2)]
+
+    def run() -> None:
+        for query, output, scale in zip(inputs, outputs, scales):
+            glm_kpool.fwht128_quant_fp8(
+                query.view(-1, 128),
+                scratch.q_fp8.view(-1, 128),
+                scratch.q_scale.view(-1),
+            )
+            output.copy_(scratch.q_fp8)
+            scale.copy_(scratch.q_scale)
+
+    run()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run()
+    for _ in range(3):
+        for query in inputs:
+            query.normal_()
+        scratch.q_fp8.view(torch.uint8).fill_(255)
+        scratch.q_scale.fill_(float("nan"))
+        graph.replay()
+        for query, output, scale in zip(inputs, outputs, scales):
+            reference_q = torch.empty_like(output)
+            reference_scale = torch.empty_like(scale)
+            glm_kpool.fwht128_quant_fp8(
+                query.view(-1, 128),
+                reference_q.view(-1, 128),
+                reference_scale.view(-1),
+            )
+            torch.testing.assert_close(output, reference_q, rtol=0, atol=0)
+            torch.testing.assert_close(scale, reference_scale, rtol=0, atol=0)
 
 
 def test_glm53_parent_table_width_tracks_dcp_sharding() -> None:
@@ -1292,9 +1426,7 @@ def test_glm53_pool_expansion_appends_only_the_incomplete_tail() -> None:
     expand_pool_ids(pool_ids, positions, output)
 
     assert torch.all(output[0, 3:] == -1)
-    assert torch.equal(
-        output[0, :3].cpu(), torch.tensor([0, 1, 2], dtype=torch.int32)
-    )
+    assert torch.equal(output[0, :3].cpu(), torch.tensor([0, 1, 2], dtype=torch.int32))
     assert torch.equal(output[1, :8].cpu(), torch.tensor([4, 5, 6, 7, 0, 1, 2, 3]))
     assert torch.all(output[1, 8:] == -1)
     assert torch.equal(output[2, :2048].cpu(), torch.arange(2048, dtype=torch.int32))

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -824,16 +824,18 @@ def test_b12x_glm5_next_full_ckv_workspaces_follow_cache_format(
 
     specs = impl._workspace_specs(plan, input_num_heads=8, include_ckv=True)
 
-    assert specs[-2:] == (
-        ((128, record_bytes), torch.uint8),
-        ((512, record_bytes), torch.uint8),
-    )
+    assert len(specs) == 3
+    assert specs[-1] == ((512, record_bytes), torch.uint8)
 
 
 @pytest.mark.parametrize("record_bytes", [528, 304])
+@pytest.mark.parametrize("rank", [0, 1])
+@pytest.mark.parametrize("padded_tokens", [2, 4])
 def test_b12x_glm5_next_full_ckv_gather_preserves_native_records(
     monkeypatch: pytest.MonkeyPatch,
     record_bytes: int,
+    rank: int,
+    padded_tokens: int,
 ) -> None:
     impl = object.__new__(B12xMLASparseImpl)
     impl._kernel_page_size = 2
@@ -847,37 +849,48 @@ def test_b12x_glm5_next_full_ckv_gather_preserves_native_records(
         .to(torch.uint8)
         .view(2, 2, record_bytes)
     )
-    local_buffer = torch.full((4, record_bytes), 255, dtype=torch.uint8)
-    gathered_buffer = torch.empty((8, record_bytes), dtype=torch.uint8)
+    gathered_buffer = torch.full((8, record_bytes), 255, dtype=torch.uint8)
+    local_tokens = padded_tokens - 1
     metadata = SimpleNamespace(
-        num_actual_tokens=3,
-        dcp_local_total_tokens=3,
-        dcp_padded_total_tokens=4,
-        dcp_local_cu_seq_lens=torch.tensor([0, 3], dtype=torch.int32),
+        num_actual_tokens=local_tokens,
+        dcp_local_total_tokens=local_tokens,
+        dcp_padded_total_tokens=padded_tokens,
+        dcp_local_cu_seq_lens=torch.tensor([0, local_tokens], dtype=torch.int32),
         block_table=torch.tensor([[0, 1]], dtype=torch.int32),
         num_reqs=1,
     )
 
     def fake_cp_gather_cache(**kwargs: Any) -> None:
-        kwargs["dst"].copy_(kwargs["src_cache"].view(-1, record_bytes)[:3])
+        kwargs["dst"].copy_(kwargs["src_cache"].view(-1, record_bytes)[:local_tokens])
 
     def fake_all_gather(_group: Any, src: torch.Tensor, dst: torch.Tensor) -> None:
+        assert src.data_ptr() == dst.data_ptr() + rank * padded_tokens * record_bytes
         dst.copy_(src.repeat(2))
 
     monkeypatch.setattr(b12x_mla_sparse.ops, "cp_gather_cache", fake_cp_gather_cache)
     monkeypatch.setattr(
         b12x_mla_sparse, "_dcp_all_gather_current_stream", fake_all_gather
     )
-    monkeypatch.setattr(b12x_mla_sparse, "get_dcp_group", lambda: object())
+    monkeypatch.setattr(
+        b12x_mla_sparse,
+        "get_dcp_group",
+        lambda: SimpleNamespace(rank_in_group=rank, world_size=2),
+    )
 
-    gathered = impl._gather_full_ckv(kv_cache, metadata, local_buffer, gathered_buffer)
+    gathered = impl._gather_full_ckv(kv_cache, metadata, gathered_buffer)
 
     expected_rank = torch.cat(
-        (kv_cache.view(-1, record_bytes)[:3], torch.zeros((1, record_bytes))),
+        (
+            kv_cache.view(-1, record_bytes)[:local_tokens],
+            torch.zeros((1, record_bytes), dtype=torch.uint8),
+        ),
         dim=0,
     )
     assert gathered.shape == (4, 2, record_bytes)
-    assert torch.equal(gathered.view(-1, record_bytes), expected_rank.repeat(2, 1))
+    assert torch.equal(
+        gathered.view(-1, record_bytes)[: 2 * padded_tokens], expected_rank.repeat(2, 1)
+    )
+    assert torch.all(gathered.view(-1, record_bytes)[2 * padded_tokens :] == 255)
 
 
 def test_b12x_glm5_next_full_ckv_gather_rejects_wrong_record_width() -> None:
@@ -893,7 +906,6 @@ def test_b12x_glm5_next_full_ckv_gather_rejects_wrong_record_width() -> None:
         impl._gather_full_ckv(
             torch.empty((2, 2, 528), dtype=torch.uint8),
             metadata,
-            torch.empty((4, 304), dtype=torch.uint8),
             torch.empty((8, 304), dtype=torch.uint8),
         )
 
@@ -1171,7 +1183,6 @@ def test_b12x_glm5_next_cache_geometry_is_finalized_before_bind(monkeypatch) -> 
     assert reservations[2] == (
         ((4096, 16, 512), torch.bfloat16),
         ((256,), torch.uint8),
-        ((131328, 528), torch.uint8),
         ((525312, 528), torch.uint8),
     )
 

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -820,11 +820,12 @@ def test_b12x_glm5_next_full_ckv_workspaces_follow_cache_format(
     impl._ckv_local_capacity = 128
     impl.dcp_world_size = 4
     impl._cache_record_bytes = record_bytes
-    plan = object()
+    plan = SimpleNamespace(layout=SimpleNamespace(nbytes=8))
 
     specs = impl._workspace_specs(plan, input_num_heads=8, include_ckv=True)
 
     assert len(specs) == 3
+    assert specs[1] == ((8,), torch.uint8)
     assert specs[-1] == ((512, record_bytes), torch.uint8)
 
 
@@ -1256,7 +1257,7 @@ def test_b12x_glm5_next_cache_geometry_is_finalized_before_bind(monkeypatch) -> 
     )
     assert reservations[2] == (
         ((4096, 16, 512), torch.bfloat16),
-        ((query_stage_bytes,), torch.uint8),
+        ((256,), torch.uint8),
         ((525312, 528), torch.uint8),
     )
 

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -901,6 +901,36 @@ def test_glm_dcp_decode_keeps_the_transport_collective(monkeypatch) -> None:
     assert calls == [(query, 1)]
 
 
+@pytest.mark.parametrize("overlap", ["none", "input", "output"])
+def test_glm_value_projection_reuses_disjoint_query_prefix(monkeypatch, overlap):
+    from vllm.v1.worker import workspace
+
+    manager = workspace.WorkspaceManager(torch.device("cpu"))
+    (storage,) = manager.get_simultaneous(((2048,), torch.bfloat16))
+    manager.lock()
+    monkeypatch.setattr(b12x_mla_sparse, "current_workspace_manager", lambda: manager)
+    impl = b12x_mla_sparse.B12xMLASparseImpl.__new__(b12x_mla_sparse.B12xMLASparseImpl)
+    impl._is_glm_next = True
+    impl._decode_max_rows = 16
+    start = 0 if overlap == "input" else 512
+    value = storage[start : start + 512].view(32, 2, 8).transpose(0, 1)
+    value.copy_(torch.randn_like(value))
+    expected = value.clone()
+    output = (
+        storage[:256].view(32, 2, 4)
+        if overlap == "output"
+        else torch.empty(32, 2, 4, dtype=torch.bfloat16)
+    )
+    actual = impl.prepare_projection_input(value, output)
+    torch.testing.assert_close(value, expected, rtol=0, atol=0)
+    if overlap != "none":
+        assert actual is None
+    else:
+        assert actual.is_contiguous()
+        assert actual.data_ptr() == storage.data_ptr()
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
 @pytest.mark.parametrize("world_size", [2, 4])
 def test_glm_dcp_output_reuses_query_storage_with_head_major_rank_slices(
     monkeypatch, world_size: int
@@ -955,6 +985,48 @@ def test_glm_dcp_output_reuses_query_storage_with_head_major_rank_slices(
             assert actual.transpose(0, 1).is_contiguous()
             scratch.fill_(255)
             assert torch.equal(actual, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("reduction,columns", [(512, 256), (256, 512)])
+def test_glm_projection_scratch_preserves_cuda_bmm(monkeypatch, reduction, columns):
+    from vllm.model_executor.layers.attention.mla_attention import (
+        _bmm_with_disjoint_batches,
+    )
+    from vllm.v1.worker import workspace
+
+    heads, rows = 32, 3072
+    elements = heads * rows * reduction
+    manager = workspace.WorkspaceManager(torch.device("cuda"))
+    (storage,) = manager.get_simultaneous(((2 * elements,), torch.bfloat16))
+    manager.lock()
+    monkeypatch.setattr(b12x_mla_sparse, "current_workspace_manager", lambda: manager)
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._is_glm_next = True
+    impl._decode_max_rows = 16
+    value = storage[elements:].view(rows, heads, reduction).transpose(0, 1)
+    value.normal_()
+    weight = torch.randn(heads, reduction, columns, device="cuda", dtype=value.dtype)
+    output = torch.empty(rows, heads, columns, device="cuda", dtype=value.dtype)
+    expected = torch.empty_like(output)
+    _bmm_with_disjoint_batches(value, weight, out=expected.transpose(0, 1))
+
+    def project():
+        packed = impl.prepare_projection_input(value, output)
+        assert packed is not None and packed.is_contiguous()
+        assert packed.data_ptr() == storage.data_ptr()
+        _bmm_with_disjoint_batches(packed, weight, out=output.transpose(0, 1))
+
+    project()
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        project()
+    for _ in range(3):
+        value.normal_()
+        _bmm_with_disjoint_batches(value, weight, out=expected.transpose(0, 1))
+        graph.replay()
+        torch.testing.assert_close(output, expected, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize(
@@ -1989,7 +2061,8 @@ def test_b12x_wo_projection_packs_and_runs_public_api(monkeypatch) -> None:
     assert torch.count_nonzero(output != 7) == 0
 
 
-def test_b12x_mhc_uses_public_plan_bind_run(monkeypatch) -> None:
+@pytest.mark.parametrize("capturing", [False, True])
+def test_b12x_mhc_uses_public_plan_bind_run(monkeypatch, capturing) -> None:
     calls: dict[str, Any] = {}
     retained_bindings: list[Any] = []
 
@@ -2031,6 +2104,7 @@ def test_b12x_mhc_uses_public_plan_bind_run(monkeypatch) -> None:
     )
     monkeypatch.setattr(b12x_mla, "_require_b12x_mhc", lambda: module)
     monkeypatch.setattr(b12x_mla, "current_workspace_manager", lambda: _Workspace())
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: capturing)
     monkeypatch.setattr(
         b12x_mla,
         "retain_cuda_graph_capture_resource",
@@ -2076,13 +2150,94 @@ def test_b12x_mhc_uses_public_plan_bind_run(monkeypatch) -> None:
     assert calls["bind"][1]["scratch"].dtype == torch.uint8
     assert calls["pre"][1]["binding"].expected_m == 3
     assert calls["post_pre"][1]["expected_m"] == 3
-    assert retained_bindings == [
-        calls["pre"][1]["binding"],
-        calls["post_pre"][1]["binding"],
-    ]
+    bindings = [calls["pre"][1]["binding"], calls["post_pre"][1]["binding"]]
+    if capturing:
+        assert len(retained_bindings) == 2
+        for owner, binding in zip(retained_bindings, bindings):
+            assert owner[0] is plan
+            assert owner[1] is binding.scratch
+    else:
+        assert retained_bindings == bindings
     assert residual_out.shape == (3, 4, 256)
     assert layer_input.shape == (3, 256)
     assert final is next_outputs[0]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("piecewise", [False, True])
+@torch.inference_mode()
+def test_b12x_mhc_graph_reuses_consumed_outputs(monkeypatch, piecewise) -> None:
+    import weakref
+
+    from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
+    from vllm.v1.worker import workspace
+
+    if torch.cuda.get_device_capability()[0] != 12:
+        pytest.skip("native B12X mHC requires SM12x")
+    device = torch.device("cuda", torch.accelerator.current_device_index())
+    manager = workspace.WorkspaceManager(device)
+    manager.reserve_all(((1024**2,), torch.uint8))
+    manager.lock()
+    monkeypatch.setattr(b12x_mla, "current_workspace_manager", lambda: manager)
+    mhc = b12x_mla.B12xMHCResidual(
+        hidden_size=4096, hc_mult=4, rms_eps=1e-6, hc_eps=1e-6, sinkhorn_iters=20
+    )
+    source = torch.randn(16, 4096, device=device, dtype=torch.bfloat16)
+    fn = torch.randn(24, 16384, device=device) * 0.001
+    fn_first = fn.view(24, 4, 4096).sum(1)
+    scale = torch.full((3,), 0.1, device=device)
+    base = torch.zeros(24, device=device)
+    norm = torch.ones(4096, device=device, dtype=torch.bfloat16)
+    consumed: list[weakref.ReferenceType[torch.Tensor]] = []
+
+    def chain(record=False):
+        residual, post, comb, x = mhc.run_pre(
+            source, fn_first, scale, base, norm_weight=norm, norm_eps=1e-6
+        )
+        for index in range(8):
+            if record and piecewise and index == 4:
+                graph.add_eager(lambda: None)
+            if record:
+                consumed.append(weakref.ref(residual))
+            residual, post, comb, x = mhc.run_post_pre(
+                x,
+                residual,
+                post,
+                comb,
+                fn,
+                scale,
+                base,
+                norm_weight=norm,
+                norm_eps=1e-6,
+            )
+        return residual, post, comb, x
+
+    chain()
+    torch.accelerator.synchronize()
+    graph = (
+        BreakableCUDAGraphCapture(pool=torch.cuda.graph_pool_handle())
+        if piecewise
+        else torch.cuda.CUDAGraph()
+    )
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with (
+        workspace.collect_cuda_graph_capture_resources() as resources,
+        torch.cuda.stream(stream),
+        graph if piecewise else torch.cuda.graph(graph),
+    ):
+        captured = chain(record=True)
+    torch.cuda.current_stream().wait_stream(stream)
+    # Keep the graph and its explicit owners live. Consumed activations must
+    # still be reclaimable by its pool, not pinned by native bindings.
+    assert resources
+    assert all(ref() is None for ref in consumed)
+    for _ in range(3):
+        source.normal_()
+        expected = chain()
+        graph.replay()
+        for actual, reference in zip(captured, expected):
+            torch.testing.assert_close(actual, reference, rtol=0, atol=0)
 
 
 def test_b12x_dsa_indexer_uses_logical_slot_contract(monkeypatch) -> None:

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -901,6 +901,83 @@ def test_glm_dcp_decode_keeps_the_transport_collective(monkeypatch) -> None:
     assert calls == [(query, 1)]
 
 
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_glm_dcp_output_reuses_query_storage_with_head_major_rank_slices(
+    monkeypatch, world_size: int
+) -> None:
+    from vllm.v1.worker.workspace import WorkspaceManager
+
+    manager = WorkspaceManager(torch.device("cpu"))
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._is_glm_next = True
+    impl._decode_max_rows = 4
+    impl._max_tokens = 32
+    impl._input_num_heads = world_size * 4
+    impl._q_head_dim = 8
+    impl._scratch_nbytes = 32 * impl._input_num_heads * 8 * 2
+    impl._decode_plan = object()
+    impl._ckv_local_capacity = 0
+    impl._cache_record_bytes = 528
+    impl.dcp_world_size = world_size
+    monkeypatch.setattr(b12x_mla_sparse, "current_workspace_manager", lambda: manager)
+    monkeypatch.setattr(b12x_mla_sparse, "should_nccl_symm_mem_ag_rs", lambda: False)
+    q_buffer, scratch = impl._borrow_workspaces()
+    manager.lock()
+    for rank in range(world_size):
+        for rows in (19, 7, 23):
+            partial = (
+                scratch[: rows * impl._input_num_heads * 8 * 2]
+                .view(torch.bfloat16)
+                .view(rows, impl._input_num_heads, 8)
+            )
+            partial.copy_(torch.arange(partial.numel()).view_as(partial) % 127)
+            original = partial.clone()
+
+            def reduce_scatter(local, packed, rank=rank, original=original):
+                assert packed.data_ptr() == q_buffer.data_ptr()
+                assert local.data_ptr() == packed.data_ptr() + rank * local.nbytes
+                assert local.is_contiguous() and packed.is_contiguous()
+                assert torch.equal(packed, original.transpose(0, 1))
+                local.mul_(world_size)
+
+            comm = SimpleNamespace(disabled=False, reduce_scatter=reduce_scatter)
+            group = SimpleNamespace(
+                rank_in_group=rank,
+                device_communicator=SimpleNamespace(pynccl_comm=comm),
+            )
+            monkeypatch.setattr(
+                b12x_mla_sparse, "get_dcp_group", lambda group=group: group
+            )
+            actual = impl.reduce_scatter_dcp_output(partial)
+            expected = original[:, rank * 4 : (rank + 1) * 4] * world_size
+            assert torch.equal(actual, expected)
+            assert torch.equal(partial, original)
+            assert actual.transpose(0, 1).is_contiguous()
+            scratch.fill_(255)
+            assert torch.equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "rows,disabled,symmetric", [(4, False, False), (8, True, False), (8, False, True)]
+)
+def test_glm_dcp_output_preserves_decode_and_special_transport_paths(
+    monkeypatch, rows, disabled, symmetric
+) -> None:
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._is_glm_next = True
+    impl._decode_max_rows = 4
+    comm = SimpleNamespace(disabled=disabled)
+    monkeypatch.setattr(
+        b12x_mla_sparse,
+        "get_dcp_group",
+        lambda: SimpleNamespace(device_communicator=SimpleNamespace(pynccl_comm=comm)),
+    )
+    monkeypatch.setattr(
+        b12x_mla_sparse, "should_nccl_symm_mem_ag_rs", lambda: symmetric
+    )
+    assert impl.reduce_scatter_dcp_output(torch.empty(rows, 8, 8)) is None
+
+
 @pytest.mark.parametrize("record_bytes", [528, 304])
 @pytest.mark.parametrize("rank", [0, 1])
 @pytest.mark.parametrize("padded_tokens", [2, 4])

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -828,6 +828,78 @@ def test_b12x_glm5_next_full_ckv_workspaces_follow_cache_format(
     assert specs[-1] == ((512, record_bytes), torch.uint8)
 
 
+@pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("transposed", [False, True])
+def test_glm_dcp_prefill_query_reuses_scratch_without_aliasing_output(
+    monkeypatch, world_size: int, transposed: bool
+) -> None:
+    from vllm.v1.worker.workspace import WorkspaceManager
+
+    manager = WorkspaceManager(torch.device("cpu"))
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._is_glm_next = True
+    impl._decode_max_rows = 4
+    impl._max_tokens = 32
+    impl._input_num_heads = world_size * 4
+    impl._q_head_dim = 8
+    impl._scratch_nbytes = 32 * impl._input_num_heads * 8 * 2
+    impl._decode_plan = object()
+    impl._ckv_local_capacity = 0
+    impl._cache_record_bytes = 528
+    impl.dcp_world_size = world_size
+    monkeypatch.setattr(b12x_mla_sparse, "current_workspace_manager", lambda: manager)
+    q_buffer, scratch = impl._borrow_workspaces()
+    manager.lock()
+    for rank in range(world_size):
+        group = SimpleNamespace(world_size=world_size, rank_in_group=rank)
+        monkeypatch.setattr(b12x_mla_sparse, "get_dcp_group", lambda group=group: group)
+        for rows in (19, 7, 23):
+            local_queries = []
+            for source in range(world_size):
+                values = (torch.arange(rows * 4 * 8) % 127 + source).to(torch.bfloat16)
+                local_queries.append(
+                    values.view(4, rows, 8).transpose(0, 1)
+                    if transposed
+                    else values.view(rows, 4, 8)
+                )
+
+            def gather(
+                _group, send, receive, rank=rank, rows=rows, local_queries=local_queries
+            ):
+                assert send.data_ptr() == receive.data_ptr() + rank * send.nbytes
+                assert torch.equal(send.view(rows, 4, 8), local_queries[rank])
+                receive.view(world_size, rows, 4, 8).copy_(torch.stack(local_queries))
+
+            monkeypatch.setattr(
+                b12x_mla_sparse, "_dcp_all_gather_current_stream", gather
+            )
+            actual = impl.gather_dcp_query(local_queries[rank])
+            assert actual.data_ptr() == q_buffer.data_ptr()
+            expected = torch.cat(local_queries, dim=1)
+            assert torch.equal(actual, expected)
+            scratch.fill_(255)
+            assert torch.equal(actual, expected)
+
+
+def test_glm_dcp_decode_keeps_the_transport_collective(monkeypatch) -> None:
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._is_glm_next = True
+    impl._decode_max_rows = 16
+    query = torch.empty((16, 4, 8), dtype=torch.bfloat16)
+    expected = torch.empty((16, 8, 8), dtype=torch.bfloat16)
+    calls = []
+
+    def gather(value, dim):
+        calls.append((value, dim))
+        return expected
+
+    monkeypatch.setattr(
+        b12x_mla_sparse, "get_dcp_group", lambda: SimpleNamespace(all_gather=gather)
+    )
+    assert impl.gather_dcp_query(query) is expected
+    assert calls == [(query, 1)]
+
+
 @pytest.mark.parametrize("record_bytes", [528, 304])
 @pytest.mark.parametrize("rank", [0, 1])
 @pytest.mark.parametrize("padded_tokens", [2, 4])
@@ -1172,17 +1244,19 @@ def test_b12x_glm5_next_cache_geometry_is_finalized_before_bind(monkeypatch) -> 
         (16, 4096, 4096),
     ]
     assert len(reservations) == 3
+    query_stage_bytes = 4096 * 64 * 512 * torch.bfloat16.itemsize
+    assert impl._scratch_nbytes == query_stage_bytes
     assert reservations[0] == (
         ((4096, 64, 512), torch.bfloat16),
-        ((256,), torch.uint8),
+        ((query_stage_bytes,), torch.uint8),
     )
     assert reservations[1] == (
         ((4096, 64, 512), torch.bfloat16),
-        ((256,), torch.uint8),
+        ((query_stage_bytes,), torch.uint8),
     )
     assert reservations[2] == (
         ((4096, 16, 512), torch.bfloat16),
-        ((256,), torch.uint8),
+        ((query_stage_bytes,), torch.uint8),
         ((525312, 528), torch.uint8),
     )
 

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -188,7 +188,8 @@ if AttentionBackendEnum.TOKENSPEED_MLA in BACKENDS_TO_TEST:
         BACKENDS_TO_TEST.remove(AttentionBackendEnum.TOKENSPEED_MLA)
 
 
-def test_mla_post_load_preserves_runtime_weight_addresses(monkeypatch):
+@pytest.mark.parametrize("has_mha_prefill", [False, True])
+def test_mla_post_load_preserves_runtime_weight_addresses(monkeypatch, has_mha_prefill):
     layer = MLAAttention.__new__(MLAAttention)
     torch.nn.Module.__init__(layer)
     layer.kv_lora_rank = 2
@@ -206,7 +207,14 @@ def test_mla_post_load_preserves_runtime_weight_addresses(monkeypatch):
     layer.dcp_q_replicate = False
     layer.quant_config = None
     layer.layer_name = "test"
-    layer.impl = SimpleNamespace(process_weights_after_loading=lambda act_dtype: None)
+    layer.impl = SimpleNamespace(
+        process_weights_after_loading=lambda act_dtype: None, is_sparse=True
+    )
+    layer.prefill_backend = object() if has_mha_prefill else None
+    packed = object()
+    provider = object()
+    layer.kv_b_proj.b12x_mxfp8_packed_weight = packed
+    layer.kv_b_proj.b12x_warmup_provider = provider
 
     monkeypatch.setattr(
         mla_attention_module, "set_default_quant_scales", lambda *_, **__: None
@@ -221,7 +229,16 @@ def test_mla_post_load_preserves_runtime_weight_addresses(monkeypatch):
         old_w_uv = layer.W_UV.clone()
         old_w_uk_t = layer.W_UK_T.clone()
 
+        assert layer.kv_b_proj.b12x_mxfp8_packed_weight is (
+            packed if has_mha_prefill else None
+        )
+        assert layer.kv_b_proj.b12x_warmup_provider is (
+            provider if has_mha_prefill else None
+        )
+
         layer.kv_b_proj.weight.add_(100)
+        layer.kv_b_proj.b12x_mxfp8_packed_weight = object()
+        layer.kv_b_proj.b12x_warmup_provider = provider
         layer.process_weights_after_loading(torch.float32)
 
     assert layer.W_UV.data_ptr() == w_uv_ptr
@@ -920,6 +937,36 @@ def test_mock_mla_dcp_fp8_decode_gathers_quantized_query(
         num_heads * impl.dcp_world_size,
         kv_lora_rank + qk_rope_head_dim,
     )
+
+
+@pytest.mark.parametrize("has_mha_prefill", [False, True])
+def test_mla_profile_reserves_only_supported_dense_context(
+    monkeypatch, has_mha_prefill
+):
+    from vllm.model_executor.layers.attention.mla_attention import MLAAttention
+
+    layer = SimpleNamespace(
+        prefill_backend=object() if has_mha_prefill else None,
+        chunked_prefill_workspace_size=128,
+        num_heads=2,
+        qk_nope_head_dim=4,
+        v_head_dim=4,
+    )
+    q = torch.ones(3, 2, 8, dtype=torch.bfloat16)
+    kv_c = torch.ones(3, 8, dtype=torch.bfloat16)
+    output = torch.full((3, 8), float("nan"), dtype=torch.bfloat16)
+    allocations = []
+    empty = torch.empty
+
+    def record_empty(shape, **kwargs):
+        allocations.append(shape)
+        return empty(shape, **kwargs)
+
+    monkeypatch.setattr(torch, "empty", record_empty)
+    actual = MLAAttention.forward_impl(layer, q, kv_c, kv_c, kv_c, None, output)
+    assert actual is output
+    assert torch.count_nonzero(output) == 0
+    assert allocations == ([(128, 2, 8)] if has_mha_prefill else [])
 
 
 def test_tokenspeed_mla_noncausal_capability():

--- a/tests/v1/core/test_contiguous_kv_packing.py
+++ b/tests/v1/core/test_contiguous_kv_packing.py
@@ -63,6 +63,7 @@ def _mixed_page_groups(n_mla=3, n_idx=3, n_swa=5):
 
 def _mock_vllm_config(layout: str | None):
     config = MagicMock()
+    config.use_request_boundary_checkpoints = False
     config.cache_config = CacheConfig()
     config.cache_config.num_gpu_blocks_override = None
     config.cache_config.kv_cache_layout = layout
@@ -211,7 +212,7 @@ def test_v41_full_context_packs_shared_global_cache_without_page_inflation():
     config.parallel_config.decode_context_parallel_size = 1
     config.parallel_config.prefill_context_parallel_size = 1
     specs = {}
-    global_names = []
+    global_names: list[str] = []
     for layer in range(43):
         prefix = f"model.layers.{layer}.self_attn"
         swa = _Cache(

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2447,6 +2447,7 @@ def test_glm5next_split_cache_preserves_physical_pages(
 
 def _glm5next_split_config() -> SimpleNamespace:
     return SimpleNamespace(
+        use_request_boundary_checkpoints=False,
         scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
         speculative_config=None,
         model_config=SimpleNamespace(max_model_len=202_752),
@@ -2584,6 +2585,7 @@ def test_glm5next_nvfp4_auto_geometry_capacity() -> None:
         prefix_cache_retention_interval=4096,
     )
     vllm_config = SimpleNamespace(
+        use_request_boundary_checkpoints=False,
         model_config=SimpleNamespace(max_model_len=202_752),
         parallel_config=SimpleNamespace(decode_context_parallel_size=4),
         cache_config=SimpleNamespace(mamba_cache_mode="align"),
@@ -3330,6 +3332,71 @@ def test_auto_fit_max_model_len_with_hybrid():
         vllm_config, [kv_cache_specs], [available_memory]
     )
     assert vllm_config.model_config.max_model_len == 1024
+
+
+@pytest.mark.parametrize("dcp", [1, 2, 4])
+@pytest.mark.parametrize("num_blocks,expected_pages", [(38, 0), (70, 15)])
+def test_boundary_capacity_includes_private_endpoints(dcp, num_blocks, expected_pages):
+    """Live MTP state alone does not cover instruction/prompt/response copies."""
+    config = SimpleNamespace(
+        use_request_boundary_checkpoints=True,
+        model_config=SimpleNamespace(max_model_len=1048576),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=dcp),
+        cache_config=SimpleNamespace(mamba_cache_mode="align"),
+    )
+    attention = MLAAttentionSpec(
+        block_size=2048,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.uint8,
+        model_version="glm5_next",
+    )
+    state = MambaSpec(
+        block_size=2048,
+        shapes=((1,),),
+        dtypes=(torch.uint8,),
+        mamba_cache_mode="align",
+        num_speculative_blocks=3,
+    )
+    groups = [KVCacheGroupSpec([f"state-{i}"], state) for i in range(6)]
+    groups.append(KVCacheGroupSpec(["attention"], attention))
+    block_bytes = kv_cache_utils._pool_bytes_per_block(groups)
+    # Six groups require five live/scratch states each; three endpoints
+    # additionally own eight blocks each. The null block is unavailable.
+    available = (num_blocks - 1) * block_bytes
+    estimate = kv_cache_utils._estimate_max_model_len_from_groups(
+        config, groups, available
+    )
+    assert estimate == expected_pages * 2048 * dcp
+    assert config.model_config.max_model_len == 1048576
+
+    if expected_pages == 0:
+        with pytest.raises(ValueError, match="even a single token"):
+            kv_cache_utils._auto_fit_max_model_len(config, [groups], [available])
+    else:
+        kv_cache_utils._auto_fit_max_model_len(config, [groups], [available])
+        assert config.model_config.max_model_len == estimate
+        assert kv_cache_utils._max_memory_usage_bytes_from_groups(config, groups) == (
+            available
+        )
+        assert kv_cache_utils._get_kv_cache_group_allocation_cost(config, groups) == (
+            available
+        )
+        cache = KVCacheConfig(
+            num_blocks=num_blocks, kv_cache_tensors=[], kv_cache_groups=groups
+        )
+        assert get_max_concurrency_for_kv_cache_config(config, cache) == (
+            num_blocks / (30 + 24 + expected_pages)
+        )
+
+    # An aligned-policy control has no endpoint reservation. Its capacity
+    # calculation must keep the ordinary live-state contract.
+    config.use_request_boundary_checkpoints = False
+    config.model_config.max_model_len = 1048576
+    control = kv_cache_utils._estimate_max_model_len_from_groups(
+        config, groups, available
+    )
+    assert control == (num_blocks - 1 - 30) * 2048 * dcp
 
 
 def test_auto_fit_max_model_len_not_triggered():

--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -80,6 +80,23 @@ def test_startup_plan_apply_gate(plan_env):
     assert explicit.cache_config.kv_cache_memory_bytes == 7 * GiB_bytes
 
 
+def test_explicit_kv_budget_releases_completed_profile_allocations(monkeypatch):
+    events = []
+    worker = _plan_worker(kv_bytes=4 * GiB_bytes)
+    worker.model_config = SimpleNamespace(multimodal_config=None)
+    worker.model_runner = SimpleNamespace(profile_run=lambda: events.append("profile"))
+    monkeypatch.setattr(gpu_worker, "maybe_apply_startup_plan", lambda worker: None)
+    monkeypatch.setattr(
+        gpu_worker.torch.accelerator, "synchronize", lambda: events.append("sync")
+    )
+    monkeypatch.setattr(
+        gpu_worker.torch.accelerator, "empty_cache", lambda: events.append("release")
+    )
+
+    assert gpu_worker.Worker.determine_available_memory(worker) == 4 * GiB_bytes
+    assert events == ["profile", "sync", "release"]
+
+
 @pytest.mark.parametrize(
     "final_free_memory,expected_available_memory",
     [(90, 75), (85, 70)],

--- a/tests/v1/worker/test_workspace.py
+++ b/tests/v1/worker/test_workspace.py
@@ -49,12 +49,16 @@ def test_workspace_lanes_do_not_alias_and_restore_context(monkeypatch) -> None:
     )
 
     assert manager._current_workspaces == [None, None, None, None]
+    assert manager.available_bytes() == 0
 
     (target,) = manager.get_simultaneous(((512,), torch.uint8))
+    assert manager.available_bytes() == 512
     with workspace.use_workspace_lane(1):
         (draft,) = manager.get_simultaneous(((256,), torch.uint8))
         (draft_reused,) = manager.get_simultaneous(((8,), torch.uint8))
+        assert manager.available_bytes() == 256
     (target_reused,) = manager.get_simultaneous(((8,), torch.uint8))
+    assert manager.available_bytes() == 512
 
     assert manager._current_workspaces[0].numel() == 512  # type: ignore[union-attr]
     assert manager._current_workspaces[1].numel() == 256  # type: ignore[union-attr]

--- a/vllm/model_executor/kernels/linear/mxfp8/b12x.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/b12x.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import torch
 
 from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
@@ -113,6 +115,11 @@ class B12xMxfp8LinearKernel(Mxfp8LinearKernel):
         packed_weight = mxfp8.pack_weight(
             weight[:out_features, :in_features].detach(),
             weight_scale[:out_features, :scale_k].detach(),
+        )
+        # Both B12X activation-precision paths read the MMA-layout scales.
+        # The row-layout copy is packaging metadata, not an execution input.
+        packed_weight = replace(
+            packed_weight, weight=replace(packed_weight.weight, scale_rows=None)
         )
         layer.b12x_mxfp8_packed_weight = reuse_packed_weight_storage(
             getattr(layer, "b12x_mxfp8_packed_weight", None),

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -790,6 +790,9 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 is_lse_base_on_e=self.impl.lse_base_on_e,
                 use_pcp=self.use_pcp,
                 query_gather_fallback=getattr(self.impl, "gather_dcp_query", None),
+                output_reduce_scatter=getattr(
+                    self.impl, "reduce_scatter_dcp_output", None
+                ),
             )
 
         self.is_aiter_triton_fp8_bmm_enabled = rocm_aiter_ops.is_fp8bmm_enabled()

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1000,18 +1000,18 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             )
 
         if attn_metadata is None:
-            # During the profile run try to simulate to worse case output size
-            # for `self.kv_b_proj(kv_c_normed)` in `_compute_prefill_context`
-            # since this can be large
-            _ = torch.empty(
-                (
-                    self.chunked_prefill_workspace_size,
-                    self.num_heads,
-                    self.qk_nope_head_dim + self.v_head_dim,
-                ),
-                device=k_c_normed.device,
-                dtype=k_c_normed.dtype,
-            )
+            if self.prefill_backend is not None:
+                # Dense MHA expands compressed keys through kv_b_proj. An
+                # MQA-only backend never materializes this context-sized tensor.
+                _ = torch.empty(
+                    (
+                        self.chunked_prefill_workspace_size,
+                        self.num_heads,
+                        self.qk_nope_head_dim + self.v_head_dim,
+                    ),
+                    device=k_c_normed.device,
+                    dtype=k_c_normed.dtype,
+                )
 
             # The zero fill is required when used with DP + EP
             # to ensure all ranks within a DP group compute the
@@ -1190,6 +1190,11 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                     mqa_ql_nope = mqa_q_nope.new_empty((N, B, L))
 
                 # Multiply (N, B, P) x (N, P, L) -> (N, B, L)
+                prepare = getattr(self.impl, "prepare_projection_input", None)
+                if prepare is not None:
+                    prepared = prepare(mqa_q_nope, mqa_ql_nope)
+                    if prepared is not None:
+                        mqa_q_nope = prepared
                 _bmm_with_disjoint_batches(mqa_q_nope, W_UK_T, out=mqa_ql_nope)
 
                 # Convert from (N, B, L) to (B, N, L)
@@ -1467,6 +1472,17 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         ) or callable(impl_warmup):
             object.__setattr__(self, "b12x_warmup_provider", self)
 
+        if (
+            self.impl.is_sparse
+            and self.prefill_backend is None
+            and getattr(self.kv_b_proj, "b12x_mxfp8_packed_weight", None) is not None
+        ):
+            # MQA-only execution reads W_UK_T/W_UV, never the packed linear.
+            # A weight reload repacks the linear before refreshing those owned
+            # matrices. Do not retain an unused copy or schedule its warmup.
+            self.kv_b_proj.b12x_mxfp8_packed_weight = None
+            self.kv_b_proj.b12x_warmup_provider = None
+
     def get_b12x_warmup_unit(
         self,
         layer: torch.nn.Module,
@@ -1568,6 +1584,11 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             )
         else:
             # Multiply + Transpose (N, B, L) x (N, L, V)->(N, B, V)->(B, N, V)
+            prepare = getattr(self.impl, "prepare_projection_input", None)
+            if prepare is not None:
+                prepared = prepare(x, out)
+                if prepared is not None:
+                    x = prepared
             _bmm_with_disjoint_batches(x, self.W_UV, out=out.transpose(0, 1))
 
 

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -789,6 +789,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 padded_num_heads=self.q_pad_num_heads,
                 is_lse_base_on_e=self.impl.lse_base_on_e,
                 use_pcp=self.use_pcp,
+                query_gather_fallback=getattr(self.impl, "gather_dcp_query", None),
             )
 
         self.is_aiter_triton_fp8_bmm_enabled = rocm_aiter_ops.is_fp8bmm_enabled()
@@ -1200,6 +1201,9 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                     )
                 else:
                     mqa_q = (mqa_ql_nope, mqa_q_pe)
+                # The input tuple owns the projection until query preparation
+                # finishes; no extra reference must retain it through attention.
+                del mqa_ql_nope
             # concatenate nope + pe -> (B, N, L + P) (fp8 op above may have fused)
             if self.impl.dcp_world_size > 1:
                 assert self.dcp_manager is not None
@@ -1211,7 +1215,11 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 else:
                     if isinstance(mqa_q, tuple):
                         # concatenate mqa_ql_nope and mqa_q_pe -> (B, N, L + P)
-                        mqa_q = torch.cat(mqa_q, dim=-1)
+                        mqa_q = (
+                            mqa_q[0]
+                            if self.qk_rope_head_dim == 0
+                            else torch.cat(mqa_q, dim=-1)
+                        )
                     if not qrep_decode and not full_ckv_dcp:
                         assert self.dcp_manager.query_gather is not None
                         mqa_q = self.dcp_manager.query_gather(mqa_q)

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -3,6 +3,7 @@
 
 from collections.abc import Callable
 from dataclasses import replace
+from math import prod
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -803,7 +804,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             )
         )
 
-    def _get_b12x_prefill_workspace(self) -> tuple[torch.Tensor, torch.Tensor]:
+    def _b12x_prefill_workspace_specs(self):
         plan = self._b12x_prefill_plan
         if plan is None:
             raise RuntimeError("b12x KDA prefill KV cache is not bound")
@@ -811,7 +812,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         if len(scratch_specs) != 1:
             raise RuntimeError("b12x KDA prefill requires exactly one scratch buffer")
         scratch_spec = scratch_specs[0]
-        scratch, output = current_workspace_manager().get_simultaneous(
+        return (
             (scratch_spec.shape, scratch_spec.dtype),
             (
                 (
@@ -822,7 +823,41 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 self.model_config.dtype,
             ),
         )
+
+    def _get_b12x_prefill_workspace(self) -> tuple[torch.Tensor, torch.Tensor]:
+        scratch, output = current_workspace_manager().get_simultaneous(
+            *self._b12x_prefill_workspace_specs()
+        )
         return scratch, output
+
+    def _borrow_b12x_prefill_transients(
+        self,
+        tokens: int,
+        dtype: torch.dtype,
+        selection_specs: tuple[tuple[tuple[int, ...], torch.dtype], ...] = (),
+    ) -> list[torch.Tensor] | None:
+        """Borrow a suffix disjoint from the subsequent KDA scratch and output.
+
+        Convolution Q/K/V must stay live throughout KDA. The workspace prefix
+        is therefore reserved using the exact KDA plan, and only existing
+        spare capacity after that prefix may hold the three convolution results
+        and optional mixed-batch selection outputs. Indexed selection retains
+        arbitrary request ordering; it does not assume a contiguous spec prefix.
+        """
+        if self.kda_prefill_backend != "b12x" or dtype != self.get_state_dtype()[0]:
+            return None
+        specs = (
+            self._b12x_prefill_workspace_specs()
+            + (((tokens, self.local_projection_size), dtype),) * 3
+            + selection_specs
+        )
+        required = sum(
+            ((prod(shape) * dt.itemsize + 255) // 256) * 256 for shape, dt in specs
+        )
+        manager = current_workspace_manager()
+        if required > manager.available_bytes():
+            return None
+        return manager.get_simultaneous(*specs)[2:]
 
     def _run_b12x_kda_prefill(
         self,
@@ -1167,6 +1202,11 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             beta=beta,
             core_attn_out=core_attn_out,
         )
+        # Recurrence has consumed every projection view. Release their backing
+        # storage before the output GEMM and collective allocate their results.
+        del mixed_qkv, g1, g2, beta, g_proj_states, f_a, projected_qkvgfab
+        if self.use_full_rank_gate:
+            del projected
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
         output[:] = self.o_proj(core_attn_out)[0]
 
@@ -1262,9 +1302,35 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 mixed_qkv_spec = mixed_qkv.index_select(0, spec_token_indx)
                 g1_spec = g1.index_select(1, spec_token_indx)
                 beta_spec = beta.index_select(1, spec_token_indx)
-                mixed_qkv_ns = mixed_qkv.index_select(0, non_spec_token_indx)
-                g1_ns = g1.index_select(1, non_spec_token_indx)
-                beta_ns = beta.index_select(1, non_spec_token_indx)
+                assert non_spec_token_indx is not None
+                n = non_spec_token_indx.numel()
+                selection = (
+                    self._borrow_b12x_prefill_transients(
+                        n,
+                        mixed_qkv.dtype,
+                        (
+                            ((n, mixed_qkv.shape[1]), mixed_qkv.dtype),
+                            ((g1.shape[0], n, *g1.shape[2:]), g1.dtype),
+                            ((beta.shape[0], n, *beta.shape[2:]), beta.dtype),
+                        ),
+                    )
+                    if m.num_prefills > 0
+                    else None
+                )
+                if selection is None:
+                    mixed_qkv_ns = mixed_qkv.index_select(0, non_spec_token_indx)
+                    g1_ns = g1.index_select(1, non_spec_token_indx)
+                    beta_ns = beta.index_select(1, non_spec_token_indx)
+                else:
+                    # Mixed-batch speculative recurrence uses the allocating
+                    # Triton path, not the shared-workspace decode kernel. These
+                    # suffix views therefore remain live until KDA consumes them.
+                    mixed_qkv_ns, g1_ns, beta_ns = selection[3:]
+                    torch.index_select(
+                        mixed_qkv, 0, non_spec_token_indx, out=mixed_qkv_ns
+                    )
+                    torch.index_select(g1, 1, non_spec_token_indx, out=g1_ns)
+                    torch.index_select(beta, 1, non_spec_token_indx, out=beta_ns)
                 g2_spec = g2_ns = None
         else:
             mixed_qkv_spec = g1_spec = beta_spec = None
@@ -1351,6 +1417,9 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                     self.local_projection_size, dim=-1
                 )
                 prefill_mixed_qkv = mixed_qkv_ns
+                conv_outputs = self._borrow_b12x_prefill_transients(
+                    mixed_qkv_ns.shape[0], mixed_qkv_ns.dtype
+                )
 
                 # Packed prefill conv would require copying V solely to make
                 # it dense for KDA. Separate calls accept the strided inputs
@@ -1361,7 +1430,9 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                     x: torch.Tensor,
                     state: torch.Tensor,
                     weight: torch.Tensor,
+                    out: torch.Tensor | None,
                 ) -> torch.Tensor:
+                    output_arg = {"out": out.transpose(0, 1)} if out is not None else {}
                     return causal_conv1d_fn(
                         x.transpose(0, 1),
                         weight,
@@ -1372,11 +1443,27 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                         cache_indices=non_spec_state_indices_tensor,
                         query_start_loc=non_spec_query_start_loc,
                         metadata=m,
+                        **output_arg,
                     ).transpose(0, 1)
 
-                q_ns = _prefill_conv(q_ns, q_conv_state, q_conv_weight)
-                k_ns = _prefill_conv(k_ns, k_conv_state, k_conv_weight)
-                v_ns = _prefill_conv(v_ns, v_conv_state, v_conv_weight)
+                q_ns = _prefill_conv(
+                    q_ns,
+                    q_conv_state,
+                    q_conv_weight,
+                    conv_outputs[0] if conv_outputs is not None else None,
+                )
+                k_ns = _prefill_conv(
+                    k_ns,
+                    k_conv_state,
+                    k_conv_weight,
+                    conv_outputs[1] if conv_outputs is not None else None,
+                )
+                v_ns = _prefill_conv(
+                    v_ns,
+                    v_conv_state,
+                    v_conv_weight,
+                    conv_outputs[2] if conv_outputs is not None else None,
+                )
                 q_ns, k_ns, v_ns = (
                     rearrange(x, "n (h d) -> 1 n h d", d=self.head_dim)
                     for x in (q_ns, k_ns, v_ns)
@@ -1653,14 +1740,12 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         # ---------- merge spec and non-spec outputs ----------
         if core_attn_out_spec is not None and core_attn_out_non_spec is not None:
             # Mixed batches require indexed placement in the original order.
-            merged = torch.empty(
-                (1, num_actual_tokens, *core_attn_out_spec.shape[2:]),
-                dtype=core_attn_out_spec.dtype,
-                device=core_attn_out_spec.device,
-            )
+            # Both mixed-path results have separate storage: speculative
+            # recurrence allocates its result and prefill owns a workspace
+            # result. The caller's destination needs no intermediate copy.
+            merged = core_attn_out[:, :num_actual_tokens]
             merged.index_copy_(1, spec_token_indx, core_attn_out_spec)
             merged.index_copy_(1, non_spec_token_indx, core_attn_out_non_spec)
-            core_attn_out[0, :num_actual_tokens] = merged[0, :num_actual_tokens]
         elif core_attn_out_non_spec is not None:
             core_attn_out[0, :num_actual_tokens] = core_attn_out_non_spec[
                 0, :num_actual_tokens

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -491,6 +491,27 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
         tl.store(o_ptrs, acc, mask=mask_1d)
 
 
+def _byte_ranges_overlap(a: torch.Tensor, b: torch.Tensor) -> bool:
+    """Conservatively test strided byte spans, allowing disjoint arena views."""
+    if not a.numel() or not b.numel():
+        return False
+    if a.untyped_storage().data_ptr() != b.untyped_storage().data_ptr():
+        return False
+
+    def span(tensor):
+        start = tensor.storage_offset() * tensor.element_size()
+        stop = (
+            start
+            + (1 + sum((n - 1) * s for n, s in zip(tensor.shape, tensor.stride())))
+            * tensor.element_size()
+        )
+        return start, stop
+
+    a_start, a_stop = span(a)
+    b_start, b_stop = span(b)
+    return a_start < b_stop and b_start < a_stop
+
+
 def causal_conv1d_fn(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -509,6 +530,7 @@ def causal_conv1d_fn(
     block_size_to_align=0,
     metadata=None,
     validate_data=False,
+    out: torch.Tensor | None = None,
 ):
     """support varlen + continuous batching when x is 2D tensor
 
@@ -559,7 +581,9 @@ def causal_conv1d_fn(
         The number of tokens already completed for each sequence
     block_size_to_align: int
         The block size to align the cached states to
-    out: same shape as `x`
+    out: Optional caller-owned output, with the same shape, dtype and device
+        as `x`. Supplied storage must be disjoint from inputs and state, and
+        requires matching input/state dtypes to avoid an output cast.
     """
     if isinstance(activation, bool) and activation:
         activation = "silu"
@@ -568,7 +592,24 @@ def causal_conv1d_fn(
     # Store original dtype to cast back at the end
     original_x_dtype = x.dtype
     x = x.to(conv_states.dtype)
-    out = torch.empty_like(x)
+    if out is None:
+        out = torch.empty_like(x)
+    elif (
+        out.shape != x.shape
+        or out.dtype != x.dtype
+        or out.dtype != original_x_dtype
+        or out.device != x.device
+    ):
+        raise ValueError(
+            "Convolution output must match input/state shape, dtype and device"
+        )
+    elif any(
+        source is not None and _byte_ranges_overlap(out, source)
+        for source in (x, weight, bias, conv_states)
+    ):
+        raise ValueError(
+            "Convolution output storage must be disjoint from inputs and state"
+        )
     if metadata is not None:
         nums_dict = metadata.nums_dict
         args = nums_dict

--- a/vllm/models/deepseek_v4/nvidia/b12x.py
+++ b/vllm/models/deepseek_v4/nvidia/b12x.py
@@ -188,7 +188,12 @@ class B12xMHCResidual:
             out=out,
             expected_m=expected_m,
         )
-        retain_cuda_graph_capture_resource(binding)
+        # Captured allocations belong to the graph pool and may be reused
+        # after their consumers finish. Retaining every bound output would pin
+        # every layer's activations. Only scratch predates the capture; eager
+        # breaks still require the complete binding to own their outputs.
+        owner = (plan, scratch) if torch.cuda.is_current_stream_capturing() else binding
+        retain_cuda_graph_capture_resource(owner)
         return binding
 
     def run_pre(

--- a/vllm/models/glm5next/nvidia/attention.py
+++ b/vllm/models/glm5next/nvidia/attention.py
@@ -22,7 +22,7 @@ from vllm.model_executor.models.deepseek_v2 import (
 from vllm.transformers_utils.configs.glm5_next import Glm5NextConfig
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
-from .pooled_indexer import Glm5NextPooledIndexer
+from .pooled_indexer import Glm5NextIndexerScratch, Glm5NextPooledIndexer
 
 
 def _select_sparse_backend(
@@ -63,6 +63,7 @@ class Glm5NextMLAAttention(nn.Module):
         skip_rope: bool | None = False,
         is_mtp_layer: bool = False,
         attn_backend: type | None = None,
+        indexer_scratch: Glm5NextIndexerScratch | None = None,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -171,6 +172,7 @@ class Glm5NextMLAAttention(nn.Module):
                 prefix=f"{prefix}.indexer",
                 # MTP compacts and reuses request-relative selections.
                 emit_physical_selection=not is_mtp_layer,
+                scratch=indexer_scratch,
             )
         else:
             self.indexer = None

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -96,7 +96,7 @@ from .multimodal import (
     Glm5NextProcessingInfo,
     Glm5NextVisionTransformer,
 )
-from .pooled_indexer import Glm5NextPooledIndexer
+from .pooled_indexer import Glm5NextIndexerScratch, Glm5NextPooledIndexer
 
 logger = init_logger(__name__)
 
@@ -333,6 +333,7 @@ class Glm5NextDecoderLayer(nn.Module):
         topk_indices_buffer: torch.Tensor | None = None,
         pool_topk_indices_buffer: torch.Tensor | None = None,
         is_mtp_layer: bool = False,
+        indexer_scratch: Glm5NextIndexerScratch | None = None,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -389,6 +390,7 @@ class Glm5NextDecoderLayer(nn.Module):
                 pool_topk_indices_buffer=pool_topk_indices_buffer,
                 skip_rope=getattr(config, "mla_nope", False),
                 is_mtp_layer=is_mtp_layer,
+                indexer_scratch=indexer_scratch,
             )
 
         # MTP layers sit past the base model's hidden layers (layer_idx >=
@@ -938,10 +940,16 @@ class Glm5NextModel(nn.Module, EagleModelMixin):
                 dtype=torch.int32,
                 device=self.device,
             )
+            indexer_scratch = Glm5NextIndexerScratch(
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                vllm_config.scheduler_config.max_num_seqs,
+                torch.device(self.device),
+            )
         else:
             # Full-MLA config (no kpool sparse indexer): no topk buffer.
             topk_indices_buffer = None
             pool_topk_indices_buffer = None
+            indexer_scratch = None
 
         if get_pp_group().is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
@@ -961,6 +969,7 @@ class Glm5NextModel(nn.Module, EagleModelMixin):
                 prefix=prefix,
                 topk_indices_buffer=topk_indices_buffer,
                 pool_topk_indices_buffer=pool_topk_indices_buffer,
+                indexer_scratch=indexer_scratch,
             )
 
         self.start_layer, self.end_layer, self.layers = make_layers(

--- a/vllm/models/glm5next/nvidia/mtp.py
+++ b/vllm/models/glm5next/nvidia/mtp.py
@@ -331,6 +331,77 @@ class Glm5NextMTP(nn.Module, DeepseekV2MixtureOfExperts):
         """Create a draft-only quantized copy of the shared target head."""
         self.model.prepare_draft_lm_head(source_head)
 
+    def share_target_indexer_storage(self, target: nn.Module) -> bool:
+        """Reuse temporary indexer storage under serial target/MTP execution.
+
+        The V2 loader calls this before profiling or graph capture, without
+        pipeline parallelism or overlapped microbatches. One MTP layer consumes
+        its selections before target execution resumes. KV views, pool tails
+        and model parameters retain independent ownership.
+        """
+        if self.model.num_mtp_layers != 1:
+            return False
+        targets = [
+            module
+            for module in target.modules()
+            if isinstance(module, Glm5NextPooledIndexer)
+        ]
+        drafts = [
+            module
+            for module in self.model.modules()
+            if isinstance(module, Glm5NextPooledIndexer)
+        ]
+        if not targets or len(drafts) != 1:
+            return False
+        source, draft = targets[0], drafts[0]
+        geometry = (
+            "max_tokens",
+            "max_seqs",
+            "max_model_len",
+            "block_size",
+            "dcp_world_size",
+            "dcp_rank",
+            "pool_interleave",
+        )
+        if any(getattr(source, key) != getattr(draft, key) for key in geometry):
+            return False
+        names = ("topk_indices_buffer", "pool_topk_indices_buffer")
+        for module in targets:
+            if module.scratch is not source.scratch or any(
+                getattr(module, name) is not getattr(source, name) for name in names
+            ):
+                return False
+        for name in names:
+            src, dst = getattr(source, name), getattr(draft, name)
+            if (src.shape, src.dtype, src.device) != (dst.shape, dst.dtype, dst.device):
+                return False
+        if any(
+            (src.shape, src.dtype, src.device) != (dst.shape, dst.dtype, dst.device)
+            for (_, src), (_, dst) in zip(
+                source.scratch.named_buffers(),
+                draft.scratch.named_buffers(),
+                strict=True,
+            )
+        ):
+            return False
+
+        replacements = {
+            id(getattr(draft, name)): getattr(source, name) for name in names
+        }
+        # The native indexer holds 512 pool IDs; MLA consumes 2051 token IDs.
+        # Rebind by identity, not by attribute name, including non-Module impls.
+        for module in self.model.modules():
+            for owner in (module, getattr(module, "impl", None)):
+                if owner is None:
+                    continue
+                for name in names:
+                    value = getattr(owner, name, None)
+                    replacement = replacements.get(id(value))
+                    if replacement is not None:
+                        setattr(owner, name, replacement)
+        draft.scratch = source.scratch
+        return True
+
     def forward(
         self,
         input_ids: torch.Tensor | None,

--- a/vllm/models/glm5next/nvidia/mtp_draft_head.py
+++ b/vllm/models/glm5next/nvidia/mtp_draft_head.py
@@ -91,8 +91,11 @@ class QuantizedDraftHead(nn.Module):
             )
         import flashinfer
 
+        # The BF16 guard above makes float() an owned temporary. In-place
+        # sanitization avoids two vocabulary-sized FP32 copies without writing
+        # to the target head or changing the quantization scale.
         weight_global_scale = (
-            _NVFP4_GLOBAL_MAX / weight.float().abs().nan_to_num().max()
+            _NVFP4_GLOBAL_MAX / weight.float().abs_().nan_to_num_().max()
         )
         weight_fp4, weight_sf = flashinfer.nvfp4_quantize(
             weight,

--- a/vllm/models/glm5next/nvidia/multimodal.py
+++ b/vllm/models/glm5next/nvidia/multimodal.py
@@ -4,6 +4,7 @@
 
 from collections.abc import Mapping
 from functools import partial
+from math import isqrt, prod
 
 import numpy as np
 import torch
@@ -24,6 +25,7 @@ from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
     QKVParallelLinear,
     RowParallelLinear,
+    UnquantizedLinearMethod,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding import get_rope
@@ -44,6 +46,12 @@ from vllm.model_executor.weight_transfer import allocate_weights
 from vllm.models.common.ops import fused_q_kv_rmsnorm
 from vllm.multimodal.parse import ImageSize, MultiModalDataItems
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
+from vllm.v1.worker.workspace import (
+    current_workspace_manager,
+    is_workspace_manager_initialized,
+)
+
+_VISION_PROJECTION_CHUNK_ROWS = 4096
 
 
 class Glm5NextVisionPatchEmbed(nn.Module):
@@ -169,6 +177,10 @@ class Glm5NextVisionAttention(nn.Module):
             prefix=f"{prefix}.attn",
         )
         self.apply_rotary_emb = ApplyRotaryEmb(enforce_enable=True)
+        self._borrow_qkv_workspace = (
+            isinstance(self.qkv.quant_method, UnquantizedLinearMethod)
+            and self.attn.attn_backend == AttentionBackendEnum.FLASH_ATTN
+        )
 
     def split_qkv(self, qkv: torch.Tensor) -> tuple[torch.Tensor, ...]:
         seq_len, bs, _ = qkv.shape
@@ -190,6 +202,25 @@ class Glm5NextVisionAttention(nn.Module):
         rotary_pos_emb_sin: torch.Tensor,
         max_seqlen: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        q, k, v = self._project_qkv(x, rotary_pos_emb_cos, rotary_pos_emb_sin)
+        context_layer = self.attn(
+            query=q,
+            key=k,
+            value=v,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        del q, k, v
+        context_layer = rearrange(context_layer, "b s h d -> s b (h d)").contiguous()
+        output, _ = self.proj(context_layer)
+        return output
+
+    def _project_qkv(
+        self,
+        x: torch.Tensor,
+        rotary_pos_emb_cos: torch.Tensor | None,
+        rotary_pos_emb_sin: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         x, _ = self.qkv(x)
         q, k, v = self.split_qkv(x)
 
@@ -204,10 +235,14 @@ class Glm5NextVisionAttention(nn.Module):
             self.k_norm.weight,
             self.q_norm.variance_epsilon,
         )
+        del q_flat, k_flat
         q = q.view(q_shape)
         k = k.view(k_shape)
 
         q, k, v = (rearrange(t, "s b ... -> b s ...").contiguous() for t in (q, k, v))
+        # Contiguous attention inputs own their storage; the packed projection
+        # and norm input copies must not stay live through attention/output GEMM.
+        del x
         if rotary_pos_emb_cos is not None and rotary_pos_emb_sin is not None:
             qk_concat = torch.cat([q, k], dim=0)
             qk_rotated = self.apply_rotary_emb(
@@ -216,18 +251,64 @@ class Glm5NextVisionAttention(nn.Module):
                 rotary_pos_emb_sin,
             )
             q, k = torch.chunk(qk_rotated, 2, dim=0)
+            del qk_concat, qk_rotated
 
-        context_layer = self.attn(
+        return q, k, v
+
+    def context_with_chunked_projection(
+        self,
+        x: torch.Tensor,
+        input_norm: nn.Module,
+        cu_seqlens: torch.Tensor,
+        rotary_pos_emb_cos: torch.Tensor,
+        rotary_pos_emb_sin: torch.Tensor,
+        max_seqlen: int | None,
+    ) -> torch.Tensor:
+        """Bound projection scratch without partitioning image attention.
+
+        Normalization, QKV projection and rotary embedding are token-local.
+        Attention still consumes the complete Q/K/V and original image/frame
+        sequence boundaries. No cache or tensor dtype changes are involved.
+        """
+        rows, batch_size, _ = x.shape
+        shape = (
+            batch_size,
+            rows,
+            self.num_attention_heads_per_partition,
+            self.hidden_size_per_attention_head,
+        )
+        manager = (
+            current_workspace_manager()
+            if self._borrow_qkv_workspace and is_workspace_manager_initialized()
+            else None
+        )
+        qkv_bytes = 3 * ((prod(shape) * x.element_size() + 255) // 256) * 256
+        if manager is not None and manager.available_bytes() >= qkv_bytes:
+            # The BF16 projections, rotary operation and FlashAttention do not
+            # borrow worker scratch. These Q/K/V views expire before the output
+            # projection; the text model executes after the encoder returns.
+            q, k, v = manager.get_simultaneous(*((shape, x.dtype),) * 3)
+        else:
+            q, k, v = (x.new_empty(shape) for _ in range(3))
+        for start in range(0, rows, _VISION_PROJECTION_CHUNK_ROWS):
+            stop = min(start + _VISION_PROJECTION_CHUNK_ROWS, rows)
+            cq, ck, cv = self._project_qkv(
+                input_norm(x[start:stop]),
+                rotary_pos_emb_cos[start:stop],
+                rotary_pos_emb_sin[start:stop],
+            )
+            q[:, start:stop].copy_(cq)
+            k[:, start:stop].copy_(ck)
+            v[:, start:stop].copy_(cv)
+            del cq, ck, cv
+        context = self.attn(
             query=q,
             key=k,
             value=v,
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
         )
-        context_layer = rearrange(context_layer, "b s h d -> s b (h d)").contiguous()
-
-        output, _ = self.proj(context_layer)
-        return output
+        return rearrange(context, "b s h d -> s b (h d)").contiguous()
 
 
 class Glm5NextVisionBlock(nn.Module):
@@ -270,6 +351,24 @@ class Glm5NextVisionBlock(nn.Module):
         rotary_pos_emb_sin: torch.Tensor,
         max_seqlen: int | None = None,
     ) -> torch.Tensor:
+        if x.shape[0] > _VISION_PROJECTION_CHUNK_ROWS:
+            context = self.attn.context_with_chunked_projection(
+                x,
+                self.norm1,
+                cu_seqlens,
+                rotary_pos_emb_cos,
+                rotary_pos_emb_sin,
+                max_seqlen,
+            )
+            for start in range(0, x.shape[0], _VISION_PROJECTION_CHUNK_ROWS):
+                stop = min(start + _VISION_PROJECTION_CHUNK_ROWS, x.shape[0])
+                x_attn, _ = self.attn.proj(context[start:stop])
+                normalized, residual = self.norm2(x[start:stop], residual=x_attn)
+                # Each token's residual is consumed before its owned input
+                # storage is reused. Attention has already read the full image.
+                x[start:stop].copy_(residual + self.mlp(normalized))
+                del normalized, residual, x_attn
+            return x
         x_attn = self.attn(
             self.norm1(x),
             cu_seqlens=cu_seqlens,
@@ -330,6 +429,7 @@ class Glm5NextPatchMerger(nn.Module):
         x = self.extra_activation_func(self.post_projection_norm(x))
         gate_up, _ = self.gate_up_proj(x)
         x = self.act_fn(gate_up)
+        del gate_up
         x, _ = self.down_proj(x)
         return x
 
@@ -600,6 +700,38 @@ class Glm5NextVisionTransformer(nn.Module):
                 max_seqlen=max_seqlen,
             )
 
+        # The GLM merger preserves the number of elements in each spatial
+        # group. Reuse the owned transformer output only after that group's
+        # normalization, convolution and merger have consumed its values.
+        if (
+            x.shape[0] > _VISION_PROJECTION_CHUNK_ROWS
+            and self.out_hidden_size == self.spatial_merge_size**2 * x.shape[-1]
+        ):
+            hidden_size = x.shape[-1]
+            for start in range(0, x.shape[0], _VISION_PROJECTION_CHUNK_ROWS):
+                stop = min(start + _VISION_PROJECTION_CHUNK_ROWS, x.shape[0])
+                x[start:stop].copy_(self.post_layernorm(x[start:stop]))
+            x = x.view(-1, self.out_hidden_size)
+            groups_per_chunk = max(
+                1, _VISION_PROJECTION_CHUNK_ROWS // self.spatial_merge_size**2
+            )
+            for start in range(0, x.shape[0], groups_per_chunk):
+                stop = min(start + groups_per_chunk, x.shape[0])
+                patches = (
+                    x[start:stop]
+                    .view(
+                        -1,
+                        self.spatial_merge_size,
+                        self.spatial_merge_size,
+                        hidden_size,
+                    )
+                    .permute(0, 3, 1, 2)
+                )
+                merged = self.downsample(patches).view(-1, self.out_hidden_size)
+                x[start:stop].copy_(self.merger(merged))
+                del patches, merged
+            return x
+
         # adapter
         x = self.post_layernorm(x)
         x = x.view(-1, self.spatial_merge_size, self.spatial_merge_size, x.shape[-1])
@@ -653,7 +785,35 @@ class Glm5NextProcessingInfo(Glm4vProcessingInfo):
         mm_kwargs = self.ctx.get_merged_mm_kwargs({})
         if (override := mm_kwargs.get("max_pixels")) is not None:
             return int(override)
-        return self._processor_pixel_budget(self.get_hf_processor().image_processor)[1]
+        processor = self.get_hf_processor().image_processor
+        if (tokens := mm_kwargs.get("max_image_tokens")) is not None:
+            return (
+                int(tokens)
+                * processor.temporal_patch_size
+                * (processor.patch_size * processor.merge_size) ** 2
+            )
+        return self._processor_pixel_budget(processor)[1]
+
+    def get_image_size_with_most_features(self) -> ImageSize:
+        """Choose an aligned canvas that exhausts the image-token budget.
+
+        A square canvas can underfill the budget: 89 by 89 merged patches
+        produce 7921 features, while a valid 80 by 100 canvas produces 8000.
+        Encoder admission and profiling must cover the rectangular maximum.
+        """
+        processor = self.get_hf_processor().image_processor
+        factor = (
+            processor.patch_size * processor.merge_size * processor.patch_expand_factor
+        )
+        cells = self._get_image_max_pixels() // (
+            processor.temporal_patch_size * factor**2
+        )
+        if cells < 1:
+            raise ValueError("Image budget must fit at least one aligned canvas cell")
+        height = isqrt(cells)
+        while cells % height:
+            height -= 1
+        return ImageSize(width=(cells // height) * factor, height=height * factor)
 
     def _get_video_max_pixels(self) -> int:
         mm_kwargs = self.ctx.get_merged_mm_kwargs({})

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -51,6 +51,55 @@ _INDEX_PAGE_SIZE = 64
 _INDEX_PAGE_BYTES = _INDEX_PAGE_SIZE * _INDEX_CACHE_WIDTH
 
 
+class Glm5NextIndexerScratch(nn.Module):
+    """Temporary storage for sequential pooled-indexer calls on one model stream.
+
+    A model owns one instance; its draft model owns another. KV views, recurrent
+    tails and selected token IDs are not scratch and remain separately owned.
+    Bind tables before graph capture; calls must finish consuming the scratch
+    before another layer overwrites it.
+    """
+
+    q_fp8: torch.Tensor
+    q_scale: torch.Tensor
+    pool_scores: torch.Tensor
+    pool_seq_lens: torch.Tensor
+    physical_active_counts: torch.Tensor
+    pool_block_table: torch.Tensor
+    decode_block_table: torch.Tensor
+
+    def __init__(self, max_tokens: int, max_seqs: int, device: torch.device) -> None:
+        super().__init__()
+        self.max_tokens = max_tokens
+        self.max_seqs = max_seqs
+        for name, shape, dtype in (
+            ("q_fp8", (max_tokens, _INDEX_HEADS, _INDEX_HEAD_DIM), torch.float8_e4m3fn),
+            ("q_scale", (max_tokens, _INDEX_HEADS), torch.float32),
+            ("pool_scores", (max_tokens, _POOL_TOPK), torch.float32),
+            ("pool_seq_lens", (max_tokens,), torch.int32),
+            ("physical_active_counts", (max_tokens,), torch.int32),
+            ("pool_block_table", (max_seqs, 1), torch.int32),
+            ("decode_block_table", (max_tokens, 1), torch.int32),
+        ):
+            self.register_buffer(
+                name, torch.empty(shape, dtype=dtype, device=device), persistent=False
+            )
+
+    def bind_tables(self, width: int, device: torch.device) -> None:
+        if self.pool_block_table.shape[1] == width and self.q_fp8.device == device:
+            return
+        if self.q_fp8.device != device:
+            raise ValueError("GLM indexer scratch and KV cache must share a device")
+        self.pool_block_table = torch.empty(
+            (self.max_seqs, width), dtype=torch.int32, device=device
+        )
+        # Short prefills can use decode metadata, so rows need the token budget,
+        # not merely max_seqs times the speculative width.
+        self.decode_block_table = torch.empty(
+            (self.max_tokens, width), dtype=torch.int32, device=device
+        )
+
+
 class Glm5NextPooledIndexer(nn.Module):
     """Produce GLM C4 pools, select them with b12x, and expand token IDs."""
 
@@ -68,6 +117,7 @@ class Glm5NextPooledIndexer(nn.Module):
         main_layer_name: str,
         prefix: str,
         emit_physical_selection: bool = True,
+        scratch: Glm5NextIndexerScratch | None = None,
     ) -> None:
         super().__init__()
         if cache_config is None:
@@ -131,6 +181,17 @@ class Glm5NextPooledIndexer(nn.Module):
             raise ValueError("GLM pool selection buffer has the wrong row capacity")
 
         device = topk_indices_buffer.device
+        self.scratch = (
+            scratch
+            if scratch is not None
+            else Glm5NextIndexerScratch(self.max_tokens, self.max_seqs, device)
+        )
+        if (
+            self.scratch.max_tokens != self.max_tokens
+            or self.scratch.max_seqs != self.max_seqs
+            or self.scratch.q_fp8.device != device
+        ):
+            raise ValueError("GLM indexer scratch has incompatible capacity or device")
         b12x_sparse_mla = get_b12x_sparse_mla()
         if b12x_sparse_mla is None or not hasattr(
             b12x_sparse_mla, "expand_pooled_topk_to_physical_slots"
@@ -214,57 +275,6 @@ class Glm5NextPooledIndexer(nn.Module):
         self.register_buffer(
             "_tail_snapshot",
             torch.empty_like(self._tail),
-            persistent=False,
-        )
-        self.register_buffer(
-            "_q_fp8",
-            torch.empty(
-                (self.max_tokens, _INDEX_HEADS, _INDEX_HEAD_DIM),
-                dtype=torch.float8_e4m3fn,
-                device=device,
-            ),
-            persistent=False,
-        )
-        self.register_buffer(
-            "_physical_active_counts",
-            torch.empty(self.max_tokens, dtype=torch.int32, device=device),
-            persistent=False,
-        )
-        self.register_buffer(
-            "_q_scale",
-            torch.empty(
-                (self.max_tokens, _INDEX_HEADS),
-                dtype=torch.float32,
-                device=device,
-            ),
-            persistent=False,
-        )
-        self.register_buffer(
-            "_pool_seq_lens",
-            torch.empty(self.max_tokens, dtype=torch.int32, device=device),
-            persistent=False,
-        )
-        self.register_buffer(
-            "_pool_scores",
-            torch.empty(
-                (self.max_tokens, _POOL_TOPK),
-                dtype=torch.float32,
-                device=device,
-            ),
-            persistent=False,
-        )
-        self.register_buffer(
-            "_pool_block_table",
-            torch.empty((self.max_seqs, 1), dtype=torch.int32, device=device),
-            persistent=False,
-        )
-        self.register_buffer(
-            "_decode_block_table",
-            torch.empty(
-                (self.max_tokens, 1),
-                dtype=torch.int32,
-                device=device,
-            ),
             persistent=False,
         )
         self._weights_proj_fp32: torch.Tensor | None = None
@@ -366,15 +376,7 @@ class Glm5NextPooledIndexer(nn.Module):
             self.dcp_world_size,
         )
         pool_table_width = parent_table_width * subpages
-        device = main_cache.device
-        self._pool_block_table = torch.empty(
-            (self.max_seqs, pool_table_width), dtype=torch.int32, device=device
-        )
-        self._decode_block_table = torch.empty(
-            (self.max_tokens, pool_table_width),
-            dtype=torch.int32,
-            device=device,
-        )
+        self.scratch.bind_tables(pool_table_width, main_cache.device)
         self._index_cache = index_cache
         self._parent_table_width = parent_table_width
         self._subpages_per_parent = subpages
@@ -413,7 +415,7 @@ class Glm5NextPooledIndexer(nn.Module):
             return None
         return (
             self.topk_indices_buffer[:num_tokens],
-            self._physical_active_counts[:num_tokens],
+            self.scratch.physical_active_counts[:num_tokens],
         )
 
     def _project_head_weights(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -450,8 +452,8 @@ class Glm5NextPooledIndexer(nn.Module):
         gate = F.linear(hidden_states, self.index_kpool_compress_gate)
         weights = self._project_head_weights(hidden_states)
 
-        q_fp8 = self._q_fp8[:rows]
-        q_scale = self._q_scale[:rows]
+        q_fp8 = self.scratch.q_fp8[:rows]
+        q_scale = self.scratch.q_scale[:rows]
         fwht128_quant_fp8(
             query.contiguous().view(-1, _INDEX_HEAD_DIM),
             q_fp8.view(-1, _INDEX_HEAD_DIM),
@@ -513,9 +515,9 @@ class Glm5NextPooledIndexer(nn.Module):
             parent_stride_pages=self._parent_stride_pages,
         )
         parent_table = main_metadata.block_table[:num_reqs, : self._parent_table_width]
-        seq_lens = self._pool_seq_lens[:live_rows]
+        seq_lens = self.scratch.pool_seq_lens[:live_rows]
         decode_only = decode_rows == live_rows
-        decode_table = self._decode_block_table[:decode_rows]
+        decode_table = self.scratch.decode_block_table[:decode_rows]
         if decode_only:
             prepare_c4_decode_metadata(
                 parent_table,
@@ -532,7 +534,7 @@ class Glm5NextPooledIndexer(nn.Module):
         else:
             expand_c4_block_table(
                 parent_table,
-                self._pool_block_table,
+                self.scratch.pool_block_table,
                 rows=num_reqs,
                 subpages_per_parent=self._subpages_per_parent,
                 parent_stride_pages=self._parent_stride_pages,
@@ -545,12 +547,14 @@ class Glm5NextPooledIndexer(nn.Module):
                 pool_interleave=self.pool_interleave,
             )
         pool_ids = self.pool_topk_indices_buffer[:rows]
-        pool_scores = self._pool_scores[:rows] if self.dcp_world_size > 1 else None
+        pool_scores = (
+            self.scratch.pool_scores[:rows] if self.dcp_world_size > 1 else None
+        )
 
         if decode_rows:
             if not decode_only:
                 gather_c4_block_table_rows(
-                    self._pool_block_table,
+                    self.scratch.pool_block_table,
                     main_metadata.req_id_per_token[:decode_rows],
                     decode_table,
                 )
@@ -590,19 +594,19 @@ class Glm5NextPooledIndexer(nn.Module):
                     active_pages = self._active_index_page_count(
                         int(request_seq_lens_cpu[local_request])
                     )
-                    if active_pages > int(self._pool_block_table.shape[1]):
+                    if active_pages > int(self.scratch.pool_block_table.shape[1]):
                         raise RuntimeError(
                             "GLM selector visible C4 pages exceed table capacity: "
                             f"active={active_pages}, "
-                            f"capacity={int(self._pool_block_table.shape[1])}"
+                            f"capacity={int(self.scratch.pool_block_table.shape[1])}"
                         )
-                    request_table = self._pool_block_table[
+                    request_table = self.scratch.pool_block_table[
                         request : request + 1, :active_pages
                     ]
                 else:
                     # DCP pool ownership is interleaved across ranks, so a global
                     # sequence length does not define a contiguous local prefix.
-                    request_table = self._pool_block_table[request : request + 1]
+                    request_table = self.scratch.pool_block_table[request : request + 1]
                 shared_table = request_table.expand(int(query_len), -1)
                 self.indexer_op.run_paged_topk(
                     q=q_fp8[row_start:row_end],
@@ -644,7 +648,7 @@ class Glm5NextPooledIndexer(nn.Module):
                 main_metadata.req_id_per_token[:live_rows],
                 main_metadata.block_table,
                 output[:live_rows],
-                self._physical_active_counts[:live_rows],
+                self.scratch.physical_active_counts[:live_rows],
                 pool_size=_POOL_SIZE,
                 block_size=self.block_size,
                 block_stride_rows=self.block_size,

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -54,10 +54,10 @@ _INDEX_PAGE_BYTES = _INDEX_PAGE_SIZE * _INDEX_CACHE_WIDTH
 class Glm5NextIndexerScratch(nn.Module):
     """Temporary storage for sequential pooled-indexer calls on one model stream.
 
-    A model owns one instance; its draft model owns another. KV views, recurrent
-    tails and selected token IDs are not scratch and remain separately owned.
-    Bind tables before graph capture; calls must finish consuming the scratch
-    before another layer overwrites it.
+    Target layers and a serial single-layer MTP model can share one instance.
+    KV views and recurrent tails remain layer-owned. Bind tables before graph
+    capture; calls must finish consuming scratch and selection outputs before
+    another layer or model overwrites them.
     """
 
     q_fp8: torch.Tensor

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -1463,10 +1463,6 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         scratch_spec = ((self._scratch_nbytes,), torch.uint8)
         ckv_specs = (
             (
-                (self._ckv_local_capacity, self._cache_record_bytes),
-                torch.uint8,
-            ),
-            (
                 (
                     self.dcp_world_size * self._ckv_local_capacity,
                     self._cache_record_bytes,
@@ -1756,7 +1752,6 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         self,
         kv_cache: torch.Tensor,
         attn_metadata: B12xMLASparseMetadata,
-        local_buffer: torch.Tensor,
         gathered_buffer: torch.Tensor,
     ) -> torch.Tensor:
         if not self.uses_full_ckv_dcp(attn_metadata, attn_metadata.num_actual_tokens):
@@ -1771,22 +1766,22 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
                 f"{self._cache_record_bytes}-byte records; "
                 f"got shape={tuple(kv_cache.shape)}, stride={kv_cache.stride()}"
             )
-        expected_local_shape = (
-            self._ckv_local_capacity,
-            self._cache_record_bytes,
-        )
         expected_gathered_shape = (
             self.dcp_world_size * self._ckv_local_capacity,
             self._cache_record_bytes,
         )
-        if tuple(local_buffer.shape) != expected_local_shape:
-            raise RuntimeError("CKV local workspace has an invalid shape")
         if tuple(gathered_buffer.shape) != expected_gathered_shape:
             raise RuntimeError("CKV gathered workspace has an invalid shape")
 
         assert attn_metadata.dcp_local_cu_seq_lens is not None
         local_tokens = attn_metadata.dcp_local_total_tokens
         padded_tokens = attn_metadata.dcp_padded_total_tokens
+        group = get_dcp_group()
+        # NCCL in-place all-gather reads each rank's contribution from its
+        # receive slice. The stride is this call's padded count, not capacity.
+        local_buffer = gathered_buffer.narrow(
+            0, group.rank_in_group * padded_tokens, padded_tokens
+        )
         if local_tokens:
             ops.cp_gather_cache(
                 src_cache=kv_cache,
@@ -1798,7 +1793,7 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         if local_tokens < padded_tokens:
             local_buffer[local_tokens:padded_tokens].zero_()
         _dcp_all_gather_current_stream(
-            get_dcp_group(),
+            group,
             local_buffer[:padded_tokens].view(-1),
             gathered_buffer[: self.dcp_world_size * padded_tokens].view(-1),
         )
@@ -1877,11 +1872,10 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         topk_indices = self.topk_indices_buffer[:num_tokens]
         kv_cache_for_run = kv_c_and_k_pe_cache
         if use_ckv_gather:
-            local_buffer, gathered_buffer = workspaces[2:]
+            gathered_buffer = workspaces[2]
             kv_cache_for_run = self._gather_full_ckv(
                 kv_c_and_k_pe_cache,
                 attn_metadata,
-                local_buffer,
                 gathered_buffer,
             )
             assert attn_metadata.ckv_selected_indices is not None

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -1465,12 +1465,17 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         input_num_heads: int,
         include_ckv: bool,
     ) -> tuple[tuple[tuple[int, ...], torch.dtype], ...]:
-        del plan
         q_spec = (
             (self._max_tokens, input_num_heads, self._q_head_dim),
             torch.bfloat16,
         )
-        scratch_spec = ((self._scratch_nbytes,), torch.uint8)
+        # Full-CKV attention has only local query heads and does not gather
+        # queries. Its cache receive buffer need not coexist with global-head
+        # query-gather scratch or the decode plan's split-K intermediates.
+        scratch_nbytes = (
+            int(plan.layout.nbytes) if include_ckv else self._scratch_nbytes
+        )
+        scratch_spec = ((scratch_nbytes,), torch.uint8)
         ckv_specs = (
             (
                 (

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -15,6 +15,9 @@ from vllm import envs
 from vllm.config import VllmConfig, get_current_vllm_config_or_none
 from vllm.config.cache import CacheDType
 from vllm.distributed import get_dcp_group
+from vllm.distributed.device_communicators.all_reduce_utils import (
+    should_nccl_symm_mem_ag_rs,
+)
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import MLACommonPrefillMetadata
 from vllm.model_executor.layers.attention.sparse_mla_attention import (
@@ -1536,6 +1539,33 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
             and num_heads == self._input_num_heads
             and self._q_head_dim == 576
         )
+
+    def reduce_scatter_dcp_output(self, output: torch.Tensor) -> torch.Tensor | None:
+        """Reuse consumed query storage for the prefill output collective.
+
+        The corrected attention output remains in disjoint kernel scratch.
+        Pack it into the query buffer in head-major order, then let NCCL write
+        each rank's reduction at its in-place receive offset. The resulting
+        head-major matrices stay live until the following value projection.
+        Decode and symmetric-memory transports retain their existing path.
+        """
+        if not self._is_glm_next or output.shape[0] <= self._decode_max_rows:
+            return None
+        group = get_dcp_group()
+        communicator = getattr(group, "device_communicator", None)
+        comm = getattr(communicator, "pynccl_comm", None)
+        if comm is None or comm.disabled or should_nccl_symm_mem_ag_rs():
+            return None
+
+        rows, heads, head_dim = output.shape
+        q_buffer = self._borrow_workspaces()[0]
+        assert output.dtype == q_buffer.dtype
+        packed = q_buffer.view(-1)[: output.numel()].view(heads, rows, head_dim)
+        packed.copy_(output.transpose(0, 1))
+        local_heads = heads // self.dcp_world_size
+        local = packed.narrow(0, group.rank_in_group * local_heads, local_heads)
+        comm.reduce_scatter(local, packed)
+        return local.transpose(0, 1)
 
     def gather_dcp_query(self, query: torch.Tensor) -> torch.Tensor:
         """Gather GLM prefill heads into caller-owned attention query storage.

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -1540,6 +1540,49 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
             and self._q_head_dim == 576
         )
 
+    def prepare_projection_input(
+        self, value: torch.Tensor, output: torch.Tensor
+    ) -> torch.Tensor | None:
+        """Reuse idle attention workspace for disjoint MLA projection batches.
+
+        Query projection runs before attention borrows its workspace; value
+        projection runs after attention finishes. A disjoint prefix may receive
+        the layout copy in either case. The projection consumes that prefix
+        before another kernel borrows the worker workspace.
+        """
+        if (
+            not self._is_glm_next
+            or value.shape[1] <= self._decode_max_rows
+            or value.dtype != torch.bfloat16
+            or value.is_contiguous()
+        ):
+            return None
+        manager = current_workspace_manager()
+        nbytes = value.numel() * value.element_size()
+        if manager.available_bytes() < nbytes:
+            return None
+        (packed,) = manager.get_simultaneous((tuple(value.shape), value.dtype))
+        for live in (value, output):
+            if packed.untyped_storage().data_ptr() != live.untyped_storage().data_ptr():
+                continue
+            start = live.storage_offset() * live.element_size()
+            stop = (
+                start
+                + (
+                    1
+                    + sum(
+                        (size - 1) * stride
+                        for size, stride in zip(live.shape, live.stride())
+                    )
+                )
+                * live.element_size()
+            )
+            packed_start = packed.storage_offset() * packed.element_size()
+            if start < packed_start + nbytes and packed_start < stop:
+                return None
+        packed.copy_(value)
+        return packed
+
     def reduce_scatter_dcp_output(self, output: torch.Tensor) -> torch.Tensor | None:
         """Reuse consumed query storage for the prefill output collective.
 

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -1395,6 +1395,16 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         if self._ckv_extend_plan is not None:
             plans.append(self._ckv_extend_plan)
         self._scratch_nbytes = max(int(plan.layout.nbytes) for plan in plans)
+        if self._is_glm_next and self.dcp_world_size > 1:
+            # Query gathering finishes before attention consumes scratch. Its
+            # rank-major receive storage can therefore reuse the kernel arena.
+            self._scratch_nbytes = max(
+                self._scratch_nbytes,
+                self._max_tokens
+                * self._input_num_heads
+                * self._q_head_dim
+                * torch.bfloat16.itemsize,
+            )
         self._ckv_local_capacity = _round_up_ckv_rank_tokens(
             self._ckv_capacity_tokens,
             page_size=kernel_page_size,
@@ -1521,6 +1531,40 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
             and num_heads == self._input_num_heads
             and self._q_head_dim == 576
         )
+
+    def gather_dcp_query(self, query: torch.Tensor) -> torch.Tensor:
+        """Gather GLM prefill heads into caller-owned attention query storage.
+
+        The rank-major receive view borrows kernel scratch only until the
+        layout copy completes on the execution stream. The attention call
+        rebinds that scratch while retaining the final query at the same address.
+        Decode and transport-specific all-gathers keep their established path.
+        """
+        group = get_dcp_group()
+        if not self._is_glm_next or query.shape[0] <= self._decode_max_rows:
+            return group.all_gather(query, dim=1)
+        communicator = getattr(group, "device_communicator", None)
+        b12x_comm = getattr(communicator, "b12x_ar_comm", None)
+        if (
+            b12x_comm is not None
+            and not b12x_comm.disabled
+            and getattr(b12x_comm, "should_all_gather", None) is not None
+            and b12x_comm.should_all_gather(query, 1)
+        ):
+            return group.all_gather(query, dim=1)
+
+        rows, local_heads, head_dim = query.shape
+        q_buffer, scratch = self._borrow_workspaces()[:2]
+        output = q_buffer[:rows]
+        receive = scratch[: output.numel() * output.element_size()].view(query.dtype)
+        receive = receive.view(self.dcp_world_size, rows, local_heads, head_dim)
+        local = receive[group.rank_in_group]
+        local.copy_(query)
+        _dcp_all_gather_current_stream(group, local.view(-1), receive.view(-1))
+        output.view(rows, self.dcp_world_size, local_heads, head_dim).copy_(
+            receive.movedim(0, 1)
+        )
+        return output
 
     def get_fused_mla_query_output(
         self,

--- a/vllm/v1/attention/ops/dcp.py
+++ b/vllm/v1/attention/ops/dcp.py
@@ -1242,6 +1242,7 @@ class MLADCPManager:
         padded_num_heads: int | None,
         is_lse_base_on_e: bool,
         use_pcp: bool,
+        query_gather_fallback: Callable[[torch.Tensor], torch.Tensor] | None = None,
     ) -> None:
         parallel_config = vllm_config.parallel_config
         self.group = get_dcp_group()
@@ -1250,6 +1251,7 @@ class MLADCPManager:
         self.max_num_tokens = get_dcp_workspace_max_num_tokens(vllm_config)
         self.use_a2a = parallel_config.dcp_comm_backend == "a2a"
         self.padded_num_heads = padded_num_heads
+        self._query_gather_fallback = query_gather_fallback
 
         self.combine = self._init_combine(
             num_heads,
@@ -1362,7 +1364,11 @@ class MLADCPManager:
         return self._gather_query
 
     def _gather_query(self, query: torch.Tensor) -> torch.Tensor:
-        query = self.group.all_gather(query, dim=1)
+        query = (
+            self.group.all_gather(query, dim=1)
+            if self._query_gather_fallback is None
+            else self._query_gather_fallback(query)
+        )
         if self.padded_num_heads is not None:
             query = reserve_query_head_storage(query, self.padded_num_heads)
         return query

--- a/vllm/v1/attention/ops/dcp.py
+++ b/vllm/v1/attention/ops/dcp.py
@@ -282,6 +282,7 @@ def cp_lse_ag_out_rs(
     is_lse_base_on_e=True,
     seq_lens: torch.Tensor | None = None,
     query_start_loc: torch.Tensor | None = None,
+    output_reduce_scatter: Callable[[torch.Tensor], torch.Tensor | None] | None = None,
 ):
     """
     cp_attn_out: [ B, H, D ]
@@ -296,7 +297,12 @@ def cp_lse_ag_out_rs(
         seq_lens=seq_lens,
         query_start_loc=query_start_loc,
     )
-    if current_platform.is_cuda() and current_platform.is_device_capability_family(120):
+    reduced = output_reduce_scatter(out) if output_reduce_scatter is not None else None
+    if reduced is not None:
+        out = reduced
+    elif current_platform.is_cuda() and current_platform.is_device_capability_family(
+        120
+    ):
         # Preserve the head-major collective output for the following MLA
         # value GEMM. Its batch matrices are disjoint, avoiding cuBLAS's
         # SM120/121 overlapping-stride read defect and a redundant transpose copy.
@@ -1243,6 +1249,8 @@ class MLADCPManager:
         is_lse_base_on_e: bool,
         use_pcp: bool,
         query_gather_fallback: Callable[[torch.Tensor], torch.Tensor] | None = None,
+        output_reduce_scatter: Callable[[torch.Tensor], torch.Tensor | None]
+        | None = None,
     ) -> None:
         parallel_config = vllm_config.parallel_config
         self.group = get_dcp_group()
@@ -1252,6 +1260,7 @@ class MLADCPManager:
         self.use_a2a = parallel_config.dcp_comm_backend == "a2a"
         self.padded_num_heads = padded_num_heads
         self._query_gather_fallback = query_gather_fallback
+        self._output_reduce_scatter = output_reduce_scatter
 
         self.combine = self._init_combine(
             num_heads,
@@ -1304,6 +1313,13 @@ class MLADCPManager:
             if use_pcp
             else cp_lse_ag_out_rs
         )
+        if combine_fn is cp_lse_ag_out_rs and self._output_reduce_scatter is not None:
+            return functools.partial(
+                cp_lse_ag_out_rs,
+                cp_group=self.group,
+                is_lse_base_on_e=is_lse_base_on_e,
+                output_reduce_scatter=self._output_reduce_scatter,
+            )
         return functools.partial(
             combine_fn,
             cp_group=self.group,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -914,6 +914,14 @@ def check_enough_kv_cache_memory(
             if groups
             else available_memory
         )
+        if vllm_config.use_request_boundary_checkpoints:
+            _check_enough_kv_cache_memory(
+                check_memory,
+                partial(_max_memory_usage_bytes_from_groups, vllm_config, groups),
+                vllm_config.model_config.max_model_len,
+                partial(_estimate_max_model_len_from_groups, vllm_config, groups),
+            )
+            return
         _check_enough_kv_cache_memory(
             check_memory,
             lambda: max_memory_usage_bytes(vllm_config, kv_cache_spec.values()),
@@ -977,6 +985,18 @@ def is_kv_cache_spec_uniform(kv_cache_spec: dict[str, KVCacheSpec]) -> bool:
     return True
 
 
+def _request_boundary_reserve_blocks(vllm_config: VllmConfig, num_groups: int) -> int:
+    """Count private instruction, prompt, and response checkpoint storage."""
+    if not num_groups or not vllm_config.use_request_boundary_checkpoints:
+        return 0
+
+    from vllm.v1.core.boundary_checkpoint import NUM_BOUNDARY_CHECKPOINT_SLOTS
+
+    # KVCacheManager.allocate_slots reserves one block per group and one
+    # auxiliary block per endpoint, separately from the live sequence state.
+    return NUM_BOUNDARY_CHECKPOINT_SLOTS * (num_groups + 1)
+
+
 def get_max_concurrency_for_kv_cache_config(
     vllm_config: VllmConfig, kv_cache_config: KVCacheConfig
 ) -> float:
@@ -997,6 +1017,9 @@ def get_max_concurrency_for_kv_cache_config(
             group.kv_cache_spec.page_size_bytes,
         )
         for group in kv_cache_config.kv_cache_groups
+    )
+    num_blocks_per_request += _request_boundary_reserve_blocks(
+        vllm_config, len(kv_cache_config.kv_cache_groups)
     )
     max_concurrency = kv_cache_config.num_blocks / num_blocks_per_request
     return max_concurrency
@@ -1426,6 +1449,9 @@ def _get_kv_cache_group_allocation_cost(
             group.kv_cache_spec.page_size_bytes,
         )
         for group in kv_cache_groups
+    )
+    num_blocks_per_request += _request_boundary_reserve_blocks(
+        vllm_config, len(kv_cache_groups)
     )
     return _get_kv_cache_bytes_per_block(kv_cache_groups) * num_blocks_per_request
 
@@ -2286,6 +2312,7 @@ def _max_memory_usage_bytes_from_groups(
                 spec.page_size_bytes,
             )
 
+    total_blocks += _request_boundary_reserve_blocks(vllm_config, len(kv_cache_groups))
     return bytes_per_block * total_blocks
 
 

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -132,7 +132,14 @@ def load_eagle_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mod
     # every module in the draft that holds a buffer reference so that
     # the per-layer indexer and sparse-attention backends all point to
     # the target's buffer.
-    if hasattr(target_inner, "topk_indices_buffer"):
+    share_indexer_storage = getattr(eagle_model, "share_target_indexer_storage", None)
+    if share_indexer_storage is not None:
+        if (
+            get_pp_group().world_size == 1
+            and not vllm_config.parallel_config.enable_dbo
+        ):
+            share_indexer_storage(target_inner)
+    elif hasattr(target_inner, "topk_indices_buffer"):
         target_buffer = target_inner.topk_indices_buffer
         if target_buffer is not None:
             for _, module in draft_inner.named_modules():

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -520,6 +520,10 @@ class Worker(WorkerBase):
             # still need a profile run which compiles the model for
             # max_num_batched_tokens
             self.model_runner.profile_run()
+            # Retired profiling allocations must be reusable by the contiguous
+            # KV pool even when automatic memory sizing is bypassed.
+            torch.accelerator.synchronize()
+            torch.accelerator.empty_cache()
 
             msg = (
                 f"Initial free memory {format_gib(self.init_snapshot.free_memory)} "

--- a/vllm/v1/worker/workspace.py
+++ b/vllm/v1/worker/workspace.py
@@ -52,11 +52,12 @@ def use_workspace_lane(lane: int) -> Iterator[None]:
 def collect_cuda_graph_capture_resources() -> Iterator[list[Any]]:
     """Collect objects whose storage is referenced by one CUDA graph.
 
-    A CUDA graph records device pointers, but it does not retain the Python
-    objects that own those allocations. Callers that allocate custom-op output
-    or scratch tensors during capture can register their owner with
-    :func:`retain_cuda_graph_capture_resource`. The graph manager keeps the
-    returned list alive for exactly as long as the captured graph.
+    A CUDA graph records device pointers, but does not retain Python owners of
+    external allocations. Register scratch and eager-break outputs allocated
+    outside its pool with :func:`retain_cuda_graph_capture_resource`. Outputs
+    allocated in the graph pool are already tracked by the CUDA allocator;
+    retaining consumed outputs here would prevent its storage reuse. The graph
+    manager keeps this list alive for exactly as long as the captured graph.
     """
     resources: list[Any] = []
     token = _cuda_graph_capture_resources.set(resources)
@@ -150,6 +151,23 @@ class WorkspaceManager:
     def is_locked(self) -> bool:
         """Check if workspace is locked."""
         return self._locked
+
+    def available_bytes(self) -> int:
+        """Capacity of the active execution slot, without allocating storage.
+
+        A borrower must ensure that no nested or concurrent operation consumes
+        this slot while its views are live.
+        """
+        ubatch_id = dbo_current_ubatch_id()
+        lane = _workspace_lane.get()
+        if lane >= self._num_lanes:
+            raise RuntimeError(
+                f"Workspace lane {lane} is not configured; manager has "
+                f"{self._num_lanes} lane(s)."
+            )
+        return self._workspace_size_bytes(
+            self._current_workspaces[ubatch_id * self._num_lanes + lane]
+        )
 
     def get_simultaneous(
         self, *shapes_and_dtypes: tuple[tuple[int, ...], torch.dtype]


### PR DESCRIPTION
## Purpose

Reduce live and temporary GPU allocations for GLM-5.3-Flash without changing target weights, FP8 KV precision, attention arithmetic, or recurrent-state ownership. These changes are included in the published **GLM Spark TP2 experimental image** and enable a qualified **1,048,576-token shared context with vision and MTP3 on two 96 GB RTX PRO 6000 Workstation GPUs**.

Status: implemented; component-qualified against `dev/jovian-judgement` at `5bca5a58d970216bd46be82575e824c6e424c465`. The full serving results in the historical image qualification section apply only to image source `7f4aecc66e857d093e012a2c57d03711bd23be4a`, not to this PR's preparation-API compatibility update. The eight image commits and their authorship remain in the ancestry.

## Changes

| Area | Resulting behavior |
|---|---|
| KV admission | Include private instruction, prompt, and response checkpoint blocks when selecting a layout, admitting maximum context, and reporting capacity. Do not admit a context that cannot reserve its checkpoint state. Aligned-policy accounting is unchanged. |
| Sparse indexer | Share temporary storage across sequential target layers. The V2 loader also shares it with a single MTP layer only when geometry matches, pipeline parallelism is one, and overlapped microbatches are disabled. Token selections, pool selections, per-layer KV, and recurrent tails retain their distinct roles. |
| DCP communication | Pack full-CKV contributions directly into each rank's receive slice. Reuse caller-owned attention scratch for query gathering and consumed query storage for the output reduce-scatter. Retain transport selection, head-major output layout, and decode behavior. Full-CKV scratch is sized for its local-head plan. |
| Packed weights and profiling | Release unused MXFP8 row-layout scales and packed sparse-MQA `kv_b_proj` after their execution representations are ready. Preserve reload support. Skip unreachable dense-MHA profiling allocations and release retired profile buffers before explicit KV allocation. |
| CUDA graph and KDA lifetime | Retain external plan/scratch owners without pinning consumed graph-pool outputs. Use disjoint workspace regions for convolution and mixed-prefill selections; preserve speculative history and the SM120/121 disjoint-batch MLA projection guard. |
| Vision | Chunk token-local projection, normalization, MLP, and merger work while keeping full-image attention. Profile the maximum rectangular image canvas, not an underfilled square. Keep valid encoder-cache entries. |

No additional quantization, weight offload, smaller image-attention window, or truncation of selected sparse tokens is introduced. The BF16 target vocabulary head and its existing private NVFP4 MTP copy are preserved.

## Preparation API compatibility and review validation

The PR head `ab51db9b4801a551e5c5fc4a6e0b4e20fb37bbf4` contains JJ `5bca5a58` through a normal merge, without rewriting the image commits. Its B12X runtime boundary is master `ff36d2d1`, which includes merged #362. [B12X #375](https://github.com/local-inference-lab/b12x/pull/375) changes only the scale-bounds regression test; it is not a runtime dependency.

- Explicit prepared plans replace removed binding/warmup APIs. GLM shared indexer storage, KDA workspace suffixes, local-head CKV scratch and DCP query/output reuse remain intact.
- Sparse MLA preparation reads `scratch_specs()`; temporary trial operands remain owned through synchronized preparation but are not retained as session-lifetime owners. Runtime still binds live operands and caller-owned scratch.
- Releasing unused packed MQA weights also releases their linear holder/provider. Reload recreates execution storage. MXFP8 scale dropping is checked against a packed weight retaining row scales, including 3,072-row prefill and changed-input graph replay.
- mHC uses JJ's functional prepared operators. The consumed-output ownership regression remains; the removed binding implementation is not reintroduced.
- The CodeRabbit vision finding is confirmed and corrected: exact factorization of an 8,191-token budget could exceed the per-axis RoPE table. Profiling now maximizes valid rectangular area within both token and RoPE limits. The ordinary 8,000-feature canvas is unchanged. The convolution output contract uses Google-style documentation.

Qualification conditions: isolated image dependency environment, PyTorch 2.13/CUDA 13.3, RTX PRO 6000 Workstation GPUs 8–9, review vLLM and B12X source mounted read-only. No clock changes or full-model serving benchmark was performed.

| Coverage | Result |
|---|---|
| KV admission/packing, serial indexer storage, KDA convolution/workspace, worker memory profile | 186 passed |
| Pooled GLM indexer, with `B12X_GLM53_GPU_TEST=1` | 57 passed |
| Selected sparse MLA/full-CKV/DCP, scratch lifetime and mHC graph ownership | 48 passed |
| MXFP8 loader/reload and NVFP4/MXFP8 precision/graph checks | 8 passed |
| Vision/image/chunked-projection components | 11 passed |
| Two-rank padded-record all-gather and query/output live-input graph replay | 2 passed |
| Final vision-bound, preparation-lifetime and mHC graph repeat | 8 passed |

Tests extend the existing files; no failure is converted into a skip or a weaker oracle. Selected commands, using the image interpreter:

```bash
/opt/venv/bin/python -m pytest tests/models/test_glm5next_indexer_storage.py tests/kernels/mamba/test_kda_conv_workspace.py tests/v1/worker/test_workspace.py tests/v1/worker/test_gpu_worker.py tests/v1/core/test_kv_cache_utils.py tests/v1/core/test_contiguous_kv_packing.py -q
B12X_GLM53_GPU_TEST=1 /opt/venv/bin/python -m pytest tests/models/test_glm5next_pooled_indexer.py -q
/opt/venv/bin/python -m pytest tests/v1/attention/test_b12x_sparse_mla_api.py -k 'full_ckv or mhc_graph_reuses or glm_dcp or projection_scratch or value_projection or preparation_releases' -q
/opt/venv/bin/python -m pytest tests/model_executor/kernels/test_b12x_linear.py -k 'mxfp8_process_weights or mxfp8_reload or dense_precision_gpu_graph' -q
```

Static checks are **not fully green**: whole-file Ruff/formatting, mypy and the accelerator-migration hook fail on unmodified JJ `5bca5a58` too. Baseline controls were run in a separate clean worktree. Those hooks were skipped for the merge commit; their configuration was not changed and unrelated JJ files were not mass-formatted. Targeted undefined/redefined/unused-local checks and the diff whitespace check pass. Mypy passes on the vision/docstring correction commit.

This does not qualify complete GLM serving after the B12X preparation migration. In particular, the historical model throughput and memory savings below must not be presented as measurements of `ab51db9b`.

## Historical published-image qualification

The published image uses vLLM source `7f4aecc66e857d093e012a2c57d03711bd23be4a`, and the companion [B12X #362 MXFP8 scale-bounds fix](https://github.com/local-inference-lab/b12x/pull/362). That fix must also be included when reproducing the Spark projection shape; it is not a vLLM memory optimization.

Configuration: TP2/DCP2, MTP3, B12X MoE and dense linears, FP8 KV, FP32 recurrent state, batch 3072, four request slots, one image at the native 8000-feature ceiling, full-and-piecewise graphs, 4 GiB KV/rank. NCCL uses two channels and a 1 MiB buffer; VRAM offset is +6000 and graphics clocks are automatic. These deployment settings are not imposed globally by this PR.

- Cold 1,048,320-token image prompt with a 256-token output allowance: correct visual answer, zero prompt/image cache hits, 145.995 seconds.
- Subsequent fresh text and exact text-prefix replays: passed without restarting the process.
- Cold image request alongside three active decoders: correct answer and progress on every decoder, zero errors.
- Fifteen text-cache cases covering request endpoints, response continuation, shared instructions, and tool history: passed.
- Full 24-layer TP2 BF16 vision comparison: bitwise parity. Two-rank DCP collective tests cover variable sizes and 2048 rows × 64 heads × 512 features, with bitwise parity and live-input CUDA graph replay.

Focused test evidence: KV sizing/packing **131 passed**; DCP workspace selection **29 passed**; serial target/MTP ownership **11 passed**; KDA lifetime/convolution **13 passed**; mHC graph ownership **2 passed**; MLA input scratch **5 passed**; packed-weight/vision components **13 passed**. These are focused suites, not a claim that every repository test passes. Earlier broader runs exposed a metadata pointer-sharing failure and A2A failures retained in the validation logs; they are not counted as passing gates.

Repository entry points for rerunning the focused regression coverage in an isolated environment:

```bash
.venv/bin/python -m pytest tests/v1/core/test_kv_cache_utils.py tests/v1/core/test_contiguous_kv_packing.py -q
.venv/bin/python -m pytest tests/models/test_glm5next_indexer_storage.py -q
.venv/bin/python -m pytest tests/kernels/mamba/test_kda_conv_workspace.py -q
```

The image's equivalent interpreter is `/opt/venv/bin/python`. GPU suites require the matching B12X installation and CUDA environment. At the published image source revision, changed-file Ruff checks and formatting, plus `git diff --check`, passed. The preparation-API update has the static-check limitations described above.

Measured immutable-image medians: **32K prefill 10,765.9 tokens/s; C1 195.7 output tokens/s / 78.75 verifier steps/s; C4 aggregate 455.1 tokens/s / 183.55 steps/s**. Decode uses temperature 1, top-p 0.95, context zero, a 15-second warmup and three 30-second measured cells. Prefill uses one warmup and 30 seconds of unique cold 32K prompts. These are capacity-qualified serving results, not an isolated speedup claim. C4 output was 4.3% below a single-cell source-validation control, while verifier rate differed by 1.0%; all samples are retained.

Measured memory reductions include **72.465 MiB/rank** from serial target/MTP indexer sharing and **292.85 MiB/rank** from mHC graph ownership. Vision component peak fell **405.27 MiB/rank**, plus **38.73 MiB** from borrowed QKV storage. Persistent and transient savings are different measurements and must not be summed.

[Image, launch command, limitations and results](https://github.com/local-inference-lab/rtx6kpro/blob/master/models/glm-5.3-flash-spark-tp2.md) · [Machine-readable qualification and raw samples](https://github.com/local-inference-lab/rtx6kpro/blob/master/models/glm-5.3-flash/tp2-experimental-qualification.json)

## Review boundary

- TP4 savings, TP2 LMCache/DFlash, multiple images, and exact multimodal endpoint replay are **not qualified** by this evidence.
- JJ `5bca5a58` is an ancestor of the PR head. The preparation-API component validation is listed separately from the source-locked image's full serving measurements.
- Duplicate-work audit: #714 includes persistent DCP workspaces in a separate TrellisMX integration; this PR reuses caller-owned GLM storage and does not add that quantization adapter. #713 addresses TP8 decode overlap, not this TP2 memory/vision composition. Neither PR is replaced or closed here. Relevant upstream GLM-memory PRs do not implement this B12X-specific composition.
- AI assistance was used for implementation, testing, and PR preparation. Existing commit authorship and contributor trailers are preserved; no independent human-review claim is made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added chunked processing for GLM-5.3 vision inputs, helping limit temporary memory use for long sequences.
  - Added support for image token-budget overrides and rectangular image sizing for improved vision coverage.
  - Added caller-provided output buffers for causal convolution operations.
  - Added workspace reuse and availability tracking for attention, decoding, and graph execution.

- **Performance**
  - Improved distributed attention buffer reuse and communication paths.
  - Reduced temporary memory usage during quantized model loading and multimodal processing.

- **Bug Fixes**
  - Improved KV-cache capacity accounting when request-boundary checkpoints are enabled.
  - Preserved model weights and outputs across quantization, draft-model execution, and graph replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->