### PR TITLE
fix(warmup): precompile seeded FP32 target sampling on JJ

### DIFF
--- a/tests/v1/worker/test_gpu_gumbel_sample.py
+++ b/tests/v1/worker/test_gpu_gumbel_sample.py
@@ -21,7 +21,7 @@ pytest.importorskip("triton")
 if not torch.cuda.is_available():
     pytest.skip("CUDA required for Gumbel sampler tests", allow_module_level=True)
 
-from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
+from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample, warmup_processed_gumbel
 
 DEVICE = "cuda"
 VOCAB_SIZE = 200_000
@@ -31,6 +31,44 @@ NUM_SAMPLES = 500_000
 HEAD_LOG_GAP = 18.0
 # 10-sigma band: a correct sampler effectively never trips it.
 Z_TOLERANCE = 10.0
+
+
+@pytest.mark.parametrize("vocab_size", [257, 129280])
+@pytest.mark.parametrize("use_fp64", [False, True])
+def test_processed_gumbel_warmup_covers_seeded_target_sampling(
+    monkeypatch, vocab_size, use_fp64
+):
+    """Explicitly seeded FP32 requests must not JIT after server warmup."""
+    from triton import knobs
+
+    device = torch.device(DEVICE)
+    warmup_processed_gumbel(vocab_size, device, use_fp64=use_fp64)
+    torch.accelerator.synchronize()
+
+    def unexpected_compile(**kwargs):
+        pytest.fail("Seeded target sampling compiled after sampler warmup")
+
+    monkeypatch.setattr(knobs.runtime, "jit_post_compile_hook", unexpected_compile)
+    for rows in (1, 2, 7, 8, 16, 31):
+        logits = torch.zeros(rows, vocab_size, device=device)
+        # InputBatch uses np.intp / torch.int64 request mappings.
+        mapping = torch.zeros(rows, dtype=torch.int64, device=device)
+        temperature = torch.ones(1, device=device)
+        seed = torch.tensor([43], dtype=torch.int64, device=device)
+        position = torch.arange(rows, dtype=torch.int64, device=device)
+        sampled = gumbel_sample(
+            logits,
+            mapping,
+            temperature,
+            seed,
+            position,
+            apply_temperature=False,
+            is_drafting=False,
+            use_fp64=use_fp64,
+        )
+        assert sampled.shape == (rows,)
+        assert ((sampled >= 0) & (sampled < vocab_size)).all()
+    torch.accelerator.synchronize()
 
 
 def _make_heavy_tailed_counts(seed: int = 1234) -> torch.Tensor:

--- a/tests/v1/worker/test_gpu_sampler_flags.py
+++ b/tests/v1/worker/test_gpu_sampler_flags.py
@@ -10,6 +10,7 @@ if not torch.cuda.is_available():
     pytest.skip("CUDA required for sampler flag tests", allow_module_level=True)
 
 from vllm.sampling_params import SamplingParams
+from vllm.v1.worker.gpu.sample.gumbel import warmup_processed_gumbel
 from vllm.v1.worker.gpu.sample.sampler import Sampler
 from vllm.v1.worker.gpu.states import RequestState
 
@@ -88,3 +89,39 @@ def test_logits_processing_cache_only_checks_active_requests():
 
     assert not np.any(sampler.needs_logits_processing[sampling_only])
     assert np.any(sampler.needs_logits_processing[with_processing])
+
+
+def test_seeded_filtered_sampler_uses_precompiled_target_kernel(monkeypatch):
+    """Exercise real UVA sampling states and the InputBatch int64 mapping ABI."""
+    from triton import knobs
+
+    sampler = _make_sampler()
+    warmup_processed_gumbel(VOCAB_SIZE, DEVICE)
+
+    def unexpected_compile(**kwargs):
+        pytest.fail("Seeded filtered sampling compiled after target warmup")
+
+    monkeypatch.setattr(knobs.runtime, "jit_post_compile_hook", unexpected_compile)
+    for req_idx in (0, 3):
+        sampler.add_request(
+            req_idx, 1, SamplingParams(temperature=1, top_p=0.95, seed=43)
+        )
+        sampler.apply_staged_writes()
+        mapping_np = np.array([req_idx], dtype=np.intp)
+        mapping = torch.from_numpy(mapping_np).to(DEVICE)
+        logits = torch.zeros((1, VOCAB_SIZE), dtype=torch.bfloat16, device=DEVICE)
+        position = torch.ones(1, dtype=torch.int64, device=DEVICE)
+        input_ids = torch.ones(1, dtype=torch.int32, device=DEVICE)
+        local_position = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+        sampled, processed = sampler.sample(
+            logits,
+            mapping,
+            mapping,
+            mapping_np,
+            position,
+            input_ids,
+            local_position,
+        )
+        assert processed.dtype == torch.float32
+        assert sampled.shape == (1,)
+    torch.accelerator.synchronize()

--- a/tests/v1/worker/test_gpu_warmup_blocks.py
+++ b/tests/v1/worker/test_gpu_warmup_blocks.py
@@ -83,7 +83,7 @@ def _make_runner(
         device=torch.device(current_platform.device_type),
         max_num_reqs=4,
         max_model_len=MAX_MODEL_LEN,
-        model_config=SimpleNamespace(get_vocab_size=lambda: 64),
+        model_config=SimpleNamespace(get_vocab_size=lambda: 64, use_fp64_gumbel=False),
         model_state=SimpleNamespace(max_encoder_len=0),
         scheduler_config=SimpleNamespace(max_num_seqs=4, max_num_batched_tokens=2048),
         kv_cache_config=SimpleNamespace(

--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -304,3 +304,30 @@ def gumbel_sample(
     max_block_idx = local_max.argmax(dim=-1, keepdim=True)
     sampled = local_argmax.gather(dim=-1, index=max_block_idx).view(-1)
     return sampled
+
+
+def warmup_processed_gumbel(
+    vocab_size: int, device: torch.device, *, use_fp64: bool = False
+) -> None:
+    """Compile target sampling of processed FP32 logits without a model forward.
+
+    FlashInfer handles unseeded filtered warmup requests, but explicit seeds
+    dispatch to Gumbel-max. Greedy warmup covers only native-dtype logits and
+    therefore cannot initialize this specialization. Temporary inputs do not
+    consume a serving request's RNG stream or modify request state.
+    """
+    logits = torch.zeros((1, vocab_size), dtype=torch.float32, device=device)
+    mapping = torch.zeros(1, dtype=torch.int64, device=device)
+    temperature = torch.ones(1, dtype=torch.float32, device=device)
+    seed = torch.zeros(1, dtype=torch.int64, device=device)
+    position = torch.zeros(1, dtype=torch.int64, device=device)
+    gumbel_sample(
+        logits,
+        mapping,
+        temperature,
+        seed,
+        position,
+        apply_temperature=False,
+        is_drafting=False,
+        use_fp64=use_fp64,
+    )

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -22,6 +22,7 @@ from vllm.v1.kv_cache_interface import CrossAttentionSpec, KVCacheSpec, MambaSpe
 from vllm.v1.request import Request
 from vllm.v1.sample.ops.topk_topp_sampler import warmup_top_k_top_p
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+from vllm.v1.worker.gpu.sample.gumbel import warmup_processed_gumbel
 
 logger = init_logger(__name__)
 
@@ -442,6 +443,11 @@ def warmup_kernels(
     worker_execute_model(cleanup_output)
     model_runner.kv_connector.set_disabled(False)
     if model_runner.is_last_pp_rank and not model_runner.is_pooling_model:
+        warmup_processed_gumbel(
+            model_runner.model_config.get_vocab_size(),
+            model_runner.device,
+            use_fp64=model_runner.model_config.use_fp64_gumbel,
+        )
         warmup_top_k_top_p(
             model_runner.model_config.get_vocab_size(),
             min(


### PR DESCRIPTION
## Purpose and resulting behavior

Precompile processed-FP32 target Gumbel sampling during V2 startup on Jovian
Judgement. Explicit seeds bypass FlashInfer, so an unseeded warmup can leave
this specialization uncompiled even when the native-dtype greedy path is ready.
With `--jit-monitor-mode error`, the first real seeded filtered request then
fails. The temporary warmup uses the InputBatch int64 mapping ABI and supports
the configured FP32/FP64 reduction mode.

No model forward, request RNG consumption, sampling mathematics, runtime
dispatch or native extension changes are introduced. The temporary vocabulary
buffer is released after warmup. This is not a fix for intermittent prefill
throughput variation.

## Related work and compatibility

This is a narrowly scoped downstream correction for the JJ runtime, not a
competing upstream sampler redesign. Upstream
[vllm-project/vllm#54630](https://github.com/vllm-project/vllm/pull/54630)
addresses the same missing dispatch coverage through three complete sampler
warmup configurations across V1/V2. JJ already has additional greedy and
top-k/top-p warmup; the missing specialization reproduced here is handled
directly without adding another model/sampler-state replay. Searches of open
fork and upstream PRs found no separate JJ correction of this exact gap.
Upstream reports #54425 and #54455 describe the general failure class.

## Validation

Status: **implemented**, **qualified** on the DS4.1 TP4/DCP1 K7 serving image
with temperature 1, top-p 0.95, seed 43 and strict JIT monitoring.

- Four CUDA no-JIT tests cover FP32/FP64 reductions, vocabulary sizes 257 and
  129280, and 1/2/7/8/16/31 rows.
- Fourteen sampler-state cases include real seeded FP32 sampling with UVA
  parameters; 64 warmup-block and greedy-sampling cases passed.
- The composed serving tree passed 183 focused tests and explicit-seed HTTP,
  text and vision smoke gates. All applicable source pre-commit checks passed.
- Exact-image R36 qualification will be added to this PR after the image build.

Test entrypoints:
`tests/v1/worker/test_gpu_gumbel_sample.py`,
`tests/v1/worker/test_gpu_sampler_flags.py`, and
`tests/v1/worker/test_gpu_warmup_blocks.py`.
Tests use the isolated serving environment and
`python -m pytest --confcutdir=tests/v1/worker`.

AI assistance was used for implementation and validation. This description
does not assert an independent human source review. The GPU qualification is
bounded to the configurations above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added GPU warmup for processed Gumbel sampling to precompile sampling kernels before requests are processed.
  * Seeded and filtered sampling now avoids triggering compilation during active sampling after warmup.

* **Tests**
  * Added coverage verifying warmup behavior across vocabulary sizes, sampling configurations, and request shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->